### PR TITLE
Remove Bash from Default Foreign Shells

### DIFF
--- a/news/rmbash.rst
+++ b/news/rmbash.rst
@@ -1,0 +1,22 @@
+**Added:**
+
+* ``xonsh.platform`` now has a new ``PATH_DEFAULT`` variable.
+
+**Changed:**
+
+* ``Env`` now guarantees that the ``$PATH`` is available and mutable when
+  initialized.
+
+**Deprecated:** None
+
+**Removed:**
+
+* Bash is no longer loaded by default as a foreign shell for initial
+  configuration. This was done to increase stock startup times. This
+  behaviour can be recovered by adding ``{"shell": "bash"}`` to your
+  ``"foreign_shells"`` in your config.json file. For more details,
+  see http://xon.sh/xonshconfig.html#foreign-shells
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -31,14 +31,14 @@ def test_env_path_str():
 
 def test_env_detype():
     env = Env(MYPATH=['wakka', 'jawaka'])
-    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
+    assert_equal('wakka' + os.pathsep + 'jawaka', env.detype()['MYPATH'])
 
 def test_env_detype_mutable_access_clear():
     env = Env(MYPATH=['wakka', 'jawaka'])
-    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
+    assert_equal('wakka' + os.pathsep + 'jawaka', env.detype()['MYPATH'])
     env['MYPATH'][0] = 'woah'
     assert_equal(None, env._detyped)
-    assert_equal({'MYPATH': 'woah' + os.pathsep + 'jawaka'}, env.detype())
+    assert_equal('woah' + os.pathsep + 'jawaka', env.detype()['MYPATH'])
 
 def test_env_detype_no_dict():
     env = Env(YO={'hey': 42})
@@ -169,9 +169,9 @@ if ON_WINDOWS:
             for fname in files:
                 fpath = os.path.join(tmpdir, fname)
                 with open(fpath, 'w') as f:
-                    f.write(fpath)               
+                    f.write(fpath)
             env = Env({'PATH': [tmpdir], 'PATHEXT': ['.COM', '.EXE', '.BAT']})
-            with mock_xonsh_env(env): 
+            with mock_xonsh_env(env):
                 assert_equal( locate_binary('file1'), os.path.join(tmpdir,'file1.exe'))
                 assert_equal( locate_binary('file1.exe'), os.path.join(tmpdir,'file1.exe'))
                 assert_equal( locate_binary('file2'), os.path.join(tmpdir,'FILE2.BAT'))

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -22,7 +22,7 @@ from xonsh.tools import (XonshError, argvquote, escape_windows_cmd_string,
 from xonsh.vox import Vox
 from xonsh.xontribs import main as xontribs_main
 from xonsh.xoreutils import _which
-from xonsh.completers._aliases import completer_alias 
+from xonsh.completers._aliases import completer_alias
 
 
 class Aliases(MutableMapping):
@@ -579,5 +579,7 @@ def make_default_aliases():
         default_aliases['ls'] = ['ls', '-G']
     else:
         default_aliases['grep'] = ['grep', '--color=auto']
+        default_aliases['egrep'] = ['egrep', '--color=auto']
+        default_aliases['fgrep'] = ['fgrep', '--color=auto']
         default_aliases['ls'] = ['ls', '--color=auto', '-v']
     return default_aliases

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -23,7 +23,7 @@ from xonsh import __version__ as XONSH_VERSION
 from xonsh.jobs import get_next_task
 from xonsh.codecache import run_script_with_cache
 from xonsh.dirstack import _get_cwd
-from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
+from xonsh.foreign_shells import load_foreign_envs
 from xonsh.platform import (BASH_COMPLETIONS_DEFAULT, ON_ANACONDA, ON_LINUX,
                             ON_WINDOWS, DEFAULT_ENCODING, ON_CYGWIN)
 from xonsh.tools import (
@@ -1432,7 +1432,7 @@ def default_env(env=None, config=None, login=True):
     if login:
         conf = load_static_config(ctx, config=config)
 
-        foreign_env = load_foreign_envs(shells=conf.get('foreign_shells', DEFAULT_SHELLS),
+        foreign_env = load_foreign_envs(shells=conf.get('foreign_shells', ()),
                                         issue_warning=False)
         if ON_WINDOWS:
             windows_foreign_env_fixes(foreign_env)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -25,7 +25,7 @@ from xonsh.codecache import run_script_with_cache
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import load_foreign_envs
 from xonsh.platform import (BASH_COMPLETIONS_DEFAULT, ON_ANACONDA, ON_LINUX,
-                            ON_WINDOWS, DEFAULT_ENCODING, ON_CYGWIN)
+    ON_WINDOWS, DEFAULT_ENCODING, ON_CYGWIN, PATH_DEFAULT)
 from xonsh.tools import (
     IS_SUPERUSER, always_true, always_false, ensure_string, is_env_path,
     str_to_env_path, env_path_to_str, is_bool, to_bool, bool_to_str,
@@ -228,7 +228,7 @@ DEFAULT_VALUES = {
     'LOADED_RC_FILES': (),
     'MOUSE_SUPPORT': False,
     'MULTILINE_PROMPT': '.',
-    'PATH': (),
+    'PATH': PATH_DEFAULT,
     'PATHEXT': (),
     'PRETTY_PRINT_RESULTS': True,
     'PROMPT': DEFAULT_PROMPT,
@@ -617,6 +617,10 @@ class Env(MutableMapping):
             args = (os.environ, )
         for key, val in dict(*args, **kwargs).items():
             self[key] = val
+        if 'PATH' not in self._d:
+            # this is here so the PATH is accessible to subprocs and so that
+            # it can be modified in-place in the xonshrc file
+            self._d['PATH'] = list(PATH_DEFAULT)
         self._detyped = None
 
     @staticmethod
@@ -695,20 +699,17 @@ class Env(MutableMapping):
         manager, the original values are restored.
         """
         old = {}
-
         # single positional argument should be a dict-like object
         if other is not None:
             for k, v in other.items():
                 old[k] = self.get(k, NotImplemented)
                 self[k] = v
-
         # kwargs could also have been sent in
         for k, v in kwargs.items():
             old[k] = self.get(k, NotImplemented)
             self[k] = v
 
         yield self
-
         # restore the values
         for k, v in old.items():
             if v is NotImplemented:

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -461,8 +461,6 @@ def ensure_shell(shell):
     return shell
 
 
-DEFAULT_SHELLS = ({'shell': 'bash'},)
-
 def _get_shells(shells=None, config=None, issue_warning=True):
     if shells is not None and config is not None:
         raise RuntimeError('Only one of shells and config may be non-None.')
@@ -475,7 +473,7 @@ def _get_shells(shells=None, config=None, issue_warning=True):
         else:
             from xonsh.environ import load_static_config
             conf = load_static_config(env, config)
-        shells = conf.get('foreign_shells', DEFAULT_SHELLS)
+        shells = conf.get('foreign_shells', ())
     return shells
 
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -221,9 +221,9 @@ the current platform.
 
 if LINUX_DISTRO == 'arch':
     BASH_COMPLETIONS_DEFAULT = (
-        '/etc/bash_completion',
+        '/usr/share/bash-completion/bash_completion',
         '/usr/share/bash-completion/completions')
-    PATH_DEFAULT = (os.path.expanduser('~/bin'), '/usr/local/sbin',
+    PATH_DEFAULT = ('/usr/local/sbin',
                     '/usr/local/bin', '/usr/bin', '/usr/bin/site_perl',
                     '/usr/bin/vendor_perl', '/usr/bin/core_perl')
 elif ON_LINUX or ON_CYGWIN:

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -2,11 +2,10 @@
     compatibility layers to make use of the 'best' implementation available
     on a platform.
 """
-
-from functools import lru_cache
 import os
-import platform
 import sys
+import platform
+from functools import lru_cache
 
 try:
     import distro
@@ -212,26 +211,33 @@ if ON_WINDOWS:
                 WINDOWS_BASH_COMMAND = bashcmd
 
 #
-# Bash completions defaults
+# Environment variables defaults
 #
 
 BASH_COMPLETIONS_DEFAULT = ()
-""" A possibly empty tuple with default paths to Bash completions known for
-    the current platform.
+"""A possibly empty tuple with default paths to Bash completions known for
+the current platform.
 """
 
 if LINUX_DISTRO == 'arch':
     BASH_COMPLETIONS_DEFAULT = (
         '/etc/bash_completion',
         '/usr/share/bash-completion/completions')
+    PATH_DEFAULT = (os.path.expanduser('~/bin'), '/usr/local/sbin',
+                    '/usr/local/bin', '/usr/bin', '/usr/bin/site_perl',
+                    '/usr/bin/vendor_perl', '/usr/bin/core_perl')
 elif ON_LINUX or ON_CYGWIN:
     BASH_COMPLETIONS_DEFAULT = (
         '/usr/share/bash-completion',
         '/usr/share/bash-completion/completions')
+    PATH_DEFAULT = (os.path.expanduser('~/bin'), '/usr/local/sbin',
+                    '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin',
+                    '/usr/games', '/usr/local/games')
 elif ON_DARWIN:
     BASH_COMPLETIONS_DEFAULT = (
         '/usr/local/etc/bash_completion',
         '/opt/local/etc/profile.d/bash_completion.sh')
+    PATH_DEFAULT = ('/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin')
 elif ON_WINDOWS and GIT_FOR_WINDOWS_PATH:
     BASH_COMPLETIONS_DEFAULT = (
         os.path.join(GIT_FOR_WINDOWS_PATH,
@@ -240,7 +246,12 @@ elif ON_WINDOWS and GIT_FOR_WINDOWS_PATH:
                      'usr\\share\\bash-completion\\completions'),
         os.path.join(GIT_FOR_WINDOWS_PATH,
                      'mingw64\\share\\git\\completion\\git-completion.bash'))
-
+    PATH_DEFAULT = tuple(winreg.QueryValueEx(winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r'SYSTEM\CurrentControlSet\Control\Session Manager\Environment'),
+        'Path')[0].split(os.pathsep))
+else:
+    PATH_DEFAULT = ()
 
 #
 # All constants as a dict


### PR DESCRIPTION
This removes Bash from the default foreign shells in an attempt to reduce the startup time.  This adds some platform specific code for the default `$PATH`, and so it probably requires some testing on environments other than my own. @melund @gforsyth @Carreau @OllieTerrance, @ellocogato, @jivanyatra - your feedback and help would be super appreciated.

Here are some timing comparisons on my desktop:

```
# interactive login shell, master
scopatz@artemis ~ $ time -p xonsh --shell-type=readline -l -i -c "print(42)"
42
real 0.35
user 0.33
sys 0.01

# interactive login shell, this branch
scopatz@artemis ~ $ time -p xonsh --shell-type=readline -l -i -c "print(42)"
42
real 0.28
user 0.27
sys 0.00

-------------

# headless shell, master
scopatz@artemis ~ $ time -p xonsh --shell-type=readline -c "print(42)"
42
real 0.28
user 0.27
sys 0.00

# headless shell, this branch
scopatz@artemis ~ $ time -p xonsh --shell-type=readline -c "print(42)"
42
real 0.28
user 0.26
sys 0.01
```

So as expected it doesn't really effect running scripts, but it knocks about 20% off of the startup time of the command line REPL, getting us ever closer to my goal of 0.1 sec :)