### PR TITLE
history show filter by timestamps

### DIFF
--- a/news/history-timestamp-filtering.rst
+++ b/news/history-timestamp-filtering.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* ``history show`` args ``-t``, ``-f``, ``-T`` ``+T`` to filter commands by timestamp
+
+* ``ensure_timestamp`` in xonsh.tools to try and convert an object to a timestamp a.k.a float
+
+* ``$XONSH_DATETIME_FORMAT`` envvar, the default format to be used with ``datetime.datetime.strptime()``
+
+**Changed:**
+
+* ``_hist_parse_args`` implementation refactor
+
+* moved all parameter checking in ``_hist_get``
+
+* ``_hist_show`` to handle numeration and timestamp printing of commands
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``ensure_slice`` bugfix for -1 index/slice
+
+**Security:** None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [pytest]
 flake8-max-line-length = 180
 flake8-ignore =
+    *.py E122
     *.py E402
     tests/tools.py E128
     xonsh/ast.py F401

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -181,6 +181,7 @@ def test_parser_show(args, exp):
               'reverse': exp[4],
               'start_time': None,
               'end_time': None,
-              'datetime_format': None}
+              'datetime_format': None,
+              'timestamp': False}
     ns = _hist_parse_args(shlex.split(args))
     assert ns.__dict__ == exp_ns

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -178,6 +178,8 @@ def test_parser_show(args, exp):
               'session': exp[1],
               'slices': exp[2],
               'numerate': exp[3],
-              'reverse': exp[4]}
+              'reverse': exp[4],
+              'start_time': None,
+              'end_time': None}
     ns = _hist_parse_args(shlex.split(args))
     assert ns.__dict__ == exp_ns

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -180,6 +180,7 @@ def test_parser_show(args, exp):
               'numerate': exp[3],
               'reverse': exp[4],
               'start_time': None,
-              'end_time': None}
+              'end_time': None,
+              'datetime_format': None}
     ns = _hist_parse_args(shlex.split(args))
     assert ns.__dict__ == exp_ns

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1125,10 +1125,14 @@ def test_expandvars(inp, exp, xonsh_builtins):
     assert expandvars(inp) == exp
 
 
-@pytest.mark.parametrize('inp, exp',[
-    (572392800.0, 572392800.0),
-    (dt.datetime(2016, 8, 2, 13, 24), dt.datetime(2016, 8, 2, 13, 24).timestamp()),
+@pytest.mark.parametrize('inp, fmt, exp',[
+    (572392800.0, None, 572392800.0),
+    ('42.1459', None, 42.1459),
+    (dt.datetime(2016, 8, 2, 13, 24), None, dt.datetime(2016, 8, 2, 13, 24).timestamp()),
+    ('2016-8-10 16:14', None, dt.datetime(2016, 8, 10, 16, 14).timestamp()),
+    ('2016/8/10 16:14:40', '%Y/%m/%d %H:%M:%S', dt.datetime(2016, 8, 10, 16, 14, 40).timestamp()),
     ])
-def test_ensure_timestamp(inp, exp):
-    obs = ensure_timestamp(inp)
+def test_ensure_timestamp(inp, fmt, exp, xonsh_builtins):
+    xonsh_builtins.__xonsh_env__['XONSH_DATETIME_FORMAT'] = '%Y-%m-%d %H:%M'
+    obs = ensure_timestamp(inp, fmt)
     assert exp == obs

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,7 +22,8 @@ from xonsh.tools import (
     subexpr_from_unbalanced, subproc_toks, to_bool, to_bool_or_int,
     to_dynamic_cwd_tuple, to_logfile_opt, pathsep_to_set, set_to_pathsep,
     is_string_seq, pathsep_to_seq, seq_to_pathsep, is_nonstring_seq_of_strings,
-    pathsep_to_upper_seq, seq_to_upper_pathsep, expandvars, is_int_as_str, is_slice_as_str
+    pathsep_to_upper_seq, seq_to_upper_pathsep, expandvars, is_int_as_str, is_slice_as_str,
+    ensure_timestamp,
     )
 from xonsh.commands_cache import CommandsCache
 from xonsh.built_ins import expand_path
@@ -1120,3 +1121,15 @@ def test_expandvars(inp, exp, xonsh_builtins):
     env = Env({'foo':'bar', 'spam': 'eggs', 'a_bool': True, 'an_int': 42, 'none': None})
     xonsh_builtins.__xonsh_env__ = env
     assert expandvars(inp) == exp
+
+
+import time
+
+
+@pytest.mark.parametrize('inp, exp',[
+    (572392800.0, 572392800.0),
+
+    ])
+def test_ensure_timestamp(inp, exp):
+    obs = ensure_timestamp(inp)
+    assert exp == obs

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,10 +1,11 @@
   # -*- coding: utf-8 -*-
 """Tests xonsh tools."""
+import builtins
+import datetime as dt
 import os
 import pathlib
-from tempfile import TemporaryDirectory
 import stat
-import builtins
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -1123,12 +1124,9 @@ def test_expandvars(inp, exp, xonsh_builtins):
     assert expandvars(inp) == exp
 
 
-import time
-
-
 @pytest.mark.parametrize('inp, exp',[
     (572392800.0, 572392800.0),
-
+    (dt.datetime(2016, 8, 2, 13, 24), dt.datetime(2016, 8, 2, 13, 24).timestamp()),
     ])
 def test_ensure_timestamp(inp, exp):
     obs = ensure_timestamp(inp)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -818,6 +818,7 @@ def test_bool_or_int_to_str(inp, exp):
         (42, slice(42, 43)),
         (None, slice(None, None, None)),
         (slice(1,2), slice(1,2)),
+        ('-1', slice(-1, None, None)),
         ('42', slice(42, 43)),
         ('-42', slice(-42, -41)),
         ('1:2:3', slice(1, 2, 3)),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -89,7 +89,9 @@ Ensurer.__doc__ = """Named tuples whose elements are functions that
 represent environment variable validation, conversion, detyping.
 """
 
-DEFAULT_ENSURERS = LazyObject(lambda: {
+@lazyobject
+def DEFAULT_ENSURERS():
+    return {
     'AUTO_CD': (is_bool, to_bool, bool_to_str),
     'AUTO_PUSHD': (is_bool, to_bool, bool_to_str),
     'AUTO_SUGGEST': (is_bool, to_bool, bool_to_str),
@@ -148,9 +150,9 @@ DEFAULT_ENSURERS = LazyObject(lambda: {
     'XONSH_SHOW_TRACEBACK': (is_bool, to_bool, bool_to_str),
     'XONSH_STORE_STDOUT': (is_bool, to_bool, bool_to_str),
     'XONSH_STORE_STDIN': (is_bool, to_bool, bool_to_str),
-    'XONSH_TRACEBACK_LOGFILE': (is_logfile_opt, to_logfile_opt,
-                                logfile_opt_to_str)
-}, globals(), 'DEFAULT_ENSURERS')
+    'XONSH_TRACEBACK_LOGFILE': (is_logfile_opt, to_logfile_opt, logfile_opt_to_str),
+    'XONSH_DATETIME_FORMAT': (is_string, ensure_string, ensure_string),
+    }
 
 
 #
@@ -303,7 +305,8 @@ def DEFAULT_VALUES():
         'XONSH_SHOW_TRACEBACK': False,
         'XONSH_STORE_STDIN': False,
         'XONSH_STORE_STDOUT': False,
-        'XONSH_TRACEBACK_LOGFILE': None
+        'XONSH_TRACEBACK_LOGFILE': None,
+        'XONSH_DATETIME_FORMAT': '%Y-%m-%d %H:%M',
     }
     if hasattr(locale, 'LC_MESSAGES'):
         dv['LC_MESSAGES'] = locale.setlocale(locale.LC_MESSAGES)
@@ -334,7 +337,9 @@ store_as_str : bool, optional
 VarDocs.__new__.__defaults__ = (True, DefaultNotGiven, False)
 
 # Please keep the following in alphabetic order - scopatz
-DEFAULT_DOCS = LazyObject(lambda: {
+@lazyobject
+def DEFAULT_DOCS():
+    return {
     'ANSICON': VarDocs('This is used on Windows to set the title, '
                        'if available.', configurable=False),
     'AUTO_CD': VarDocs(
@@ -637,7 +642,10 @@ DEFAULT_DOCS = LazyObject(lambda: {
         'XONSH_SHOW_TRACEBACK has been set. Its value must be a writable file '
         'or None / the empty string if traceback logging is not desired. '
         'Logging to a file is not enabled by default.'),
-}, globals(), 'DEFAULT_DOCS')
+    'XONSH_DATETIME_FORMAT': VarDocs(
+        'The format that is used for ``datetime.strptime()`` in various places'
+        'i.e the history timestamp option'),
+    }
 
 
 #

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -89,6 +89,7 @@ Ensurer.__doc__ = """Named tuples whose elements are functions that
 represent environment variable validation, conversion, detyping.
 """
 
+
 @lazyobject
 def DEFAULT_ENSURERS():
     return {
@@ -335,6 +336,7 @@ store_as_str : bool, optional
 """
 # iterates from back
 VarDocs.__new__.__defaults__ = (True, DefaultNotGiven, False)
+
 
 # Please keep the following in alphabetic order - scopatz
 @lazyobject

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -8,6 +8,7 @@ import time
 import uuid
 import argparse
 import builtins
+import datetime
 import functools
 import itertools
 import threading
@@ -348,9 +349,11 @@ def _hist_create_parser():
                       action='store_true', help='reverses the direction')
     show.add_argument('-n', dest='numerate', default=False, action='store_true',
                       help='numerate each command')
-    show.add_argument('-t', dest='end_time', default=None,
+    show.add_argument('-t', dest='timestamp', default=False,
+                      action='store_true', help='show command timestamps')
+    show.add_argument('-T', dest='end_time', default=None,
                       help='show only commands before timestamp')
-    show.add_argument('+t', dest='start_time', default=None,
+    show.add_argument('+T', dest='start_time', default=None,
                       help='show only commands after timestamp')
     show.add_argument('-f', dest='datetime_format', default=None,
                       help='the datetime format to be used for filtering and printing')
@@ -465,12 +468,20 @@ def _hist_show(ns, *args, **kwargs):
         return
     if ns.reverse:
         commands = reversed(list(commands))
-    if not ns.numerate:
+    if not ns.numerate and not ns.timestamp:
         for c, _, _ in commands:
             print(c)
-    else:
+    elif not ns.timestamp:
         for c, _, i in commands:
             print('{}: {}'.format(i, c))
+    elif not ns.numerate:
+        for c, ts, _ in commands:
+            dt = datetime.datetime.fromtimestamp(ts).ctime()
+            print('({}) {}'.format(dt, c))
+    else:
+        for c, ts, i in commands:
+            dt = datetime.datetime.fromtimestamp(ts).ctime()
+            print('{}:({}) {}'.format(i, dt, c))
 
 
 # Interface to History

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -453,22 +453,23 @@ def _hist_show(ns, *args, **kwargs):
     """Show the requested portion of shell history.
     Accepts same parameters with `_hist_get`.
     """
-    commands = _hist_get(ns.session,
-                        slices=ns.slices,
-                        start_time=ns.start_time,
-                        end_time=ns.end_time,
-                        **kwargs)
     try:
-        if ns.reverse:
-            commands = reversed(list(commands))
-        if not ns.numerate:
-            for c, _, _ in commands:
-                print(c)
-        else:
-            for c, _, i in commands:
-                print('{}: {}'.format(i, c))
+        commands = _hist_get(ns.session,
+                            slices=ns.slices,
+                            start_time=ns.start_time,
+                            end_time=ns.end_time,
+                            **kwargs)
     except ValueError as err:
         print("history: error: {}".format(err), file=sys.stderr)
+        return
+    if ns.reverse:
+        commands = reversed(list(commands))
+    if not ns.numerate:
+        for c, _, _ in commands:
+            print(c)
+    else:
+        for c, _, i in commands:
+            print('{}: {}'.format(i, c))
 
 
 # Interface to History

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -8,7 +8,6 @@ import time
 import uuid
 import argparse
 import builtins
-import datetime
 import functools
 import itertools
 import threading
@@ -18,7 +17,7 @@ import collections.abc as abc
 from xonsh.lazyasd import lazyobject
 from xonsh.lazyjson import LazyJSON, ljdump, LJNode
 from xonsh.tools import (ensure_slice, to_history_tuple,
-                         expanduser_abs_path)
+                         expanduser_abs_path, ensure_timestamp)
 from xonsh.diff_history import _dh_create_parser, _dh_main_action
 
 
@@ -457,10 +456,10 @@ def _hist_show(ns, *args, **kwargs):
     """
     try:
         commands = _hist_get(ns.session,
-                            slices=ns.slices,
-                            start_time=ns.start_time,
-                            end_time=ns.end_time,
-                            datetime_format=ns.datetime_format)
+                             slices=ns.slices,
+                             start_time=ns.start_time,
+                             end_time=ns.end_time,
+                             datetime_format=ns.datetime_format)
     except ValueError as err:
         print("history: error: {}".format(err), file=sys.stderr)
         return

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -353,6 +353,8 @@ def _hist_create_parser():
                       help='show only commands before timestamp')
     show.add_argument('+t', dest='start_time', default=None,
                       help='show only commands after timestamp')
+    show.add_argument('-f', dest='datetime_format', default=None,
+                      help='the datetime format to be used for filtering and printing')
     show.add_argument('session', nargs='?', choices=_HIST_SESSIONS.keys(), default='session',
                       help='Choose a history session, defaults to current session')
     show.add_argument('slices', nargs='*', default=None,
@@ -411,7 +413,7 @@ def _hist_filter_ts(commands, start_time, end_time):
             yield cmd
 
 
-def _hist_get(session='session', *, slices=None,
+def _hist_get(session='session', *, slices=None, datetime_format=None,
               start_time=None, end_time=None, location=None):
     """Get the requested portion of shell history.
 
@@ -440,11 +442,11 @@ def _hist_get(session='session', *, slices=None,
         if start_time is None:
             start_time = 0.0
         else:
-            start_time = ensure_timestamp(start_time)
+            start_time = ensure_timestamp(start_time, datetime_format)
         if end_time is None:
             end_time = float('inf')
         else:
-            end_time = ensure_timestamp(end_time)
+            end_time = ensure_timestamp(end_time, datetime_format)
         cmds = _hist_filter_ts(cmds, start_time, end_time)
     return cmds
 
@@ -458,7 +460,7 @@ def _hist_show(ns, *args, **kwargs):
                             slices=ns.slices,
                             start_time=ns.start_time,
                             end_time=ns.end_time,
-                            **kwargs)
+                            datetime_format=ns.datetime_format)
     except ValueError as err:
         print("history: error: {}".format(err), file=sys.stderr)
         return

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1588,6 +1588,9 @@ def iglobpath(s, ignore_case=False, sort_result=None):
 
 
 def ensure_timestamp(t):
-    t = float(t)
+    try:
+        t = float(t)
+    except TypeError:
+        t = t.timestamp()
     return t
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -933,7 +933,10 @@ def ensure_slice(x):
         return x
     try:
         x = int(x)
-        s = slice(x, x+1)
+        if x != -1:
+            s = slice(x, x+1)
+        else:
+            s = slice(-1, None, None)
     except ValueError:
         x = x.strip('[]()')
         m = SLICE_REG.fullmatch(x)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1585,3 +1585,9 @@ def _iglobpath(s, ignore_case=False, sort_result=None):
 def iglobpath(s, ignore_case=False, sort_result=None):
     """Simple wrapper around iglob that also expands home and env vars."""
     return _iglobpath(s, ignore_case=ignore_case, sort_result=sort_result)[0]
+
+
+def ensure_timestamp(t):
+    t = float(t)
+    return t
+

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1592,12 +1592,16 @@ def iglobpath(s, ignore_case=False, sort_result=None):
 
 
 def ensure_timestamp(t, datetime_format=None):
+    if isinstance(t, (int, float)):
+        return t
+    try:
+        return float(t)
+    except (ValueError, TypeError):
+        pass
     if datetime_format is None:
         datetime_format = builtins.__xonsh_env__['XONSH_DATETIME_FORMAT']
     if isinstance(t, datetime.datetime):
-        t = t.timepstamp()
-    try:
-        t = float(t)
-    except TypeError:
         t = t.timestamp()
+    else:
+        t = datetime.datetime.strptime(t, datetime_format).timestamp()
     return t

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -20,7 +20,9 @@ Implementations:
 import builtins
 import collections
 import collections.abc as abc
+import contextlib
 import ctypes
+import datetime
 import functools
 import glob
 import os
@@ -31,7 +33,6 @@ import sys
 import threading
 import traceback
 import warnings
-import contextlib
 
 # adding further imports from xonsh modules is discouraged to avoid circular
 # dependencies
@@ -1590,10 +1591,13 @@ def iglobpath(s, ignore_case=False, sort_result=None):
     return _iglobpath(s, ignore_case=ignore_case, sort_result=sort_result)[0]
 
 
-def ensure_timestamp(t):
+def ensure_timestamp(t, datetime_format=None):
+    if datetime_format is None:
+        datetime_format = builtins.__xonsh_env__['XONSH_DATETIME_FORMAT']
+    if isinstance(t, datetime.datetime):
+        t = t.timepstamp()
     try:
         t = float(t)
     except TypeError:
         t = t.timestamp()
     return t
-


### PR DESCRIPTION
added optional `history show` args:
`-T` `+T` to filter by timestamp
`-t` to print the timestamps
`-f` for the datetime format

some refactoring aswell and a `ensure_slice` bugfix