### PR TITLE
Fix `xonsh` not being include in setup.py scripts

### DIFF
--- a/news/xonsh_darwin.rst
+++ b/news/xonsh_darwin.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+* Bug preventing `xonsh` executable being installed on macOS.
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ def main():
     with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'r') as f:
         readme = f.read()
     scripts = ['scripts/xon.sh']
-    if 'win' in sys.platform:
+    if sys.platform == 'win32':
         scripts.append('scripts/xonsh.bat')
     else:
         scripts.append('scripts/xonsh')


### PR DESCRIPTION
If you use macOS, the expression `'win' in sys.platform` is `True`, since `sys.platform == 'darwin'`. This would prevent `xonsh` to be added in the scripts.