### PR TITLE
s.strip needs to be method call, 's.strip()', for the example to work

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -474,7 +474,7 @@ result is automatically converted to a string. For example,
     4
     >>> echo @([42, 'yo'])
     42 yo
-    >>> echo "hello" | @(lambda a, s=None: s.strip + " world")
+    >>> echo "hello" | @(lambda a, s=None: s.strip() + " world\n")
     hello world
 
 This syntax can be used inside of a captured or uncaptured subprocess, and can


### PR DESCRIPTION
s.strip needs to be method call, 's.strip()', for the example  correctly.  While not necessary, adding the newline ('world\n') puts 'hello
world' on its own line of output instead of having the xonsh prompt
appended to it.