### PR TITLE
fix undefined PWD in default environment

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1425,6 +1425,7 @@ def default_env(env=None, config=None, login=True):
     # in order of increasing precedence
     ctx = dict(BASE_ENV)
     ctx.update(os.environ)
+    ctx['PWD'] = _get_cwd()
     # other shells' PROMPT definitions generally don't work in XONSH:
     try:
         del ctx['PROMPT']

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1412,7 +1412,7 @@ def windows_foreign_env_fixes(ctx):
             ctx[ev] = os.environ[ev]
         elif ev in ctx:
             del ctx[ev]
-    ctx['PWD'] = _get_cwd()
+    ctx['PWD'] = _get_cwd() or ''
 
 
 def foreign_env_fixes(ctx):
@@ -1425,7 +1425,7 @@ def default_env(env=None, config=None, login=True):
     # in order of increasing precedence
     ctx = dict(BASE_ENV)
     ctx.update(os.environ)
-    ctx['PWD'] = _get_cwd()
+    ctx['PWD'] = _get_cwd() or ''
     # other shells' PROMPT definitions generally don't work in XONSH:
     try:
         del ctx['PROMPT']


### PR DESCRIPTION
Somewhere between `0.3.4` and now, `PWD` stopped being defined in the default xonsh environment, which breaks a bunch of things (but only at new logins when `xonsh` is the default shell).  

Simple fix to ensure that it exists, so that `$PROMPT` can be resolved and useful things like `cd` work