### PR TITLE
Conda env parentheses

### DIFF
--- a/news/conda_env_paren.rst
+++ b/news/conda_env_paren.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* Show conda environement name in prompt in parentheses similiar what conda does. 
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1157,7 +1157,6 @@ def env_name(pre_chars='(', post_chars=')'):
     """
     env_path = builtins.__xonsh_env__.get('VIRTUAL_ENV', '')
     if len(env_path) == 0 and ON_ANACONDA:
-        pre_chars, post_chars = '[', ']'
         env_path = builtins.__xonsh_env__.get('CONDA_DEFAULT_ENV', '')
     env_name = os.path.basename(env_path)
     if env_name:


### PR DESCRIPTION
Conda's own activate/deactivate script has switched from brackets to parentheses when showing the environment name in the prompt. This PR does the same 