### PR TITLE
Proposal: Inline "suite"

### DIFF
--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -395,14 +395,12 @@ class Lexer(object):
 
     def input(self, s):
         """Calls the lexer on the string s."""
-        print('HEY', repr(s))
         self.token_stream = get_tokens(s, self)
 
     def token(self):
         """Retrieves the next token."""
         self.beforelast = self.last
         self.last = next(self.token_stream, None)
-        print(self.last)
         return self.last
 
     def __iter__(self):

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -66,47 +66,7 @@ it up here and generate a single PLY token of the given type.  Otherwise, it
 will fall back to handling that token using one of the handlers in
 ``special_handlers``.
 """
-<<<<<<< HEAD
 del _token_map
-=======
-
-# operators
-_op_map = {
-    # punctuation
-    ',': 'COMMA', '.': 'PERIOD', ':': 'COLON',
-    '...': 'ELLIPSIS',
-    # basic operators
-    '+': 'PLUS', '-': 'MINUS', '*': 'TIMES', '@': 'AT', '/': 'DIVIDE',
-    '//': 'DOUBLEDIV', '%': 'MOD', '**': 'POW', '|': 'PIPE',
-    '~': 'TILDE', '^': 'XOR', '<<': 'LSHIFT', '>>': 'RSHIFT',
-    '<': 'LT', '<=': 'LE', '>': 'GT', '>=': 'GE', '==': 'EQ',
-    '!=': 'NE', '->': 'RARROW',
-    # assignment operators
-    '=': 'EQUALS', '+=': 'PLUSEQUAL', '-=': 'MINUSEQUAL',
-    '*=': 'TIMESEQUAL', '@=': 'ATEQUAL', '/=': 'DIVEQUAL', '%=': 'MODEQUAL',
-    '**=': 'POWEQUAL', '<<=': 'LSHIFTEQUAL', '>>=': 'RSHIFTEQUAL',
-    '&=': 'AMPERSANDEQUAL', '^=': 'XOREQUAL', '|=': 'PIPEEQUAL',
-    '//=': 'DOUBLEDIVEQUAL',
-    # extra xonsh operators
-    '?': 'QUESTION', '??': 'DOUBLE_QUESTION', '@$': 'ATDOLLAR',
-    '&': 'AMPERSAND',
-}
-for (op, type) in _op_map.items():
-    token_map[(OP, op)] = type
-
-token_map[IOREDIRECT] = 'IOREDIRECT'
-token_map[STRING] = 'STRING'
-token_map[DOLLARNAME] = 'DOLLAR_NAME'
-token_map[NUMBER] = 'NUMBER'
-token_map[REGEXPATH] = 'REGEXPATH'
-token_map[NEWLINE] = 'NEWLINE'
-token_map[INDENT] = 'INDENT'
-token_map[DEDENT] = 'DEDENT'
-if PYTHON_VERSION_INFO >= (3, 5, 0):
-    token_map[ASYNC] = 'ASYNC'
-    token_map[AWAIT] = 'AWAIT'
->>>>>>> new handling of semicolons inside of inline block
-
 
 def _make_matcher_handler(tok, typ, pymode, ender):
     matcher = (')' if tok.endswith('(') else

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -81,6 +81,8 @@ _xonsh_tokens = {
     '||':  'DOUBLEPIPE',
     '&&':  'DOUBLEAMPER',
     '@(':  'ATLPAREN',
+    '!{':  'BANGLBRACE',
+    '}!':  'RBRANCEBANG',
     '!(':  'BANGLPAREN',
     '![':  'BANGLBRACKET',
     '$(':  'DOLLARLPAREN',
@@ -90,7 +92,7 @@ _xonsh_tokens = {
     '@$(': 'ATDOLLARLPAREN',
 }
 
-additional_parenlevs = frozenset({'@(', '!(', '![', '$(', '$[', '${', '@$('})
+additional_parenlevs = frozenset({'@(', '!(', '![', '$(', '$[', '${', '@$(', '!{'})
 
 for k, v in _xonsh_tokens.items():
     exec('%s = N_TOKENS' % v)
@@ -214,8 +216,8 @@ _redir_check = {'{}>'.format(i) for i in _redir_names}.union(_redir_check)
 _redir_check = {'{}>>'.format(i) for i in _redir_names}.union(_redir_check)
 _redir_check = frozenset(_redir_check)
 Operator = group(r"\*\*=?", r">>=?", r"<<=?", r"!=", r"//=?", r"->",
-                 r"@\$\(?", r'\|\|', '&&', r'@\(', r'!\(', r'!\[', r'\$\(',
-                 r'\$\[', '\${', r'\?\?', r'\?', AUGASSIGN_OPS, r"~")
+                 r"@\$\(?", r'\|\|', '&&', r'@\(', r'!\(', r'!\[', r'!{', r'}!',
+                 r'\$\(', r'\$\[', '\${', r'\?\?', r'\?', AUGASSIGN_OPS, r"~")
 
 Bracket = '[][(){}]'
 Special = group(r'\r?\n', r'\.\.\.', r'[:;.,@]')

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -82,7 +82,7 @@ _xonsh_tokens = {
     '&&':  'DOUBLEAMPER',
     '@(':  'ATLPAREN',
     '!{':  'BANGLBRACE',
-    '}!':  'RBRANCEBANG',
+    '}!':  'RBRACEBANG',
     '!(':  'BANGLPAREN',
     '![':  'BANGLBRACKET',
     '$(':  'DOLLARLPAREN',
@@ -736,6 +736,8 @@ def _tokenize(readline, encoding):
                         parenlev -= 1
                     elif token in additional_parenlevs:
                         parenlev += 1
+                    elif token == '}!':
+                        parenlev -= 1
                     if stashed:
                         yield stashed
                         stashed = None


### PR DESCRIPTION
There was some discussion in the IRC/Gitter.im rooms a while back about potentially adding a way to add "inline" blocks to xonsh.

This adds a new syntax `!{...}` to wrap "suites," in addition to the normal newline- and indent-based scheme,  to allow for writing more complicated statements on one line.  For example:

```
hartz@tabby ~ $ for i in range(3): !{print(7); print(8)}
7
8
7
8
7
8

hartz@tabby ~ $ for i in range(5): !{if i%2 == 0: !{print('YAY');print(i)} else: !{print('OH NO'); print(i+0)};print(i+20)}
YAY
0
20
OH NO
1
21
YAY
2
22
OH NO
3
23
YAY
4
24
```

This PR is a partial implementation of this idea.  Still a few things missing:
- documentation
- tests
- changes to `subproc_toks` to allow proper automatic wrapping of subproc mode commands (only manually-wrapped subproc commands work as of now)

but I wanted to put this in to gather opinions from core devs before going too far down this road.
