### PR TITLE
Fix crash caused by malformed prompt or title

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Current Developments
 
 * Strip leading space in commands passed using the "-c" switch
 * Fixed xonfig wizard failing on Windows due to colon in created filename.
+* Fixed crash resulting from malformed ``$PROMPT`` or ``$TITLE``.
 
 **Security:** None
 

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -84,6 +84,13 @@ def test_format_prompt_with_broken_template_in_func():
         assert_in('user', partial_format_prompt(p))
         assert_in('user', format_prompt(p))
 
+def test_format_prompt_with_invalid_func():
+    def p():
+        foo = bar  # raises exception
+        return '{user}'
+    assert_is_instance(partial_format_prompt(p), str)
+    assert_is_instance(format_prompt(p), str)
+
 def test_HISTCONTROL():
     env = Env(HISTCONTROL=None)
     assert_is_instance(env['HISTCONTROL'], set)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1136,6 +1136,13 @@ def _get_fmtter(formatter_dict=None):
 
 
 def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
+    try:
+        return _format_prompt_main(template, formatter_dict)
+    except:
+        return template() if callable(template) else template
+
+
+def _format_prompt_main(template, formatter_dict):
     """Formats a xonsh prompt template string."""
     template = template() if callable(template) else template
     fmtter = _get_fmtter(formatter_dict)
@@ -1160,7 +1167,7 @@ def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
         return _partial_format_prompt_main(template=template,
                                            formatter_dict=formatter_dict)
     except:
-        return template
+        return template() if callable(template) else template
 
 
 def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1135,11 +1135,23 @@ def _get_fmtter(formatter_dict=None):
     return fmtter
 
 
+def _failover_template_format(template):
+    if callable(template):
+        try:
+            # Exceptions raises from function of producing $PROMPT
+            # in user's xonshrc should not crash xonsh
+            return template()
+        except:
+            print_exception()
+            return '$ '
+    return template
+
+
 def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
     try:
         return _format_prompt_main(template, formatter_dict)
     except:
-        return template() if callable(template) else template
+        return _failover_template_format(template)
 
 
 def _format_prompt_main(template, formatter_dict):
@@ -1167,7 +1179,7 @@ def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
         return _partial_format_prompt_main(template=template,
                                            formatter_dict=formatter_dict)
     except:
-        return template() if callable(template) else template
+        return _failover_template_format(template)
 
 
 def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1141,7 +1141,7 @@ def _failover_template_format(template):
             # Exceptions raises from function of producing $PROMPT
             # in user's xonshrc should not crash xonsh
             return template()
-        except:
+        except Exception:
             print_exception()
             return '$ '
     return template


### PR DESCRIPTION
Following @adqm 's fixing prompt in #1150 , this PR try to fix bad `$TITLE` and `$PROMPT` from callables.

The following prompt in xonshrc was causing xonsh crash:

```
def render_prompt():
    return '{HELLO'
$PROMPT = render_prompt
```

@adqm @scopatz please help to review it, thanks.