### PR TITLE
Add support for `__all__` in xontribs

### DIFF
--- a/docs/tutorial_xontrib.rst
+++ b/docs/tutorial_xontrib.rst
@@ -69,8 +69,8 @@ default, they cannot be unloaded (easily).
 .. note::
 
     When a xontrib is loaded from a config file or via the xontrib command,
-    its public variables are placed in the current execution context, just
-    like variables set in run control files.
+    its public variables are placed in the current execution context unless
+    `__all__` is defined, just like in regular Python modules.
 
 Loading xontribs in the config file is as simple as adding a list of string
 xontrib names to the top-level ``"xontribs"`` key. For example, the following

--- a/docs/tutorial_xontrib.rst
+++ b/docs/tutorial_xontrib.rst
@@ -70,7 +70,7 @@ default, they cannot be unloaded (easily).
 
     When a xontrib is loaded from a config file or via the xontrib command,
     its public variables are placed in the current execution context unless
-    `__all__` is defined, just like in regular Python modules.
+    ``__all__`` is defined, just like in regular Python modules.
 
 Loading xontribs in the config file is as simple as adding a list of string
 xontrib names to the top-level ``"xontribs"`` key. For example, the following

--- a/news/xontrib-all.rst
+++ b/news/xontrib-all.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Xontribs may now define ``__all__`` as a module top-level to limit what gets exported to the shell context
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_xontribs.py
+++ b/tests/test_xontribs.py
@@ -1,6 +1,52 @@
 """xontrib tests, such as they are"""
-from xonsh.xontribs import xontrib_metadata
+import pytest
+from xonsh.xontribs import xontrib_metadata, xontrib_context
+import sys
 
 def test_load_xontrib_metadata():
     # Simply tests that the xontribs JSON files isn't malformed.
     xontrib_metadata()
+
+@pytest.yield_fixture
+def tmpmod(tmpdir):
+    """
+    Same as tmpdir but also adds/removes it to the front of sys.path
+    """
+    sys.path.insert(0, str(tmpdir))
+    try:
+        yield tmpdir
+    finally:
+        del sys.path[0]
+
+def test_noall(tmpmod):
+    """
+    Tests what get's exported from a module without __all__
+    """
+
+    with tmpmod.mkdir("xontrib").join("spameggs.py").open('w') as x:
+        x.write("""
+spam = 1
+eggs = 2
+_foobar = 3
+""")
+
+    ctx = xontrib_context('spameggs')
+    assert ctx == {'spam': 1, 'eggs': 2}
+
+def test_withall(tmpmod):
+    """
+    Tests what get's exported from a module with __all__
+    """
+
+    with tmpmod.mkdir("xontrib").join("spameggs.py").open('w') as x:
+        x.write("""
+__all__ = 'spam', '_foobar'
+spam = 1
+eggs = 2
+_foobar = 3
+""")
+
+    print(xontrib_context)
+
+    ctx = xontrib_context('spameggs')
+    assert ctx == {'spam': 1, '_foobar': 3}

--- a/tests/test_xontribs.py
+++ b/tests/test_xontribs.py
@@ -1,7 +1,7 @@
 """xontrib tests, such as they are"""
+import sys
 import pytest
 from xonsh.xontribs import xontrib_metadata, xontrib_context
-import sys
 
 def test_load_xontrib_metadata():
     # Simply tests that the xontribs JSON files isn't malformed.

--- a/tests/test_xontribs.py
+++ b/tests/test_xontribs.py
@@ -10,13 +10,19 @@ def test_load_xontrib_metadata():
 @pytest.yield_fixture
 def tmpmod(tmpdir):
     """
-    Same as tmpdir but also adds/removes it to the front of sys.path
+    Same as tmpdir but also adds/removes it to the front of sys.path.
+
+    Also cleans out any modules loaded as part of the test.
     """
     sys.path.insert(0, str(tmpdir))
+    loadedmods = set(sys.modules.keys())
     try:
         yield tmpdir
     finally:
         del sys.path[0]
+        newmods = set(sys.modules.keys()) - loadedmods
+        for m in newmods:
+            del sys.modules[m]
 
 def test_noall(tmpmod):
     """
@@ -45,8 +51,6 @@ spam = 1
 eggs = 2
 _foobar = 3
 """)
-
-    print(xontrib_context)
 
     ctx = xontrib_context('spameggs')
     assert ctx == {'spam': 1, '_foobar': 3}

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -36,8 +36,9 @@ def xontrib_context(name):
                           ImportWarning)
         return {}
     m = importlib.import_module(spec.name)
-    if hasattr(m, '__all__'):
-        ctx = {k: getattr(m, k) for k in m.__all__}
+    pubnames = getattr(m, '__all__', None)
+    if pubnames is not None:
+        ctx = {k: getattr(m, k) for k in pubnames}
     else:
         ctx = {k: getattr(m, k) for k in dir(m) if not k.startswith('_')}
     return ctx

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -36,7 +36,10 @@ def xontrib_context(name):
                           ImportWarning)
         return {}
     m = importlib.import_module(spec.name)
-    ctx = {k: getattr(m, k) for k in dir(m) if not k.startswith('_')}
+    if hasattr(m, '__all__'):
+        ctx = {k: getattr(m, k) for k in m.__all__}
+    else:
+        ctx = {k: getattr(m, k) for k in dir(m) if not k.startswith('_')}
     return ctx
 
 


### PR DESCRIPTION
In reference to #1464, allow xontribs to explicitly define their public API by defining `__all__`, just like regular Python modules.

The goal is to make `xontrib load spam` and `from xontrib.spam import *` effectively the same.