### PR TITLE
Do not throw an exception on 'completer list' if a completer has no docstring

### DIFF
--- a/news/completer_list_bugs.rst
+++ b/news/completer_list_bugs.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+* Fixed ``_list_completers`` such that it does not throw a ValueError if no completer is registered.
+* Fixed ``_list_completers`` such that it does not throw an AttributeError if a completer has no docstring.
+
+**Security:** None

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -6,6 +6,7 @@ from xonsh.completers.tools import justify
 
 VALID_ACTIONS = frozenset({'add', 'remove', 'list'})
 
+
 def _add_one_completer(name, func, loc='end'):
     new = OrderedDict()
     if loc == 'start':
@@ -39,7 +40,10 @@ def _list_completers(args, stdin=None):
     ml = max(len(i) for i in _comp)
     _strs = []
     for c in _comp:
-        doc = ' '.join(_comp[c].__doc__.split()) or 'No description provided'
+        if _comp[c].__doc__ is None:
+            doc = 'No description provided'
+        else:
+            doc = ' '.join(_comp[c].__doc__.split())
         doc = justify(doc, 80, ml + 3)
         _strs.append('{: >{}} : {}'.format(c, ml, doc))
     return o + '\n'.join(_strs) + '\n'

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -37,7 +37,7 @@ def _add_one_completer(name, func, loc='end'):
 def _list_completers(args, stdin=None):
     o = "Registered Completer Functions: \n"
     _comp = builtins.__xonsh_completers__
-    ml = max(len(i) for i in _comp)
+    ml = max(len(i) for i in _comp, default=0)
     _strs = []
     for c in _comp:
         if _comp[c].__doc__ is None:

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -37,7 +37,7 @@ def _add_one_completer(name, func, loc='end'):
 def _list_completers(args, stdin=None):
     o = "Registered Completer Functions: \n"
     _comp = builtins.__xonsh_completers__
-    ml = max(len(i) for i in _comp, default=0)
+    ml = max((len(i) for i in _comp), default=0)
     _strs = []
     for c in _comp:
         if _comp[c].__doc__ is None:


### PR DESCRIPTION
Solves a current bug:

> $ test = lambda a, b, c, d, e: set()

> $ completer add testname test

> $ completer list
>Traceback (most recent call last):
>  File ".../xonsh/0.3.4/libexec/lib/python3.5/site-packages/xonsh/proc.py", line 335, in wrapped_simple_command
>    r = f(args, i)
>  File ".../xonsh/0.3.4/libexec/lib/python3.5/site-packages/xonsh/completers/_aliases.py", line 114, in completer_alias
>    return func(args[1:], stdin=stdin)
>  File ".../xonsh/0.3.4/libexec/lib/python3.5/site-packages/xonsh/completers/_aliases.py", line 42, in _list_completers
>    doc = ' '.join(_comp[c].__doc__.split()) or 'No description provided'
AttributeError: 'NoneType' object has no attribute 'split'

The problem was that the original code called split on the completer function's docstring, which might be None.
Previously, an all-whitespace docstring would have triggered the 'No description provided' label, this is no longer the case. If this was intentional, we can easily bring it back.