### PR TITLE
Trim the heading g in Git SHA of xonfig

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,9 +121,10 @@ def dirty_version():
         open('xonsh/dev.githash', 'w').close()
         print('failed to parse git version', file=sys.stderr)
         return False
+    sha = sha.strip('g')
     replace_version(base, N)
     with open('xonsh/dev.githash', 'w') as f:
-        f.write(sha.strip('g'))
+        f.write(sha)
     print('wrote git version: ' + sha, file=sys.stderr)
     return True
 

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ def dirty_version():
         return False
     replace_version(base, N)
     with open('xonsh/dev.githash', 'w') as f:
-        f.write(sha)
+        f.write(sha.strip('g'))
     print('wrote git version: ' + sha, file=sys.stderr)
     return True
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -131,7 +131,7 @@ def githash():
     install_base = os.path.dirname(__file__)
     try:
         with open('{}/dev.githash'.format(install_base), 'r') as f:
-            sha = f.read().strip()
+            sha = f.read().strip(' g\n')
         if not sha:
             sha = None
     except FileNotFoundError:

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -131,7 +131,7 @@ def githash():
     install_base = os.path.dirname(__file__)
     try:
         with open('{}/dev.githash'.format(install_base), 'r') as f:
-            sha = f.read().strip(' g\n')
+            sha = f.read().strip()
         if not sha:
             sha = None
     except FileNotFoundError:


### PR DESCRIPTION
The g in `Git SHA` makes no sense other than look similar to `[9a-f]`.. Let's trim it!

```
+------------------+--------------+
| xonsh            | 0.4.3.dev209 |
| Git SHA          | gd32819f     |
| Python           | 3.5.2        |
| PLY              | 3.7          |
| have readline    | True         |
| prompt toolkit   | 1.0.3        |
| shell type       | readline     |
| pygments         | 2.1.3        |
| on posix         | True         |
| on linux         | False        |
| on darwin        | True         |
| on windows       | False        |
| on cygwin        | False        |
| is superuser     | False        |
| default encoding | utf-8        |
+------------------+--------------+
```