### PR TITLE
point xonfig wizard to hidden docs attribute

### DIFF
--- a/news/fix_xonfig.rst
+++ b/news/fix_xonfig.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Bug where xonfig wizard can't find ENV docs
+
+**Security:** None

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -206,7 +206,7 @@ def _make_flat_wiz(kidfunc, *args):
 
 def make_env():
     """Makes an environment variable wizard."""
-    w = _make_flat_wiz(make_envvar, sorted(builtins.__xonsh_env__.docs.keys()))
+    w = _make_flat_wiz(make_envvar, sorted(builtins.__xonsh_env__._docs.keys()))
     return w
 
 


### PR DESCRIPTION
#1231 made `docs` a hidden attribute of `builtins.__xonsh_env__`, but `xonfig wizard` still looks for a visible attribute and throws an error on first-time startup.