### PR TITLE
Better ptk completion display

### DIFF
--- a/news/ptk-completion-display.rst
+++ b/news/ptk-completion-display.rst
@@ -2,7 +2,7 @@
 
 **Changed:** 
 
-* `prompt_toolkit` completions now only show the rightmost portion
+* ``prompt_toolkit`` completions now only show the rightmost portion
   of a given completion in the dropdown
 
 **Deprecated:** None

--- a/news/ptk-completion-display.rst
+++ b/news/ptk-completion-display.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** 
+
+* `prompt_toolkit` completions now only show the rightmost portion
+  of a given completion in the dropdown
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -43,6 +43,8 @@ class PromptToolkitCompleter(Completer):
                 c_prefix = _commonprefix([a.strip('\'/').rsplit('/', 1)[0]
                                           for a in completions])
                 for comp in completions:
+                    if comp.endswith('/') and not c_prefix.startswith('/'):
+                        c_prefix = ''
                     display = comp[len(c_prefix):].lstrip('/')
                     yield Completion(comp, -l, display=display)
 

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -40,19 +40,11 @@ class PromptToolkitCompleter(Completer):
                     pass
                 elif len(os.path.commonprefix(completions)) <= len(prefix):
                     self.reserve_space()
-                # don't mess with envvar and path expansion comps
-#                if any(x in prefix for x in ['$', '/']):
-                c_prefix = _commonprefix([a.strip('\'/').rsplit('/', 1)[0] for a in completions])
+                c_prefix = _commonprefix([a.strip('\'/').rsplit('/', 1)[0]
+                                          for a in completions])
                 for comp in completions:
                     display = comp[len(c_prefix):].lstrip('/')
                     yield Completion(comp, -l, display=display)
-#                else:  # don't show common prefixes in attr completions
-#                    prefix, _, compprefix = prefix.rpartition('.')
-#                    for comp in completions:
-#                        if comp.rsplit('.', 1)[0] in prefix:
-#                            comp = comp.rsplit('.', 1)[-1]
-#                        l = len(compprefix) if compprefix in comp else 0
-#                        yield Completion(comp, -l)
 
     def reserve_space(self):
         cli = builtins.__xonsh_shell__.shell.prompter.cli

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -4,7 +4,7 @@ import os
 import builtins
 
 from prompt_toolkit.layout.dimension import LayoutDimension
-from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.completion import Completer, Completion, _commonprefix
 
 
 class PromptToolkitCompleter(Completer):
@@ -41,16 +41,17 @@ class PromptToolkitCompleter(Completer):
                 elif len(os.path.commonprefix(completions)) <= len(prefix):
                     self.reserve_space()
                 # don't mess with envvar and path expansion comps
-                if any(x in prefix for x in ['$', '/']):
-                    for comp in completions:
-                        yield Completion(comp, -l)
-                else:  # don't show common prefixes in attr completions
-                    prefix, _, compprefix = prefix.rpartition('.')
-                    for comp in completions:
-                        if comp.rsplit('.', 1)[0] in prefix:
-                            comp = comp.rsplit('.', 1)[-1]
-                        l = len(compprefix) if compprefix in comp else 0
-                        yield Completion(comp, -l)
+#                if any(x in prefix for x in ['$', '/']):
+                common_prefix = _commonprefix([a.strip('\'') for a in completions])
+                for comp in completions:
+                    yield Completion(comp, -l, display=comp[len(common_prefix):])
+#                else:  # don't show common prefixes in attr completions
+#                    prefix, _, compprefix = prefix.rpartition('.')
+#                    for comp in completions:
+#                        if comp.rsplit('.', 1)[0] in prefix:
+#                            comp = comp.rsplit('.', 1)[-1]
+#                        l = len(compprefix) if compprefix in comp else 0
+#                        yield Completion(comp, -l)
 
     def reserve_space(self):
         cli = builtins.__xonsh_shell__.shell.prompter.cli

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -42,9 +42,10 @@ class PromptToolkitCompleter(Completer):
                     self.reserve_space()
                 # don't mess with envvar and path expansion comps
 #                if any(x in prefix for x in ['$', '/']):
-                common_prefix = _commonprefix([a.strip('\'') for a in completions])
+                c_prefix = _commonprefix([a.strip('\'/').rsplit('/', 1)[0] for a in completions])
                 for comp in completions:
-                    yield Completion(comp, -l, display=comp[len(common_prefix):])
+                    display = comp[len(c_prefix):].lstrip('/')
+                    yield Completion(comp, -l, display=display)
 #                else:  # don't show common prefixes in attr completions
 #                    prefix, _, compprefix = prefix.rpartition('.')
 #                    for comp in completions:


### PR DESCRIPTION
Ok, fingers crossed, but I think I finally cracked this.  @blahgeek, could you take a look at this and see if it covers the corner cases you mentioned in #1639 

Quick summary:
`numpy.<TAB>` will show `abs(, absolute(...`
`cd xon` will show (for example) `xonsh/, xonda/`
`cd git/xon` will show (as above) `xonsh/, xonda/`

file/folder names with dots and spaces seem to work well.  Note that the quotes around file/folders will spaces won't be shown in the completion but will appear when you select that completion.