### PR TITLE
remove unneded echo

### DIFF
--- a/docs/add_to_shell.rst
+++ b/docs/add_to_shell.rst
@@ -13,7 +13,7 @@ Then, as root, add xonsh to the shell list
 
 .. code-block:: bash
 
-   # echo $(which xonsh) >> /etc/shells
+   # which xonsh >> /etc/shells
 
 To change shells, run
 


### PR DESCRIPTION
I'm not sure why it was there, but tested on bash and xonsh and it doesn't seem to be needed.