### PR TITLE
fix alias preference issue

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -417,14 +417,18 @@ def run_subproc(cmds, captured=False):
         elif builtins.__xonsh_stderr_uncaptured__ is not None:
             stderr = builtins.__xonsh_stderr_uncaptured__
         uninew = (ix == last_cmd) and (not _capture_streams)
-
+        # find alias
         if callable(cmd[0]):
             alias = cmd[0]
         else:
             alias = builtins.aliases.get(cmd[0], None)
-            binary_loc = locate_binary(cmd[0])
-
         procinfo['alias'] = alias
+        # find binary location, if not callable
+        if alias is None:
+            binary_loc = locate_binary(cmd[0])
+        elif not callable(alias):
+            binary_loc = locate_binary(alias[0])
+        # implement AUTO_CD
         if (alias is None and
                 builtins.__xonsh_env__.get('AUTO_CD') and
                 len(cmd) == 1 and


### PR DESCRIPTION
This is an alternative to #1290 that looks up the binary location of the *alias*, if applicable, not the binary location of the original command.

With some of the new command cache behaviour, this is a little more tricky to trigger.  I have been using the following: `aliases['/bin/ls'] = ['echo', '.']`  This should print a single dot, rather than the contents of the current directory:

```console
scopatz@artemis ~ $ aliases['/bin/ls'] = ['echo', '.']
scopatz@artemis ~ $ c = !(/bin/ls); c
CompletedCommand(stdin=None, stdout='.\n', stderr='', pid=7128, returncode=0, args=['/bin/ls'], 
    alias=['echo', '.'], stdin_redirect=None, stdout_redirect=None, stderr_redirect=None, 
    timestamp=(1466649889.561564, 1466649889.6136434), executed_cmd=['/bin/echo', '.'])
scopatz@artemis ~ $ /bin/ls
.
```

Note that in the above, the `executed_cmd` starts with `/bin/echo`, not `/bin/ls`.  Therefore we can be sure that the alias is taking precedence. On master, this is `/bin/ls`