### PR TITLE
temporary files shouldn't cause the news-related test to break

### DIFF
--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -33,5 +33,5 @@ def test_news():
                            os.path.dirname(__file__)), 'news')
     for f in scandir(newsdir):
         base, ext = os.path.splitext(f.path)
-        assert '.rst' == ext
+        assert 'rst' in ext
         yield check_news_file, f.path


### PR DESCRIPTION
This small change modifies the news-related test to check that `rst` is a substring of the extension or all news files, rather than matching the extension directly.  This means that the presence of vim's backup files (`.rst~`) doesn't cause the test to fail.