### PR TITLE
history syntax

### DIFF
--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -552,7 +552,7 @@ class History(object):
         self.rtns = CommandField('rtn', self)
 
     def __getitem__(self, item):
-        print("GETTING HISTORY:", item)
+        return self.show(slices=item)
 
     def __len__(self):
         return self._len
@@ -609,15 +609,11 @@ class History(object):
         return hf
 
     def show(self, *args, **kwargs):
-        """Return shell history as a list
+        """Return session history."""
+        return list(c for c, *_ in _hist_get(*args, **kwargs))
 
-        Valid options:
-            `session` - returns xonsh history from current session
-            `xonsh`   - returns xonsh history from all sessions
-            `zsh`     - returns all zsh history
-            `bash`    - returns all bash history
-        """
-        return list(_hist_get(*args, **kwargs))
+    def get(self, index, *args, **kwargs):
+        return list(c for c, *_ in _hist_get(*args, **kwargs))[index]
 
 
 def _hist_info(ns, hist):

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -551,6 +551,9 @@ class History(object):
         self.outs = CommandField('out', self)
         self.rtns = CommandField('rtn', self)
 
+    def __getitem__(self, item):
+        print("GETTING HISTORY:", item)
+
     def __len__(self):
         return self._len
 

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -203,6 +203,7 @@ def special_handlers():
     _make_matcher_handler('$(', 'DOLLAR_LPAREN', False, ')', sh)
     _make_matcher_handler('$[', 'DOLLAR_LBRACKET', False, ']', sh)
     _make_matcher_handler('${', 'DOLLAR_LBRACE', True, '}', sh)
+    _make_matcher_handler('!{', 'BANG_LBRACE', True, '}', sh)
     _make_matcher_handler('!(', 'BANG_LPAREN', False, ')', sh)
     _make_matcher_handler('![', 'BANG_LBRACKET', False, ']', sh)
     _make_matcher_handler('@(', 'AT_LPAREN', True, ')', sh)
@@ -349,6 +350,7 @@ class Lexer(object):
                 'BANG_LBRACKET',         # ![
                 'DOLLAR_LPAREN',         # $(
                 'DOLLAR_LBRACE',         # ${
+                'BANG_LBRACE',           # !{
                 'DOLLAR_LBRACKET',       # $[
                 'ATDOLLAR_LPAREN',       # @$(
                 ) + tuple(i.upper() for i in kwmod.kwlist)

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2130,22 +2130,15 @@ class BaseParser(object):
         return ast.Subscript(value=xenv, slice=idx, ctx=ast.Load(),
                              lineno=lineno, col_offset=col)
 
-    # def _hist_getter_by_name(self, var, lineno=None, col=None):
-    #     xhist = self._xhist(lineno=lineno, col=col)
-    #     func = ast.Attribute(value=xhist, attr='get', ctx=ast.Load(),
-    #                          lineno=lineno, col_offset=col)
-    #     return ast.Call(func=func,
-    #                     args=[ast.Str(s=var, lineno=lineno, col_offset=col),
-    #                           ast.Str(s='', lineno=lineno, col_offset=col)],
-    #                     keywords=[], starargs=None, kwargs=None,
-    #                     lineno=lineno, col_offset=col)
-
-    # def _envvar_by_name(self, var, lineno=None, col=None):
-    #     """Looks up a xonsh variable by name."""
-    #     xhist = self._xhist(lineno=lineno, col=col)
-    #     idx = ast.Index(value=ast.Str(s=var, lineno=lineno, col_offset=col))
-    #     return ast.Subscript(value=xhist, slice=idx, ctx=ast.Load(),
-    #                          lineno=lineno, col_offset=col)
+    def _hist_getter_by_name(self, var, lineno=None, col=None):
+        xhist = self._xhist(lineno=lineno, col=col)
+        func = ast.Attribute(value=xhist, attr='get', ctx=ast.Load(),
+                             lineno=lineno, col_offset=col)
+        return ast.Call(func=func,
+                        args=[ast.Str(s=var, lineno=lineno, col_offset=col),
+                              ast.Str(s='', lineno=lineno, col_offset=col)],
+                        keywords=[], starargs=None, kwargs=None,
+                        lineno=lineno, col_offset=col)
 
     def _subproc_cliargs(self, args, lineno=None, col=None):
         """Creates an expression for subprocess CLI arguments."""
@@ -2251,19 +2244,19 @@ class BaseParser(object):
         p0._cliarg_action = 'append'
         p[0] = p0
 
-    # def p_subproc_atom_hist_lookup(self, p):
-    #     """subproc_atom : bang_lbrace_tok test RBRACE"""
-    #     p1 = p[1]
-    #     lineno, col = p1.lineno, p1.lexpos
-    #     xhist = self._xhist(lineno=lineno, col=col)
-    #     func = ast.Attribute(value=xhist, attr='get', ctx=ast.Load(),
-    #                          lineno=lineno, col_offset=col)
-    #     p0 = ast.Call(func=func, args=[p[2], ast.Str(s='', lineno=lineno,
-    #                                                  col_offset=col)],
-    #                   keywords=[], starargs=None, kwargs=None, lineno=lineno,
-    #                   col_offset=col)
-    #     p0._cliarg_action = 'append'
-    #     p[0] = p0
+    def p_subproc_atom_hist_lookup(self, p):
+        """subproc_atom : bang_lbrace_tok test RBRACE"""
+        p1 = p[1]
+        lineno, col = p1.lineno, p1.lexpos
+        xhist = self._xhist(lineno=lineno, col=col)
+        func = ast.Attribute(value=xhist, attr='get', ctx=ast.Load(),
+                             lineno=lineno, col_offset=col)
+        p0 = ast.Call(func=func, args=[p[2], ast.Str(s='', lineno=lineno,
+                                                     col_offset=col)],
+                      keywords=[], starargs=None, kwargs=None, lineno=lineno,
+                      col_offset=col)
+        p0._cliarg_action = 'append'
+        p[0] = p0
 
     def p_subproc_atom_pyeval(self, p):
         """subproc_atom : AT_LPAREN test RPAREN"""

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -97,11 +97,12 @@ _xonsh_tokens = {
     '$(': 'DOLLARLPAREN',
     '$[': 'DOLLARLBRACKET',
     '${': 'DOLLARLBRACE',
+    '!{': 'BANGLBRACE',
     '??': 'DOUBLEQUESTION',
     '@$(': 'ATDOLLARLPAREN',
 }
 
-additional_parenlevs = frozenset({'@(', '!(', '![', '$(', '$[', '${', '@$('})
+additional_parenlevs = frozenset({'@(', '!(', '![', '$(', '$[', '${', '!{', '@$('})
 
 _glbs = globals()
 for v in _xonsh_tokens.values():
@@ -236,7 +237,7 @@ _redir_check = {'{}>>'.format(i) for i in _redir_names}.union(_redir_check)
 _redir_check = frozenset(_redir_check)
 Operator = group(r"\*\*=?", r">>=?", r"<<=?", r"!=", r"//=?", r"->",
                  r"@\$\(?", r'\|\|', '&&', r'@\(', r'!\(', r'!\[', r'\$\(',
-                 r'\$\[', '\${', r'\?\?', r'\?', AUGASSIGN_OPS, r"~")
+                 r'\$\[', '\${', '!{', r'\?\?', r'\?', AUGASSIGN_OPS, r"~")
 
 Bracket = '[][(){}]'
 Special = group(r'\r?\n', r'\.\.\.', r'[:;.,@]')


### PR DESCRIPTION
a first draft on implementing history syntax, #1411 
currently `!{...}` is used but this is subject to changes.