### PR TITLE
Attempted fix for PermissionError and ProcessLookupError on Cygwin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,9 @@ Current Developments
 * Ensured that the prompt_toolkit shell functions, even without a ``completer``
   attribute.
 * Fixed crash resulting from malformed ``$PROMPT`` or ``$TITLE``.
+* xonsh no longer backgrounds itself after every command on Cygwin.
+* Fixed an issue about ``os.killpg()`` on Cygwin which caused xonsh to crash
+  occasionally
 
 **Security:** None
 
@@ -76,7 +79,6 @@ v0.3.4
   ``activate``/``deactivate`` aliases for the conda environements.
 * Fixed crash resulting from errors other than syntax errors in run control
   file.
-* xonsh no longer backgrounds itself after every command on Cygwin.
 
 
 v0.3.3

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -24,6 +24,19 @@ if ON_DARWIN:
 elif ON_WINDOWS:
     pass
 
+elif ON_CYGWIN:
+    # Similar to what happened on OSX, more issues on Cygwin
+    # (see Github issue #514).
+    def _send_signal(job, signal):
+        try:
+            os.killpg(job['pgrp'], signal)
+        except (PermissionError, ProcessLookupError):
+            for pid in job['pids']:
+                try:
+                    os.kill(pid, signal)
+                except:
+                    pass
+
 else:
     def _send_signal(job, signal):
         os.killpg(job['pgrp'], signal)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -30,7 +30,7 @@ elif ON_CYGWIN:
     def _send_signal(job, signal):
         try:
             os.killpg(job['pgrp'], signal)
-        except (PermissionError, ProcessLookupError):
+        except Exception:
             for pid in job['pids']:
                 try:
                     os.kill(pid, signal)


### PR DESCRIPTION
This is the first attempt at a fix for the `ProcessLookupError` and `PermissionError` exceptions under Cygwin (discussed in #541).

@OllieTerrance, @ellocogato, @jivanyatra: would you mind testing this out?  As I mentioned, I am unable to reproduce the issue.