### PR TITLE
add mock xonsh env to test

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -85,11 +85,13 @@ def test_format_prompt_with_broken_template_in_func():
         assert_in('user', format_prompt(p))
 
 def test_format_prompt_with_invalid_func():
-    def p():
-        foo = bar  # raises exception
-        return '{user}'
-    assert_is_instance(partial_format_prompt(p), str)
-    assert_is_instance(format_prompt(p), str)
+    env = Env({'XONSH_SHOW_TRACEBACK': False})
+    with mock_xonsh_env(env):
+        def p():
+            foo = bar  # raises exception
+            return '{user}'
+        assert_is_instance(partial_format_prompt(p), str)
+        assert_is_instance(format_prompt(p), str)
 
 def test_HISTCONTROL():
     env = Env(HISTCONTROL=None)


### PR DESCRIPTION
`test_format_prompt_with_invalid_func` raises an exception
(intentionally).  when this is checked against `partial_format_prompt`
it eventually makes its way to `print_exception` in `tools.py` which
expects `env` to have an attribute `is_manually_set`.

This just adds a mock xonsh env to the test so that `env` is properly
defined.

I think this was the test failing in #1223 

And no, I don't like that it's failing sporadically.  