### PR TITLE
remove flake8 checks because they are broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 
 script:
   - if [[ $RUN_COVERAGE = true ]]; then
-      py.test --flake8 --cov=. --cov-report=term --timeout=10;
+      py.test --cov=. --cov-report=term --timeout=10;
     else
       py.test --timeout=10;
     fi

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,9 +1,7 @@
 ply>=3.8
 pytest>=2.9.1
-pytest-flake8>=0.5
 pytest-cov>=2.3.0
 pytest-timeout>=1.0.0
 prompt-toolkit>=1.0.3
 pygments>=2.1.3
 codecov>=2.0.5
-flake8<3.0.0


### PR DESCRIPTION
the pytest flake8 extension is not working particularly well.  I am not opposed to having it enabled if it doesn't continuously break CI.  This strips it out.  I am happy to re-enable it if someone submits a PR that can pass CI