### PR TITLE
Simplify Env.__repr__

### DIFF
--- a/news/simplify_env_repr.rst
+++ b/news/simplify_env_repr.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** 
+
+* ``__repr__`` on the environment only shows a short representation of the 
+  object instead of printing the whole environment dictionary
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -784,7 +784,7 @@ class Env(MutableMapping):
         return str(self._d)
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format(self.__class__.__module__,
+        return '{0}.{1}(...)'.format(self.__class__.__module__,
                                      self.__class__.__name__, self._d)
 
     def _repr_pretty_(self, p, cycle):


### PR DESCRIPTION
This simplifies  `__xonsh_env__._repr__()` so it does not print the whole environment dictionary.

 It does not change the string representation of the object or the pretty print method. So it does not change what happens if we type: `${...}` at the prompt. 

Before this , calling help on env methods would print the entire enviroment: 
```
snail@sea ~ $ ${...}.swap?   
Type:         method
String form:  <bound method Env.swap of xonsh.environ.Env({'GIT_LFS_PATH': ['C:\\Program Files\\Git LFS'], 'COM <...> 'ANYBODY', 'CONDA_DEFAULT_ENV': 'C:\\Users\\mel\\Anaconda3\\envs\\x', 'SESSIONNAME': 'Console'})>
File:         c:\users\mel\documents\xonsh\xonsh\environ.py
Definition:   (*args, **kwds)
Docstring:
Provides a context manager for temporarily swapping out certain
environment variables with other values. On exit from the context
manager, the original values are restored.

<bound method Env.swap of xonsh.environ.Env({'GIT_LFS_PATH': ['C:\\Program Files\\Git LFS'], 
.....
<VERY LONG SNIPPET>
....
'C:\\Users\\mel\\Anaconda3\\envs\\x', 'SESSIONNAME': 'Console'})>
```
After this change it renders more nicely:

```
snail@sea ~ $ ${...}.swap?  
Type:         method
String form:  <bound method Env.swap of xonsh.environ.Env(...)>
File:         c:\users\mel\documents\xonsh\xonsh\environ.py
Definition:   (*args, **kwds)
Docstring:
Provides a context manager for temporarily swapping out certain
environment variables with other values. On exit from the context
manager, the original values are restored.

<bound method Env.swap of xonsh.environ.Env(...)>
```` 

