### PR TITLE
fix xon.sh to make it take the current python and not a generic python3

### DIFF
--- a/news/fix-xonsh-python.rst
+++ b/news/fix-xonsh-python.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* xon.sh uses the interpreter used to install instead of the default python3.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ class xinstall(install):
             import traceback
             traceback.print_exc()
             print('Installing Jupyter hook failed.')
-        install.run(self)
+        super().run()
         if dirty:
             restore_version()
 
@@ -193,7 +193,7 @@ class xsdist(sdist):
         build_tables()
         amalgamate_source()
         dirty = dirty_version()
-        sdist.make_release_tree(self, basedir, files)
+        super().make_release_tree(basedir, files)
         if dirty:
             restore_version()
 
@@ -213,11 +213,30 @@ class install_scripts_quoted_shebang(install_scripts):
             contents = contents.replace(shebang, quoted_shebang)
         super().write_script(script_name, contents, mode, *ignored)
 
+
+class install_scripts_rewrite(install_scripts):
+    """Rewrite python3 to the current python executable"""
+    def run(self):
+        super().run()
+        if os.name == 'posix' and not self.dry_run:
+            for file in self.get_outputs():
+                if file.endswith('xon.sh'):
+                    bs_cmd = self.get_finalized_command('build_scripts')
+                    exec_param = getattr(bs_cmd, 'executable', None)
+
+                    with open(file, 'r') as f:
+                        content = f.read()
+
+                    processed = content.replace(' python3 ', ' {} '.format(exec_param))
+
+                    with open(file, 'w') as f:
+                        f.write(processed)
+
 # The custom install needs to be used on Windows machines
 if os.name == 'nt':
     cmdclass = {'install': xinstall, 'sdist': xsdist, 'install_scripts': install_scripts_quoted_shebang}
 else:
-    cmdclass = {'install': xinstall, 'sdist': xsdist}
+    cmdclass = {'install': xinstall, 'sdist': xsdist, 'install_scripts': install_scripts_rewrite}
 
 
 if HAVE_SETUPTOOLS:
@@ -230,6 +249,11 @@ if HAVE_SETUPTOOLS:
             develop.run(self)
             if dirty:
                 restore_version()
+
+        def install_script(self, dist, script_name, script_text, dev_path=None):
+            if script_name == 'xon.sh':
+                script_text = script_text.replace(' python3 ', ' {} '.format(sys.executable))
+            super().install_script(dist, script_name, script_text, dev_path)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -215,19 +215,20 @@ class install_scripts_quoted_shebang(install_scripts):
 
 
 class install_scripts_rewrite(install_scripts):
-    """Rewrite python3 to the current python executable"""
+    """Change default python3 to the concrete python binary used to install/develop inside xon.sh script"""
     def run(self):
         super().run()
-        if os.name == 'posix' and not self.dry_run:
+        if not self.dry_run:
             for file in self.get_outputs():
                 if file.endswith('xon.sh'):
+                    # this is the value distutils use on its shebang translation
                     bs_cmd = self.get_finalized_command('build_scripts')
                     exec_param = getattr(bs_cmd, 'executable', None)
 
                     with open(file, 'r') as f:
                         content = f.read()
 
-                    processed = content.replace(' python3 ', ' {} '.format(exec_param))
+                    processed = content.replace(' python3 ', ' "{}" '.format(exec_param))
 
                     with open(file, 'w') as f:
                         f.write(processed)
@@ -252,7 +253,8 @@ if HAVE_SETUPTOOLS:
 
         def install_script(self, dist, script_name, script_text, dev_path=None):
             if script_name == 'xon.sh':
-                script_text = script_text.replace(' python3 ', ' {} '.format(sys.executable))
+                # change default python3 to the concrete python binary used to install/develop inside xon.sh script
+                script_text = script_text.replace(' python3 ', ' "{}" '.format(sys.executable))
             super().install_script(dist, script_name, script_text, dev_path)
 
 


### PR DESCRIPTION
This is to make xon.sh work on os x homebrew or anywhere were the python you install is not the global python3