### PR TITLE
Better sorting of completions. 

### DIFF
--- a/news/sorted_comp.rst
+++ b/news/sorted_comp.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* Ignore case and leading a quotes when sorting completions 
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -48,5 +48,6 @@ class Completer(object):
                 res = out
                 lprefix = len(prefix)
             if res is not None and len(res) != 0:
-                return tuple(sorted(res)), lprefix
+                def sortkey(s): return s.lstrip(''''"''').lower()
+                return tuple(sorted(res, key=sortkey)), lprefix
         return set(), lprefix


### PR DESCRIPTION
Ignore case and any leading quotes when sorting the completions. This makes path completions look much nicer. 

Right now sorting is done by the top level completer, but we could consider letting the individual completers sort their own results. 