### PR TITLE
fix PTK check and add warning if pygments not installed

### DIFF
--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -81,7 +81,7 @@ def pygments_version():
 @functools.lru_cache(1)
 def has_prompt_toolkit():
     """ Tests if the `prompt_toolkit` is available. """
-    spec = importlib.util.find_spec('pygments')
+    spec = importlib.util.find_spec('prompt_toolkit')
     return (spec is not None)
 
 

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -21,9 +21,6 @@ from xonsh.ptk.history import PromptToolkitHistory
 from xonsh.ptk.key_bindings import load_xonsh_bindings
 from xonsh.ptk.shortcuts import Prompter
 
-pyghooks = LazyObject(lambda: importlib.import_module('xonsh.pyghooks'),
-                      globals(), 'pyghooks')
-
 try:
     from pygments.styles import get_all_styles
     from pygments.token import Token
@@ -32,7 +29,6 @@ try:
 
 except ImportError:
     from prompt_toolkit.token import Token
-    lambda get_all_styles: DEFAULT_STYLE
     Color = Token.Color
     def partial_color_tokenize(p):
         return [(Color.NO_COLOR, p)]
@@ -96,10 +92,10 @@ class PromptToolkitShell(BaseShell):
                     'display_completions_in_columns': multicolumn,
                     }
             if builtins.__xonsh_env__.get('COLOR_INPUT') and HAS_PYGMENTS:
-                prompt_args['lexer'] = PygmentsLexer(pyghooks.XonshLexer)
+                prompt_args['lexer'] = PygmentsLexer(XonshLexer)
 
             if HAS_PYGMENTS:
-                prompt_args['style'] = style_from_pygments(pyghooks.xonsh_style_proxy(self.styler))
+                prompt_args['style'] = style_from_pygments(xonsh_style_proxy(self.styler))
             line = self.prompter.prompt(**prompt_args)
         return line
 

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -1,26 +1,42 @@
 # -*- coding: utf-8 -*-
 """The prompt_toolkit based xonsh shell."""
 import builtins
+import importlib
 
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.shortcuts import print_tokens
 from prompt_toolkit.filters import Condition
-from prompt_toolkit.styles import PygmentsStyle
-from pygments.styles import get_all_styles
-from pygments.token import Token
+from prompt_toolkit.styles import style_from_pygments
 
 from xonsh.base_shell import BaseShell
 from xonsh.tools import print_exception
 from xonsh.environ import partial_format_prompt
-from xonsh.platform import ptk_version, ptk_version_info
-from xonsh.pyghooks import (XonshLexer, partial_color_tokenize,
-                            xonsh_style_proxy)
+from xonsh.lazyasd import LazyObject
+from xonsh.platform import ptk_version, ptk_version_info, HAS_PYGMENTS
+
 from xonsh.ptk.completer import PromptToolkitCompleter
 from xonsh.ptk.history import PromptToolkitHistory
 from xonsh.ptk.key_bindings import load_xonsh_bindings
 from xonsh.ptk.shortcuts import Prompter
+
+pyghooks = LazyObject(lambda: importlib.import_module('xonsh.pyghooks'),
+                      globals(), 'pyghooks')
+
+try:
+    from pygments.styles import get_all_styles
+    from pygments.token import Token
+    from xonsh.pyghooks import (XonshLexer, partial_color_tokenize,
+                                xonsh_style_proxy)
+
+except ImportError:
+    from prompt_toolkit.token import Token
+    lambda get_all_styles: DEFAULT_STYLE
+    Color = Token.Color
+    def partial_color_tokenize(p):
+        return [(Color.NO_COLOR, p)]
+
 
 
 class PromptToolkitShell(BaseShell):
@@ -57,7 +73,8 @@ class PromptToolkitShell(BaseShell):
         auto_suggest = auto_suggest if env.get('AUTO_SUGGEST') else None
         completions_display = env.get('COMPLETIONS_DISPLAY')
         multicolumn = (completions_display == 'multi')
-        self.styler.style_name = env.get('XONSH_COLOR_STYLE')
+        if HAS_PYGMENTS:
+            self.styler.style_name = env.get('XONSH_COLOR_STYLE')
         completer = None if completions_display == 'none' else self.pt_completer
         prompt_tokens = self.prompt_tokens(None)
         get_prompt_tokens = lambda cli: prompt_tokens
@@ -69,7 +86,6 @@ class PromptToolkitShell(BaseShell):
                     'auto_suggest': auto_suggest,
                     'get_prompt_tokens': get_prompt_tokens,
                     'get_rprompt_tokens': get_rprompt_tokens,
-                    'style': PygmentsStyle(xonsh_style_proxy(self.styler)),
                     'completer': completer,
                     'multiline': multiline,
                     'get_continuation_tokens': self.continuation_tokens,
@@ -79,8 +95,11 @@ class PromptToolkitShell(BaseShell):
                     'key_bindings_registry': self.key_bindings_manager.registry,
                     'display_completions_in_columns': multicolumn,
                     }
-            if builtins.__xonsh_env__.get('COLOR_INPUT'):
-                prompt_args['lexer'] = PygmentsLexer(XonshLexer)
+            if builtins.__xonsh_env__.get('COLOR_INPUT') and HAS_PYGMENTS:
+                prompt_args['lexer'] = PygmentsLexer(pyghooks.XonshLexer)
+
+            if HAS_PYGMENTS:
+                prompt_args['style'] = style_from_pygments(pyghooks.xonsh_style_proxy(self.styler))
             line = self.prompter.prompt(**prompt_args)
         return line
 
@@ -151,7 +170,7 @@ class PromptToolkitShell(BaseShell):
             p = partial_format_prompt(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
-        toks = partial_color_tokenize(p)
+        toks = pyghooks.partial_color_tokenize(p)
         return toks
 
     def continuation_tokens(self, cli, width):

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -9,7 +9,8 @@ from xonsh.xontribs import update_context
 from xonsh.environ import xonshrc_context
 from xonsh.execer import Execer
 from xonsh.platform import (best_shell_type, has_prompt_toolkit,
-                            ptk_version_is_supported, ptk_version_info)
+                            ptk_version_is_supported, ptk_version_info,
+                            HAS_PYGMENTS)
 from xonsh.tools import XonshError, to_bool_or_int
 
 
@@ -59,6 +60,10 @@ class Shell(object):
             elif not ptk_version_is_supported():
                 warn('prompt-toolkit version < v1.0.0 is not supported. '
                      'Please update prompt-toolkit. Using readline instead.')
+                shell_type = 'readline'
+            elif not HAS_PYGMENTS:
+                warn('prompt_toolkit is available but requires pygments.  '
+                     'Please install pygments. Using readline shell')
                 shell_type = 'readline'
         env['SHELL_TYPE'] = shell_type
         # actually make the shell

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -62,9 +62,7 @@ class Shell(object):
                      'Please update prompt-toolkit. Using readline instead.')
                 shell_type = 'readline'
             elif not HAS_PYGMENTS:
-                warn('prompt_toolkit is available but requires pygments.  '
-                     'Please install pygments. Using readline shell')
-                shell_type = 'readline'
+                warn('pygments not found. syntax highlighting disabled.')
         env['SHELL_TYPE'] = shell_type
         # actually make the shell
         if shell_type == 'none':


### PR DESCRIPTION
kept getting weird errors when pygments wasn't installed in an environment but prompt_toolkit was.  this should take care of those and provide something a little more helpful.