### PR TITLE
Handle More Syntax Errors

### DIFF
--- a/news/more_syntax_errors.rst
+++ b/news/more_syntax_errors.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* xonsh now properly handles syntax error messages arising from using values in inappropriate contexts (e.g., ``del 7``).
+
+**Security:** None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1809,29 +1809,29 @@ def test_syntax_error_del_ifexp():
     with pytest.raises(SyntaxError):
         PARSER.parse('del x if y else z')
 
-def test_syntax_error_del_comps():
-    with pytest.raises(SyntaxError):
-        PARSER.parse('del [i for i in foo]')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('del {i for i in foo}')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('del {k:v for k,v in d.items()}')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('del (i for i in foo)')
 
-def test_syntax_error_del_ops():
+@pytest.mark.parametrize('exp', ['[i for i in foo]',
+                                 '{i for i in foo}',
+                                 '(i for i in foo)',
+                                 '{k:v for k,v in d.items()}'])
+def test_syntax_error_del_comps(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('del x + y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('del x and y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('del -y')
+        PARSER.parse('del {}'.format(exp))
 
-def test_syntax_error_del_cmp():
+
+@pytest.mark.parametrize('exp', ['x + y',
+                                 'x and y',
+                                 '-x'])
+def test_syntax_error_del_ops(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('del x > y')
+        PARSER.parse('del {}'.format(exp))
+
+
+@pytest.mark.parametrize('exp', ['x > y',
+                                 'x > y == z'])
+def test_syntax_error_del_cmp(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('del x > y > z')
+        PARSER.parse('del {}'.format(exp))
 
 def test_syntax_error_lonely_del():
     with pytest.raises(SyntaxError):
@@ -1861,29 +1861,30 @@ def test_syntax_error_assign_ifexp():
     with pytest.raises(SyntaxError):
         PARSER.parse('x if y else z = 8')
 
-def test_syntax_error_assign_comps():
-    with pytest.raises(SyntaxError):
-        PARSER.parse('[i for i in foo] = y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('{i for i in foo} = y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('{k:v for k,v in d.items()} = y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('(k for k in d) = y')
 
-def test_syntax_error_assign_ops():
+@pytest.mark.parametrize('exp', ['[i for i in foo]',
+                                 '{i for i in foo}',
+                                 '(i for i in foo)',
+                                 '{k:v for k,v in d.items()}'])
+def test_syntax_error_assign_comps(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('x + y = z')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('x and y = z')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('-y = z')
+        PARSER.parse('{} = z'.format(exp))
 
-def test_syntax_error_assign_cmp():
+
+@pytest.mark.parametrize('exp', ['x + y',
+                                 'x and y',
+                                 '-x'])
+def test_syntax_error_assign_ops(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('x > y = z')
+        PARSER.parse('{} = z'.format(exp))
+
+
+@pytest.mark.parametrize('exp', ['x > y',
+                                 'x > y == z'])
+def test_syntax_error_assign_cmp(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('x > y > z = a')
+        PARSER.parse('{} = a'.format(exp))
+
 
 def test_syntax_error_augassign_literal():
     with pytest.raises(SyntaxError):
@@ -1909,26 +1910,26 @@ def test_syntax_error_augassign_ifexp():
     with pytest.raises(SyntaxError):
         PARSER.parse('x if y else z += 8')
 
-def test_syntax_error_augassign_comps():
-    with pytest.raises(SyntaxError):
-        PARSER.parse('[i for i in foo] += y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('{i for i in foo} += y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('{k:v for k,v in d.items()} += y')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('(k for k in d) += y')
 
-def test_syntax_error_augassign_ops():
+@pytest.mark.parametrize('exp', ['[i for i in foo]',
+                                 '{i for i in foo}',
+                                 '(i for i in foo)',
+                                 '{k:v for k,v in d.items()}'])
+def test_syntax_error_augassign_comps(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('x + y += z')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('x and y += z')
-    with pytest.raises(SyntaxError):
-        PARSER.parse('-y += z')
+        PARSER.parse('{} += z'.format(exp))
 
-def test_syntax_error_augassign_cmp():
+
+@pytest.mark.parametrize('exp', ['x + y',
+                                 'x and y',
+                                 '-x'])
+def test_syntax_error_augassign_ops(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('x > y += z')
+        PARSER.parse('{} += z'.format(exp))
+
+
+@pytest.mark.parametrize('exp', ['x > y',
+                                 'x > y +=+= z'])
+def test_syntax_error_augassign_cmp(exp):
     with pytest.raises(SyntaxError):
-        PARSER.parse('x > y > z += a')
+        PARSER.parse('{} += a'.format(exp))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1782,3 +1782,153 @@ def test_redirect_error_to_output(r, o):
     assert check_xonsh_ast({}, '$[echo "test" {} {}> test.txt]'.format(r, o), False)
     assert check_xonsh_ast({}, '$[< input.txt echo "test" {} {}> test.txt]'.format(r, o), False)
     assert check_xonsh_ast({}, '$[echo "test" {} {}> test.txt < input.txt]'.format(r, o), False)
+
+# test invalid expressions
+
+def test_syntax_error_del_literal():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del 7')
+
+def test_syntax_error_del_constant():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del True')
+
+def test_syntax_error_del_emptytuple():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del ()')
+
+def test_syntax_error_del_call():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del foo()')
+
+def test_syntax_error_del_lambda():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del lambda x: "yay"')
+
+def test_syntax_error_del_ifexp():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del x if y else z')
+
+def test_syntax_error_del_comps():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del [i for i in foo]')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del {i for i in foo}')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del {k:v for k,v in d.items()}')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del (i for i in foo)')
+
+def test_syntax_error_del_ops():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del x + y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del x and y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del -y')
+
+def test_syntax_error_del_cmp():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del x > y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del x > y > z')
+
+def test_syntax_error_lonely_del():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('del')
+
+def test_syntax_error_assign_literal():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('7 = x')
+
+def test_syntax_error_assign_constant():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('True = 8')
+
+def test_syntax_error_assign_emptytuple():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('() = x')
+
+def test_syntax_error_assign_call():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('foo() = x')
+
+def test_syntax_error_assign_lambda():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('lambda x: "yay" = y')
+
+def test_syntax_error_assign_ifexp():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x if y else z = 8')
+
+def test_syntax_error_assign_comps():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('[i for i in foo] = y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('{i for i in foo} = y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('{k:v for k,v in d.items()} = y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('(k for k in d) = y')
+
+def test_syntax_error_assign_ops():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x + y = z')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x and y = z')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('-y = z')
+
+def test_syntax_error_assign_cmp():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x > y = z')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x > y > z = a')
+
+def test_syntax_error_augassign_literal():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('7 += x')
+
+def test_syntax_error_augassign_constant():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('True += 8')
+
+def test_syntax_error_augassign_emptytuple():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('() += x')
+
+def test_syntax_error_augassign_call():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('foo() += x')
+
+def test_syntax_error_augassign_lambda():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('lambda x: "yay" += y')
+
+def test_syntax_error_augassign_ifexp():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x if y else z += 8')
+
+def test_syntax_error_augassign_comps():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('[i for i in foo] += y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('{i for i in foo} += y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('{k:v for k,v in d.items()} += y')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('(k for k in d) += y')
+
+def test_syntax_error_augassign_ops():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x + y += z')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x and y += z')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('-y += z')
+
+def test_syntax_error_augassign_cmp():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x > y += z')
+    with pytest.raises(SyntaxError):
+        PARSER.parse('x > y > z += a')

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -163,7 +163,7 @@ class Execer(object):
                 if (e.loc is None) or (last_error_line == e.loc.lineno and
                                        last_error_col in (e.loc.column + 1,
                                                           e.loc.column)):
-                    raise original_error
+                    raise original_error from None
                 last_error_col = e.loc.column
                 last_error_line = e.loc.lineno
                 idx = last_error_line - 1

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -17,6 +17,7 @@ from xonsh.lexer import Lexer, LexToken
 from xonsh.platform import PYTHON_VERSION_INFO
 from xonsh.tokenize import SearchPath
 from xonsh.lazyasd import LazyObject
+from xonsh.parsers.context_check import check_contexts
 
 RE_SEARCHPATH = LazyObject(lambda: re.compile(SearchPath), globals(),
                            'RE_SEARCHPATH')
@@ -309,6 +310,8 @@ class BaseParser(object):
         while self.parser is None:
             time.sleep(0.01)  # block until the parser is ready
         tree = self.parser.parse(input=s, lexer=self.lexer, debug=debug_level)
+        if tree is not None:
+            check_contexts(tree)
         # hack for getting modes right
         if mode == 'single':
             if isinstance(tree, ast.Expression):

--- a/xonsh/parsers/context_check.py
+++ b/xonsh/parsers/context_check.py
@@ -4,6 +4,7 @@ import collections
 
 _all_keywords = frozenset(keyword.kwlist)
 
+
 def _not_assignable(x, augassign=False):
     """
     If ``x`` represents a value that can be assigned to, return ``None``.
@@ -46,6 +47,7 @@ def _not_assignable(x, augassign=False):
 
 _loc = collections.namedtuple('_loc', ['lineno', 'column'])
 
+
 def check_contexts(tree):
     c = ContextCheckingVisitor()
     c.visit(tree)
@@ -53,6 +55,7 @@ def check_contexts(tree):
         e = SyntaxError(c.error[0])
         e.loc = _loc(c.error[1], c.error[2])
         raise e
+
 
 class ContextCheckingVisitor(ast.NodeVisitor):
     def __init__(self):
@@ -73,9 +76,9 @@ class ContextCheckingVisitor(ast.NodeVisitor):
                 msg = "can't assign to {}".format(err)
                 self.error = msg, i.lineno, i.col_offset
                 break
-    
+
     def visit_AugAssign(self, node):
-       err = _not_assignable(node.target, True)
-       if err is not None:
-           msg = "illegal target for augmented assignment: {}".format(err)
-           self.error = msg, node.target.lineno, node.target.col_offset
+        err = _not_assignable(node.target, True)
+        if err is not None:
+            msg = "illegal target for augmented assignment: {}".format(err)
+            self.error = msg, node.target.lineno, node.target.col_offset

--- a/xonsh/parsers/context_check.py
+++ b/xonsh/parsers/context_check.py
@@ -1,0 +1,81 @@
+import ast
+import keyword
+import collections
+
+_all_keywords = frozenset(keyword.kwlist)
+
+def _not_assignable(x, augassign=False):
+    """
+    If ``x`` represents a value that can be assigned to, return ``None``.
+    Otherwise, return a string describing the object.  For use in generating
+    meaningful syntax errors.
+    """
+    if augassign and isinstance(x, (ast.Tuple, ast.List)):
+        return 'literal'
+    elif isinstance(x, (ast.Tuple, ast.List)):
+        if len(x.elts) == 0:
+            return '()'
+        for i in x.elts:
+            res = _not_assignable(i)
+            if res is not None:
+                return res
+    elif isinstance(x, (ast.Set, ast.Dict, ast.Num, ast.Str, ast.Bytes)):
+        return 'literal'
+    elif isinstance(x, ast.Call):
+        return 'function call'
+    elif isinstance(x, ast.Lambda):
+        return 'lambda'
+    elif isinstance(x, (ast.BoolOp, ast.BinOp, ast.UnaryOp)):
+        return 'operator'
+    elif isinstance(x, ast.IfExp):
+        return 'conditional expression'
+    elif isinstance(x, ast.ListComp):
+        return 'list comprehension'
+    elif isinstance(x, ast.DictComp):
+        return 'dictionary comprehension'
+    elif isinstance(x, ast.SetComp):
+        return 'set comprehension'
+    elif isinstance(x, ast.GeneratorExp):
+        return 'generator expression'
+    elif isinstance(x, ast.Compare):
+        return 'comparison'
+    elif isinstance(x, ast.Name) and x.id in _all_keywords:
+        return 'keyword'
+    elif isinstance(x, ast.NameConstant):
+        return 'keyword'
+
+_loc = collections.namedtuple('_loc', ['lineno', 'column'])
+
+def check_contexts(tree):
+    c = ContextCheckingVisitor()
+    c.visit(tree)
+    if c.error is not None:
+        e = SyntaxError(c.error[0])
+        e.loc = _loc(c.error[1], c.error[2])
+        raise e
+
+class ContextCheckingVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.error = None
+
+    def visit_Delete(self, node):
+        for i in node.targets:
+            err = _not_assignable(i)
+            if err is not None:
+                msg = "can't delete {}".format(err)
+                self.error = msg, i.lineno, i.col_offset
+                break
+
+    def visit_Assign(self, node):
+        for i in node.targets:
+            err = _not_assignable(i)
+            if err is not None:
+                msg = "can't assign to {}".format(err)
+                self.error = msg, i.lineno, i.col_offset
+                break
+    
+    def visit_AugAssign(self, node):
+       err = _not_assignable(node.target, True)
+       if err is not None:
+           msg = "illegal target for augmented assignment: {}".format(err)
+           self.error = msg, node.target.lineno, node.target.col_offset


### PR DESCRIPTION
This patch allows xonsh to gracefully handle more syntax errors than before.

There is a class of syntax errors that seem not to result from expressions that are invalid as specified by the grammar, but rather from using certain expressions in contexts they aren't made for (e.g., `del 7`).  Previously, xonsh did not report these as syntax errors; rather, they fell through the parsing stage and were reported as other `ValueError`s downstream, which prevented the automatic jump to subprocess mode.

Not a life-changing fix, probably, but it does make all (I think) syntax errors behave in the same way.  Partially addresses #776, though the real error with that particular expression was from the dollar sign.