### PR TITLE
Dirty version numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ xonsh.egg-info/
 docs/_build/
 docs/envvarsbody
 docs/xontribsbody
+xonsh/dev.githash
 
 # temporary files from vim and emacs
 *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include logo.txt
+include githash

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include logo.txt
-include githash

--- a/news/dirtyversion.rst
+++ b/news/dirtyversion.rst
@@ -1,0 +1,14 @@
+**Added:** 
+
+* dev versions now display a ``devN`` counter at the end and ``xonfig info``
+  also displays the git sha of the current build
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -112,12 +112,13 @@ def dirty_version():
     try:
         _version = subprocess.check_output(['git', 'describe', '--tags'])
         _version = _version.decode('ascii')
-        try:
-            base, N, sha = _version.strip().split('-')
-        except ValueError: #on base release
-            open('xonsh/dev.githash', 'w').close()
-            return False
     except subprocess.CalledProcessError:
+        return False
+
+    try:
+        base, N, sha = _version.strip().split('-')
+    except ValueError: #on base release
+        open('xonsh/dev.githash', 'w').close()
         return False
 
     replace_version(base, N)

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -126,6 +126,26 @@ def is_readline_available():
 
 
 #
+# Dev release info
+#
+
+@functools.lru_cache(1)
+def githash():
+    from xonsh import main
+    install_base = main.__file__.rsplit('/', 1)[0]
+    try:
+        with open('{}/dev.githash'.format(install_base), 'r') as f:
+            hash = f.readlines()
+        if not hash:
+            hash = None
+        else:
+            hash = hash.pop()
+    except FileNotFoundError:
+        hash = None
+    return hash
+
+
+#
 # Encoding
 #
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -131,18 +131,15 @@ def is_readline_available():
 
 @functools.lru_cache(1)
 def githash():
-    from xonsh import main
-    install_base = main.__file__.rsplit('/', 1)[0]
+    install_base = os.path.dirname(__file__)
     try:
         with open('{}/dev.githash'.format(install_base), 'r') as f:
-            hash = f.readlines()
-        if not hash:
-            hash = None
-        else:
-            hash = hash.pop()
+            sha = f.read().strip()
+        if not sha:
+            sha = None
     except FileNotFoundError:
-        hash = None
-    return hash
+        sha = None
+    return sha
 
 
 #

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -20,7 +20,7 @@ from xonsh import __version__ as XONSH_VERSION
 from xonsh.environ import is_template_string
 from xonsh.platform import (is_readline_available, ptk_version,
     PYTHON_VERSION_INFO, pygments_version, ON_POSIX, ON_LINUX, linux_distro,
-    ON_DARWIN, ON_WINDOWS, ON_CYGWIN, DEFAULT_ENCODING)
+    ON_DARWIN, ON_WINDOWS, ON_CYGWIN, DEFAULT_ENCODING, githash)
 from xonsh.tools import (to_bool, is_string, print_exception, is_superuser,
     color_style_names, print_color, color_style)
 from xonsh.xontribs import xontrib_metadata, find_xontrib
@@ -353,6 +353,8 @@ def _info(ns):
         ('is superuser', is_superuser()),
         ('default encoding', DEFAULT_ENCODING),
         ])
+    if githash():
+        data.append(('git SHA', githash()))
     formatter = _xonfig_format_json if ns.json else _xonfig_format_human
     s = formatter(data)
     return s

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -352,9 +352,8 @@ def _info(ns):
         ('on cygwin', ON_CYGWIN),
         ('is superuser', is_superuser()),
         ('default encoding', DEFAULT_ENCODING),
+        ('git SHA', githash())
         ])
-    if githash():
-        data.append(('git SHA', githash()))
     formatter = _xonfig_format_json if ns.json else _xonfig_format_human
     s = formatter(data)
     return s


### PR DESCRIPTION
Ok, here's my first crack at this.  When doing any of `setup.py [install | develop | sdist]`, check if we're in a git repo.  If there is a tag on the most recent commit assume it's a "clean" version and write an empty file `dev.githash`

If there's not a tag, append the number of commits since the most recent version (as given by `git describe --tags`) to `__version__` in `__init__.py` as per PEP440, write git short SHA to dev.githash file (which is ignored in `.gitignore`).  

Then do the actually install, then `checkout --` changes to `__init__.py` if any were made during the course of installation.  

`xonfig` reads the version number as usual.  If it finds a non-empty `dev.githash` file, it adds that on to the end of the `xonfig info` readout.

Possible pitfall:  If you make changes to `__init__.py`, don't commit them and run `setup.py` it will discard your changes.  This doesn't seem like a likely thing to me, but I'm all ears.


```console
+------------------+----------------+
| xonsh            | 0.4.1.dev13    |
| Python           | 3.5.1          |
| PLY              | 3.7            |
| have readline    | True           |
| prompt toolkit   | 1.0.1          |
| shell type       | prompt_toolkit |
| pygments         | 2.1.1          |
| on posix         | True           |
| on linux         | True           |
| distro           | arch           |
| on darwin        | False          |
| on windows       | False          |
| on cygwin        | False          |
| is superuser     | False          |
| default encoding | utf-8          |
| git SHA          | g65b3b06       |
+------------------+----------------+
```