### PR TITLE
Fixing an error I encountered in the intro wizard

### DIFF
--- a/news/fix-name-error.rst
+++ b/news/fix-name-error.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Unqualified usage of Unstorable in xonsh setup wizard that was causing the
+  wizard to crash and burn
+
+**Security:** None

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -240,7 +240,7 @@ def make_xontrib(xontrib, package):
     if msg.endswith('\n'):
         msg = msg[:-1]
     mnode = wiz.Message(message=msg)
-    convert = lambda x: name if to_bool(x) else Unstorable
+    convert = lambda x: name if to_bool(x) else wiz.Unstorable
     pnode = wiz.StoreNonEmpty(XONTRIB_PROMPT, converter=convert,
                               path=_xontrib_path)
     return mnode, pnode


### PR DESCRIPTION
A `NameError` appeared in the xonsh wizard.  This PR fixes that.  Would it be
of interest to put a testing harness around this xonsh wizard code?  I'm not
really even sure how to go about doing that, but would be interested in working
on it if some guidance could be provided.

```
$ xonsh wizard
<snip>
Would you like to enable xontribs now, yes or no [default: no]? yes

distributed
url: http://xon.sh
package: xonsh
license: BSD 3-clause
installed? yes
The distributed parallel computing library hooks for xonsh.
Importantly this provides a subsitute 'dworker' command which enables
distributed workers to have access to xonsh builtins.

Furthermore, this xontrib adds a 'DSubmitter' context manager for
executing a block remotely. Moroever, this also adds a convienece
function 'dsubmit()' for creating DSubmitter and Executor instances
at the same time. Thus users may submit distributed jobs with::

    with dsubmit('127.0.0.1:8786', rtn='x') as dsub:
        x = $(echo I am elsewhere)

    res = dsub.future.result()
    print(res)

This is useful for long running or non-blocking jobs.
Add this xontrib, yes or no [default: no]? no
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
NameError: name 'Unstorable' is not defined
```