### PR TITLE
Background pkg_resource import

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -150,7 +150,7 @@ class _LazyModule(_ModuleType):
             pkg = dct['pkg']
             asname = dct['asname']
             if asname is None:
-                glbs[pkg] = _modules[pkg]
+                glbs[pkg] = m = _modules[pkg]
             else:
                 glbs[asname] = m
             dct['loaded'] = True

--- a/news/pkgrsrc.rst
+++ b/news/pkgrsrc.rst
@@ -1,0 +1,21 @@
+**Added:**
+
+* New ``xonsh.bg_pkg_resources`` module for loading the ``pkg_resources``
+  module in a background thread.
+
+**Changed:**
+
+* Sped up loading of pygments by ~100x by loading ``pkg_resources`` in
+  background.
+* Sped up loading of prompt-toolkit by ~2x-3x by loading ``pkg_resources``
+  in background.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Minor amalgamate bug with ``import pkg.mod`` amalgamated imports.
+
+**Security:** None

--- a/xonsh/__init__.py
+++ b/xonsh/__init__.py
@@ -9,6 +9,8 @@ else:
     import sys as _sys
     try:
         from xonsh import __amalgam__
+        bg_pkg_resources = __amalgam__
+        _sys.modules['xonsh.bg_pkg_resources'] = __amalgam__
         completer = __amalgam__
         _sys.modules['xonsh.completer'] = __amalgam__
         lazyasd = __amalgam__

--- a/xonsh/bg_pkg_resources.py
+++ b/xonsh/bg_pkg_resources.py
@@ -1,0 +1,44 @@
+"""Background thread loader for pkg_resources."""
+import os
+import sys
+import time
+import builtins
+import threading
+import importlib
+
+
+class PkgResourcesLoader(threading.Thread):
+    """Thread to load the pkg_resources module."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.daemon = True
+        self.start()
+
+    def run(self):
+        # wait for other modules to stop being imported
+        i = 0
+        last = -6
+        hist = [-5, -4, -3, -2, -1]
+        while not all(last == x for x in hist):
+            time.sleep(0.001)
+            last = hist[i%5] = len(sys.modules)
+            i += 1
+        # now import pkg_resources properly
+        if sys.modules['pkg_resources'] is None:
+            del sys.modules['pkg_resources']
+        pr = importlib.import_module('pkg_resources')
+        if 'pygments.plugin' in sys.modules:
+            sys.modules['pygments.plugin'].pkg_resources = pr
+
+
+def load_pkg_resources_in_background():
+    """Entry point for loading pkg_resources module in background."""
+    if 'pkg_resources' in sys.modules:
+        return
+    env = getattr(builtins, '__xonsh_env__', os.environ)
+    if env.get('XONSH_DEBUG', None):
+        import pkg_resources
+        return
+    sys.modules['pkg_resources'] = None
+    PkgResourcesLoader()

--- a/xonsh/ptk/__init__.py
+++ b/xonsh/ptk/__init__.py
@@ -1,0 +1,3 @@
+# must come before ptk / pygments imports
+from xonsh.bg_pkg_resources import load_pkg_resources_in_background
+load_pkg_resources_in_background()

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -9,6 +9,10 @@ from warnings import warn
 from collections import ChainMap
 from collections.abc import MutableMapping
 
+# must come before pygments imports
+from xonsh.bg_pkg_resources import load_pkg_resources_in_background
+load_pkg_resources_in_background()
+
 from pygments.lexer import inherit, bygroups, using, this
 from pygments.lexers.shell import BashLexer
 from pygments.lexers.agile import PythonLexer


### PR DESCRIPTION
The ugly head of the terrifying `pkg_resource` module shows its face again.  This provides a mechanism for importing this module in a background thread.  This has serious implications for the startup and load times of xonsh, pygments, and prompt toolkit.  

I have thrown some profiling into https://github.com/xonsh/import-profiling

Importing just pygments:

* with `pkg_resources`, [244 ms](https://xonsh.github.io/import-profiling/with_pkg_resources_pyg.html)
* without `pkg_resources`, [2.65 ms](https://xonsh.github.io/import-profiling/without_pkg_resources_pyg.html)

You can see importing pygments and prompt toolkit:

* with `pkg_resources`, [228 ms](https://xonsh.github.io/import-profiling/with_pkg_resources.html)
* without `pkg_resources`, [73 ms](https://xonsh.github.io/import-profiling/without_pkg_resources.html)

You can see importing pyghook:

* with `pkg_resources` in foreground, [246 ms](https://xonsh.github.io/import-profiling/xpyg-withoutbg.html)
* with `pkg_resources` in background, [80 ms](https://xonsh.github.io/import-profiling/xpyg-withbg.html)

You can see importing ptk.shortcuts:

* with `pkg_resources` in foreground, [292 ms](https://xonsh.github.io/import-profiling/xptk-withoutbg.html)
* with `pkg_resources` in background, [124 ms](https://xonsh.github.io/import-profiling/xptk-withbg.html)

So even though this is weird, I think it is worth having.

Really, pygments should move towards making the  `pkg_resources` imports truly lazy, [see pygments.plugin](https://bitbucket.org/birkenfeld/pygments-main/src/e79a7126551c39d5f8c1b83a79c14e86992155a4/pygments/plugin.py?at=default&fileviewer=file-view-default). However, this was easier than relearning hg and pygments doesn't seem to release that frequently anyways.