### PR TITLE
Fix windows title

### DIFF
--- a/news/windows-settitle.rst
+++ b/news/windows-settitle.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed bug on Windows preventing xonsh from changing the console title.
+
+**Security:** None

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -231,7 +231,8 @@ class BaseShell(object):
         term = env.get('TERM', None)
         # Shells running in emacs sets TERM to "dumb" or "eterm-color".
         # Do not set title for these to avoid garbled prompt.
-        if term is None or term in ['dumb', 'eterm-color', 'linux']:
+        if (term is None and not ON_WINDOWS) or term in ['dumb', 'eterm-color',
+                                                         'linux']:
             return
         t = env.get('TITLE')
         if t is None:


### PR DESCRIPTION
$TERM is not set on Windows. This prevented xonsh from ever setting the title on the console window. 