### PR TITLE
Fix (windows) bug in  locate_binary()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Current Developments
   in the prompt_toolkit shell would cause xonsh to crash.
 * Fixed broken behavior when using ``cd ..`` to move into a nonexistent
   directory.
+* Fixed regression on Windows with the locate_binary() function. 
+  The bug prevented `source-cmd` from working correctly and broke the 
+  ``activate``/``deactivate`` aliases for the conda environements. 
 
 **Security:** None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -768,9 +768,10 @@ def locate_binary(name):
 
     directories = builtins.__xonsh_env__.get('PATH')
 
-    # Windows users expect t obe able to execute files in the same directory without `./`
-    #if ON_WINDOWS:
-    #    directories = [_get_cwd()] + directories
+    # Windows users expect t obe able to execute files in the same directory
+    # without `./`
+    if ON_WINDOWS:
+        directories = [_get_cwd()] + directories
 
     try:
         return next(chain.from_iterable(_yield_executables(directory, name) for

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -750,9 +750,10 @@ class Env(MutableMapping):
 
 def _yield_executables(directory, name):
     if ON_WINDOWS:
+        base_name, ext = os.path.splitext(name.lower())
         for fname in executables_in(directory):
-            base_name, ext = os.path.splitext(fname)
-            if name.lower() == base_name.lower():
+            fbase, fext = os.path.splitext(fname.lower())
+            if base_name == fbase and (len(ext) == 0 or ext == fext):
                 yield os.path.join(directory, fname)
     else:
         for x in executables_in(directory):
@@ -768,8 +769,8 @@ def locate_binary(name):
     directories = builtins.__xonsh_env__.get('PATH')
 
     # Windows users expect t obe able to execute files in the same directory without `./`
-    if ON_WINDOWS:
-        directories = [_get_cwd()] + directories
+    #if ON_WINDOWS:
+    #    directories = [_get_cwd()] + directories
 
     try:
         return next(chain.from_iterable(_yield_executables(directory, name) for


### PR DESCRIPTION
This fixes a regression in `locate_binary()` which prevented it from finding executables when their exetension was also provided. 

The bug broke the `source-cmd` command and thus  the  `activate`/`deactivate` conda scripts. I am sorry for not noticing.