### PR TITLE
add a 'kill' alias to use jobs indexes

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -12,7 +12,7 @@ from xonsh.lazyasd import lazyobject
 from xonsh.dirstack import cd, pushd, popd, dirs, _get_cwd
 from xonsh.environ import locate_binary
 from xonsh.foreign_shells import foreign_shell_data
-from xonsh.jobs import jobs, fg, bg, clean_jobs
+from xonsh.jobs import jobs, fg, bg, clean_jobs, kill
 from xonsh.history import history_main
 from xonsh.platform import (ON_ANACONDA, ON_DARWIN, ON_WINDOWS, ON_FREEBSD,
                             ON_NETBSD, scandir)
@@ -536,7 +536,7 @@ def make_default_aliases():
         'ipynb': ['jupyter', 'notebook', '--no-browser'],
         'which': which,
         'xontrib': xontribs_main,
-        'completer': xca.completer_alias
+        'completer': xca.completer_alias,
     }
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.
@@ -588,18 +588,22 @@ def make_default_aliases():
             default_aliases['sudo'] = sudo
     elif ON_DARWIN:
         default_aliases['ls'] = ['ls', '-G']
+        default_aliases['kill'] = kill
     elif ON_FREEBSD:
         default_aliases['grep'] = ['grep', '--color=auto']
         default_aliases['egrep'] = ['egrep', '--color=auto']
         default_aliases['fgrep'] = ['fgrep', '--color=auto']
         default_aliases['ls'] = ['ls', '-G']
+        default_aliases['kill'] = kill
     elif ON_NETBSD:
         default_aliases['grep'] = ['grep', '--color=auto']
         default_aliases['egrep'] = ['egrep', '--color=auto']
         default_aliases['fgrep'] = ['fgrep', '--color=auto']
+        default_aliases['kill'] = kill
     else:
         default_aliases['grep'] = ['grep', '--color=auto']
         default_aliases['egrep'] = ['egrep', '--color=auto']
         default_aliases['fgrep'] = ['fgrep', '--color=auto']
         default_aliases['ls'] = ['ls', '--color=auto', '-v']
+        default_aliases['kill'] = kill
     return default_aliases


### PR DESCRIPTION
The zsh jobs management allow user to call a 'kill' builtin command with
'%' + index of the job, to kill a given job. This patch introduces the
same behavior in xonsh.

Unfortunately, as it calls the system 'kill' command, which doesn't exist
under Windows, I've added this alias only for unix systems.

A better way would be to re-implement the kill binary, and calling the
os.kill() function.
