### PR TITLE
New option to use <Enter> to confirm completion instead of running command

### DIFF
--- a/news/completion-confirm.rst
+++ b/news/completion-confirm.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* New option ``COMPLETION_CONFIRM``. When set, ``<Enter>`` is used to confirm
+* New option ``COMPLETIONS_CONFIRM``. When set, ``<Enter>`` is used to confirm
   completion instead of running command while completion menu is displayed.
 
 **Changed:** None

--- a/news/completion-confirm.rst
+++ b/news/completion-confirm.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+* New option ``COMPLETION_CONFIRM``. When set, ``<Enter>`` is used to confirm
+  completion instead of running command while completion menu is displayed.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -244,6 +244,7 @@ def DEFAULT_VALUES():
         'CDPATH': (),
         'COLOR_INPUT': True,
         'COLOR_RESULTS': True,
+        'COMPLETION_CONFIRM': False,
         'COMPLETIONS_DISPLAY': 'multi',
         'COMPLETIONS_MENU_ROWS': 5,
         'DIRSTACK_SIZE': 20,
@@ -393,6 +394,10 @@ def DEFAULT_DOCS():
         "writing \"$COMPLETIONS_DISPLAY = None\" and \"$COMPLETIONS_DISPLAY "
         "= 'none'\" are equivalent. Only usable with "
         "$SHELL_TYPE=prompt_toolkit"),
+    'COMPLETION_CONFIRM': VarDocs(
+        'While tab-completions menu is displayed, press <Enter> to confirm '
+        'completion instead of running command. This only affects the '
+        'prompt-toolkit shell.'),
     'COMPLETIONS_MENU_ROWS': VarDocs(
         'Number of rows to reserve for tab-completions menu if '
         "$COMPLETIONS_DISPLAY is 'single' or 'multi'. This only affects the "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -102,7 +102,7 @@ def DEFAULT_ENSURERS():
     'COLOR_INPUT': (is_bool, to_bool, bool_to_str),
     'COLOR_RESULTS': (is_bool, to_bool, bool_to_str),
     'COMPLETIONS_BRACKETS': (is_bool, to_bool, bool_to_str),
-    'COMPLETION_CONFIRM': (is_bool, to_bool, bool_to_str),
+    'COMPLETIONS_CONFIRM': (is_bool, to_bool, bool_to_str),
     'COMPLETIONS_DISPLAY': (is_completions_display_value,
                             to_completions_display_value, str),
     'COMPLETIONS_MENU_ROWS': (is_int, int, str),
@@ -247,7 +247,7 @@ def DEFAULT_VALUES():
         'COLOR_INPUT': True,
         'COLOR_RESULTS': True,
         'COMPLETIONS_BRACKETS': True,
-        'COMPLETION_CONFIRM': False,
+        'COMPLETIONS_CONFIRM': False,
         'COMPLETIONS_DISPLAY': 'multi',
         'COMPLETIONS_MENU_ROWS': 5,
         'DIRSTACK_SIZE': 20,
@@ -401,7 +401,7 @@ def DEFAULT_DOCS():
         "writing \"$COMPLETIONS_DISPLAY = None\" and \"$COMPLETIONS_DISPLAY "
         "= 'none'\" are equivalent. Only usable with "
         "$SHELL_TYPE=prompt_toolkit"),
-    'COMPLETION_CONFIRM': VarDocs(
+    'COMPLETIONS_CONFIRM': VarDocs(
         'While tab-completions menu is displayed, press <Enter> to confirm '
         'completion instead of running command. This only affects the '
         'prompt-toolkit shell.'),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -101,6 +101,7 @@ def DEFAULT_ENSURERS():
     re.compile('\w*DIRS$'): (is_env_path, str_to_env_path, env_path_to_str),
     'COLOR_INPUT': (is_bool, to_bool, bool_to_str),
     'COLOR_RESULTS': (is_bool, to_bool, bool_to_str),
+    'COMPLETION_CONFIRM': (is_bool, to_bool, bool_to_str),
     'COMPLETIONS_DISPLAY': (is_completions_display_value,
                             to_completions_display_value, str),
     'COMPLETIONS_MENU_ROWS': (is_int, int, str),

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -107,6 +107,15 @@ class EndOfLine(Filter):
         return bool(at_end and not last_line)
 
 
+class ShouldConfirmCompletion(Filter):
+    """
+    Check if completion needs confirmation
+    """
+    def __call__(self, cli):
+        return (builtins.__xonsh_env__.get('COMPLETION_CONFIRM', True)
+                and bool(cli.current_buffer.complete_state))
+
+
 # Copied from prompt-toolkit's key_binding/bindings/basic.py
 @Condition
 def ctrl_d_condition(cli):
@@ -172,6 +181,16 @@ def load_xonsh_bindings(key_bindings_manager):
         """ Wrapper around carriage_return multiline parser """
         b = event.cli.current_buffer
         carriage_return(b, event.cli)
+
+    @handle(Keys.ControlJ, filter=ShouldConfirmCompletion())
+    def enter_confirm_completion(event):
+        """Ignore <enter> (confirm completion)"""
+        event.current_buffer.complete_state = None
+
+    @handle(Keys.Escape, filter=ShouldConfirmCompletion())
+    def esc_cancel_completion(event):
+        """Use <ESC> to cancel completion"""
+        event.cli.current_buffer.cancel_completion()
 
     @handle(Keys.Left, filter=BeginningOfLine())
     def wrap_cursor_back(event):

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -112,7 +112,7 @@ class ShouldConfirmCompletion(Filter):
     Check if completion needs confirmation
     """
     def __call__(self, cli):
-        return (builtins.__xonsh_env__.get('COMPLETION_CONFIRM', True)
+        return (builtins.__xonsh_env__.get('COMPLETION_CONFIRM', False)
                 and bool(cli.current_buffer.complete_state))
 
 

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -112,7 +112,7 @@ class ShouldConfirmCompletion(Filter):
     Check if completion needs confirmation
     """
     def __call__(self, cli):
-        return (builtins.__xonsh_env__.get('COMPLETION_CONFIRM')
+        return (builtins.__xonsh_env__.get('COMPLETIONS_CONFIRM')
                 and cli.current_buffer.complete_state)
 
 

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -112,8 +112,8 @@ class ShouldConfirmCompletion(Filter):
     Check if completion needs confirmation
     """
     def __call__(self, cli):
-        return (builtins.__xonsh_env__.get('COMPLETION_CONFIRM', False)
-                and bool(cli.current_buffer.complete_state))
+        return (builtins.__xonsh_env__.get('COMPLETION_CONFIRM')
+                and cli.current_buffer.complete_state)
 
 
 # Copied from prompt-toolkit's key_binding/bindings/basic.py


### PR DESCRIPTION
Like fish shell, while completion menu is displayed, pressing `<Enter>` do not run the command.