### PR TITLE
Fix for pipeline issues

### DIFF
--- a/news/fix_pipeline.rst
+++ b/news/fix_pipeline.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed issue where input was directed to the last process in a pipeline,
+  rather than the first.
+
+**Security:** None

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -99,7 +99,7 @@ else:
 
     def _set_pgrp(info):
         try:
-            info['pgrp'] = os.getpgid(info['obj'].pid)
+            info['pgrp'] = os.getpgid(info['pids'][0])
         except ProcessLookupError:
             pass
 


### PR DESCRIPTION
This small change should fix issues we've had with pipelines, in particular #1102, by giving the terminal to the _first_ process in a pipeline, rather than the last.