### PR TITLE
Fix #1173

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ v0.3.4
   ``activate``/``deactivate`` aliases for the conda environements. 
 * Fixed crash resulting from errors other than syntax errors in run control
   file.
-
+* Fixed xonfig wizard failing on Windows due to colon in created filename.
 
 
 v0.3.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,9 @@ Current Developments
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
+
+* Fixed xonfig wizard failing on Windows due to colon in created filename.
 
 **Security:** None
 
@@ -46,7 +48,6 @@ v0.3.4
   ``activate``/``deactivate`` aliases for the conda environements. 
 * Fixed crash resulting from errors other than syntax errors in run control
   file.
-* Fixed xonfig wizard failing on Windows due to colon in created filename.
 
 
 v0.3.3

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1171,7 +1171,7 @@ def backup_file(fname):
     import shutil
     from datetime import datetime
     base, ext = os.path.splitext(fname)
-    newfname = base + '.' + datetime.now().isoformat() + ext
+    newfname = '%s.%s%s' % (base, datetime.now().isoformat().replace(':', '-'), ext)
     shutil.move(fname, newfname)
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1171,7 +1171,8 @@ def backup_file(fname):
     import shutil
     from datetime import datetime
     base, ext = os.path.splitext(fname)
-    newfname = '%s.%s%s' % (base, datetime.now().isoformat().replace(':', '-'), ext)
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+    newfname = '%s.%s%s' % (base, timestamp, ext)
     shutil.move(fname, newfname)
 
 


### PR DESCRIPTION
String concatenations using `__add__` are inefficient after a certain number of additions in a row, so I am using string formatting instead. I made the decision to simply replace ":" with "-" because using `datetime`'s `strftime` to recreate `isoformat`'s behavior would involve replicating quite a bit of [isoformat's logic](https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat).