### PR TITLE
correctly preserve parameters

### DIFF
--- a/news/pr-params.rst
+++ b/news/pr-params.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Correctly preserve arguments given to xon.sh, in case there are quoted ones.
+
+**Security:** None

--- a/scripts/xon.sh
+++ b/scripts/xon.sh
@@ -7,4 +7,4 @@ if [ -z "${LC_ALL+x}" ] && [ -z "${LC_CTYPE+x}" ] && \
 fi
 
 # run python
-exec /usr/bin/env PYTHONUNBUFFERED=1 python3 -u -m xonsh $@
+exec /usr/bin/env PYTHONUNBUFFERED=1 python3 -u -m xonsh "$@"


### PR DESCRIPTION
In case there are arguments containing spaces, there were splited. For
example:

$ xonsh -c 'echo 123'
['/home/rom1/python/xonsh/__main__.py', '-c', 'echo', '123']

$

With this patch:

$ xonsh -c 'echo 123'
['/home/rom1/python/xonsh/__main__.py', '-c', 'echo 123']
123
$