### PR TITLE
Cygwin: don't use pthread_sigmask

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Current Developments
   in the prompt_toolkit shell would cause xonsh to crash.
 * Fixed broken behavior when using ``cd ..`` to move into a nonexistent
   directory.
+* Partial workaround for Cygwin where ``pthread_sigmask`` appears to be missing
+  from the ``signal`` module.
 
 **Security:** None
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -8,7 +8,7 @@ import builtins
 from subprocess import TimeoutExpired, check_output
 from collections import deque
 
-from xonsh.platform import ON_DARWIN, ON_WINDOWS
+from xonsh.platform import ON_DARWIN, ON_WINDOWS, ON_CYGWIN
 
 tasks = deque()
 
@@ -94,10 +94,12 @@ else:
         #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
         # this will give the terminal to the process group pgid
         if _shell_tty is not None and os.isatty(_shell_tty):
-            oldmask = signal.pthread_sigmask(signal.SIG_BLOCK,
-                                             _block_when_giving)
+            if not ON_CYGWIN:
+                oldmask = signal.pthread_sigmask(signal.SIG_BLOCK,
+                                                 _block_when_giving)
             os.tcsetpgrp(_shell_tty, pgid)
-            signal.pthread_sigmask(signal.SIG_SETMASK, oldmask)
+            if not ON_CYGWIN:
+                signal.pthread_sigmask(signal.SIG_SETMASK, oldmask)
 
     # check for shell tty
     try:

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -345,6 +345,7 @@ def _info(ns):
     data.extend([
         ('on darwin', platform.ON_DARWIN),
         ('on windows', platform.ON_WINDOWS),
+        ('on cygwin', platform.ON_CYGWIN),
         ('is superuser', tools.IS_SUPERUSER),
         ('default encoding', platform.DEFAULT_ENCODING),
         ])


### PR DESCRIPTION
Follow-up from #514.  The signal library doesn't provide `pthread_sigmask()` on Windows or Cygwin.