### PR TITLE
Fix locate_binary assuming path is a list

### DIFF
--- a/news/path_tuple.rst
+++ b/news/path_tuple.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed ``xonsh.environ.locate_binary()`` to handle PATH variable are given as a tuple. 
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -819,7 +819,7 @@ def locate_binary(name):
     # Windows users expect to be able to execute files in the same directory
     # without `./`
     if ON_WINDOWS:
-        directories = [_get_cwd()] + directories
+        directories = [_get_cwd()] + list(directories)
     try:
         return next(chain.from_iterable(_yield_executables(directory, name) for
                     directory in directories if os.path.isdir(directory)))


### PR DESCRIPTION
This fixes crash when path is tuple and not list.