### PR TITLE
branch space fix

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -984,7 +984,7 @@ def current_branch(pad=NotImplemented):
     if isinstance(branch, subprocess.TimeoutExpired):
         branch = '<branch-timeout>'
         _first_branch_timeout_message()
-    return branch
+    return branch or None
 
 
 def git_dirty_working_directory(cwd=None, include_untracked=False):


### PR DESCRIPTION
When the branch name in an empty string for the default prompt, there would sometime be two spaces.  This fixes that issue.  @Carreau and I discussed this at SciPy