### PR TITLE
 stop autocomplete from autoselecting first entry

### DIFF
--- a/news/completion.rst
+++ b/news/completion.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* `prompt_toolkit` completion no longer automatically selects the first entry on first tab-press when completing multiple directories at once
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -183,6 +183,11 @@ def load_xonsh_bindings(key_bindings_manager):
         """
         Tab-completion: where the first tab completes the common suffix and the
         second tab lists all the completions.
+
+        Notes
+        -----
+        This method was forked from the mainline prompt-toolkit repo.
+        Copyright (c) 2014, Jonathan Slenders, All rights reserved.
         """
         b = event.current_buffer
 

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -4,7 +4,8 @@ import builtins
 
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import (Condition, Filter, IsMultiline,
-                                    HasSelection)
+                                    HasSelection, EmacsInsertMode,
+                                    ViInsertMode)
 from prompt_toolkit.keys import Keys
 from xonsh.aliases import xonsh_exit
 from xonsh.tools import ON_WINDOWS
@@ -127,6 +128,7 @@ def load_xonsh_bindings(key_bindings_manager):
     """
     handle = key_bindings_manager.registry.add_binding
     has_selection = HasSelection()
+    insert_mode = ViInsertMode() | EmacsInsertMode()
 
     @handle(Keys.Tab, filter=TabShouldInsertIndentFilter())
     def _(event):
@@ -175,5 +177,27 @@ def load_xonsh_bindings(key_bindings_manager):
         b.cursor_left(count=abs(relative_begin_index))
         b.cursor_down(count=1)
 
+
+    @handle(Keys.ControlI, filter=insert_mode)
+    def generate_completions(event):
+        """
+        Tab-completion: where the first tab completes the common suffix and the
+        second tab lists all the completions.
+        """
+        b = event.current_buffer
+
+        def second_tab():
+            if b.complete_state:
+                b.complete_next()
+            else:
+                event.cli.start_completion(select_first=False)
+
+        # On the second tab-press, or when already navigating through
+        # completions.
+        if event.is_repeat or b.complete_state:
+            second_tab()
+        else:
+            event.cli.start_completion(insert_common_part=True,
+                                    select_first=False)
 def _is_blank(l):
     return len(l.strip()) == 0


### PR DESCRIPTION
 stop autocomplete from autoselecting first entry
    
This was mentioned in #1338.  If I have the following directory
structure
    
```console
foo/
 -bar/
 -bag/
 -bing/
 -bong/
```
    
and have already completed to `cd foo/` and hit TAB, ptk will autoselect
the first entry of the completions.  This is incredibly annoying if
there are many possible selections and you would like to filter through
them by prefix.
    
This forks the `generate_completions` event from PTK and stops it from
autoselecting the first entry (but still displays possibilities)
