### PR TITLE
No error in parser error

### DIFF
--- a/news/noerr.rst
+++ b/news/noerr.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed parser error line number exception from being raised while trying to
+  raise a SyntaxError.
+
+**Security:** None

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -405,8 +405,13 @@ class BaseParser(object):
             err_line_pointer = ''
         else:
             col = loc.column + 1
-            err_line = line.splitlines()[loc.lineno - 1]
-            err_line_pointer = '\n{}\n{: >{}}'.format(err_line, '^', col)
+            lines = line.splitlines()
+            i = loc.lineno - 1
+            if 0 <= i < len(lines):
+                err_line = lines[i]
+                err_line_pointer = '\n{}\n{: >{}}'.format(err_line, '^', col)
+            else:
+                err_line_pointer = ''
         err = SyntaxError('{0}: {1}{2}'.format(loc, msg, err_line_pointer))
         err.loc = loc
         raise err


### PR DESCRIPTION
Sometimes locs report lineno incorrectly, and we should fail correctly. 