### PR TITLE
Don't use bare `except:`

### DIFF
--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -34,7 +34,7 @@ def partial_color_format(template, style='default', cmap=None, hide=False):
     """
     try:
         return _partial_color_format_main(template, style=style, cmap=cmap, hide=hide)
-    except:
+    except Exception:
         return template
 
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -551,7 +551,7 @@ def run_subproc(cmds, captured=False):
                 output = stdoutfile.read()
             try:
                 _nstdout.close()
-            except:
+            except Exception:
                 pass
             os.unlink(_stdout_name)
         elif prev_proc.stdout not in (None, sys.stdout):
@@ -572,7 +572,7 @@ def run_subproc(cmds, captured=False):
                     errout = stderrfile.read()
                 try:
                     _nstderr.close()
-                except:
+                except Exception:
                     pass
                 os.unlink(_stderr_name)
             elif unnamed:

--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -103,7 +103,7 @@ def compile_code(filename, code, execer, glb, loc, mode):
         old_filename = execer.filename
         execer.filename = filename
         ccode = execer.compile(code, glbs=glb, locs=loc, mode=mode)
-    except:
+    except Exception:
         raise
     finally:
         execer.filename = old_filename

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -25,7 +25,7 @@ def complete_from_man(prefix, line, start, end, ctx):
         try:
             with open(OPTIONS_PATH, 'rb') as f:
                 OPTIONS = pickle.load(f)
-        except:
+        except Exception:
             OPTIONS = {}
     if not prefix.startswith('-'):
         return set()
@@ -44,7 +44,7 @@ def complete_from_man(prefix, line, start, end, ctx):
             OPTIONS[cmd] = matches
             with open(OPTIONS_PATH, 'wb') as f:
                 pickle.dump(OPTIONS, f)
-        except:
+        except Exception:
             return set()
     return {s for s in OPTIONS[cmd]
             if get_filter_function()(s, prefix)}

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1200,7 +1200,7 @@ def _failover_template_format(template):
 def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
     try:
         return _format_prompt_main(template, formatter_dict)
-    except:
+    except Exception:
         return _failover_template_format(template)
 
 
@@ -1228,7 +1228,7 @@ def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
     try:
         return _partial_format_prompt_main(template=template,
                                            formatter_dict=formatter_dict)
-    except:
+    except Exception:
         return _failover_template_format(template)
 
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -40,7 +40,7 @@ elif ON_CYGWIN:
             for pid in job['pids']:
                 try:
                     os.kill(pid, signal)
-                except:
+                except Exception:
                     pass
 else:
     def _send_signal(job, signal):
@@ -49,7 +49,7 @@ else:
             for pid in job['pids']:
                 try:
                     os.kill(pid, signal)
-                except:
+                except Exception:
                     pass
         else:
             os.killpg(job['pgrp'], signal)

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -17,7 +17,7 @@ def _distro():
         import distro as d
     except ImportError:
         d = None
-    except:
+    except Exception:
         raise
     return d
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -206,7 +206,7 @@ def partial_color_tokenize(template):
     color = Color.NO_COLOR
     try:
         toks, color = _partial_color_tokenize_main(template, styles)
-    except:
+    except Exception:
         toks = [(Color.NO_COLOR, template)]
     if styles is not None:
         styles[color]  # ensure color is available

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -78,7 +78,7 @@ def setup_readline():
             RL_COMPLETION_SUPPRESS_APPEND = None
         try:
             RL_STATE = ctypes.c_int.in_dll(lib, 'rl_readline_state')
-        except:
+        except Exception:
             pass
         RL_CAN_RESIZE = hasattr(lib, 'rl_reset_screen_size')
     env = builtins.__xonsh_env__
@@ -160,7 +160,7 @@ def fix_readline_state_after_ctrl_c():
             _q = readline.rl.mode.process_keyevent_queue
             if len(_q) > 1:
                 _q.pop()
-        except:
+        except Exception:
             pass
     if RL_STATE is None:
         return

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -531,7 +531,7 @@ def _tokopen(filename):
         text = TextIOWrapper(buffer, encoding, line_buffering=True)
         text.mode = 'r'
         return text
-    except:
+    except Exception:
         buffer.close()
         raise
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1270,7 +1270,7 @@ def _get_color_indexes(style_map):
                 rgb = (int(attr.color[0:2], 16),
                        int(attr.color[2:4], 16),
                        int(attr.color[4:6], 16))
-            except:
+            except Exception:
                 rgb = None
             yield token, index, rgb
 
@@ -1524,7 +1524,7 @@ def expandvars(path):
                             value = dollar + brace + '...' + rbrace
                         else:
                             value = dollar + brace + var + rbrace
-                    except:
+                    except Exception:
                         value = dollar + brace + var + rbrace
                     res += value
             else:


### PR DESCRIPTION
Bare `except:` also [catches](https://docs.python.org/3/library/exceptions.html#exception-hierarchy) SystemExit, KeyboardInterrupt, GeneratorExit, causing unexpected problems.

Fixes #1372