### PR TITLE
Implement basic comma-separated braces expansion

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -123,7 +123,9 @@ def expand_braces(s):
                 [prefix + middle + suffix for middle in middles] +
                 suffixes
             )
-    return ' '.join(_split_braces(s))
+    if regex.fullmatch(s):
+        return ' '.join(_split_braces(s))
+    return s
 
 
 def reglob(path, parts=None, i=None):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -98,6 +98,34 @@ def expand_path(s):
     return os.path.expanduser(s)
 
 
+def expand_braces(s):
+    # XXX: Doesn't handle escaping literal braces
+    """Takes a string and expands brace-enclosed comma-separated lists into
+    space-separated arguments.
+    """
+    regex = re.compile('(.*?){(.*)}(.*)')
+    def _split_braces(s, nesting=0):
+        matches = regex.fullmatch(s)
+        prefix, middle, suffix = matches.groups()
+        if regex.fullmatch(middle):
+            middles = _split_braces(middle, nesting + 1)
+        else:
+            middles = middle.split(',')
+        if not nesting:
+            return [prefix + middle + suffix for middle in middles]
+        else:
+            prefixes = prefix.split(',')
+            suffixes = suffix.split(',')
+            prefix, prefixes = prefixes[-1], prefixes[:-1]
+            suffix, suffixes = suffixes[0], suffixes[1:]
+            return (
+                prefixes +
+                [prefix + middle + suffix for middle in middles] +
+                suffixes
+            )
+    return ' '.join(_split_braces(s))
+
+
 def reglob(path, parts=None, i=None):
     """Regular expression-based globbing."""
     if parts is None:
@@ -692,6 +720,7 @@ def load_builtins(execer=None, config=None, login=False, ctx=None):
     builtins.__xonsh_regexsearch__ = regexsearch
     builtins.__xonsh_glob__ = globpath
     builtins.__xonsh_expand_path__ = expand_path
+    builtins.__xonsh_expand_braces__ = expand_braces
     builtins.__xonsh_exit__ = False
     builtins.__xonsh_stdout_uncaptured__ = None
     builtins.__xonsh_stderr_uncaptured__ = None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1552,6 +1552,7 @@ def globpath(s, ignore_case=False, return_empty=False, sort_result=None):
 
 
 def _iglobpath(s, ignore_case=False, sort_result=None):
+    s = builtins.__xonsh_expand_braces__(s)
     s = builtins.__xonsh_expand_path__(s)
     if sort_result is None:
         sort_result = builtins.__xonsh_env__.get('GLOB_SORTED')

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1552,7 +1552,6 @@ def globpath(s, ignore_case=False, return_empty=False, sort_result=None):
 
 
 def _iglobpath(s, ignore_case=False, sort_result=None):
-    s = builtins.__xonsh_expand_braces__(s)
     s = builtins.__xonsh_expand_path__(s)
     if sort_result is None:
         sort_result = builtins.__xonsh_env__.get('GLOB_SORTED')


### PR DESCRIPTION
Everything in the title, yet for some reason `echo "{1,2}"` doesn't yield the expected result, while manually invoking `from xonsh.tools import expand_case_matching; expand_case_matching('{1,2}')` works.

Please help ^__^
