### PR TITLE
Proposal: a better way to add optional items to the prompt

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1205,8 +1205,7 @@ By default, the following variables are available for use:
     ``/path/to/xonsh``.
   * ``cwd_base``: The basename of the current working directory, e.g. ``xonsh`` in
     ``/path/to/xonsh``.
-  * ``curr_branch``: The name of the current git branch (preceded by space),
-    if any.
+  * ``curr_branch``: The name of the current git branch, if any.
   * ``branch_color``: ``{BOLD_GREEN}`` if the current git branch is clean,
     otherwise ``{BOLD_RED}``. This is yellow if the branch color could not be
     determined.
@@ -1268,9 +1267,6 @@ For example:
     2 ~ $
     8 ~ $
 
-If a function in ``$FORMATTER_DICT`` returns ``None``, the ``None`` will be
-interpreted as an empty string.
-
 Environment variables and functions are also available with the ``$``
 prefix.  For example:
 
@@ -1278,6 +1274,36 @@ prefix.  For example:
 
     snail@home ~ $ $PROMPT = "{$LANG} >"
     en_US.utf8 >
+
+Note that some entries of the ``$FORMATTER_DICT`` are not always applicable, for
+example, ``curr_branch`` returns ``None`` if the current directory is not in a
+repository. The ``None`` will be interpreted as an empty string.
+
+But let's consider a problem:
+
+.. code-block:: console
+
+    snail@home ~/xonsh $ $PROMPT = "{cwd_base} [{curr_branch}] $ "
+    xonsh [master] $ cd ..
+    ~ [] $
+
+We want the branch to be displayed in square brackets, but we also don't want
+the brackets (and the extra space) to be displayed when there is no branch. The
+solution is to add a nested format string (separated with a colon) that will be
+invoked only if the value is not ``None``:
+
+.. code-block:: console
+
+    snail@home ~/xonsh $ $PROMPT = "{cwd_base}{curr_branch: [{}]} $ "
+    xonsh [master] $ cd ..
+    ~ $
+
+The curly brackets act as a placeholder, because the additional part is an
+ordinary format string. What we're doing here is equivalent to this expression:
+
+.. code-block:: python
+    " [{}]".format(curr_branch()) if curr_branch() is not None else ""
+
 
 Executing Commands and Scripts
 ==============================

--- a/news/prompt-optional-items.rst
+++ b/news/prompt-optional-items.rst
@@ -1,0 +1,33 @@
+**Added:**
+
+* A new way to add optional items to the prompt format string has been added.
+  Instead of relying on formatter dict items being padded with a space, now the
+  padding characters are specified in the format string itself, in place of the
+  format spec (after a ``:``).
+
+  For example, previously the prompt string ``{cwd}{curr_branch} $`` would rely
+  on ``curr_branch`` giving its output prepended with a space for separation,
+  or outputting nothing if it is not applicable. Now ``curr_branch`` just
+  outputs a value or ``None``, and the prompt string has to specify the
+  surrounding characters: ``{cwd}{curr_branch: {}} $``. Here the  value of
+  ``curr_branch`` will be prepended with a space (``{}`` is a placeholder for
+  the value itself). The format string after ``:`` is applied only if the value
+  is not ``None``.
+
+**Changed:**
+
+* Because of the addition of "optional items" to the prompt format string, the
+  functions ``xonsh.environ.current_branch``, ``xonsh.environ.env_name`` and
+  formatter dict items ``curr_branch``, ``current_job``, ``env_name`` are
+  no longer padded with a separator.
+
+**Deprecated:** None
+
+**Removed:**
+
+* ``xonsh.environ.format_prompt`` has been dropped; ``partial_format_prompt``
+  can be used instead.
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -64,6 +64,26 @@ def test_format_prompt():
         obs = partial_format_prompt(template=p, formatter_dict=formatter_dict)
         assert exp == obs
 
+def test_format_prompt_with_format_spec():
+    formatter_dict = {
+        'a_string': 'cats',
+        'a_number': 7,
+        'empty': '',
+        'current_job': (lambda: 'sleep'),
+        'none': (lambda: None),
+        }
+    cases = {
+        '{a_number:{0:^3}}cats': ' 7 cats',
+        '{current_job:{} | }xonsh': 'sleep | xonsh',
+        '{none:{} | }{a_string}{empty:!}': 'cats!',
+        '{none:{}}': '',
+        '{{{a_string:{{{}}}}}}': '{{cats}}',
+        '{{{none:{{{}}}}}}': '{}',
+        }
+    for p, exp in cases.items():
+        obs = partial_format_prompt(template=p, formatter_dict=formatter_dict)
+        assert exp == obs
+
 def test_format_prompt_with_broken_template():
     for p in ('{user', '{user}{hostname'):
         assert partial_format_prompt(p) == p

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -7,8 +7,8 @@ import builtins
 from tempfile import TemporaryDirectory
 from xonsh.tools import ON_WINDOWS
 
-from xonsh.environ import (Env, format_prompt, load_static_config,
-    locate_binary, partial_format_prompt)
+from xonsh.environ import (Env, load_static_config, locate_binary,
+    partial_format_prompt)
 
 from tools import mock_xonsh_env
 
@@ -61,21 +61,16 @@ def test_format_prompt():
         '{f} jawaka': 'wakka jawaka',
         }
     for p, exp in cases.items():
-        obs = format_prompt(template=p, formatter_dict=formatter_dict)
-        assert exp == obs
-    for p, exp in cases.items():
         obs = partial_format_prompt(template=p, formatter_dict=formatter_dict)
         assert exp == obs
 
 def test_format_prompt_with_broken_template():
     for p in ('{user', '{user}{hostname'):
         assert partial_format_prompt(p) == p
-        assert format_prompt(p) == p
 
     # '{{user' will be parsed to '{user'
     for p in ('{{user}', '{{user'):
         assert 'user' in partial_format_prompt(p)
-        assert 'user' in format_prompt(p)
 
 def test_format_prompt_with_broken_template_in_func():
     for p in (
@@ -86,14 +81,12 @@ def test_format_prompt_with_broken_template_in_func():
     ):
         # '{{user' will be parsed to '{user'
         assert 'user' in partial_format_prompt(p)
-        assert 'user' in format_prompt(p)
 
 def test_format_prompt_with_invalid_func():
     def p():
         foo = bar  # raises exception
         return '{user}'
     assert isinstance(partial_format_prompt(p), str)
-    assert isinstance(format_prompt(p), str)
 
 def test_HISTCONTROL():
     env = Env(HISTCONTROL=None)

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -13,7 +13,7 @@ from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
                              update_cache, run_compiled_code)
 from xonsh.completer import Completer
-from xonsh.environ import multiline_prompt, format_prompt, partial_format_prompt
+from xonsh.environ import multiline_prompt, partial_format_prompt
 
 
 class _TeeOut(object):
@@ -236,7 +236,7 @@ class BaseShell(object):
         t = env.get('TITLE')
         if t is None:
             return
-        t = format_prompt(t)
+        t = partial_format_prompt(t)
         if ON_WINDOWS and 'ANSICON' not in env:
             t = escape_windows_cmd_string(t)
             os.system('title {}'.format(t))

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1197,32 +1197,6 @@ def _failover_template_format(template):
     return template
 
 
-def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
-    try:
-        return _format_prompt_main(template, formatter_dict)
-    except Exception:
-        return _failover_template_format(template)
-
-
-def _format_prompt_main(template, formatter_dict):
-    """Formats a xonsh prompt template string."""
-    template = template() if callable(template) else template
-    fmtter = _get_fmtter(formatter_dict)
-    included_names = set(i[1] for i in _FORMATTER.parse(template))
-    fmt = {}
-    for name in included_names:
-        if name is None:
-            continue
-        if name.startswith('$'):
-            v = builtins.__xonsh_env__[name[1:]]
-        else:
-            v = fmtter[name]
-        val = v() if callable(v) else v
-        val = '' if val is None else val
-        fmt[name] = val
-    return template.format(**fmt)
-
-
 def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
     """Formats a xonsh prompt template string."""
     try:


### PR DESCRIPTION
To describe the situation, let's say my $PROMPT is:
```
{last_return} | {hostname}@{user} | {curr_branch} | {cwd} {prompt_end}
```
`last_return` is just something I came up with - the return status of the last executed program, let's say I don't want it displayed if it's zero. Similarly, `curr_branch` is the current git branch, which is not applicable most of the time. So I don't want my prompt to look like this most of the time:
```
 | hostname@user | | ~ $
```
I know that currently this is alleviated by adding spaces to the formatter dict items themselves, so I am supposed to write my prompt like this:
```
{last_return}{hostname}@{user}{curr_branch} {cwd} {prompt_end}
```
... and rely on `last_return` and `curr_branch` appending a space. But as I demonstrated, that is not flexible enough to do what I want (without reimplementing the formatter dict items to append a pipe instead). Especially if I want some optional part to come at the beginning/end of the format string.

What I propose is allowing users to write their prompt strings like this:

`{last_return:{} | }{hostname}@{user}{curr_branch: | {}} | {cwd} {prompt_end}`

... so that any desired separator can be picked. So, the format string will be applied to the value, like so: `'{} | '.format(formatter_dict['last_return']())`, except if `formatter_dict['last_return']()` returns `None` in the first place, then nothing will be inserted.

See for yourself how it affects the user: https://github.com/xonsh/xonsh/pull/1369/commits/f911613d
(This commit basically keeps the default behavior the same but simplfies and generalizes the implementation of formatter dict items)

Removing the reliance on hardcoded space-based separation from the standard formatter dict values will facilitate flexible implementation of prompt strings, even ones similar to [powerline](https://github.com/powerline/powerline#vim-statusline), without having to redefine half of the formatter dict itself.

As a bonus, sometimes it might be desirable to apply format specs to the values, so that will be possible now: `{last_return:{:3} | }`

Backwards compatibility:
The format specs were previously ignored anyway as far as I can see so this will not cause errors. However, it will cause some whitespace to disappear around the optional parts of $PROMPT strings that are unaware of this change.
