### PR TITLE
enable character selection in vi_mode

### DIFF
--- a/news/vi_mode_change.rst
+++ b/news/vi_mode_change.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* In ``VI_MODE``, the ``v`` key will enter character selection mode, not open
+  the editor.  ``Ctrl-X Ctrl-E`` will still open an editor in any mode
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -136,7 +136,7 @@ def load_xonsh_bindings(key_bindings_manager):
         """
         event.cli.current_buffer.insert_text(env.get('INDENT'))
 
-    @handle(Keys.ControlX, Keys.ControlE, filter= ~has_selection)
+    @handle(Keys.ControlX, Keys.ControlE, filter=~has_selection)
     def open_editor(event):
         """ Open current buffer in editor """
         event.current_buffer.open_in_editor(event.cli)

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -3,7 +3,8 @@
 import builtins
 
 from prompt_toolkit.enums import DEFAULT_BUFFER
-from prompt_toolkit.filters import Condition, Filter, IsMultiline
+from prompt_toolkit.filters import (Condition, Filter, IsMultiline,
+                                    HasSelection)
 from prompt_toolkit.keys import Keys
 from xonsh.aliases import exit
 from xonsh.tools import ON_WINDOWS
@@ -125,6 +126,7 @@ def load_xonsh_bindings(key_bindings_manager):
     Load custom key bindings.
     """
     handle = key_bindings_manager.registry.add_binding
+    has_selection = HasSelection()
 
     @handle(Keys.Tab, filter=TabShouldInsertIndentFilter())
     def _(event):
@@ -133,6 +135,11 @@ def load_xonsh_bindings(key_bindings_manager):
         indent instead of autocompleting.
         """
         event.cli.current_buffer.insert_text(env.get('INDENT'))
+
+    @handle(Keys.ControlX, Keys.ControlE, filter= ~has_selection)
+    def open_editor(event):
+        """ Open current buffer in editor """
+        event.current_buffer.open_in_editor(event.cli)
 
     @handle(Keys.BackTab)
     def insert_literal_tab(event):

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -36,7 +36,6 @@ class PromptToolkitShell(BaseShell):
                 'enable_auto_suggest_bindings': True,
                 'enable_search': True,
                 'enable_abort_and_exit_bindings': True,
-                'enable_open_in_editor': True,
                 }
 
         self.key_bindings_manager = KeyBindingManager(**key_bindings_manager_args)


### PR DESCRIPTION
When `open_in_editor` is enabled, the `VI_MODE` binding to open the
editor is `v`, which is unexpected, as `v` should be character
selection.

The `open_in_editor` option has been disabled, but the `Ctrl-X Ctrl-E`
shortcut to open the current buffer in an editor has been explicitly
enabled, so there shouldn't be any change of behavior for anyone except
those who were using `v` to open an editor in `VI_MODE` (which I think
is no one).