### PR TITLE
Implementation of #1175, "!(command) could be usefully iterable"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,12 @@ Xonsh Change Log
 Current Developments
 ====================
 **Added:** None
+* ``!(command)`` is now usefully iterable, yielding lines of stdout
+* Added XonshCalledProcessError, which includes the relevant CompletedCommand.
+  Also handles differences between Py3.4 and 3.5 in CalledProcessError
 
 **Changed:** None
+* XonshError and XonshCalledProcessError are now in builtins
 
 **Deprecated:** None
 
@@ -41,9 +45,9 @@ v0.3.4
 * Partial workaround for Cygwin where ``pthread_sigmask`` appears to be missing
   from the ``signal`` module.
 * Fixed crash resulting from malformed ``$PROMPT``.
-* Fixed regression on Windows with the locate_binary() function. 
-  The bug prevented `source-cmd` from working correctly and broke the 
-  ``activate``/``deactivate`` aliases for the conda environements. 
+* Fixed regression on Windows with the locate_binary() function.
+  The bug prevented `source-cmd` from working correctly and broke the
+  ``activate``/``deactivate`` aliases for the conda environements.
 * Fixed crash resulting from errors other than syntax errors in run control
   file.
 
@@ -75,7 +79,7 @@ v0.3.3
 * ``_`` is now updated by ``![]``, to contain the appropriate
   ``CompletedCommand`` object.
 * On Windows if bash is not on the path look in the registry for the defaults
-  install directory for GitForWindows. 
+  install directory for GitForWindows.
 
 
 
@@ -87,8 +91,8 @@ v0.3.3
 
 * Fixed crashed bash-completer when bash is not avaiable on Windows
 * Fixed bug on Windows where tab-completion for executables would return all files.
-* Fixed bug on Windows which caused the bash $PROMPT variable to be used when no 
-  no $PROMPT variable was set in .xonshrc 
+* Fixed bug on Windows which caused the bash $PROMPT variable to be used when no
+  no $PROMPT variable was set in .xonshrc
 * Improved start-up times by caching information about bash completion
   functions
 * The --shell-type CLI flag now takes precedence over $SHELL_TYPE specified in

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -389,7 +389,6 @@ output in an except clause.  Examples of each:
                 if not line.strip():
                     continue
                 filename = line.split('grep: ', 1)[1].rsplit(':', 1)[0]
-                print(filename)
                 failures.append(filename)
         return {'matches': matches, 'failures': failures}
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -31,7 +31,7 @@ from xonsh.proc import (ProcProxy, SimpleProcProxy, ForegroundProcProxy,
                         CompletedCommand, HiddenCompletedCommand)
 from xonsh.tools import (
     suggest_commands, XonshError, expandvars, CommandsCache, globpath,
-    iglobpath
+    iglobpath, XonshError, XonshCalledProcessError
 )
 
 
@@ -661,6 +661,8 @@ def load_builtins(execer=None, config=None, login=False, ctx=None):
     builtins.evalx = None if execer is None else execer.eval
     builtins.execx = None if execer is None else execer.exec
     builtins.compilex = None if execer is None else execer.compile
+    builtins.XonshError = XonshError
+    builtins.XonshCalledProcessError = XonshCalledProcessError
 
     # Need this inline/lazy import here since we use locate_binary that relies on __xonsh_env__ in default aliases
     builtins.default_aliases = builtins.aliases = Aliases(make_default_aliases())
@@ -718,6 +720,8 @@ def unload_builtins():
              'execx',
              'compilex',
              'default_aliases',
+             'XonshError',
+             'XonshCalledProcessError',
              '__xonsh_all_jobs__',
              '__xonsh_ensure_list_of_strs__',
              '__xonsh_history__',

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -564,6 +564,7 @@ def run_subproc(cmds, captured=False):
     if captured == 'stdout':
         return output
     elif captured is not False:
+        procinfo['executed_cmd'] = aliased_cmd
         procinfo['pid'] = prev_proc.pid
         procinfo['returncode'] = prev_proc.returncode
         procinfo['timestamp'] = (starttime, time.time())

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -564,6 +564,7 @@ def run_subproc(cmds, captured=False):
     if captured == 'stdout':
         return output
     elif captured is not False:
+        procinfo['executed_cmd'] = aliased_cmd
         procinfo['pid'] = prev_proc.pid
         procinfo['returncode'] = prev_proc.returncode
         procinfo['timestamp'] = (starttime, time.time())
@@ -657,6 +658,9 @@ def load_builtins(execer=None, config=None, login=False, ctx=None):
     builtins.__xonsh_all_jobs__ = {}
     builtins.__xonsh_ensure_list_of_strs__ = ensure_list_of_strs
     # public built-ins
+    builtins.XonshError = XonshError
+    builtins.XonshBlockError = XonshBlockError
+    builtins.XonshCalledProcessError = XonshCalledProcessError
     builtins.evalx = None if execer is None else execer.eval
     builtins.execx = None if execer is None else execer.exec
     builtins.compilex = None if execer is None else execer.compile
@@ -713,6 +717,9 @@ def unload_builtins():
              '__xonsh_subproc_uncaptured__',
              '__xonsh_execer__',
              '__xonsh_commands_cache__',
+             'XonshError',
+             'XonshBlockError',
+             'XonshCalledProcessError',
              'evalx',
              'execx',
              'compilex',

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -541,7 +541,8 @@ _CCTuple = namedtuple("_CCTuple", ["stdin",
                                    "stdin_redirect",
                                    "stdout_redirect",
                                    "stderr_redirect",
-                                   "timestamp"])
+                                   "timestamp",
+                                   "executed_cmd"])
 
 class CompletedCommand(_CCTuple):
     """Represents a completed subprocess-mode command."""
@@ -564,15 +565,11 @@ class CompletedCommand(_CCTuple):
             if snippet or not (end == -1):
                 yield snippet
             start = end + 1    # to the other side of \n
-        # No \n was found.  ..if a \r is present, it's without \n -- so it
-        # doesn't count as a line ending. ..return all text on the tail.
-        #yield repr(stdout[start:])
         if self.returncode:
-            error = CalledProcessError(
-                self.returncode, 
-                self.args,
-                stdout,
-                self)
+            # I included self, as providing access to stderr and other details
+            # useful when instance isn't assigned to a variable in the shell.
+            cmd = self.executed_cmd
+            error = CalledProcessError(self.returncode, cmd, stdout, self)
             error.completed_command = self
             raise error
             

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -19,7 +19,7 @@ from subprocess import (Popen, PIPE, DEVNULL, STDOUT, TimeoutExpired,
                         CalledProcessError)
 
 from xonsh.tools import (redirect_stdout, redirect_stderr, ON_WINDOWS, ON_LINUX,
-                         fallback, print_exception)
+                         fallback, print_exception, XonshCalledProcessError)
 
 if ON_LINUX:
     from xonsh.teepty import TeePTY
@@ -545,6 +545,7 @@ _CCTuple = namedtuple("_CCTuple", ["stdin",
                                    "timestamp",
                                    "executed_cmd"])
 
+
 class CompletedCommand(_CCTuple):
     """Represents a completed subprocess-mode command."""
 
@@ -553,7 +554,7 @@ class CompletedCommand(_CCTuple):
 
     def __iter__(self):
         stdout = self.stdout
-        start = 0;
+        start = 0
         end = 0
         while end != -1:
             end = stdout.find('\n', start)
@@ -569,10 +570,8 @@ class CompletedCommand(_CCTuple):
         if self.returncode:
             # I included self, as providing access to stderr and other details
             # useful when instance isn't assigned to a variable in the shell.
-            cmd = self.executed_cmd
-            error = CalledProcessError(self.returncode, cmd, stdout, self)
-            error.completed_command = self
-            raise error
+            raise XonshCalledProcessError(self.returncode, self.executed_cmd,
+                                          stdout, self.stderr, self)
 
     @property
     def inp(self):

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -566,6 +566,9 @@ class CompletedCommand(_CCTuple):
             yield pre
             pre = post
 
+
+    def itercheck(self):
+        yield from self
         if self.returncode:
             # I included self, as providing access to stderr and other details
             # useful when instance isn't assigned to a variable in the shell.

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -15,7 +15,8 @@ import builtins
 from functools import wraps
 from threading import Thread
 from collections import Sequence, namedtuple
-from subprocess import Popen, PIPE, DEVNULL, STDOUT, TimeoutExpired, CalledProcessError
+from subprocess import (Popen, PIPE, DEVNULL, STDOUT, TimeoutExpired,
+                        CalledProcessError)
 
 from xonsh.tools import (redirect_stdout, redirect_stderr, ON_WINDOWS, ON_LINUX,
                          fallback, print_exception)
@@ -572,7 +573,7 @@ class CompletedCommand(_CCTuple):
             error = CalledProcessError(self.returncode, cmd, stdout, self)
             error.completed_command = self
             raise error
-            
+
     @property
     def inp(self):
         """Creates normalized input string from args."""

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -46,7 +46,7 @@ class XonshError(Exception):
     pass
 
 
-class XonshCalledProcessError(XonshError, CalledProcessError):
+class XonshCalledProcessError(CalledProcessError):
     """Raised when there's an error with a called process
 
     Inherits from XonshError and subprocess.CalledProcessError, catching

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1218,7 +1218,8 @@ def backup_file(fname):
     import shutil
     from datetime import datetime
     base, ext = os.path.splitext(fname)
-    newfname = base + '.' + datetime.now().isoformat() + ext
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+    newfname = '%s.%s%s' % (base, timestamp, ext)
     shutil.move(fname, newfname)
 
 


### PR DESCRIPTION
Implementation of #1175.

I had to add an additional member to _CCTuple, as the actually-executed command couldn't be reassembled by a user without knowledge of Xonsh internals.  I'm pretty sure this is ready to go.

Example code probably explains it best -- here's usage.

```python
# Setup
from subprocess import CalledProcessError

mkdir bleh
cd bleh
touch foo.txt bar.txt


# Simple usage example
for filename in !(ls -1 --color=no):
    print(filename)
# Output:
# foo.txt
# bar.txt


# Example with error handling
try:
    for filename in !(ls -1 --color=no bar.txt foo.txt baz.txt bing.txt):
        print(filename)
except CalledProcessError as error:
        print("Error {} while executing {}".format(error.returncode, error.args[1]))
        print("stderr output:\n" + error.completed_command.stderr)
# Output:
#bar.txt
#foo.txt
#Error 2 while executing ['/bin/ls', '--color', '-1', '--color=no', 'bar.txt', 'foo.txt', 'baz.txt', 'bing.txt']
#stderr output:
#/bin/ls: cannot access 'baz.txt': No such file or directory
#/bin/ls: cannot access 'bing.txt': No such file or directory
```