### PR TITLE
xonsh/tools.py: Do not discard last line

### DIFF
--- a/news/stripfix.rst
+++ b/news/stripfix.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Text of instructions to download missing program now does not get off and
+  appears in whole.
+
+**Security:** None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -540,7 +540,7 @@ def command_not_found(cmd):
     c = '/usr/lib/command-not-found {0}; exit 0'
     s = subprocess.check_output(c.format(cmd), universal_newlines=True,
                                 stderr=subprocess.STDOUT, shell=True)
-    s = '\n'.join(s.splitlines()[:-1]).strip()
+    s = '\n'.join(s.rstrip().splitlines()).strip()
     return s
 
 


### PR DESCRIPTION
Instead of discarding the last line, we can just strip it.

Fixes https://github.com/xonsh/xonsh/issues/1180