### PR TITLE
Enable (some) coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ python:
 install:
   - pip install -r requirements-tests.txt
 script:
-  - nosetests -q
+  - nosetests -q --with-coverage --cover-package=xonsh
+after_success:
+  - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 10
+    patch:
+      default:
+        target: 0%

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,3 +2,5 @@ ply
 nose
 prompt-toolkit
 pygments
+coverage
+codecov


### PR DESCRIPTION
Not sure exactly how xonsh is tested completely, so I expect most of the
coverage process to be wrong (for now)

Codecov have [browser
extensions](https://github.com/codecov/browser-extension) that allow you
to see the coverage directly in the pull requests in GitHub.

We might have to give codecov some limited access to the repo (webhook),
and tell the codecov bot to shut its mouth once it's enabled. But it's
super non intrusive, and kind-of useful when you refactor to see that
your code is tested.

Also set some sensible where coverage would fail only if it drops by 10%
in 1 PR.