### PR TITLE
Implement '+' and '-' for fg, and related changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Xonsh Change Log
 
 Current Developments
 ====================
-**Added:** None
+**Added:**
+
+* Arguments '+' and '-' for fg [job control]
 
 **Changed:**
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,7 +83,7 @@ If you want to run your "work in progress version" without installing
 and in a fresh environment you can use Docker. If Docker is installed
 you just have to run this::
 
-  $ python docker.py
+  $ python xonsh-in-docker.py
 
 This will build and run the current state of the repository in an isolated
 container (it may take a while the first time you run it). There are two

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -736,7 +736,8 @@ Each job has a unique identifier (starting with 1 and counting upward).  By
 default, the ``fg`` and ``bg`` commands operate on the job that was started
 most recently.  You can bring older jobs to the foreground or background by
 specifying the appropriate ID; for example, ``fg 1`` brings the job with ID 1
-to the foreground.
+to the foreground. Additionally, specify "+" for the most recent job and "-"
+for the second most recent job.
 
 String Literals in Subprocess-mode
 ====================================

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -253,9 +253,9 @@ def fg(args, stdin=None):
         act = tasks[0]  # take the last manipulated task by default
     elif len(args) == 1:
         try:
-            if args[0] == '+': # take the last manipulated task
-                 act = tasks[0]
-            elif args[0] == '-': # take the second to last manipulated task
+            if args[0] == '+':  # take the last manipulated task
+                act = tasks[0]
+            elif args[0] == '-':  # take the second to last manipulated task
                 act = tasks[1]
             else:
                 act = int(args[0])

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -182,12 +182,13 @@ def print_one_job(num):
         job = builtins.__xonsh_all_jobs__[num]
     except KeyError:
         return
+    pos = '+' if tasks[0] == num else '-' if tasks[1] == num else ' '
     status = job['status']
     cmd = [' '.join(i) if isinstance(i, list) else i for i in job['cmds']]
     cmd = ' '.join(cmd)
     pid = job['pids'][-1]
     bg = ' &' if job['bg'] else ''
-    print('[{}] {}: {}{} ({})'.format(num, status, cmd, bg, pid))
+    print('[{}]{} {}: {}{} ({})'.format(num, pos, status, cmd, bg, pid))
 
 
 def get_next_job_number():

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -240,7 +240,8 @@ def fg(args, stdin=None):
     xonsh command: fg
 
     Bring the currently active job to the foreground, or, if a single number is
-    given as an argument, bring that job to the foreground.
+    given as an argument, bring that job to the foreground. Additionally,
+    specify "+" for the most recent job and "-" for the second most recent job.
     """
 
     _clear_dead_jobs()
@@ -250,10 +251,15 @@ def fg(args, stdin=None):
     if len(args) == 0:
         act = tasks[0]  # take the last manipulated task by default
     elif len(args) == 1:
-        try:
-            act = int(args[0])
-        except ValueError:
-            return '', 'Invalid job: {}\n'.format(args[0])
+        if args[0] == '+': # take the last manipulated task
+             act = tasks[0]
+        elif args[0] == '-': # take the second to last manipulated task
+            act = tasks[1]
+        else:
+            try:
+                act = int(args[0])
+            except ValueError:
+                return '', 'Invalid job: {}\n'.format(args[0])
         if act not in builtins.__xonsh_all_jobs__:
             return '', 'Invalid job: {}\n'.format(args[0])
     else:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -252,15 +252,16 @@ def fg(args, stdin=None):
     if len(args) == 0:
         act = tasks[0]  # take the last manipulated task by default
     elif len(args) == 1:
-        if args[0] == '+': # take the last manipulated task
-             act = tasks[0]
-        elif args[0] == '-': # take the second to last manipulated task
-            act = tasks[1]
-        else:
-            try:
+        try:
+            if args[0] == '+': # take the last manipulated task
+                 act = tasks[0]
+            elif args[0] == '-': # take the second to last manipulated task
+                act = tasks[1]
+            else:
                 act = int(args[0])
-            except ValueError:
-                return '', 'Invalid job: {}\n'.format(args[0])
+        except (ValueError, IndexError):
+            return '', 'Invalid job: {}\n'.format(args[0])
+
         if act not in builtins.__xonsh_all_jobs__:
             return '', 'Invalid job: {}\n'.format(args[0])
     else:


### PR DESCRIPTION
This implements '+' and '-' for fg for BASHwards compatibility. I use job control a ton and switch between jobs frequently, so these are important to me. I also modified print_one_job() to include a job's position (indicated with a '+' and '-' after the job number). 

This PR also includes a fix to the developer's guide, fixing a reference to docker.py which was renamed to xonsh-in-docker.py.