### PR TITLE
Catch FileNotFoundError when git is not on PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def dirty_version():
     try:
         _version = subprocess.check_output(['git', 'describe', '--tags'])
         _version = _version.decode('ascii')
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
 
     try:


### PR DESCRIPTION
This should fix https://github.com/xonsh/xonsh/issues/1350