### PR TITLE
Vox API

### DIFF
--- a/docs/api/vox.rst
+++ b/docs/api/vox.rst
@@ -1,10 +1,10 @@
 .. _xonsh_vox:
 
 ******************************************************
-Vox (``xontrib.vox``)
+Vox (``xontrib.voxapi``)
 ******************************************************
 
-.. automodule:: xontrib.vox
+.. automodule:: xontrib.voxapi
     :members:
     :undoc-members:
     :inherited-members:

--- a/docs/api/vox.rst
+++ b/docs/api/vox.rst
@@ -1,10 +1,10 @@
 .. _xonsh_vox:
 
 ******************************************************
-Vox (``xonsh.vox``)
+Vox (``xontrib.vox``)
 ******************************************************
 
-.. automodule:: xonsh.vox
+.. automodule:: xontrib.vox
     :members:
     :undoc-members:
     :inherited-members:

--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -13,6 +13,10 @@ Luckily, xonsh ships with its own virtual environments manager called **Vox**.
 Vox
 ===
 
+First, load the vox xontrib::
+
+    $ xontrib load vox
+
 To create a new environment with vox, run ``vox new <envname>``::
 
     $ vox new myenv

--- a/news/vox_api.rst
+++ b/news/vox_api.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* A new API class was added to Vox: ``xontrib.vox.Vox``. This allows programtic access to the virtual environment machinery for other xontribs. See the API documentation for details.
+* A new API class was added to Vox: ``xontrib.voxapi.Vox``. This allows programtic access to the virtual environment machinery for other xontribs. See the API documentation for details.
 
 **Changed:** 
 

--- a/news/vox_api.rst
+++ b/news/vox_api.rst
@@ -1,0 +1,15 @@
+**Added:**
+
+* A new API class was added to Vox: ``xontrib.vox.Vox``. This allows programtic access to the virtual environment machinery for other xontribs. See the API documentation for details.
+
+**Changed:** 
+
+* Vox was moved to xontrib. Behaves exactly the same as before, just need to add it to your xontribs.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -1,0 +1,39 @@
+"""Vox tests"""
+
+import builtins
+import stat
+import os
+from xonsh.vox import Vox
+
+def test_crud(xonsh_builtins, tmpdir):
+    """
+    Creates a virtual environment, gets it, enumerates it, and then deletes it.
+    """
+    xonsh_builtins.__xonsh_env__['VIRTUALENV_HOME'] = str(tmpdir)
+    vox = Vox()
+    vox.create('spam')
+    assert stat.S_ISDIR(tmpdir.join('spam').stat().mode)
+
+    env, bin = vox['spam']
+    assert env == str(tmpdir.join('spam'))
+    assert os.path.isdir(bin)
+
+    assert 'spam' in vox
+
+    del vox['spam']
+
+    assert not tmpdir.join('spam').check()
+
+def test_activate(xonsh_builtins, tmpdir):
+    """
+    Creates a virtual environment, gets it, enumerates it, and then deletes it.
+    """
+    xonsh_builtins.__xonsh_env__['VIRTUALENV_HOME'] = str(tmpdir)
+    # I consider the case that the user doesn't have a PATH set to be unreasonable
+    xonsh_builtins.__xonsh_env__.setdefault('PATH', [])
+    vox = Vox()
+    vox.create('spam')
+    vox.activate('spam')
+    assert xonsh_builtins.__xonsh_env__['VIRTUAL_ENV'] == vox['spam'].env
+    vox.deactivate()
+    assert 'VIRTUAL_ENV' not in xonsh_builtins.__xonsh_env__

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -3,7 +3,7 @@
 import builtins
 import stat
 import os
-from xontrib.vox import Vox
+from xontrib.voxapi import Vox
 
 def test_crud(xonsh_builtins, tmpdir):
     """

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -3,7 +3,7 @@
 import builtins
 import stat
 import os
-from xonsh.vox import Vox
+from xontrib.vox import Vox
 
 def test_crud(xonsh_builtins, tmpdir):
     """

--- a/xonsh/__init__.py
+++ b/xonsh/__init__.py
@@ -37,8 +37,6 @@ else:
         _sys.modules['xonsh.tokenize'] = __amalgam__
         tools = __amalgam__
         _sys.modules['xonsh.tools'] = __amalgam__
-        vox = __amalgam__
-        _sys.modules['xonsh.vox'] = __amalgam__
         ast = __amalgam__
         _sys.modules['xonsh.ast'] = __amalgam__
         contexts = __amalgam__

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -20,7 +20,7 @@ from xonsh.replay import replay_main
 from xonsh.timings import timeit_alias
 from xonsh.tools import (XonshError, argvquote, escape_windows_cmd_string,
                          to_bool)
-from xonsh.vox import Vox
+from xonsh.vox import VoxHandler
 from xonsh.xontribs import xontribs_main
 from xonsh.xoreutils import _which
 from xonsh.completers._aliases import completer_alias
@@ -460,7 +460,7 @@ def trace(args, stdin=None):
 
 def vox(args, stdin=None):
     """Runs Vox environment manager."""
-    vox = Vox()
+    vox = VoxHandler()
     return vox(args, stdin=stdin)
 
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -20,7 +20,6 @@ from xonsh.replay import replay_main
 from xonsh.timings import timeit_alias
 from xonsh.tools import (XonshError, argvquote, escape_windows_cmd_string,
                          to_bool)
-from xonsh.vox import VoxHandler
 from xonsh.xontribs import xontribs_main
 from xonsh.xoreutils import _which
 from xonsh.completers._aliases import completer_alias
@@ -458,12 +457,6 @@ def trace(args, stdin=None):
         pass
 
 
-def vox(args, stdin=None):
-    """Runs Vox environment manager."""
-    vox = VoxHandler()
-    return vox(args, stdin=stdin)
-
-
 def showcmd(args, stdin=None):
     """usage: showcmd [-h|--help|cmd args]
 
@@ -513,7 +506,6 @@ def make_default_aliases():
         'scp-resume': ['rsync', '--partial', '-h', '--progress', '--rsh=ssh'],
         'showcmd': showcmd,
         'ipynb': ['jupyter', 'notebook', '--no-browser'],
-        'vox': vox,
         'which': which,
         'xontrib': xontribs_main,
         'completer': completer_alias

--- a/xonsh/vox.py
+++ b/xonsh/vox.py
@@ -16,7 +16,7 @@ class NoEnvironmentActive(Exception): pass
 
 class Vox(collections.abc.Mapping):
     """API access to Vox and virtual environments, in a dict-like format.
-    
+
     Makes use of the VirtualEnvironment namedtuple:
     1. ``env``: The full path to the environment
     2. ``bin``: The full path to the bin/Scripts directory of the environment

--- a/xonsh/vox.py
+++ b/xonsh/vox.py
@@ -8,7 +8,7 @@ import builtins
 from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
 
 
-class Vox:
+class VoxHandler:
     """Vox is a virtual environment manager for xonsh."""
 
     def __init__(self):

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -22,6 +22,11 @@
   "description": ["Matplotlib hooks for xonsh, including the new 'mpl' alias ",
                   "that displays the current figure on the screen."]
   },
+ {"name": "vox",
+  "package": "xonsh",
+  "url": "http://xon.sh",
+  "description": ["Python virtual environment manager for xonsh."]
+  },
  {"name": "prompt_ret_code",
   "package": "xontrib-prompt-ret-code",
   "url": "https://github.com/Siecje/xontrib-prompt-ret-code",

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -308,3 +308,11 @@ class VoxHandler:
     vox help (-h, --help)
         Show help
 """)
+
+
+def _vox(args, stdin=None):
+    """Runs Vox environment manager."""
+    vox = VoxHandler()
+    return vox(args, stdin=stdin)
+
+aliases['vox'] = _vox

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -1,11 +1,14 @@
+"""Python virtual environment manager for xonsh."""
+
+import xontrib.voxapi as _voxapi
+
 class _VoxHandler:
     """Vox is a virtual environment manager for xonsh."""
 
     def __init__(self):
         """Ensure that $VIRTUALENV_HOME is defined and declare the available vox commands"""
 
-        import xontrib.voxapi
-        self.vox = xontrib.voxapi.Vox()
+        self.vox = _voxapi.Vox()
 
         self.commands = {
             ('new',): self.create_env,
@@ -104,7 +107,7 @@ class _VoxHandler:
         for name in names:
             try:
                 del self.vox[name]
-            except self.vox.EnvironmentInUse:
+            except _voxapi.EnvironmentInUse:
                 print('The "%s" environment is currently active. In order to remove it, deactivate it first with "vox deactivate %s".\n' % (name, name),
                       file=sys.stderr)
                 return

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -1,180 +1,11 @@
-"""Python virtual environment manager for xonsh."""
-import os
-import sys
-import venv
-import shutil
-import builtins
-import collections
-import collections.abc
-
-from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
-
-VirtualEnvironment = collections.namedtuple('VirtualEnvironment', ['env', 'bin'])
-
-class EnvironmentInUse(Exception): pass
-
-class NoEnvironmentActive(Exception): pass
-
-class Vox(collections.abc.Mapping):
-    """API access to Vox and virtual environments, in a dict-like format.
-
-    Makes use of the VirtualEnvironment namedtuple:
-
-    1. ``env``: The full path to the environment
-    2. ``bin``: The full path to the bin/Scripts directory of the environment
-    """
-
-    def __init__(self):
-        if not builtins.__xonsh_env__.get('VIRTUALENV_HOME'):
-            home_path = os.path.expanduser('~')
-            self.venvdir = os.path.join(home_path, '.virtualenvs')
-            builtins.__xonsh_env__['VIRTUALENV_HOME'] = self.venvdir
-        else:
-            self.venvdir = builtins.__xonsh_env__['VIRTUALENV_HOME']
-
-    def create(self, name):
-        """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
-
-        Parameters
-        ----------
-        name : str
-            Virtual environment name
-        """
-        env_path = os.path.join(self.venvdir, name)
-        venv.create(env_path, with_pip=True)
-
-    @staticmethod
-    def _binname():
-        if ON_WINDOWS:
-            return 'Scripts'
-        elif ON_POSIX:
-            return 'bin'
-        else:
-            raise OSError('This OS is not supported.')
-
-    def __getitem__(self, name):
-        """Get information about a virtual environment.
-
-        Parameters
-        ----------
-        name : str or Ellipsis
-            Virtual environment name or absolute path. If ... is given, return 
-            the current one (throws a KeyError if there isn't one).
-        """
-        if name is ...:
-            env_path = builtins.__xonsh_env__['VIRTUAL_ENV']
-        elif os.path.isabs(name):
-            env_path = name
-        else:
-            env_path = os.path.join(self.venvdir, name)
-        bin_dir = self._binname()
-        bin_path = os.path.join(env_path, bin_dir)
-        # Actually check if this is an actual venv or just a organizational directory
-        # eg, if 'spam/eggs' is a venv, reject 'spam'
-        if not os.path.exists(bin_path):
-            raise KeyError()
-        return VirtualEnvironment(env_path, bin_path)
-
-    def __iter__(self):
-        """List available virtual environments found in $VIRTUALENV_HOME.
-        """
-        # FIXME: Handle subdirs--this won't discover eg ``spam/eggs``
-        for x in scandir(self.venvdir):
-            if x.is_dir():
-                yield x.name
-
-    def __len__(self):
-        """Counts known virtual environments, using the same rules as iter().
-        """
-        l = 0
-        for _ in self:
-            l += 1
-        return l
-
-    def active(self):
-        """Get the name of the active virtual environment.
-
-        You can use this as a key to get further information.
-
-        Returns None if no environment is active.
-        """
-        if 'VIRTUAL_ENV' not in builtins.__xonsh_env__:
-            return
-        env_path = builtins.__xonsh_env__['VIRTUAL_ENV']
-        if env_path.startswith(self.venvdir):
-            name = env_path[len(self.venvdir):]
-            if name[0] == '/':
-                name = name[1:]
-            return name
-        else:
-            return env_path
-
-    def activate(self, name):
-        """
-        Activate a virtual environment.
-
-        Parameters
-        ----------
-        name : str
-            Virtual environment name or absolute path.
-        """
-        env = builtins.__xonsh_env__
-        env_path, bin_path = self[name]
-        if 'VIRTUAL_ENV' in env:
-            self.deactivate()
-
-        type(self).oldvars = {'PATH': env['PATH']}
-        env['PATH'].insert(0, bin_path)
-        env['VIRTUAL_ENV'] = env_path
-        if 'PYTHONHOME' in env:
-            type(self).oldvars['PYTHONHOME'] = env.pop('PYTHONHOME')
-
-    def deactivate(self):
-        """
-        Deactive the active virtual environment. Returns the name of it.
-        """
-        env = builtins.__xonsh_env__
-        if 'VIRTUAL_ENV' not in env:
-            raise NoEnvironmentActive('No environment currently active.')
-
-        env_path, bin_path = self[...]
-        env_name = self.active()
-
-        if hasattr(type(self), 'oldvars'):
-            for k,v in type(self).oldvars.items():
-                env[k] = v
-            del type(self).oldvars
-
-        env.pop('VIRTUAL_ENV')
-
-        return env_name
-
-    def __delitem__(self, name):
-        """
-        Permanently deletes a virtual environment.
-
-        Parameters
-        ----------
-        name : str
-            Virtual environment name or absolute path.
-        """
-        env_path = self[name].env
-        try:
-            if self[...].env == env_path:
-                raise EnvironmentInUse('The "%s" environment is currently active.' % name)
-        except KeyError:
-            # No current venv, ... fails
-            pass
-        shutil.rmtree(env_path)
-
-
-class VoxHandler:
+class _VoxHandler:
     """Vox is a virtual environment manager for xonsh."""
 
     def __init__(self):
         """Ensure that $VIRTUALENV_HOME is defined and declare the available vox commands"""
 
-        self.vox = Vox()
+        import xontrib.voxapi
+        self.vox = xontrib.voxapi.Vox()
 
         self.commands = {
             ('new',): self.create_env,
@@ -273,7 +104,7 @@ class VoxHandler:
         for name in names:
             try:
                 del self.vox[name]
-            except EnvironmentInUse:
+            except self.vox.EnvironmentInUse:
                 print('The "%s" environment is currently active. In order to remove it, deactivate it first with "vox deactivate %s".\n' % (name, name),
                       file=sys.stderr)
                 return
@@ -311,10 +142,10 @@ class VoxHandler:
         Show help
 """)
 
+    @classmethod
+    def handle(cls, args, stdin=None):
+        """Runs Vox environment manager."""
+        vox = cls()
+        return vox(args, stdin=stdin)
 
-def _vox(args, stdin=None):
-    """Runs Vox environment manager."""
-    vox = VoxHandler()
-    return vox(args, stdin=stdin)
-
-aliases['vox'] = _vox
+aliases['vox'] = _VoxHandler.handle

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -4,6 +4,7 @@ import sys
 import venv
 import shutil
 import builtins
+import collections
 import collections.abc
 
 from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
@@ -18,6 +19,7 @@ class Vox(collections.abc.Mapping):
     """API access to Vox and virtual environments, in a dict-like format.
 
     Makes use of the VirtualEnvironment namedtuple:
+
     1. ``env``: The full path to the environment
     2. ``bin``: The full path to the bin/Scripts directory of the environment
     """

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -1,0 +1,168 @@
+"""Python virtual environment manager for xonsh."""
+import os
+import sys
+import venv
+import shutil
+import builtins
+import collections
+import collections.abc
+
+from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
+
+VirtualEnvironment = collections.namedtuple('VirtualEnvironment', ['env', 'bin'])
+
+class Vox(collections.abc.Mapping):
+    """API access to Vox and virtual environments, in a dict-like format.
+
+    Makes use of the VirtualEnvironment namedtuple:
+
+    1. ``env``: The full path to the environment
+    2. ``bin``: The full path to the bin/Scripts directory of the environment
+    """
+
+    class EnvironmentInUse(Exception): pass
+
+    class NoEnvironmentActive(Exception): pass
+
+    def __init__(self):
+        if not builtins.__xonsh_env__.get('VIRTUALENV_HOME'):
+            home_path = os.path.expanduser('~')
+            self.venvdir = os.path.join(home_path, '.virtualenvs')
+            builtins.__xonsh_env__['VIRTUALENV_HOME'] = self.venvdir
+        else:
+            self.venvdir = builtins.__xonsh_env__['VIRTUALENV_HOME']
+
+    def create(self, name):
+        """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
+
+        Parameters
+        ----------
+        name : str
+            Virtual environment name
+        """
+        env_path = os.path.join(self.venvdir, name)
+        venv.create(env_path, with_pip=True)
+
+    @staticmethod
+    def _binname():
+        if ON_WINDOWS:
+            return 'Scripts'
+        elif ON_POSIX:
+            return 'bin'
+        else:
+            raise OSError('This OS is not supported.')
+
+    def __getitem__(self, name):
+        """Get information about a virtual environment.
+
+        Parameters
+        ----------
+        name : str or Ellipsis
+            Virtual environment name or absolute path. If ... is given, return 
+            the current one (throws a KeyError if there isn't one).
+        """
+        if name is ...:
+            env_path = builtins.__xonsh_env__['VIRTUAL_ENV']
+        elif os.path.isabs(name):
+            env_path = name
+        else:
+            env_path = os.path.join(self.venvdir, name)
+        bin_dir = self._binname()
+        bin_path = os.path.join(env_path, bin_dir)
+        # Actually check if this is an actual venv or just a organizational directory
+        # eg, if 'spam/eggs' is a venv, reject 'spam'
+        if not os.path.exists(bin_path):
+            raise KeyError()
+        return VirtualEnvironment(env_path, bin_path)
+
+    def __iter__(self):
+        """List available virtual environments found in $VIRTUALENV_HOME.
+        """
+        # FIXME: Handle subdirs--this won't discover eg ``spam/eggs``
+        for x in scandir(self.venvdir):
+            if x.is_dir():
+                yield x.name
+
+    def __len__(self):
+        """Counts known virtual environments, using the same rules as iter().
+        """
+        l = 0
+        for _ in self:
+            l += 1
+        return l
+
+    def active(self):
+        """Get the name of the active virtual environment.
+
+        You can use this as a key to get further information.
+
+        Returns None if no environment is active.
+        """
+        if 'VIRTUAL_ENV' not in builtins.__xonsh_env__:
+            return
+        env_path = builtins.__xonsh_env__['VIRTUAL_ENV']
+        if env_path.startswith(self.venvdir):
+            name = env_path[len(self.venvdir):]
+            if name[0] == '/':
+                name = name[1:]
+            return name
+        else:
+            return env_path
+
+    def activate(self, name):
+        """
+        Activate a virtual environment.
+
+        Parameters
+        ----------
+        name : str
+            Virtual environment name or absolute path.
+        """
+        env = builtins.__xonsh_env__
+        env_path, bin_path = self[name]
+        if 'VIRTUAL_ENV' in env:
+            self.deactivate()
+
+        type(self).oldvars = {'PATH': env['PATH']}
+        env['PATH'].insert(0, bin_path)
+        env['VIRTUAL_ENV'] = env_path
+        if 'PYTHONHOME' in env:
+            type(self).oldvars['PYTHONHOME'] = env.pop('PYTHONHOME')
+
+    def deactivate(self):
+        """
+        Deactive the active virtual environment. Returns the name of it.
+        """
+        env = builtins.__xonsh_env__
+        if 'VIRTUAL_ENV' not in env:
+            raise NoEnvironmentActive('No environment currently active.')
+
+        env_path, bin_path = self[...]
+        env_name = self.active()
+
+        if hasattr(type(self), 'oldvars'):
+            for k,v in type(self).oldvars.items():
+                env[k] = v
+            del type(self).oldvars
+
+        env.pop('VIRTUAL_ENV')
+
+        return env_name
+
+    def __delitem__(self, name):
+        """
+        Permanently deletes a virtual environment.
+
+        Parameters
+        ----------
+        name : str
+            Virtual environment name or absolute path.
+        """
+        env_path = self[name].env
+        try:
+            if self[...].env == env_path:
+                raise EnvironmentInUse('The "%s" environment is currently active.' % name)
+        except KeyError:
+            # No current venv, ... fails
+            pass
+        shutil.rmtree(env_path)

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -1,4 +1,4 @@
-"""Python virtual environment manager for xonsh."""
+"""API for Vox, the Python virtual environment manager for xonsh."""
 import os
 import sys
 import venv
@@ -11,6 +11,10 @@ from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
 
 VirtualEnvironment = collections.namedtuple('VirtualEnvironment', ['env', 'bin'])
 
+class EnvironmentInUse(Exception): pass
+
+class NoEnvironmentActive(Exception): pass
+
 class Vox(collections.abc.Mapping):
     """API access to Vox and virtual environments, in a dict-like format.
 
@@ -19,10 +23,6 @@ class Vox(collections.abc.Mapping):
     1. ``env``: The full path to the environment
     2. ``bin``: The full path to the bin/Scripts directory of the environment
     """
-
-    class EnvironmentInUse(Exception): pass
-
-    class NoEnvironmentActive(Exception): pass
 
     def __init__(self):
         if not builtins.__xonsh_env__.get('VIRTUALENV_HOME'):


### PR DESCRIPTION
Adds a dict-like object for API access to Vox and virtual environments.

This also allows for testing the Vox machinery (the basics of which is included).

This also changes a few details of the algorithms, namely that instead of dynamically recalculating the old value of `PATH`, it stores the old value and restores it on deactivation. `$PYTHONHOME` is also handled, to bring Vox in line with traditional venv activate scripts.