### PR TITLE
Cygwin Fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Current Developments
   ``activate``/``deactivate`` aliases for the conda environements. 
 * Fixed crash resulting from errors other than syntax errors in run control
   file.
+* xonsh no longer backgrounds itself after every command on Cygwin.
 
 **Security:** None
 

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -125,15 +125,3 @@ The packages ``win_unicode_console`` can be installed using pip or conda.
 .. code-block:: bat
 
   > conda install --channel xonsh win_unicode_console
-
-Running Under Cygwin
---------------------
-
-Cygwin support in xonsh is a work in progress.  Currently, there are some
-issues.  Most noticeably, running xonsh by running the ``xonsh`` command from
-within Cygwin bash will cause xonsh to background itself after every command
-that is run.  This should be addressed in a future version, but in the
-meantime, invoking xonsh via ``exec xonsh`` should work.
-
-It is possible to use xonsh as your default shell in Cygwin by adding ``exec
-xonsh`` to your ``.bash_profile`` file.

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -90,14 +90,17 @@ else:
     _block_when_giving = (signal.SIGTTOU, signal.SIGTTIN,
                           signal.SIGTSTP, signal.SIGCHLD)
 
+    # _give_terminal_to is a simplified version of:
+    #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
+    # this will give the terminal to the process group pgid
     if ON_CYGWIN:
         import ctypes
         _libc = ctypes.CDLL('cygwin1.dll')
 
+        # on cygwin, signal.pthread_sigmask does not exist in Python, even
+        # though pthread_sigmask is defined in the kernel.  thus, we use
+        # ctypes to mimic the calls in the "normal" version below.
         def _give_terminal_to(pgid):
-            # over-simplified version of:
-            #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
-            # this will give the terminal to the process group pgid
             if _shell_tty is not None and os.isatty(_shell_tty):
                 omask = ctypes.c_ulong()
                 mask = ctypes.c_ulong()
@@ -113,9 +116,6 @@ else:
                                   ctypes.byref(omask), None)
     else:
         def _give_terminal_to(pgid):
-            # over-simplified version of:
-            #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
-            # this will give the terminal to the process group pgid
             if _shell_tty is not None and os.isatty(_shell_tty):
                 oldmask = signal.pthread_sigmask(signal.SIG_BLOCK,
                                                  _block_when_giving)


### PR DESCRIPTION
This should fix one of the issues discussed in #514, where xonsh would background itself after every command when running under Cygwin.

There is still one more issue outstanding (discussed in #514, which I have not been able to reproduce), but this should take us most of the way toward being completely functional in Cygwin with no hacks required!