### PR TITLE
fix parsing for bare tuple of tuples

### DIFF
--- a/news/bare-tuple-of-tuples.rst
+++ b/news/bare-tuple-of-tuples.rst
@@ -6,6 +6,8 @@
 
 **Removed:** None
 
-**Fixed:** fix parsing for tuple of tuples (like `(),()`)
+**Fixed:**
+
+* fix parsing for tuple of tuples (like `(),()`)
 
 **Security:** None

--- a/news/bare-tuple-of-tuples.rst
+++ b/news/bare-tuple-of-tuples.rst
@@ -1,0 +1,11 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** fix parsing for tuple of tuples (like `(),()`)
+
+**Security:** None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -437,6 +437,15 @@ def test_tuple_three():
 def test_tuple_three_comma():
     check_ast('(1, 42, 65,)')
 
+def test_bare_tuple_of_tuples():
+    check_ast('(),')
+    check_ast('((),),(1,)')
+    check_ast('(),(),')
+    check_ast('[],')
+    check_ast('[],()')
+    check_ast('(),[],')
+    check_ast('((),[()],)')
+
 def test_set_one():
     check_ast('{42}')
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -442,6 +442,7 @@ def test_bare_tuple_of_tuples():
     check_ast('((),),(1,)')
     check_ast('(),(),')
     check_ast('[],')
+    check_ast('[],[]')
     check_ast('[],()')
     check_ast('(),[],')
     check_ast('((),[()],)')

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1675,6 +1675,7 @@ class BaseParser(object):
             # empty container atom
             p0 = ast.Tuple(elts=[], ctx=ast.Load(), lineno=self.lineno,
                            col_offset=self.col)
+            p0._real_tuple = True
         elif isinstance(p2, ast.AST):
             p0 = p2
             p0._lopen_lineno, p0._lopen_col = p1_tok.lineno, p1_tok.lexpos
@@ -1894,15 +1895,16 @@ class BaseParser(object):
         """testlist : test"""
         p1 = p[1]
         if isinstance(p1, ast.Tuple) and (hasattr(p1, '_real_tuple') and
-                                          p1._real_tuple):
+                                          p1._real_tuple and p1.elts):
             p1.lineno, p1.col_offset = lopen_loc(p1.elts[0])
         p[0] = p1
 
     def p_testlist_single(self, p):
         """testlist : test COMMA"""
         p1 = p[1]
-        if isinstance(p1, ast.Tuple) and (hasattr(p1, '_real_tuple') and
-                                          p1._real_tuple):
+        if isinstance(p1, ast.List) or (isinstance(p1, ast.Tuple) and
+                                        hasattr(p1, '_real_tuple') and
+                                        p1._real_tuple):
             lineno, col = lopen_loc(p1)
             p[0] = ast.Tuple(elts=[p1], ctx=ast.Load(),
                              lineno=p1.lineno, col_offset=p1.col_offset)
@@ -1914,8 +1916,9 @@ class BaseParser(object):
                     | test comma_test_list
         """
         p1 = p[1]
-        if isinstance(p1, ast.Tuple) and (hasattr(p1, '_real_tuple') and
-                                          p1._real_tuple):
+        if isinstance(p1, ast.List) or (isinstance(p1, ast.Tuple) and
+                                        hasattr(p1, '_real_tuple') and
+                                        p1._real_tuple):
             lineno, col = lopen_loc(p1)
             p1 = ast.Tuple(elts=[p1], ctx=ast.Load(),
                            lineno=p1.lineno, col_offset=p1.col_offset)


### PR DESCRIPTION
trying to fix #1593 

I think it's reasonable to set `_real_tuple` to an empty tuple `()`, is that correct? What does `_real_tuple` supposed to mean?

Thanks