### PR TITLE
WIP Collecting `test*.xsh` files when testing

### DIFF
--- a/news/test_xsh.rst
+++ b/news/test_xsh.rst
@@ -1,0 +1,12 @@
+**Added:** 
+* Added a local py.test framwork to collect and run `test_*.xsh` files. 
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/test_xsh.rst
+++ b/news/test_xsh.rst
@@ -1,5 +1,6 @@
 **Added:** 
-* Added a local py.test framwork to collect and run `test_*.xsh` files. 
+
+* Added a py.test plugin to collect `test_*.xsh` files and run `test_*()` functions. 
 
 **Changed:** None
 

--- a/setup.py
+++ b/setup.py
@@ -310,7 +310,7 @@ def main():
         skw['entry_points'] = {
             'pygments.lexers': ['xonsh = xonsh.pyghooks:XonshLexer',
                                 'xonshcon = xonsh.pyghooks:XonshConsoleLexer'],
-            'pytest11': ['xonsh = xonsh.pytest_plugin'] 
+            'pytest11': ['xonsh = xonsh.pytest_plugin']
         }
         skw['cmdclass']['develop'] = xdevelop
     setup(**skw)
@@ -318,4 +318,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/setup.py
+++ b/setup.py
@@ -310,10 +310,12 @@ def main():
         skw['entry_points'] = {
             'pygments.lexers': ['xonsh = xonsh.pyghooks:XonshLexer',
                                 'xonshcon = xonsh.pyghooks:XonshConsoleLexer'],
-            }
+            'pytest11': ['xonsh = xonsh.pytest_plugin'] 
+        }
         skw['cmdclass']['develop'] = xdevelop
     setup(**skw)
 
 
 if __name__ == '__main__':
     main()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from xonsh.built_ins import ensure_list_of_strs
 from xonsh.execer import Execer
 from xonsh.tools import XonshBlockError
 from xonsh.events import events
-import glob
 
 from tools import DummyShell, sp
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,6 @@ from xonsh.events import events
 
 from tools import DummyShell, sp
 
-pytest_plugins = ("xonsh.pytest_plugin",)
-
 
 @pytest.fixture
 def xonsh_execer(monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,53 +1,19 @@
 import glob
 import builtins
-from traceback import format_list, extract_tb
 
 import pytest
-from tools import DummyShell, sp
+
 import xonsh.built_ins
+
 from xonsh.built_ins import ensure_list_of_strs
 from xonsh.execer import Execer
 from xonsh.tools import XonshBlockError
 from xonsh.events import events
 import glob
 
+from tools import DummyShell, sp
 
-
-def _limited_traceback(excinfo):
-    """ Return a formatted traceback with all the stack
-        from this frame (i.e __file__) up removed
-    """
-    tb = extract_tb(excinfo.tb)
-    try:
-        idx = [__file__ in e for e in tb].index(True)
-        return format_list(tb[idx+1:])
-    except ValueError:
-        return format_list(tb)
-
-def pytest_collect_file(parent, path):
-    if path.ext == ".xsh" and path.basename.startswith("test"):
-        return XshFile(path, parent)
-
-class XshFile(pytest.File):
-    def collect(self):
-        name = self.fspath.basename
-        yield XshItem(name, self)
-
-class XshItem(pytest.Item):
-    def __init__(self, name, parent):
-        super().__init__(name, parent)
-
-    def runtest(self):
-        xonsh_main([str(self.parent.fspath), '--no-script-cache', '--no-rc'])
-
-    def repr_failure(self, excinfo):
-        """ called when self.runtest() raises an exception. """
-        formatted_tb = _limited_traceback(excinfo)
-        formatted_tb.insert(0, "Xonsh execution failed\n")
-        return "".join(formatted_tb)
-
-    def reportinfo(self):
-        return self.fspath, 0, "usecase: %s" % self.name
+pytest_plugins = ("xonsh.pytest_plugin",)
 
 
 @pytest.fixture

--- a/tests/test_xonsh.xsh
+++ b/tests/test_xonsh.xsh
@@ -1,0 +1,19 @@
+
+
+assert 1 + 1 == 2
+
+
+$USER = 'snail'
+
+x = 'USER'
+assert x in ${...}
+assert ${'U' + 'SER'} == 'snail'
+
+
+echo "Yoo hoo"
+$(echo $USER)
+
+x = 'xonsh'
+y = 'party'
+out = $(echo @(x + ' ' + y))
+assert out == 'xonsh party\n'

--- a/tests/test_xonsh.xsh
+++ b/tests/test_xonsh.xsh
@@ -1,19 +1,18 @@
 
 
-assert 1 + 1 == 2
+def test_simple():
+  assert 1 + 1 == 2
 
+  
+def test_envionment():
+  $USER = 'snail'
+  x = 'USER'
+  assert x in ${...}
+  assert ${'U' + 'SER'} == 'snail'
 
-$USER = 'snail'
-
-x = 'USER'
-assert x in ${...}
-assert ${'U' + 'SER'} == 'snail'
-
-
-echo "Yoo hoo"
-$(echo $USER)
-
-x = 'xonsh'
-y = 'party'
-out = $(echo @(x + ' ' + y))
-assert out == 'xonsh party\n'
+  
+def test_xonsh_party():
+  x = 'xonsh'
+  y = 'party'
+  out = $(echo @(x + ' ' + y))
+  assert out == 'xonsh party\n'

--- a/xonsh/__init__.py
+++ b/xonsh/__init__.py
@@ -1,7 +1,7 @@
 __version__ = '0.4.5'
 
 # amalgamate exclude jupyter_kernel parser_table parser_test_table pyghooks
-# amalgamate exclude winutils wizard
+# amalgamate exclude winutils wizard pytest_plugin
 import os as _os
 if _os.getenv('XONSH_DEBUG', ''):
     pass

--- a/xonsh/pytest_plugin.py
+++ b/xonsh/pytest_plugin.py
@@ -1,13 +1,13 @@
 import sys
 import importlib
-from traceback import format_list, extract_tb, format_exception
+from traceback import format_list, extract_tb
 
 import pytest
-import xonsh.imphooks
+from xonsh import imphooks
 
 
 def pytest_configure(config):
-    xonsh.imphooks.install_hook()
+    imphooks.install_hook()
 
 
 def pytest_collection_modifyitems(items):
@@ -57,7 +57,7 @@ class XshFunction(pytest.Item):
         """ called when self.runtest() raises an exception. """
         formatted_tb = _limited_traceback(excinfo)
         formatted_tb.insert(0, "xonsh execution failed\n")
-        formatted_tb.append(excinfo.type.__name__ +": " + str(excinfo.value))
+        formatted_tb.append('{}: {}'.format(excinfo.type.__name__, excinfo.value))
         return "".join(formatted_tb)
 
     def reportinfo(self):

--- a/xonsh/pytest_plugin.py
+++ b/xonsh/pytest_plugin.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Pytest plugin for testing xsh files."""
 import sys
 import importlib
 from traceback import format_list, extract_tb

--- a/xonsh/pytest_plugin.py
+++ b/xonsh/pytest_plugin.py
@@ -5,11 +5,11 @@ import importlib
 from traceback import format_list, extract_tb
 
 import pytest
-from xonsh import imphooks
+from xonsh.imphooks import install_hook
 
 
 def pytest_configure(config):
-    imphooks.install_hook()
+    install_hook()
 
 
 def pytest_collection_modifyitems(items):

--- a/xonsh/pytest_plugin.py
+++ b/xonsh/pytest_plugin.py
@@ -1,0 +1,57 @@
+import sys
+import importlib
+from traceback import format_list, extract_tb
+
+import pytest
+import xonsh.imphooks
+
+
+def pytest_configure(config):
+    xonsh.imphooks.install_hook()
+
+
+def _limited_traceback(excinfo):
+    """ Return a formatted traceback with all the stack
+        from this frame (i.e __file__) up removed
+    """
+    tb = extract_tb(excinfo.tb)
+    try:
+        idx = [__file__ in e for e in tb].index(True)
+        return format_list(tb[idx+1:])
+    except ValueError:
+        return format_list(tb)
+
+
+def pytest_collect_file(parent, path):
+    if path.ext.lower() == ".xsh" and path.basename.startswith("test_"):
+        return XshFile(path, parent)
+
+
+class XshFile(pytest.File):
+    def collect(self):
+        sys.path.append(self.fspath.dirname)
+        mod = importlib.import_module(self.fspath.purebasename)
+        sys.path.pop(0)
+        tests = [t for t in dir(mod) if t.startswith('test_')]
+        for test_name in tests:
+            obj = getattr(mod, test_name)
+            if hasattr(obj, '__call__'):
+                yield XshItem(test_name, self, obj)
+
+
+class XshItem(pytest.Item):
+    def __init__(self, name, parent, test_func):
+        super().__init__(name, parent)
+        self._test_func = test_func
+
+    def runtest(self):
+        self._test_func()
+
+    def repr_failure(self, excinfo):
+        """ called when self.runtest() raises an exception. """
+        formatted_tb = _limited_traceback(excinfo)
+        formatted_tb.insert(0, "xonsh execution failed\n")
+        return "".join(formatted_tb)
+
+    def reportinfo(self):
+        return self.fspath, 0, "xonsh test: {}".format(self.name)


### PR DESCRIPTION
Very basic implementation. It runs all `test*.xsh` it finds during tests. Fails if they files raises an exception. 

Any other ideas are welcome. 