### PR TITLE
Use `__all__` in the included xontribs

### DIFF
--- a/xontrib/distributed.py
+++ b/xontrib/distributed.py
@@ -3,6 +3,7 @@ from xonsh.contexts import Functor
 
 __all__ = 'DSubmitter', 'dsubmit'
 
+
 def dworker(args, stdin=None):
     """Programatic access to the dworker utility, to allow launching
     workers that also have access to xonsh builtins.

--- a/xontrib/distributed.py
+++ b/xontrib/distributed.py
@@ -1,13 +1,14 @@
 """Hooks for the distributed parallel computing library."""
 from xonsh.contexts import Functor
 
+__all__ = 'DSubmitter', 'dsubmit'
 
 def dworker(args, stdin=None):
     """Programatic access to the dworker utility, to allow launching
     workers that also have access to xonsh builtins.
     """
-    from distributed.cli import dworker as _dworker
-    _dworker.main.main(args=args, prog_name='dworker', standalone_mode=False)
+    from distributed.cli import dworker
+    dworker.main.main(args=args, prog_name='dworker', standalone_mode=False)
 
 
 aliases['dworker'] = dworker
@@ -67,7 +68,3 @@ def dsubmit(*a, args=(), kwargs=None, rtn='', **kw):
     e = Executor(*a, **kw)
     dsub = DSubmitter(e, args=args, kwargs=kwargs, rtn=rtn)
     return dsub
-
-
-# some cleanup
-del dworker, Functor

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -4,6 +4,7 @@ from xonsh.proc import foreground as foreground
 
 __all__ = ()
 
+
 @foreground
 def mpl(args, stdin=None):
     """Hooks to matplotlib"""

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -1,13 +1,14 @@
 """Matplotlib xontribution."""
 
-from xonsh.proc import foreground as _foreground
+from xonsh.proc import foreground as foreground
 
+__all__ = ()
 
-@_foreground
-def _mpl(args, stdin=None):
+@foreground
+def mpl(args, stdin=None):
     """Hooks to matplotlib"""
     from xontrib.mplhooks import show
     show()
 
 
-aliases['mpl'] = _mpl
+aliases['mpl'] = mpl

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -6,6 +6,7 @@ import xonsh.lazyasd as lazyasd
 
 __all__ = ()
 
+
 class VoxHandler:
     """Vox is a virtual environment manager for xonsh."""
 

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -1,11 +1,12 @@
 """Python virtual environment manager for xonsh."""
 
-import sys as _sys
-import xontrib.voxapi as _voxapi
-import xonsh.lazyasd as _lazyasd
+import sys
+import xontrib.voxapi as voxapi
+import xonsh.lazyasd as lazyasd
 
+__all__ = ()
 
-class _VoxHandler:
+class VoxHandler:
     """Vox is a virtual environment manager for xonsh."""
 
     def parser():
@@ -57,7 +58,7 @@ class _VoxHandler:
         subparsers.add_parser('help', help='Show this help message')
         return parser
 
-    parser = _lazyasd.LazyObject(parser, locals(), 'parser')
+    parser = lazyasd.LazyObject(parser, locals(), 'parser')
 
     aliases = {
         'create': 'new',
@@ -71,7 +72,7 @@ class _VoxHandler:
     }
 
     def __init__(self):
-        self.vox = _voxapi.Vox()
+        self.vox = voxapi.Vox()
 
     def __call__(self, args, stdin=None):
         """Call the right handler method for a given command."""
@@ -98,7 +99,7 @@ class _VoxHandler:
         try:
             self.vox.activate(args.name)
         except KeyError:
-            print('This environment doesn\'t exist. Create it with "vox new %s".\n' % name, file=_sys.stderr)
+            print('This environment doesn\'t exist. Create it with "vox new %s".\n' % name, file=sys.stderr)
             return None
         else:
             print('Activated "%s".\n' % args.name)
@@ -107,7 +108,7 @@ class _VoxHandler:
         """Deactive the active virtual environment."""
 
         if self.vox.active() is None:
-            print('No environment currently active. Activate one with "vox activate".\n', file=_sys.stderr)
+            print('No environment currently active. Activate one with "vox activate".\n', file=sys.stderr)
             return None
         env_name = self.vox.deactivate()
         print('Deactivated "%s".\n' % env_name)
@@ -122,7 +123,7 @@ class _VoxHandler:
             return None
 
         if not envs:
-            print('No environments available. Create one with "vox new".\n', file=_sys.stderr)
+            print('No environments available. Create one with "vox new".\n', file=sys.stderr)
             return None
 
         print('Available environments:')
@@ -134,9 +135,9 @@ class _VoxHandler:
         for name in args.names:
             try:
                 del self.vox[name]
-            except _voxapi.EnvironmentInUse:
+            except voxapi.EnvironmentInUse:
                 print('The "%s" environment is currently active. In order to remove it, deactivate it first with "vox deactivate %s".\n' % (name, name),
-                      file=_sys.stderr)
+                      file=sys.stderr)
                 return
             else:
                 print('Environment "%s" removed.' % name)
@@ -152,4 +153,4 @@ class _VoxHandler:
         return vox(args, stdin=stdin)
 
 
-aliases['vox'] = _VoxHandler.handle
+aliases['vox'] = VoxHandler.handle

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -7,6 +7,7 @@ import collections.abc
 
 from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
 
+
 VirtualEnvironment = collections.namedtuple('VirtualEnvironment', ['env', 'bin'])
 
 


### PR DESCRIPTION
While this isn't strictly necessary, it helps keep the code tidy and keeps the stock xontribs as examples of best practices.