### PR TITLE
merge from master and replace some new nose test with pytest

### DIFF
--- a/news/cc.rst
+++ b/news/cc.rst
@@ -1,0 +1,20 @@
+**Added:**
+
+* New ``pathsep_to_set()`` and ``set_to_pathsep()`` functions convert to/from
+  ``os.pathsep`` separated strings to a set of strings.
+
+**Changed:**
+
+* ``CommandsCache`` is now a mapping from command names to a tuple of
+  (executable locations, has alias flags). This enables faster lookup times.
+* ``locate_bin()`` now uses the ``CommandsCache``, rather than scanning the
+  ``$PATH`` itself.
+* ``$PATHEXT`` is now a set, rather than a list.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -55,7 +55,7 @@ def test_eval_recursive_callable_partial():
         assert ALIASES.get('indirect_cd')(['arg2', 'arg3']) == ['..', 'arg2', 'arg3']
 
 class TestWhich:
-    # Tests for the _whichgen function which is the only thing we 
+    # Tests for the _whichgen function which is the only thing we
     # use from the _which.py module.
     def setup(self):
         # Setup two folders with some test files.
@@ -64,8 +64,10 @@ class TestWhich:
         if ON_WINDOWS:
             self.testapps = ['whichtestapp1.exe',
                              'whichtestapp2.wta']
+            self.exts = ['.EXE']
         else:
             self.testapps = ['whichtestapp1']
+            self.exts = None
         for app in self.testapps:
             for d in self.testdirs:
                 path = os.path.join(d.name, app)
@@ -79,20 +81,21 @@ class TestWhich:
     def test_whichgen(self):
         testdir = self.testdirs[0].name
         arg = 'whichtestapp1'
-        matches = list(_which.whichgen(arg, path=[testdir]))
+        matches = list(_which.whichgen(arg, path=[testdir], exts=self.exts))
         assert len(matches) == 1
         assert self._file_match(matches[0][0], os.path.join(testdir, arg))
 
     def test_whichgen_failure(self):
         testdir = self.testdirs[0].name
         arg = 'not_a_file'
-        matches = list(_which.whichgen(arg, path=[testdir]))
+        matches = list(_which.whichgen(arg, path=[testdir], exts=self.exts))
         assert len(matches) == 0
 
     def test_whichgen_verbose(self):
         testdir = self.testdirs[0].name
         arg = 'whichtestapp1'
-        matches = list(_which.whichgen(arg, path=[testdir], verbose=True))
+        matches = list(_which.whichgen(arg, path=[testdir], exts=self.exts,
+                                       verbose=True))
         assert len(matches) == 1
         match, from_where = matches[0]
         assert self._file_match(match, os.path.join(testdir, arg))
@@ -102,7 +105,8 @@ class TestWhich:
         testdir0 = self.testdirs[0].name
         testdir1 = self.testdirs[1].name
         arg = 'whichtestapp1'
-        matches = list(_which.whichgen(arg, path=[testdir0, testdir1]))
+        matches = list(_which.whichgen(arg, path=[testdir0, testdir1],
+                                       exts=self.exts))
         assert len(matches) == 2
         assert self._file_match(matches[0][0], os.path.join(testdir0, arg))
         assert self._file_match(matches[1][0], os.path.join(testdir1, arg))
@@ -111,13 +115,13 @@ class TestWhich:
         def test_whichgen_ext_failure(self):
             testdir = self.testdirs[0].name
             arg = 'whichtestapp2'
-            matches = list(_which.whichgen(arg, path=[testdir]))
+            matches = list(_which.whichgen(arg, path=[testdir], exts=self.exts))
             assert len(matches) == 0
 
         def test_whichgen_ext_success(self):
                 testdir = self.testdirs[0].name
                 arg = 'whichtestapp2'
-                matches = list(_which.whichgen(arg, path=[testdir], exts = ['.wta']))
+                matches = list(_which.whichgen(arg, path=[testdir], exts=['.wta']))
                 assert len(matches) == 1
                 assert self._file_match(matches[0][0], os.path.join(testdir, arg))
 

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -10,7 +10,9 @@ from xonsh.built_ins import load_builtins, unload_builtins
 from tools import mock_xonsh_env
 LOADED_HERE = False
 
-def setup_module():
+IMP_ENV = {'PATH': [], 'PATHEXT': []}
+
+def setup():
     global LOADED_HERE
     if built_ins.BUILTINS_LOADED:
         unload_builtins()  # make sure we have a clean env from other tests.
@@ -22,22 +24,22 @@ def teardown_module():
         unload_builtins()
 
 def test_import():
-    with mock_xonsh_env({'PATH': []}):
+    with mock_xonsh_env(IMP_ENV):
         import sample
         assert ('hello mom jawaka\n' == sample.x)
 
 def test_absolute_import():
-    with mock_xonsh_env({'PATH': []}):
+    with mock_xonsh_env(IMP_ENV):
         from xpack import sample
         assert ('hello mom jawaka\n' == sample.x)
 
 def test_relative_import():
-    with mock_xonsh_env({'PATH': []}):
+    with mock_xonsh_env(IMP_ENV):
         from xpack import relimp
         assert ('hello mom jawaka\n' == relimp.sample.x)
         assert ('hello mom jawaka\ndark chest of wonders' == relimp.y)
 
 def test_sub_import():
-    with mock_xonsh_env({'PATH': []}):
+    with mock_xonsh_env(IMP_ENV):
         from xpack.sub import sample
         assert ('hello mom jawaka\n' == sample.x)

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -12,7 +12,7 @@ LOADED_HERE = False
 
 IMP_ENV = {'PATH': [], 'PATHEXT': []}
 
-def setup():
+def setup_module():
     global LOADED_HERE
     if built_ins.BUILTINS_LOADED:
         unload_builtins()  # make sure we have a clean env from other tests.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,8 +14,10 @@ def test_login_shell():
         pass
 
     with patch('xonsh.main.Shell', Shell), mock_xonsh_env({}):
-        xonsh.main.premain([])
-        assert not (builtins.__xonsh_env__.get('XONSH_LOGIN'))
+        with patch('sys.stdin.isatty') as faketty:
+            faketty.return_value = True
+            xonsh.main.premain([])
+            assert builtins.__xonsh_env__.get('XONSH_LOGIN')
 
     with patch('xonsh.main.Shell', Shell), mock_xonsh_env({}):
         xonsh.main.premain(['-i'])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -814,7 +814,7 @@ def test_call_int_base_dict():
 def test_call_dict_kwargs():
     yield check_ast, 'dict(**{"base": 8})'
 
-@.mark.(ipif(VER_MAJOR_MINOR < VER_3_5, reason='Py3.5 only test'))
+@pytest.mark.skipif(VER_MAJOR_MINOR < VER_3_5, reason='Py3.5 only test')
 def test_call_list_many_star_args():
     check_ast('min(*[1, 2], 3, *[4, 5])')
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -444,7 +444,7 @@ def test_pathsep_to_set():
         ]
     for inp, exp in cases:
         obs = pathsep_to_set(inp)
-        yield assert_equal, exp, obs
+        assert exp == obs
 
 
 def test_set_to_pathsep():
@@ -456,19 +456,19 @@ def test_set_to_pathsep():
         ]
     for inp, exp in cases:
         obs = set_to_pathsep(inp, sort=(len(inp) > 1))
-        yield assert_equal, exp, obs
+        assert exp == obs
 
 
 def test_is_string_seq():
-    yield assert_true, is_string_seq('42.0')
-    yield assert_true, is_string_seq(['42.0'])
-    yield assert_false, is_string_seq([42.0])
+    assert is_string_seq('42.0')
+    assert is_string_seq(['42.0'])
+    assert not is_string_seq([42.0])
 
 
 def test_is_nonstring_seq_of_strings():
-    yield assert_false, is_nonstring_seq_of_strings('42.0')
-    yield assert_true, is_nonstring_seq_of_strings(['42.0'])
-    yield assert_false, is_nonstring_seq_of_strings([42.0])
+    assert not is_nonstring_seq_of_strings('42.0')
+    assert is_nonstring_seq_of_strings(['42.0'])
+    assert not is_nonstring_seq_of_strings([42.0])
 
 
 def test_pathsep_to_seq():
@@ -480,7 +480,7 @@ def test_pathsep_to_seq():
         ]
     for inp, exp in cases:
         obs = pathsep_to_seq(inp)
-        yield assert_equal, exp, obs
+        assert exp == obs
 
 
 def test_seq_to_pathsep():
@@ -492,7 +492,7 @@ def test_seq_to_pathsep():
         ]
     for inp, exp in cases:
         obs = seq_to_pathsep(inp)
-        yield assert_equal, exp, obs
+        assert exp == obs
 
 
 def test_pathsep_to_upper_seq():
@@ -504,7 +504,7 @@ def test_pathsep_to_upper_seq():
         ]
     for inp, exp in cases:
         obs = pathsep_to_upper_seq(inp)
-        yield assert_equal, exp, obs
+        assert exp == obs
 
 
 def test_seq_to_upper_pathsep():
@@ -516,7 +516,7 @@ def test_seq_to_upper_pathsep():
         ]
     for inp, exp in cases:
         obs = seq_to_upper_pathsep(inp)
-        yield assert_equal, exp, obs
+        assert exp == obs
 
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,7 +18,10 @@ from xonsh.tools import (
     is_int_as_str, is_logfile_opt, is_slice_as_str, is_string,
     is_string_or_callable, logfile_opt_to_str, str_to_env_path,
     subexpr_from_unbalanced, subproc_toks, to_bool, to_bool_or_int,
-    to_dynamic_cwd_tuple, to_logfile_opt)
+    to_dynamic_cwd_tuple, to_logfile_opt, pathsep_to_set, set_to_pathsep,
+    is_string_seq, pathsep_to_seq, seq_to_pathsep, is_nonstring_seq_of_strings,
+    pathsep_to_upper_seq, seq_to_upper_pathsep,
+    )
 
 LEXER = Lexer()
 LEXER.build()
@@ -430,6 +433,92 @@ def test_ensure_string():
     for inp, exp in cases:
         obs = ensure_string(inp)
         assert exp == obs
+
+
+def test_pathsep_to_set():
+    cases = [
+        ('', set()),
+        ('a', {'a'}),
+        (os.pathsep.join(['a', 'b']), {'a', 'b'}),
+        (os.pathsep.join(['a', 'b', 'c']), {'a', 'b', 'c'}),
+        ]
+    for inp, exp in cases:
+        obs = pathsep_to_set(inp)
+        yield assert_equal, exp, obs
+
+
+def test_set_to_pathsep():
+    cases = [
+        (set(), ''),
+        ({'a'}, 'a'),
+        ({'a', 'b'}, os.pathsep.join(['a', 'b'])),
+        ({'a', 'b', 'c'}, os.pathsep.join(['a', 'b', 'c'])),
+        ]
+    for inp, exp in cases:
+        obs = set_to_pathsep(inp, sort=(len(inp) > 1))
+        yield assert_equal, exp, obs
+
+
+def test_is_string_seq():
+    yield assert_true, is_string_seq('42.0')
+    yield assert_true, is_string_seq(['42.0'])
+    yield assert_false, is_string_seq([42.0])
+
+
+def test_is_nonstring_seq_of_strings():
+    yield assert_false, is_nonstring_seq_of_strings('42.0')
+    yield assert_true, is_nonstring_seq_of_strings(['42.0'])
+    yield assert_false, is_nonstring_seq_of_strings([42.0])
+
+
+def test_pathsep_to_seq():
+    cases = [
+        ('', []),
+        ('a', ['a']),
+        (os.pathsep.join(['a', 'b']), ['a', 'b']),
+        (os.pathsep.join(['a', 'b', 'c']), ['a', 'b', 'c']),
+        ]
+    for inp, exp in cases:
+        obs = pathsep_to_seq(inp)
+        yield assert_equal, exp, obs
+
+
+def test_seq_to_pathsep():
+    cases = [
+        ([], ''),
+        (['a'], 'a'),
+        (['a', 'b'], os.pathsep.join(['a', 'b'])),
+        (['a', 'b', 'c'], os.pathsep.join(['a', 'b', 'c'])),
+        ]
+    for inp, exp in cases:
+        obs = seq_to_pathsep(inp)
+        yield assert_equal, exp, obs
+
+
+def test_pathsep_to_upper_seq():
+    cases = [
+        ('', []),
+        ('a', ['A']),
+        (os.pathsep.join(['a', 'B']), ['A', 'B']),
+        (os.pathsep.join(['A', 'b', 'c']), ['A', 'B', 'C']),
+        ]
+    for inp, exp in cases:
+        obs = pathsep_to_upper_seq(inp)
+        yield assert_equal, exp, obs
+
+
+def test_seq_to_upper_pathsep():
+    cases = [
+        ([], ''),
+        (['a'], 'A'),
+        (['a', 'b'], os.pathsep.join(['A', 'B'])),
+        (['a', 'B', 'c'], os.pathsep.join(['A', 'B', 'C'])),
+        ]
+    for inp, exp in cases:
+        obs = seq_to_upper_pathsep(inp)
+        yield assert_equal, exp, obs
+
+
 
 
 def test_is_env_path():

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -21,8 +21,8 @@ VER_3_4 = (3, 4)
 VER_3_5 = (3, 5)
 VER_MAJOR_MINOR = sys.version_info[:2]
 VER_FULL = sys.version_info[:3]
-ON_MAC = (platform.system() == 'Darwin')
-ON_WINDOWS = (platform.system() == 'Windows')
+ON_DARWIN = platform.ON_DARWIN
+ON_WINDOWS = platform.ON_WINDOWS
 
 def sp(cmd):
     return subprocess.check_output(cmd, universal_newlines=True)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -22,6 +22,7 @@ VER_3_5 = (3, 5)
 VER_MAJOR_MINOR = sys.version_info[:2]
 VER_FULL = sys.version_info[:3]
 ON_MAC = (platform.system() == 'Darwin')
+ON_WINDOWS = (platform.system() == 'Windows')
 
 def sp(cmd):
     return subprocess.check_output(cmd, universal_newlines=True)
@@ -108,8 +109,11 @@ def check_exec(input, **kwargs):
         EXECER.exec(input, **kwargs)
 
 def check_eval(input):
-    with mock_xonsh_env({'AUTO_CD': False, 'XONSH_ENCODING' :'utf-8',
-                         'XONSH_ENCODING_ERRORS': 'strict', 'PATH': []}):
+    env = {'AUTO_CD': False, 'XONSH_ENCODING' :'utf-8',
+           'XONSH_ENCODING_ERRORS': 'strict', 'PATH': []}
+    if ON_WINDOWS:
+        env['PATHEXT'] = ['.COM', '.EXE', '.BAT', '.CMD']
+    with mock_xonsh_env(env):
         EXECER.debug_level = DEBUG_LEVEL
         EXECER.eval(input)
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -393,7 +393,7 @@ def which(args, stdin=None, stdout=None, stderr=None):
         if pargs.exts:
             exts = pargs.exts
         else:
-            exts = builtins.__xonsh_env__.get('PATHEXT', ['.COM', '.EXE', '.BAT'])
+            exts = builtins.__xonsh_env__['PATHEXT']
     else:
         exts = None
 

--- a/xonsh/xoreutils/_which.py
+++ b/xonsh/xoreutils/_which.py
@@ -90,9 +90,10 @@ __all__ = ["which", "whichall", "whichgen", "WhichError"]
 
 import os
 import sys
-import getopt
 import stat
-from collections import MutableSequence
+import getopt
+import builtins
+import collections.abc as abc
 
 #---- exceptions
 
@@ -191,16 +192,16 @@ def whichgen(command, path=None, verbose=0, exts=None):
     # Windows has the concept of a list of extensions (PATHEXT env var).
     if sys.platform.startswith("win"):
         if exts is None:
-            exts = os.environ.get("PATHEXT", "").split(os.pathsep)
+            exts = builtins.__xonsh_env__['PATHEXT']
             # If '.exe' is not in exts then obviously this is Win9x and
             # or a bogus PATHEXT, then use a reasonable default.
             for ext in exts:
                 if ext.lower() == ".exe":
                     break
             else:
-                exts = ['.COM', '.EXE', '.BAT']
-        elif not isinstance(exts, MutableSequence):
-            raise TypeError("'exts' argument must be a list or None")
+                exts = ['.COM', '.EXE', '.BAT', '.CMD']
+        elif not isinstance(exts, abc.Sequence):
+            raise TypeError("'exts' argument must be a sequence or None")
     else:
         if exts is not None:
             raise WhichError("'exts' argument is not supported on "\
@@ -220,7 +221,7 @@ def whichgen(command, path=None, verbose=0, exts=None):
             if sys.platform.startswith("win") and len(dirName) >= 2\
                and dirName[0] == '"' and dirName[-1] == '"':
                 dirName = dirName[1:-1]
-            for ext in ['']+exts:
+            for ext in ([''] + exts):
                 absName = os.path.abspath(
                     os.path.normpath(os.path.join(dirName, command+ext)))
                 if os.path.isfile(absName):


### PR DESCRIPTION
atm the only failling test i see in python3.5 is:

```
        for inp, exp in getitem_cases:
            obs = EnvPath(inp)[0]  # call to __getitem__
>           assert expand(exp) == obs
E           assert '/home/laerus/' == '~/'
E             - /home/laerus/
E             + ~/

tests/test_tools.py:572: AssertionError
```
which seems like a legit bug in EnvPath