### PR TITLE
fix reported PLY version in bundled PLY

### DIFF
--- a/news/ply.rst
+++ b/news/ply.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Version number reported by bundled PLY
+* ``xonfig`` no longer breaks if PLY is externally installed and version 3.8
+
+**Security:** None

--- a/xonsh/ply/__init__.py
+++ b/xonsh/ply/__init__.py
@@ -1,5 +1,5 @@
 # PLY package
 # Author: David Beazley (dave@dabeaz.com)
 
-__version__ = '3.7'
+__version__ = '3.8'
 __all__ = ['lex','yacc']

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -337,6 +337,10 @@ def _xonfig_format_json(data):
 
 def _info(ns):
     env = builtins.__xonsh_env__
+    try:
+        ply.__version__ = ply.__version__
+    except AttributeError:
+        ply.__version__ = '3.8'
     data = [
         ('xonsh', XONSH_VERSION),
         ('Git SHA', githash()),


### PR DESCRIPTION
As discussed in #1506 , PLY didn't bump its version number in `__init__.py` when they moved from 3.7 -> 3.8