### PR TITLE
Enshorten attr comp

### DIFF
--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -106,7 +106,8 @@ def attr_complete(prefix, ctx, filter_func):
             rpl = opt
         # note that prefix[:prelen-len(attr)] != prefix[:-len(attr)]
         # when len(attr) == 0.
-        comp = prefix[:prelen - len(attr)] + rpl
+    #    comp = prefix[:prelen - len(attr)] + rpl
+        comp = rpl
         attrs.add(comp)
     return attrs
 

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -106,8 +106,7 @@ def attr_complete(prefix, ctx, filter_func):
             rpl = opt
         # note that prefix[:prelen-len(attr)] != prefix[:-len(attr)]
         # when len(attr) == 0.
-    #    comp = prefix[:prelen - len(attr)] + rpl
-        comp = rpl
+        comp = prefix[:prelen - len(attr)] + rpl
         attrs.add(comp)
     return attrs
 

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -41,6 +41,8 @@ class PromptToolkitCompleter(Completer):
                 elif len(os.path.commonprefix(completions)) <= len(prefix):
                     self.reserve_space()
                 for comp in completions:
+                    prefix = prefix.rsplit('.', 1)[-1]
+                    l = len(prefix) if prefix in comp else 0
                     yield Completion(comp, -l)
 
     def reserve_space(self):

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -40,9 +40,11 @@ class PromptToolkitCompleter(Completer):
                     pass
                 elif len(os.path.commonprefix(completions)) <= len(prefix):
                     self.reserve_space()
+                prefix, _, compprefix = prefix.rpartition('.')
                 for comp in completions:
-                    prefix = prefix.rsplit('.', 1)[-1]
-                    l = len(prefix) if prefix in comp else 0
+                    if comp.rsplit('.', 1)[0] in prefix:
+                        comp = comp.rsplit('.', 1)[-1]
+                    l = len(compprefix) if compprefix in comp else 0
                     yield Completion(comp, -l)
 
     def reserve_space(self):


### PR DESCRIPTION
Resolves #937 

This was bugging me.  This is only a problem with prompt_toolkit.

Before:
![2016-08-25-163033_747x151_escrotum](https://cloud.githubusercontent.com/assets/3596999/17984984/b34d78fc-6ae1-11e6-8f77-971707b011be.png)

Now:
![2016-08-25-163322_724x153_escrotum](https://cloud.githubusercontent.com/assets/3596999/17984986/b5e44ece-6ae1-11e6-8931-a1b116fdf1eb.png)

That ghost space isn't actually present... some weird artifact from interaction with wcwidth and scrot, I think.

And enshorten is a perfectly xromulent word.
