### PR TITLE
Fix crash on win when Bash is not avaiable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,8 @@ v0.3.3
 * RC files are now executed directly in the appropriate context.
 * ``_`` is now updated by ``![]``, to contain the appropriate
   ``CompletedCommand`` object.
+* On Windows if bash is not on the path look in the registry for the defaults
+  install directory for GitForWindows. 
 
 
 
@@ -55,6 +57,7 @@ v0.3.3
 
 **Fixed:**
 
+* Fixed crashed bash-completer when bash is not avaiable on Windows
 * Fixed bug on Windows where tab-completion for executables would return all files.
 * Fixed bug on Windows which caused the bash $PROMPT variable to be used when no 
   no $PROMPT variable was set in .xonshrc 

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -34,6 +34,12 @@ for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 """
 
 
+if ON_WINDOWS:
+    from xonsh.platform import WINDOWS_BASH_COMMAND as BASH_COMMAND
+else: 
+    BASH_COMMAND = 'bash'
+
+
 def update_bash_completion():
     global BASH_COMPLETE_FUNCS, BASH_COMPLETE_FILES, BASH_COMPLETE_HASH
     global CACHED_FUNCS, CACHED_FILES, CACHED_HASH, INITED
@@ -108,9 +114,9 @@ def complete_from_bash(prefix, line, begidx, endidx, ctx):
         end=endidx + 1, prefix=prefix, prev=shlex.quote(prev))
     try:
         out = subprocess.check_output(
-            ['bash'], input=script, universal_newlines=True,
+            [BASH_COMMAND], input=script, universal_newlines=True,
             stderr=subprocess.PIPE, env=builtins.__xonsh_env__.detype())
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         out = ''
 
     rtn = set(out.splitlines())
@@ -161,11 +167,15 @@ def _load_bash_complete_files():
 
 
 def _source_completions(source):
-    return subprocess.check_output(
-            ['bash'], input='\n'.join(source), universal_newlines=True,
+    try:
+        import pdb; pdb.set_trace()
+        return subprocess.check_output(
+            [BASH_COMMAND], input='\n'.join(source), universal_newlines=True,
             env=builtins.__xonsh_env__.detype(), stderr=subprocess.DEVNULL)
+    except FileNotFoundError:
+        return ''
 
-
+        
 def _collect_completions_sources():
     sources = []
     completers = builtins.__xonsh_env__.get('BASH_COMPLETIONS', ())

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -168,7 +168,6 @@ def _load_bash_complete_files():
 
 def _source_completions(source):
     try:
-        import pdb; pdb.set_trace()
         return subprocess.check_output(
             [BASH_COMMAND], input='\n'.join(source), universal_newlines=True,
             env=builtins.__xonsh_env__.detype(), stderr=subprocess.DEVNULL)

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -36,7 +36,7 @@ for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 
 if ON_WINDOWS:
     from xonsh.platform import WINDOWS_BASH_COMMAND as BASH_COMMAND
-else: 
+else:
     BASH_COMMAND = 'bash'
 
 
@@ -174,7 +174,7 @@ def _source_completions(source):
     except FileNotFoundError:
         return ''
 
-        
+
 def _collect_completions_sources():
     sources = []
     completers = builtins.__xonsh_env__.get('BASH_COMPLETIONS', ())

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -198,7 +198,6 @@ if ON_WINDOWS:
         GIT_FOR_WINDOWS_PATH = None
 
 
-
 if ON_WINDOWS:
     # Check that bash in on path otherwise try the default bin directory 
     # used by Git for windows

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -35,7 +35,6 @@ ON_POSIX = (os.name == 'posix')
 """ ``True`` if executed on a POSIX-compliant platform, else ``False``. """
 
 
-
 #
 # Python & packages
 #
@@ -188,30 +187,30 @@ if ON_WINDOWS:
 else:
     win_unicode_console = None
 
-    
+
 if ON_WINDOWS:
     import winreg
-    try: 
+    try:
         key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, 'SOFTWARE\\GitForWindows')
         GIT_FOR_WINDOWS_PATH, type = winreg.QueryValueEx(key, "InstallPath")
-    except FileNotFoundError:    
+    except FileNotFoundError:
         GIT_FOR_WINDOWS_PATH = None
 
 
 if ON_WINDOWS:
-    # Check that bash in on path otherwise try the default bin directory 
+    # Check that bash in on path otherwise try the default bin directory
     # used by Git for windows
     import subprocess
     WINDOWS_BASH_COMMAND = 'bash'
-    try: 
-        subprocess.check_call([WINDOWS_BASH_COMMAND,'--version'])
+    try:
+        subprocess.check_call([WINDOWS_BASH_COMMAND, '--version'])
     except FileNotFoundError:
-        if GIT_FOR_WINDOWS_PATH: 
+        if GIT_FOR_WINDOWS_PATH:
             bashcmd = os.path.join(GIT_FOR_WINDOWS_PATH, 'bin\\bash.exe')
             if os.path.isfile(bashcmd):
                 WINDOWS_BASH_COMMAND = bashcmd
 
-            
+
 #
 # Bash completions defaults
 #

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -188,7 +188,31 @@ if ON_WINDOWS:
 else:
     win_unicode_console = None
 
+    
+if ON_WINDOWS:
+    import winreg
+    try: 
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, 'SOFTWARE\\GitForWindows')
+        GIT_FOR_WINDOWS_PATH, type = winreg.QueryValueEx(key, "InstallPath")
+    except FileNotFoundError:    
+        GIT_FOR_WINDOWS_PATH = None
 
+
+
+if ON_WINDOWS:
+    # Check that bash in on path otherwise try the default bin directory 
+    # used by Git for windows
+    import subprocess
+    WINDOWS_BASH_COMMAND = 'bash'
+    try: 
+        subprocess.check_call([WINDOWS_BASH_COMMAND,'--version'])
+    except FileNotFoundError:
+        if GIT_FOR_WINDOWS_PATH: 
+            bashcmd = os.path.join(GIT_FOR_WINDOWS_PATH, 'bin\\bash.exe')
+            if os.path.isfile(bashcmd):
+                WINDOWS_BASH_COMMAND = bashcmd
+
+            
 #
 # Bash completions defaults
 #
@@ -210,13 +234,13 @@ elif ON_DARWIN:
     BASH_COMPLETIONS_DEFAULT = (
         '/usr/local/etc/bash_completion',
         '/opt/local/etc/profile.d/bash_completion.sh')
-elif ON_WINDOWS:
-    progamfiles = os.environ.get('PROGRAMFILES', 'C:/Program Files')
+elif ON_WINDOWS and GIT_FOR_WINDOWS_PATH:
     BASH_COMPLETIONS_DEFAULT = (
-        progamfiles + '/Git/usr/share/bash-completion',
-        progamfiles + '/Git/usr/share/bash-completion/completions',
-        progamfiles + '/Git/mingw64/share/git/completion/git-completion.bash')
+        os.path.join(GIT_FOR_WINDOWS_PATH, 'usr\\share\\bash-completion'),
+        os.path.join(GIT_FOR_WINDOWS_PATH, 'usr\\share\\bash-completion\\completions'),
+        os.path.join(GIT_FOR_WINDOWS_PATH, 'mingw64\\share\\git\\completion\\git-completion.bash'))
 
+        
 #
 # All constants as a dict
 #

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -196,9 +196,7 @@ if ON_WINDOWS:
     except FileNotFoundError:
         GIT_FOR_WINDOWS_PATH = None
 
-
-if ON_WINDOWS:
-    # Check that bash in on path otherwise try the default bin directory
+    # Check that bash is on path otherwise try the default directory
     # used by Git for windows
     import subprocess
     WINDOWS_BASH_COMMAND = 'bash'


### PR DESCRIPTION
This fixes a crash when bash is not on PATH on Windows. 

Not having bash on the path is the default if users have installed GitForWindows with default settings.

I have added a functionality to locate GitForWindows Bash binary using the registry if it is not on PATH. This PR will ensure that bash completion will work for all windows users that have GitForWindows installed. 
