### PR TITLE
Anaconda config

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -12,7 +12,7 @@ script:
   - conda build recipe
 
 after_success:
-   - conda convert -p all /opt/miniconda/conda-bld/linux-64/xonsh-*.tar.bz2 -o /opt/miniconda/conda-bld
+   - conda convert -p all -f /opt/miniconda/conda-bld/linux-64/xonsh-*.tar.bz2 -o /opt/miniconda/conda-bld
 
 after_failure:
    - echo "Build failed!"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,14 @@
 package:
   name: xonsh
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '0.0.0') }}
+  version: {{ GIT_DESCRIBE_TAG + '.dev' + GIT_DESCRIBE_NUMBER }}
 
 source:
-   git_url: ../
+   path: ../
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  number: 0
+  string: {{'py' + CONDA_PY + '_' + GIT_DESCRIBE_HASH }}
   skip: True  # [py2k]
   entry_points:
     - xonsh = xonsh.main:main


### PR DESCRIPTION
This updates the conda build configuration for the xonsh/channel/dev packages on Anaconda.org. The packages now get a version that matches what @gforsyth just made. 
```
...
The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    xonsh-0.4.2.dev1           |    py35_g84270d3         950 KB  xonsh
....
```

It also has a potential fix for missing Windows developer builds. Apparently, conda-convert have started to refuse to convert to windows because entry-point conversion is not supported. This is not a problem because we supply a xonsh.bat file in scripts as a fallback. 