### PR TITLE
Increment line numbers on transformation

### DIFF
--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -2,7 +2,13 @@
 from nose.tools import assert_equal
 
 from xonsh import ast
-from xonsh.ast import Tuple, Name, Store
+from xonsh.ast import Tuple, Name, Store, min_line
+
+from tools import execer_setup, check_parse
+
+
+def setup():
+    execer_setup()
 
 
 def test_gather_names_name():
@@ -18,3 +24,11 @@ def test_gather_names_tuple():
     exp = {'y', 'z'}
     obs = ast.gather_names(node)
     assert_equal(exp, obs)
+
+
+def test_multilline_num():
+    code = ('x = 1\n'
+            'ls -l\n')  # this second line wil be transformed
+    tree = check_parse(code)
+    lsnode = tree.body[1]
+    assert_equal(2, min_line(lsnode))

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -130,5 +130,6 @@ def check_eval(input):
 def check_parse(input):
     with mock_xonsh_env(None):
         EXECER.debug_level = DEBUG_LEVEL
-        EXECER.parse(input, ctx=None)
+        tree = EXECER.parse(input, ctx=None)
+    return tree
 

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -12,7 +12,7 @@ from ast import Module, Num, Expr, Str, Bytes, UnaryOp, UAdd, USub, Invert, \
     YieldFrom, Return, IfExp, Lambda, arguments, arg, Call, keyword, \
     Attribute, Global, Nonlocal, If, While, For, withitem, With, Try, \
     ExceptHandler, FunctionDef, ClassDef, Starred, NodeTransformer, \
-    Interactive, Expression, Index, literal_eval, dump, walk
+    Interactive, Expression, Index, literal_eval, dump, walk, increment_lineno
 from ast import Ellipsis  # pylint: disable=redefined-builtin
 # pylint: enable=unused-import
 import textwrap
@@ -214,7 +214,7 @@ class CtxAwareTransformer(NodeTransformer):
             if not isinstance(newnode, AST):
                 # take the first (and only) Expr
                 newnode = newnode[0]
-            newnode.lineno = node.lineno
+            increment_lineno(newnode, n=node.lineno - 1)
             newnode.col_offset = node.col_offset
         except SyntaxError:
             newnode = node


### PR DESCRIPTION
This fixes an unnoticed, outstanding issue with line numbers on transformed nodes. This was first found by @pelson in #1125