### PR TITLE
Remove version control info from default prompt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Current Developments
   should be wrapped in ``![]`` automatically
 * ``prompt_toolkit`` is now loaded lazily, decreasing load times when using
   the ``readline`` shell.
+* Removed version control information from the default prompt.
 * RC files are now executed directly in the appropriate context.
 
 **Deprecated:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -138,14 +138,12 @@ def is_callable_default(x):
     return callable(x) and getattr(x, '_xonsh_callable_default', False)
 if ON_WINDOWS:
     DEFAULT_PROMPT = ('{env_name}'
-                      '{BOLD_INTENSE_GREEN}{user}@{hostname}{BOLD_INTENSE_CYAN} '
-                      '{cwd}{branch_color}{curr_branch}{NO_COLOR} '
-                      '{BOLD_INTENSE_CYAN}{prompt_end}{NO_COLOR} ')
+                      '{BOLD_INTENSE_GREEN}{user}@{hostname} '
+                      '{BOLD_INTENSE_CYAN}{cwd} {prompt_end}{NO_COLOR} ')
 else:
     DEFAULT_PROMPT = ('{env_name}'
-                      '{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
-                      '{cwd}{branch_color}{curr_branch}{NO_COLOR} '
-                      '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
+                      '{BOLD_GREEN}{user}@{hostname} '
+                      '{BOLD_BLUE}{cwd} {prompt_end}{NO_COLOR} ')
 
 DEFAULT_TITLE = '{current_job}{user}@{hostname}: {cwd} | xonsh'
 


### PR DESCRIPTION
As mentioned in #1105, the computing the VCS branch information can take a really long time, depending on one's hardware configuration.  I think it is in our interest to remove this from the default prompt (though this is, of course, up for discussion).

I think this will make things more palatable for new users, and those who want the branch information can still make it happen (it's described on the tutorial).