### PR TITLE
Run Control Fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Current Developments
 **Changed:**
 
 * ``$PROMPT`` from foreign shells is now ignored.
+* ``$RC_FILES`` environment variable now stores the run control files we
+  attempted to load.
+* Only show the prompt for the wizard if we did not attempt to load any run
+  control files (as opposed to if none were successfully loaded).
 
 **Deprecated:** None
 
@@ -26,6 +30,8 @@ Current Developments
 * Fixed regression on Windows with the locate_binary() function. 
   The bug prevented `source-cmd` from working correctly and broke the 
   ``activate``/``deactivate`` aliases for the conda environements. 
+* Fixed crash resulting from errors other than syntax errors in run control
+  file.
 
 **Security:** None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -216,6 +216,7 @@ DEFAULT_VALUES = {
     'PUSHD_MINUS': False,
     'PUSHD_SILENT': False,
     'RAISE_SUBPROC_ERROR': False,
+    'RC_FILES': (),
     'RIGHT_PROMPT': '',
     'SHELL_TYPE': 'best',
     'SUGGEST_COMMANDS': True,
@@ -402,6 +403,9 @@ DEFAULT_DOCS = {
         'This is most useful in xonsh scripts or modules where failures '
         'should cause an end to execution. This is less useful at a terminal. '
         'The error that is raised is a subprocess.CalledProcessError.'),
+    'RC_FILES': VarDocs(
+        'List of strings representing filenames of run control files we '
+        'attempted to load.'),
     'RIGHT_PROMPT': VarDocs('Template string for right-aligned text '
         'at the prompt. This may be parameterized in the same way as '
         'the $PROMPT variable. Currently, this is only available in the '
@@ -1297,6 +1301,7 @@ def load_static_config(ctx, config=None):
 
 def xonshrc_context(rcfiles=None, execer=None, initial=None):
     """Attempts to read in xonshrc file, and return the contents."""
+    builtins.__xonsh_env__['RC_FILES'] = tuple(rcfiles)
     loaded = builtins.__xonsh_env__['LOADED_RC_FILES'] = []
     if initial is None:
         env = {}
@@ -1314,6 +1319,11 @@ def xonshrc_context(rcfiles=None, execer=None, initial=None):
         except SyntaxError as err:
             loaded.append(False)
             msg = 'syntax error in xonsh run control file {0!r}: {1!s}'
+            warn(msg.format(rcfile, err), RuntimeWarning)
+            continue
+        except Exception as err:
+            loaded.append(False)
+            msg = 'error running xonsh run control file {0!r}: {1!s}'
             warn(msg.format(rcfile, err), RuntimeWarning)
             continue
     return env

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -177,6 +177,12 @@ def xonshconfig(env):
     xc = os.path.join(xcd, 'config.json')
     return xc
 
+if ON_WINDOWS:
+    DEFAULT_XONSHRC = (os.path.join(os.environ['ALLUSERSPROFILE'],
+                                     'xonsh', 'xonshrc'),
+                       os.path.expanduser('~/.xonshrc'))
+else:
+    DEFAULT_XONSHRC = ('/etc/xonshrc', os.path.expanduser('~/.xonshrc'))
 
 # Default values should generally be immutable, that way if a user wants
 # to set them they have to do a copy and write them to the environment.
@@ -216,7 +222,6 @@ DEFAULT_VALUES = {
     'PUSHD_MINUS': False,
     'PUSHD_SILENT': False,
     'RAISE_SUBPROC_ERROR': False,
-    'RC_FILES': (),
     'RIGHT_PROMPT': '',
     'SHELL_TYPE': 'best',
     'SUGGEST_COMMANDS': True,
@@ -230,10 +235,7 @@ DEFAULT_VALUES = {
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
     'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
     'XONSHCONFIG': xonshconfig,
-    'XONSHRC': ((os.path.join(os.environ['ALLUSERSPROFILE'],
-                              'xonsh', 'xonshrc'),
-                os.path.expanduser('~/.xonshrc')) if ON_WINDOWS
-               else ('/etc/xonshrc', os.path.expanduser('~/.xonshrc'))),
+    'XONSHRC': DEFAULT_XONSHRC,
     'XONSH_CACHE_SCRIPTS': True,
     'XONSH_CACHE_EVERYTHING': False,
     'XONSH_COLOR_STYLE': 'default',
@@ -403,9 +405,6 @@ DEFAULT_DOCS = {
         'This is most useful in xonsh scripts or modules where failures '
         'should cause an end to execution. This is less useful at a terminal. '
         'The error that is raised is a subprocess.CalledProcessError.'),
-    'RC_FILES': VarDocs(
-        'List of strings representing filenames of run control files we '
-        'attempted to load.'),
     'RIGHT_PROMPT': VarDocs('Template string for right-aligned text '
         'at the prompt. This may be parameterized in the same way as '
         'the $PROMPT variable. Currently, this is only available in the '
@@ -1301,7 +1300,6 @@ def load_static_config(ctx, config=None):
 
 def xonshrc_context(rcfiles=None, execer=None, initial=None):
     """Attempts to read in xonshrc file, and return the contents."""
-    builtins.__xonsh_env__['RC_FILES'] = tuple(rcfiles)
     loaded = builtins.__xonsh_env__['LOADED_RC_FILES'] = []
     if initial is None:
         env = {}
@@ -1309,6 +1307,7 @@ def xonshrc_context(rcfiles=None, execer=None, initial=None):
         env = initial
     if rcfiles is None or execer is None:
         return env
+    env['XONSHRC'] = tuple(rcfiles)
     for rcfile in rcfiles:
         if not os.path.isfile(rcfile):
             loaded.append(False)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -255,7 +255,9 @@ def main(argv=None):
         # otherwise, enter the shell
         env['XONSH_INTERACTIVE'] = True
         ignore_sigtstp()
-        if not env['LOADED_CONFIG'] and not any(env['RC_FILES']):
+        if (env['XONSH_INTERACTIVE'] and
+                not env['LOADED_CONFIG'] and
+                not any(os.path.isfile(i) for i in env['XONSHRC'])):
             print('Could not find xonsh configuration or run control files.')
             from xonsh import xonfig  # lazy import
             xonfig.main(['wizard', '--confirm'])

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -255,7 +255,7 @@ def main(argv=None):
         # otherwise, enter the shell
         env['XONSH_INTERACTIVE'] = True
         ignore_sigtstp()
-        if not env['LOADED_CONFIG'] and not any(env['LOADED_RC_FILES']):
+        if not env['LOADED_CONFIG'] and not any(env['RC_FILES']):
             print('Could not find xonsh configuration or run control files.')
             from xonsh import xonfig  # lazy import
             xonfig.main(['wizard', '--confirm'])


### PR DESCRIPTION
This patch makes two changes:

* Prevents xonsh from crashing if there is an error other than a syntax error in a run control file
* Modifies the behavior of the xonfig wizard so that it only under the following conditions:
    * we are running interactively
    * no config.json was loaded
    * none of the rc files exists

This way, if there are errors in all the rc files, but they do indeed exist, we do not show the wizard.