### PR TITLE
change from set window title to window + icon (tab) title

### DIFF
--- a/news/set-title.rst
+++ b/news/set-title.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* $TITLE now changes both icon (tab) and window title
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -246,7 +246,7 @@ class BaseShell(object):
             with open(1, 'wb', closefd=False) as f:
                 # prevent xonsh from answering interative questions
                 # on the next command by writing the title
-                f.write("\x1b]2;{0}\x07".format(t).encode())
+                f.write("\x1b]0;{0}\x07".format(t).encode())
                 f.flush()
 
     @property


### PR DESCRIPTION
On iterm2 (and maybe other terminals) you have a way to set tab title and window title independent of each other. By changing this escape we set both to the same value, which should be ok until we have a better way to do this.

Documentation for it in http://tldp.org/HOWTO/Xterm-Title-3.html