### PR TITLE
restore alias preference in alias binary collision

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -440,7 +440,7 @@ def run_subproc(cmds, captured=False):
                 aliased_cmd = alias + cmd[1:]
             else:
                 aliased_cmd = cmd
-            if binary_loc is not None:
+            if binary_loc is not None and alias is None:
                 try:
                     aliased_cmd = get_script_subproc_command(binary_loc,
                                                              aliased_cmd[1:])


### PR DESCRIPTION
#1271 reintroduced a problem where if an alias has the same name as an existing binary, xonsh prefers the binary over the alias.  This goes against our "Python always wins" philosophy.  

@melund can you check this to make sure that self-referential aliases still work on your end?  I never had that problem so can't tell if this reintroduces the same problem.