### PR TITLE
fixes for windows test failures

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -626,7 +626,6 @@ def test_is_dynamic_cwd_width():
 
 def test_is_logfile_opt():
     cases = [
-        ('/dev/null', True),
         ('throwback.log', True),
         ('', True),
         (None, True),
@@ -637,6 +636,8 @@ def test_is_logfile_opt():
         ((1, 2), False),
         (("wrong", "parameter"), False)
     ]
+    if not ON_WINDOWS:
+        cases.append(('/dev/null', True))
     for inp, exp in cases:
         obs = is_logfile_opt(inp)
         yield assert_equal, exp, obs
@@ -647,10 +648,11 @@ def test_to_logfile_opt():
         (False, None),
         (1, None),
         (None, None),
-        ('/dev/null', '/dev/null'),
         ('throwback.log', 'throwback.log'),
-        ('/dev/nonexistent_dev', None),
     ]
+    if not ON_WINDOWS:
+        cases.append(('/dev/null', '/dev/null'))
+        cases.append(('/dev/nonexistent_dev', None))
     for inp, exp in cases:
         obs = to_logfile_opt(inp)
         yield assert_equal, exp, obs


### PR DESCRIPTION
I don't think the `/dev/null` test is a) necessary or b) meaningful on
Windows.  And it should fail, if it's passed, since `/dev/null` isn't
writeable or creatable file on Windows (I think).

I believe that the second set of tests that I've changed also have
little to no meaning on Windows.

Definitely need @melund to take a look at this when he has a chance.