### PR TITLE
some amalgamate updates from @yaroslavvb

### DIFF
--- a/news/amalup.rst
+++ b/news/amalup.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* amalgamate now works on Python 2 and allows relative imports.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
These don't affect xonsh because they enable Python 2.7 support and relative imports, but I would like to keep this in sync with what is in the xonsh/amalgamate repo.