### PR TITLE
Make `which -v` extremely vocal

### DIFF
--- a/news/vocal-which.rst
+++ b/news/vocal-which.rst
@@ -1,0 +1,13 @@
+**Added:** 
+
+* ``which -v`` now calls superhelp, which will print highlighted source.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -24,6 +24,7 @@ from xonsh.xontribs import xontribs_main
 from xonsh.xoreutils import _which
 from xonsh.completers._aliases import completer_alias
 
+
 class Aliases(abc.MutableMapping):
     """Represents a location to hold and look up aliases."""
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -24,7 +24,6 @@ from xonsh.xontribs import xontribs_main
 from xonsh.xoreutils import _which
 from xonsh.completers._aliases import completer_alias
 
-
 class Aliases(abc.MutableMapping):
     """Represents a location to hold and look up aliases."""
 
@@ -402,6 +401,7 @@ def which(args, stdin=None, stdout=None, stderr=None):
                     print(arg, file=stdout)
             else:
                 print("aliases['{}'] = {}".format(arg, builtins.aliases[arg]), file=stdout)
+                builtins.__xonsh_superhelp__(builtins.aliases[arg])
             nmatches += 1
             if not pargs.all:
                 continue

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -396,13 +396,13 @@ def which(args, stdin=None, stdout=None, stderr=None):
         # skip alias check if user asks to skip
         if (arg in builtins.aliases and not pargs.skip):
             if pargs.plain or not pargs.verbose:
-                if isinstance(builtins.aliases[arg], list):
+                if not callable(builtins.aliases[arg]):
                     print(' '.join(builtins.aliases[arg]), file=stdout)
                 else:
                     print(arg, file=stdout)
             else:
                 print("aliases['{}'] = {}".format(arg, builtins.aliases[arg]), file=stdout)
-                if not isinstance(builtins.aliases[arg], list):
+                if callable(builtins.aliases[arg]):
                     builtins.__xonsh_superhelp__(builtins.aliases[arg])
             nmatches += 1
             if not pargs.all:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -401,7 +401,8 @@ def which(args, stdin=None, stdout=None, stderr=None):
                     print(arg, file=stdout)
             else:
                 print("aliases['{}'] = {}".format(arg, builtins.aliases[arg]), file=stdout)
-                builtins.__xonsh_superhelp__(builtins.aliases[arg])
+                if not isinstance(builtins.aliases[arg], list):
+                    builtins.__xonsh_superhelp__(builtins.aliases[arg])
             nmatches += 1
             if not pargs.all:
                 continue


### PR DESCRIPTION
Fixes #306 

When you pass the `-v` flag to `which`, it'll now call superhelp.