### PR TITLE
fixed piped jobs including alias on OS X

### DIFF
--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -22,6 +22,8 @@ if ON_DARWIN:
         # any zombie processes in the process group.
         # See github issue #1012 for details
         for pid in job['pids']:
+            if pid is None:  # the pid of an aliased proc is None
+                continue
             os.kill(pid, signal)
 
 elif ON_WINDOWS:


### PR DESCRIPTION
On mac, xonsh crashes with the following command (where `which` is aliased by Python func):

```
which -a ls | grep ls
```

@adqm @scopatz Could you please have a review. Thanks.