### PR TITLE
WIP: Add MacOS/OSX hosts to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 language: python
-python:
-  - 3.4
-  - 3.5
-  - "nightly"
+
+matrix:
+    include:
+        - os: linux
+          python: "nightly"
+          env: TOXENV=py36
+        - os: linux
+          python: 3.5
+          env: TOXENV=py35
+        - os: linux
+          python: 3.4
+          env: TOXENV=py34
+        - os: osx
+          language: generic
+          env: TOXENV=py35
+        - os: osx
+          language: generic
+          env: TOXENV=py34
 install:
-  - pip install -r requirements-tests.txt
+    - ./install.sh
 script:
-  - coverage run --source xonsh -m py.test -q
+  - python3 -m coverage run --source xonsh -m py.test -v --timeout=10 tests/
 after_success:
   - codecov

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    case "${TOXENV}" in
+        py35)
+            # Install Python 3.5 from source
+            wget https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz
+            tar -xf Python-3.5.2.tar.xz
+            cd Python-3.5.2
+            ./configure
+            make
+            make install
+            cd ..
+            rm -rf Python-3.5.2
+        ;;
+        py34)
+            # Install Python 3.4 from source
+            wget https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz
+            tar -xf Python-3.4.3.tar.xz
+            cd Python-3.4.3
+            ./configure
+            make
+            make install
+            cd ..
+            rm -rf Python-3.4.3
+        ;;
+    esac
+fi
+
+pip3 install -r requirements-tests.txt

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 ply
-pytest
+pytest==2.9.1
+pytest-timeout
 prompt-toolkit
 pygments
 coverage


### PR DESCRIPTION
Using https://docs.travis-ci.com/user/multi-os/ to test on MacOS/OSX with Python version 3.4 and 3.5.

As Travis doesn't support Python on MacOS/OSX yet, it get slightly hacky ... but not too bad.

I also added a `pytest-timeouts` testing dependency. I can definitely remove this, but I find it greatly helps find tests that hang ...