### PR TITLE
Only run appveyor on Py35

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,12 +1,9 @@
 version: 0.3.4.{build}
 os: Windows Server 2012 R2
 install:
-- C:\Python34\Scripts\pip install ply pyreadline nose pygments prompt_toolkit
 - C:\Python35\Scripts\pip install ply pyreadline nose pygments prompt_toolkit
 build_script:
-- C:\Python34\python setup.py install
 - C:\Python35\python setup.py install
 test_script:
-- C:\Python34\Scripts\nosetests -q
 - C:\Python35\Scripts\nosetests -q
 


### PR DESCRIPTION
Only run appveyor on Py35. This should make it run a bit faster so we avoid waiting for appveyor all the time