### PR TITLE
don't abspath in EnvVar

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -25,19 +25,18 @@ def test_env_path_list():
     env = Env(MYPATH=['/home/wakka'])
     assert_equal(['/home/wakka'], env['MYPATH'].paths)
     env = Env(MYPATH=['wakka'])
-    assert_equal([os.path.abspath('wakka')], env['MYPATH'].paths)
+    assert_equal(['wakka'], env['MYPATH'].paths)
 
 def test_env_path_str():
     env = Env(MYPATH='/home/wakka' + os.pathsep + '/home/jawaka')
     assert_equal(['/home/wakka', '/home/jawaka'], env['MYPATH'].paths)
     env = Env(MYPATH='wakka' + os.pathsep + 'jawaka')
-    assert_equal([os.path.abspath('wakka'), os.path.abspath('jawaka')],
+    assert_equal(['wakka', 'jawaka'],
                  env['MYPATH'].paths)
 
 def test_env_detype():
     env = Env(MYPATH=['wakka', 'jawaka'])
-    assert_equal(os.path.abspath('wakka') + os.pathsep + \
-                 os.path.abspath('jawaka'),
+    assert_equal('wakka' + os.pathsep + 'jawaka',
                  env.detype()['MYPATH'])
 
 def test_env_detype_mutable_access_clear():
@@ -48,15 +47,12 @@ def test_env_detype_mutable_access_clear():
     assert_equal(None, env._detyped)
     assert_equal('/home/woah' + os.pathsep + '/home/jawaka',
                  env.detype()['MYPATH'])
-
     env = Env(MYPATH=['wakka', 'jawaka'])
-    assert_equal(os.path.abspath('wakka') + os.pathsep + \
-                 os.path.abspath('jawaka'),
+    assert_equal('wakka' + os.pathsep + 'jawaka',
                  env.detype()['MYPATH'])
     env['MYPATH'][0] = 'woah'
     assert_equal(None, env._detyped)
-    assert_equal(os.path.abspath('woah') + os.pathsep + \
-                 os.path.abspath('jawaka'),
+    assert_equal('woah' + os.pathsep + 'jawaka',
                  env.detype()['MYPATH'])
 
 def test_env_detype_no_dict():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -472,12 +472,9 @@ def test_env_path_to_str():
 
 
 def test_env_path():
-    """
-    Test the EnvPath class.
-    """
+    """Test the EnvPath class."""
     # lambda to expand the expected paths
-    expand = lambda path: \
-            os.path.realpath(os.path.expanduser(os.path.expandvars(path)))
+    expand = lambda path: os.path.expanduser(os.path.expandvars(path))
     getitem_cases = [
         ('xonsh_dir', 'xonsh_dir'),
         ('.', '.'),
@@ -486,12 +483,12 @@ def test_env_path():
         (b'~/../', '~/../'),
     ]
     for inp, exp in getitem_cases:
-        obs = EnvPath(inp)[0] # call to __getitem__
+        obs = EnvPath(inp)[0]  # call to __getitem__
         yield assert_equal, expand(exp), obs
 
     # cases that involve path-separated strings
     multipath_cases = [
-        (os.pathsep.join(['xonsh_dir', '../', './', '~/']),
+        (os.pathsep.join(['xonsh_dir', '../', '.', '~/']),
          ['xonsh_dir', '../', '.', '~/']),
         ('/home/wakka' + os.pathsep + '/home/jakka' + os.pathsep + '~/',
          ['/home/wakka', '/home/jakka', '~/'])
@@ -503,14 +500,14 @@ def test_env_path():
     # cases that involve pathlib.Path objects
     pathlib_cases = [
         (pathlib.Path('/home/wakka'), ['/home/wakka']),
-        (pathlib.Path('~/'), ['~/']),
+        (pathlib.Path('~/'), ['~']),
         (pathlib.Path('.'), ['.']),
         (['/home/wakka', pathlib.Path('/home/jakka'), '~/'],
          ['/home/wakka', '/home/jakka', '~/']),
         (['/home/wakka', pathlib.Path('../'), '../'],
-         ['/home/wakka', '../', '../']),
+         ['/home/wakka', '..', '../']),
         (['/home/wakka', pathlib.Path('~/'), '~/'],
-         ['/home/wakka', '~/', '~/']),
+         ['/home/wakka', '~', '~/']),
     ]
 
     for inp, exp in pathlib_cases:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -102,21 +102,17 @@ class XonshCalledProcessError(XonshError, CalledProcessError):
 
 
 def expandpath(path):
-    """
-    Performs environment variable / user expansion on a given path
+    """Performs environment variable / user expansion on a given path
     if the relevant flag has been set.
     """
     env = getattr(builtins, '__xonsh_env__', os.environ)
     if env.get('EXPAND_ENV_VARS', False):
-        # expand variables and use os.path.abspath to handle cases
-        # with relative paths like ../ or ./
         path = os.path.expanduser(expandvars(path))
-    return os.path.abspath(path)
+    return path
 
 
 def decode_bytes(path):
-    """
-    Tries to decode a path in bytes using XONSH_ENCODING if available,
+    """Tries to decode a path in bytes using XONSH_ENCODING if available,
     otherwise using sys.getdefaultencoding().
     """
     env = getattr(builtins, '__xonsh_env__', os.environ)
@@ -126,8 +122,7 @@ def decode_bytes(path):
 
 
 class EnvPath(collections.MutableSequence):
-    """
-    A class that implements an environment path, which is a list of
+    """A class that implements an environment path, which is a list of
     strings. Provides a custom method that expands all paths if the
     relevant env variable has been set.
     """
@@ -769,13 +764,13 @@ def is_string(x):
 def is_slice(x):
     """Tests if something is a slice"""
     return isinstance(x, slice)
-        
+
 def is_slice_as_str(x):
     """
     Tests if a str is a slice
     If not a string to begin with is automatically false
     """
-    if isinstance(x, str): 
+    if isinstance(x, str):
         if ':' in x:
             x = x.strip('[]()')
             try:
@@ -783,9 +778,9 @@ def is_slice_as_str(x):
                         for x in x.split(':')))
             except ValueError:
                 return False
-        else: 
+        else:
             return False
-        return True  
+        return True
     return False
 
 def is_callable(x):


### PR DESCRIPTION
This is a hotfix for not expanding relative paths in EnvVar, as reported in #1214.  @melund, would you mind trying this out and merging it :) It seems to work on my machine.  Sorry again about merging the other one. I had no idea Windows had that behaviour. Mea culpa