### PR TITLE
Fix xonfig_main bugs

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -241,7 +241,7 @@ def main(argv=None):
                 not any(os.path.isfile(i) for i in env['XONSHRC'])):
             print('Could not find xonsh configuration or run control files.')
             from xonsh import xonfig  # lazy import
-            xonfig.main(['wizard', '--confirm'])
+            xonfig.xonfig_main(['wizard', '--confirm'])
         shell.cmdloop()
     postmain(args)
 

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -286,7 +286,7 @@ def make_xonfig_wizard(default_file=None, confirm=False):
         passer = wiz.Pass()
         saver = wiz.Save(check=False, ask_filename=False,
                          default_file=default_file)
-        w = wiz.Question(q, {1: wiz, 2: passer, 3: saver},
+        w = wiz.Question(q, {1: w, 2: passer, 3: saver},
                          converter=lambda x: int(x) if x != '' else 2)
     return w
 

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -201,8 +201,8 @@ def _make_flat_wiz(kidfunc, *args):
         if k is None:
             continue
         flatkids.extend(k)
-    wiz = wiz.Wizard(children=flatkids)
-    return wiz
+    wizard = wiz.Wizard(children=flatkids)
+    return wizard
 
 
 def make_env_wiz():
@@ -462,7 +462,7 @@ _XONFIG_MAIN_ACTIONS = {
 
 def xonfig_main(args=None):
     """Main xonfig entry point."""
-    if not args or (args[0] not in _MAIN_ACTIONS and
+    if not args or (args[0] not in _XONFIG_MAIN_ACTIONS and
                     args[0] not in {'-h', '--help'}):
         args.insert(0, 'info')
     parser = _xonfig_create_parser()


### PR DESCRIPTION
* main.py ignored `--config-file` command line option
* main.py called the old `xonfig.main` function, which doesn't exists anymore
* the `wiz` variable in xonfig.py was conflicting with the global `wiz`
* `_MAIN_ACTIONS` was renamed to `_XONFIG_MAIN_ACTIONS`
* `make_xonfig_wizard` returned an instance of the `wizard` module instead of an initialized Wizard.