### PR TITLE
added top level xonsh enterpoint for dev

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+"""
+A helper xonsh enterpoint for developers.
+
+With this file, we can run/test xonsh inside the xonsh's repo like following:
+
+$ python3 main.py -c 'echo hi'
+"""
+
+from xonsh.main import main
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When developing xonsh inside the repo and If we want to test something without installing the code to system, we would run following command:

```
the-repo $ python3 xonsh/main.py -c 'echo hi'
```

But we will get `AttributeError: module 'platform' has no attribute 'system'` since Python will add `the-repo/xonsh` to the beginning of `sys.path`, and we have our own `platform` module inside this dir which causes this issue.

This PR is trying to add a helper enterpoint for developers only, which allow you to test xonsh like this:

```
the-repo $ python3 main.py -c 'echo hi'
```

Does this PR make sense to you?