### PR TITLE
Windows: Reset the PROMPT environment variable before starting subprocesses

### DIFF
--- a/news/replace_prompt.rst
+++ b/news/replace_prompt.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** 
+
+* On Windows the ``PROMPT`` environment variable is reset to `$P$G` before starting
+  subprocesses. This prevents the unformatted xonsh ``PROMPT`` tempalte from showing up 
+  when running batch files with ``ECHO ON```  
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -468,10 +468,15 @@ def run_subproc(cmds, captured=False):
             subproc_kwargs = {}
             if ON_POSIX and cls is Popen:
                 subproc_kwargs['preexec_fn'] = _subproc_pre
+            env = ENV.detype()
+            if ON_WINDOWS:
+                # Over write prompt variable as xonsh's $PROMPT does
+                # not make much sense for other subprocs
+                env['PROMPT'] = '$P$G'
             try:
                 proc = cls(aliased_cmd,
                            universal_newlines=uninew,
-                           env=ENV.detype(),
+                           env=env,
                            stdin=stdin,
                            stdout=stdout,
                            stderr=stderr,


### PR DESCRIPTION
Reset the PROMPT environment variable before starting subprocesses on Windows. 

The problem is that windows also uses 'PROMPT' to render the prompt in cmd.exe. Thus, if 'echo ON' is set we this a lot when running batch files: 

```cmd
{env_name}{CONEMU_BOLD}{BOLD_INTENSE_GREEN}{user}@{hostname}{INTENSE_CYAN} {cwd} {INTENSE_CYAN}
set "SRC_DIR=C:\Users\mel\Anaconda3\conda-bld\work"
```

This PR avoids that the xonsh prompt template string is shown everywhere by replacing `PROMPT` with '$P$G'. (i.e. `path/to/current/dir>`) 

```cmd
C:\Users\mel\Documents\xonsh>set "SRC_DIR=C:\Users\mel\Anaconda3\conda-bld\work"
```

Is this also a problem on other platforms? 

Alternatively, I could set `PROMPT` to a colorless formatted version of the real xonsh prompt. This PR is just the simplest implementation I could think of, and I believe that it is probably enough. 



