### PR TITLE
update the osx guide

### DIFF
--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -28,7 +28,7 @@ You can install xonsh using homebrew, conda, pip, or from source.
 
 .. code-block:: bash
 
-    $ pip install xonsh
+    $ pip3 install xonsh
 
 
 **source:** Download the source `from github <https://github.com/xonsh/xonsh>`_
@@ -37,19 +37,26 @@ the following from the source directory,
 
 .. code-block:: bash
 
-    $ python setup.py install
+    $ python3 setup.py install
 
 
-.. include:: add_to_shell.rst
-
-.. include:: dependencies.rst
-
-
-GNU Readline
-============
+Extras for OSX
+==============
 
 On Mac OSX, it is *strongly* recommended to install the ``gnureadline`` library if using the readline shell.  ``gnureadline`` can be installed via pip:
 
 .. code-block:: bash
 
-    $ pip install gnureadline
+    $ pip3 install gnureadline
+
+Xonsh has support for using bash completion files on the shell, to use it you need to install the bash-completion package
+
+.. code-block:: bash
+
+    $ brew install bash-completion
+
+
+
+.. include:: add_to_shell.rst
+
+.. include:: dependencies.rst


### PR DESCRIPTION
- Python 3 default binaries instead of leaving it open for interpretation
- Moved the readline comment up (seems important)
- Put a line about bash-completion