### PR TITLE
Furthe fixes to meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: {{ GIT_DESCRIBE_TAG + '.dev' + GIT_DESCRIBE_NUMBER }}
 
 source:
-   path: ../
+   git_url: ../
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
Using 'path:' in meta.yaml seems to cause problems for Anaconda.org despite what the documentation says :/

This PR reverts that part. 