### PR TITLE
Bring hashbang parsing in line with bash, zsh, sh, and Linux

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -230,7 +230,7 @@ def get_script_subproc_command(fname, args):
     else:
         interp = m.group(1).strip()
         if len(interp) > 0:
-            interp = shlex.split(interp)
+            interp = interp.split(' ', 1)
         else:
             interp = ['xonsh']
     if ON_WINDOWS:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -8,7 +8,6 @@ import os
 import re
 import sys
 import time
-import shlex
 import signal
 import atexit
 import inspect


### PR DESCRIPTION
In doing some testing for #1156, I discovered that the way xonsh parses shbangs is different than every other example I had installed (sh, bash, zsh, and Linux).

To test this, I used a small C program:

``` c
#include <stdio.h>

int main (int argc, char *argv[])
{
    for(int i = 0; i < argc; i++) {
        printf("%i\t%s\n", i, argv[i]);
    }
    getchar();
}
```

And a script:

```
#!/tmp/shbang hello world
```
