### PR TITLE
xonfig colors preview

### DIFF
--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -1,0 +1,5 @@
+import xonsh.completers.path as xcp
+
+def test_pattern_need_quotes():
+    # just make sure the regex compiles
+    xcp.PATTERN_NEED_QUOTES.match('')

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -14,7 +14,7 @@ from xonsh.completers.tools import get_filter_function
 def PATTERN_NEED_QUOTES():
     pattern = r'\s`\$\{\}\,\*\(\)"\'\?&'
     if xp.ON_WINDOWS:
-        pattern.append('%')
+        pattern += '%'
     pattern = '[' + pattern + ']' + r'|\band\b|\bor\b'
     return re.compile(pattern)
 

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -85,6 +85,11 @@
   "package": "xontrib-powerline",
   "url": "https://github.com/santagada/xontrib-powerline",
   "description": ["Powerline for Xonsh shell"]
+ },
+ {"name": "prompt_vi_mode",
+  "package": "xontrib-prompt-vi-mode",
+  "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
+  "description": ["vi-mode status formatter for xonsh prompt"]
  }
  ],
  "packages": {
@@ -179,6 +184,13 @@
    "url": "https://github.com/meatballs/xontrib-thefuck",
    "install": {
     "pip": "pip install xontrib-thefuck"
+   }
+  },
+  "xontrib-prompt-vi-mode": {
+   "license": "MIT",
+   "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
+   "install": {
+    "pip": "pip install xontrib-prompt-vi-mode"
    }
   }
  }


### PR DESCRIPTION
let's users set an argument to preview a color palette, eg `xonfig colors monokai`.

----

(propably should be moved to an issue)

i noticed in the chat that an extension of `xonfig styles` was discussed. i could amend that, provided there's an agreed feature set. i can come up with two proposals:

`xonfig style list` (like `styles`), `xonfig style set <name>`, `xonfig style unset`

or 

`xonfig get color_style`, `xonfig set color_style <name>`, `xonfig set color_style`

whether to store to `xonshrc` or `config.json` could be selected by switches. and by a setting in one of them.

is there already an api to manipulate the config files?
