### PR TITLE
Add missing -r flag to pip install command in developer's guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -158,7 +158,7 @@ Dependencies
 
 Prep your environment for running the tests::
 
-    $ pip install requirements-tests.txt
+    $ pip install -r requirements-tests.txt
 
 
 ----------------------------------


### PR DESCRIPTION
At least on OSX, `pip install requirements-tests.txt` fails with:

    Collecting requirements-tests.txt
      Could not find a version that satisfies the requirement requirements-tests.txt (from versions: )
    No matching distribution found for requirements-tests.txt

`pip install -h` tells me:

    -r, --requirement <file>    Install from the given requirements file. This option can be used
                                multiple times.