### PR TITLE
Fix typo in LazyDict.__delitem__

### DIFF
--- a/xonsh/lazyasd.py
+++ b/xonsh/lazyasd.py
@@ -128,7 +128,7 @@ class LazyDict(abc.MutableMapping):
 
     def __delitem__(self, key):
         if key in self._d:
-            del self._d[lkey]
+            del self._d[key]
         else:
             del self._loaders[key]
             self._destruct()


### PR DESCRIPTION
The only visible result of this error would probably be when not all values from this LazyDict were loaded and xonsh would have been closed at that point. So not very likely :-)

Closes: https://github.com/xonsh/xonsh/issues/1382

[PR done via the github web ui...]