### PR TITLE
Implement #1169

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,9 +27,8 @@ v0.3.4
   attempted to load.
 * Only show the prompt for the wizard if we did not attempt to load any run
   control files (as opposed to if none were successfully loaded).
-
-
-
+* Provide ``$XONSH_SOURCE`` for scripts in the environment variables pointing to
+  the currently running script's path
 
 
 **Fixed:**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ Current Developments
 ====================
 **Added:** None
 
-**Changed:** None
+**Changed:**
+
+* Provide ``$XONSH_SOURCE`` for scripts in the environment variables pointing to
+  the currently running script's path
 
 **Deprecated:** None
 
@@ -27,8 +30,6 @@ v0.3.4
   attempted to load.
 * Only show the prompt for the wizard if we did not attempt to load any run
   control files (as opposed to if none were successfully loaded).
-* Provide ``$XONSH_SOURCE`` for scripts in the environment variables pointing to
-  the currently running script's path
 
 
 **Fixed:**

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -507,7 +507,7 @@ DEFAULT_DOCS = {
         'This is the location where xonsh data files are stored, such as '
         'history.', default="'$XDG_DATA_HOME/xonsh'"),
     'XONSH_ENCODING': VarDocs(
-        'This is the encoding that xonsh should use for subrpocess operations.',
+        'This is the encoding that xonsh should use for subprocess operations.',
         default='sys.getdefaultencoding()'),
     'XONSH_ENCODING_ERRORS': VarDocs(
         'The flag for how to handle encoding errors should they happen. '
@@ -538,6 +538,10 @@ DEFAULT_DOCS = {
         'Set to True to always show traceback or False to always hide. '
         'If undefined then the traceback is hidden but a notice is shown on how '
         'to enable the full traceback.'),
+    'XONSH_SOURCE': VarDocs(
+        "When running a xonsh script, this variable contains the absolute path "
+        "to the currently executing script's file.",
+        configurable=False),
     'XONSH_STORE_STDIN': VarDocs(
         'Whether or not to store the stdin that is supplied to the !() and ![] '
         'operators.'),

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -240,9 +240,11 @@ def main(argv=None):
         run_code_with_cache(args.command, shell.execer, mode='single')
     elif args.mode == XonshMode.script_from_file:
         # run a script contained in a file
-        if os.path.isfile(args.file):
+        path = os.path.abspath(os.path.expanduser(args.file))
+        if os.path.isfile(path):
             sys.argv = args.args
             env['ARGS'] = [args.file] + args.args
+            env['XONSH_SOURCE'] = path
             run_script_with_cache(args.file, shell.execer, glb=shell.ctx, loc=None, mode='exec')
         else:
             print('xonsh: {0}: No such file or directory.'.format(args.file))

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -120,7 +120,6 @@ def arg_undoers():
         '-c': (lambda args: setattr(args, 'command', None)),
         '-i': (lambda args: setattr(args, 'force_interactive', False)),
         '-l': (lambda args: setattr(args, 'login', False)),
-        '-c': (lambda args: setattr(args, 'command', None)),
         '--no-script-cache': (lambda args: setattr(args, 'scriptcache', True)),
         '--cache-everything': (lambda args: setattr(args, 'cacheall', False)),
         '--config-path': (lambda args: delattr(args, 'config_path')),


### PR DESCRIPTION
I create the path before branching, so the same work (absolutizing and normalizing the path) isn't done twice if the branch is taken. [os.path.abspath](https://docs.python.org/3/library/os.path.html#os.path.abspath) normalizes _and_ absolutizes the path.