### PR TITLE
Fix execution on Linux, resolve #266

### DIFF
--- a/scripts/xonsh
+++ b/scripts/xonsh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-export PYTHONUNBUFFERED="XONSH_SET"
+export PYTHONUNBUFFERED=1
 /usr/bin/env python -c "from xonsh.main import main; main()"

--- a/scripts/xonsh
+++ b/scripts/xonsh
@@ -1,3 +1,3 @@
-#!/usr/bin/env python -u
-from xonsh.main import main
-main()
+#!/usr/bin/env sh
+export PYTHONUNBUFFERED="XONSH_SET"
+/usr/bin/env python -c "from xonsh.main import main; main()"


### PR DESCRIPTION
Export an environment variable PYTHONUNBUFFERED: equivalent to the `-u` flag, producing unbuffered output from python. Environment variable is an arbitrary string.