### PR TITLE
Suggest to add conda-forge as a default channel

### DIFF
--- a/docs/linux.rst
+++ b/docs/linux.rst
@@ -11,7 +11,8 @@ You can install xonsh using ``conda``, ``pip``, or from source.
 
 .. code-block:: bash
 
-    $ conda install -c conda-forge xonsh
+    $ conda config --add channels conda-forge
+    $ conda install xonsh
 
 .. note:: For the bleeding edge development version use ``conda install -c xonsh/channel/dev xonsh``
 

--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -18,7 +18,8 @@ You can install xonsh using homebrew, conda, pip, or from source.
 
 .. code-block:: bash
 
-    $ conda install -c conda-forge xonsh
+    $ conda config --add channels conda-forge
+    $ conda install xonsh
 
 .. note:: For the bleeding edge development version use ``conda install -c xonsh/channel/dev xonsh``
     

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -20,7 +20,8 @@ Install xonsh with the following command:
 
 .. code-block:: bat
 
-   > conda install xonsh --channel conda-forge
+   > conda config --add channels conda-forge
+   > conda install xonsh
 
 .. note:: For the bleeding edge development version use ``conda install -c xonsh/channel/dev xonsh``
 


### PR DESCRIPTION
This updates the conda install directions, so it aligns with the suggestions on https://conda-forge.github.io/#about

```
conda config --add channels conda-forge
conda install xonsh
```

It also has the benefit that users can later update with `conda update xonsh` without having to remember the channel. 

