### PR TITLE
add xonda to xontribs

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -60,6 +60,11 @@
   "url": "https://github.com/Granitas/xonsh-autoxsh",
   "description": ["Adds automatic execution of xonsh script files called",
 	          "`.autoxsh` when enterting a directory with `cd` function"]
+ },
+ {"name": "xonda",
+  "package": "xonda",
+  "url": "https://github.com/gforsyth/xonda",
+  "description": ["A thin wrapper around conda with tab completion"]
  }
  ],
  "packages": {
@@ -119,6 +124,13 @@
    "url": "https://github.com/Granitas/xonsh-autoxsh",
    "install": {
     "pip": "pip install xonsh-autoxsh"
+   }
+  },
+  "xonda": {
+   "license": "MIT",
+   "url": "https://github.com/gforsyth/xonda",
+   "install": {
+    "pip": "pip install xonda"
    }
   }
  }


### PR DESCRIPTION
I wrote `xonda` as a thin wrapper around `conda`.  Instead of the (imo) messy activate and deactivate scripts, this just uses `xonsh` `PATH` magic to change environments.  And it has tab completion!  I have no idea if it works on Windows.  @melund -- do you want to try it out?