### PR TITLE
Check all names for subproc wrapping

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -74,9 +74,10 @@ Python variables, this could be transformed to the equivalent (Python)
 expressions ``ls - l`` or ``ls-l``.  Neither of which are valid listing
 commands.
 
-What xonsh does to overcome such ambiguity is to check if the left-most
-name (``ls`` above) is in the present Python context. If it is, then it takes
-the line to be valid xonsh as written. If the left-most name cannot be found,
+What xonsh does to overcome such ambiguity is to check if the names in the
+expression (``ls`` and ``l`` above) are in the present Python context. If they are,
+then it takes
+the line to be valid xonsh as written. If one of the names cannot be found,
 then xonsh assumes that the left-most name is an external command. It thus
 attempts to parse the line after wrapping it in an uncaptured subprocess
 call ``![]``.  If wrapped version successfully parses, the ``![]`` version

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -267,11 +267,11 @@ have also been written as ``ls - l`` or ``ls-l``.  So how does xonsh know
 that ``ls -l`` is meant to be run in subprocess-mode?
 
 For any given line that only contains an expression statement (expr-stmt,
-see the Python AST docs for more information), if the left-most name cannot
-be found as a current variable name xonsh will try to parse the line as a
-subprocess command instead.  In the above, if ``ls`` is not a variable,
-then subprocess mode will be attempted. If parsing in subprocess mode fails,
-then the line is left in Python-mode.
+see the Python AST docs for more information), if all the names cannot
+be found as current variables name xonsh will try to parse the line as a
+subprocess command instead.  In the above, if ``ls`` ans ``l`` are not a
+variables, then subprocess mode will be attempted. If parsing in subprocess
+mode fails, then the line is left in Python-mode.
 
 In the following example, we will list the contents of the directory
 with ``ls -l``. Then we'll make new variable names ``ls`` and ``l`` and then
@@ -284,7 +284,7 @@ the directories again.
     >>> ls -l
     total 0
     -rw-rw-r-- 1 snail snail 0 Mar  8 15:46 xonsh
-    >>> # set an ls variable to force python-mode
+    >>> # set ls and l variables to force python-mode
     >>> ls = 44
     >>> l = 2
     >>> ls -l
@@ -1132,7 +1132,7 @@ with keyword arguments:
 Removing an alias is as easy as deleting the key from the alias dictionary:
 
 .. code-block:: xonshcon
-    
+
     >>> del aliases['banana']
 
 .. note::

--- a/news/allnames.rst
+++ b/news/allnames.rst
@@ -1,0 +1,16 @@
+**Added:** None
+
+**Changed:**
+
+* Context sensitive AST transformation now checks that all names in an
+  expression are in scope. If they are, then Python mode is retained. However,
+  if even one is missing, subprocess wrapping is attempted. Previously, only the
+  left-most name was examined for being within scope.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -226,12 +226,13 @@ class CtxAwareTransformer(NodeTransformer):
 
     def is_in_scope(self, node):
         """Determines whether or not the current node is in scope."""
-        lname = leftmostname(node)
-        if lname is None:
-            return node
+        names = gather_names(node)
+        if not names:
+            return True
         inscope = False
         for ctx in reversed(self.contexts):
-            if lname in ctx:
+            names -= ctx
+            if not names:
                 inscope = True
                 break
         return inscope


### PR DESCRIPTION
Ok, this was shamefully easy in retrospect.  Note that the actual code diff is only +5/-4 lines, which I guess is a testament to our documentation and testing :)  See #1541 for the inspiration here.