### PR TITLE
attempt at new tab PWD for vte

### DIFF
--- a/docs/linux.rst
+++ b/docs/linux.rst
@@ -92,7 +92,6 @@ lines to your ``~/.bashrc file``:
 
 Default Ubuntu .bashrc breaks Foreign Shell Functions
 =====================================================
-
 Xonsh supports importing functions from foreign shells using the
 `ForeignShellFunctionAlias` class, which calls functions as if they were
 aliases. This is implemented by executing a command that sources the file
@@ -103,7 +102,7 @@ The default user `~/.bashrc` file in Ubuntu 15.10 has the following snippet at
 the top, which causes the script to exit immediately if not run interactively.
 
 .. code-block:: bash
-                
+
     # If not running interactively, don't do anything
     case $- in
         *i*) ;;
@@ -114,3 +113,17 @@ This means that any function you have added to the file after this point will be
 registered as a xonsh alias but will fail on execution. Previous versions of
 Ubuntu have a different test for interactivity at the top of the file that
 yields the same problem.
+
+
+New Terminal Tabs Do Not Start in Correct Directory
+===================================================
+If you use Gnome Terminal or another VTE terminal and it doesn't start new tabs
+in the CWD of the original TAB, this is because of a custom VTE interface. To
+fix this, please add ``{vte_new_tab_cwd}`` somewhere to you prompt:
+
+.. code-block:: xonsh
+
+    $PROMPT = '{vte_new_tab_cwd}' + $PROMPT
+
+This will issue the proper escape sequence to the terminal without otherwise
+affecting the displayed prompt.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1211,9 +1211,11 @@ By default, the following variables are available for use:
     determined.
   * ``branch_bg_color``: Like, ``{branch_color}``, but sets a background color
     instead.
-  * ``prompt_end``: `#` if the user has root/admin permissions `$` otherwise
+  * ``prompt_end``: ``#`` if the user has root/admin permissions ``$`` otherwise
   * ``current_job``: The name of the command currently running in the
     foreground, if any.
+  * ``vte_new_tab_cwd``: Issues VTE escape sequence for opening new tabs in the
+    current working directory on some linux terminals. This is not usually needed.
 
 You can also color your prompt easily by inserting keywords such as ``{GREEN}``
 or ``{BOLD_BLUE}``.  Colors have the form shown below:

--- a/news/vte.rst
+++ b/news/vte.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Certain linux VTE terminals would not start new tabs in the previous CWD.
+  This may now be rectified by adding ``{vte_new_tab_cwd}`` somewhere to the
+  prompt.
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1170,7 +1170,13 @@ else:
     USER = 'USER'
 
 
-def new_vte_cwd():
+def vte_new_tab_cwd():
+    """This prints an escape squence that tells VTE terminals the hostname
+    and pwd. This should not be needed in most cases, but sometimes is for
+    certain Linux terminals that do not read the PWD from the environment
+    on startup. Note that this does not return a string, it simply prints
+    and flushes the escape sequence to stdout directly.
+    """
     env = builtins.__xonsh_env__
     t = '\033]7;file://{}{}\007'
     s = t.format(env.get('HOSTNAME'), env.get('PWD'))
@@ -1190,7 +1196,7 @@ FORMATTER_DICT = LazyObject(lambda: dict(
     branch_bg_color=branch_bg_color,
     current_job=_current_job,
     env_name=env_name,
-    new_vte_cwd=new_vte_cwd,
+    vte_new_tab_cwd=vte_new_tab_cwd,
     ), globals(), 'FORMATTER_DICT')
 
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1170,6 +1170,13 @@ else:
     USER = 'USER'
 
 
+def new_vte_cwd():
+    env = builtins.__xonsh_env__
+    t = '\033]7;file://{}{}\007'
+    s = t.format(env.get('HOSTNAME'), env.get('PWD'))
+    print(s, end='', flush=True)
+
+
 FORMATTER_DICT = LazyObject(lambda: dict(
     user=os.environ.get(USER, '<user>'),
     prompt_end='#' if is_superuser() else '$',
@@ -1183,6 +1190,7 @@ FORMATTER_DICT = LazyObject(lambda: dict(
     branch_bg_color=branch_bg_color,
     current_job=_current_job,
     env_name=env_name,
+    new_vte_cwd=new_vte_cwd,
     ), globals(), 'FORMATTER_DICT')
 
 


### PR DESCRIPTION
Hey @dotsdl @uy-do-or-die can you try this and let us know! You need to add this to the front or end of your prompt, to get this to work:

Try `$PROMPT = '{new_vte_cwd}' + $PROMPT` and if that doesn't work, then please try `$PROMPT = $PROMPT + '{new_vte_cwd}'`

This is an attempt to fix #1253