### PR TITLE
Wrap Bash's Tab Completions in Quotes

### DIFF
--- a/news/completer_quotes.rst
+++ b/news/completer_quotes.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Results of the ``bash`` tab completer are now properly escaped (quoted) when necessary.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/completers/__init__.py
+++ b/xonsh/completers/__init__.py
@@ -6,8 +6,6 @@ else:
     import sys as _sys
     try:
         from xonsh.completers import __amalgam__
-        bash = __amalgam__
-        _sys.modules['xonsh.completers.bash'] = __amalgam__
         completer = __amalgam__
         _sys.modules['xonsh.completers.completer'] = __amalgam__
         pip = __amalgam__
@@ -26,6 +24,8 @@ else:
         _sys.modules['xonsh.completers.python'] = __amalgam__
         base = __amalgam__
         _sys.modules['xonsh.completers.base'] = __amalgam__
+        bash = __amalgam__
+        _sys.modules['xonsh.completers.bash'] = __amalgam__
         dirs = __amalgam__
         _sys.modules['xonsh.completers.dirs'] = __amalgam__
         init = __amalgam__

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -10,6 +10,7 @@ import subprocess
 import xonsh.lazyasd as xl
 import xonsh.platform as xp
 
+from xonsh.completers.path import _quote_paths
 
 RE_DASHF = xl.LazyObject(lambda: re.compile(r'-F\s+(\w+)'),
                          globals(), 'RE_DASHF')
@@ -114,7 +115,7 @@ def complete_from_bash(prefix, line, begidx, endidx, ctx):
     except (subprocess.CalledProcessError, FileNotFoundError):
         out = ''
 
-    rtn = set(out.splitlines())
+    rtn = _quote_paths(set(out.splitlines()), '', '')
     return rtn
 
 


### PR DESCRIPTION
This change causes the results of Bash's tab completion to be escaped (quoted) where necessary (e.g., filenames with spaces).