### PR TITLE
remove pacman completion xontrib

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -50,11 +50,6 @@
   "url": "https://github.com/xsteadfastx/xonsh-docker-tabcomplete",
   "description": ["Adds tabcomplete functionality to docker inside of xonsh."]
  },
- {"name": "pacman_tabcomplete",
-  "package": "xonsh-pacman-tabcomplete",
-  "url": "https://github.com/gforsyth/xonsh-pacman-tabcomplete",
-  "description": ["Adds tabcomplete functionality to pacman inside of xonsh."]
- },
  {"name": "scrapy_tabcomplete",
   "package": "xonsh-scrapy-tabcomplete",
   "url": "https://github.com/Granitas/xonsh-scrapy-tabcomplete",
@@ -125,13 +120,6 @@
     "pip": "pip install xonsh-docker-tabcomplete"
    }
   },
-  "xonsh-pacman-tabcomplete": {
-   "license": "MIT",
-   "url": "https://github.com/gforsyth/xonsh-pacman-tabcomplete",
-   "install": {
-    "pip": "pip install xonsh-pacman-tabcomplete"
-   }
-   },
   "xonsh-scrapy-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-scrapy-tabcomplete",


### PR DESCRIPTION
This xontrib is no longer needed thanks to improvements in
bash-completion imports.  Yay!  One less thing to maintain!