### PR TITLE
Improve first set of "Developer's Guide" instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,6 +15,22 @@ develop xonsh.
 
 .. note:: All code changes must go through the pull request review procedure.
 
+
+Making Your First Change
+========================
+
+First, install xonsh from source and open a xonsh shell in your favorite terminal application. See installation instructions for details.
+
+Next, make a trivial change (e.g. ``print("hello!")`` in ``main.py``).
+
+Finally, run the following commands. You should see the effects of your change (e.g. ``hello!``)::
+
+        $ $XONSH_DEBUG=1
+        $ xonsh
+
+The xonsh build process collapses all Python source files into a single ``__amalgam__.py`` file. When xonsh is started with a falsy value for `$XONSH_DEBUG <envvars.html>`_, it imports Python modules straight from ``__amalgam__.py``, which decreases startup times by eliminating the cost of runtime imports. But setting ``$ $XONSH_DEBUG=1`` will suppress amalgamated imports. Reloading the xonsh shell (``$ xonsh``) won't simply import the stale ``__amalgam__.py`` file that doesn't contain your new change, but will instead import the unamalgamated source code which does contain your change. You can now load every subsequent change by reloading xonsh, and if your code changes don't seem to have any effect, make sure you check ``$XONSH_DEBUG`` first!
+
+
 Changelog
 =========
 Pull requests will often have CHANGELOG entries associated with. However,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -244,7 +244,9 @@ Contributing
 We highly encourage contributions to xonsh!  If you would like to contribute,
 it is as easy as forking the repository on GitHub, making your changes, and
 issuing a pull request.  If you have any questions about this process don't
-hesitate to ask the mailing list (xonsh@googlegroups.com).
+hesitate to ask the mailing list (xonsh@googlegroups.com) or the `Gitter <https://gitter.im/xonsh/xonsh>`_ channel.
+
+See the `Developer's Guide <devguide.html>`_ for more information about contributing.
 
 ==========
 Contact Us


### PR DESCRIPTION
Prominently explain `$XONSH_DEBUG` and amalgamation. 

Explanations probably aren't perfect, but they will immensely help people make their first contribution.

Also link to the "Developer's Guide" from "Contributing" section of homepage.

https://github.com/xonsh/xonsh/issues/1341