### PR TITLE
Fix win tests

### DIFF
--- a/news/win_test_fixes.rst
+++ b/news/win_test_fixes.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Fix some test problems when win_unicode_console was installed on windows.
+
+**Security:** None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,6 @@ from xonsh.platform import ON_WINDOWS
 from tools import DummyShell, sp
 
 
-
-
 @pytest.fixture
 def xonsh_execer(monkeypatch):
     """Initiate the Execer with a mocked nop `load_builtins`"""
@@ -67,6 +65,7 @@ def xonsh_builtins():
     del builtins.compilex
     del builtins.aliases
     del builtins.events
+
 
 if ON_WINDOWS:
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,10 @@ from xonsh.built_ins import ensure_list_of_strs
 from xonsh.execer import Execer
 from xonsh.tools import XonshBlockError
 from xonsh.events import events
-
+from xonsh.platform import ON_WINDOWS
 from tools import DummyShell, sp
+
+
 
 
 @pytest.fixture
@@ -65,3 +67,17 @@ def xonsh_builtins():
     del builtins.compilex
     del builtins.aliases
     del builtins.events
+
+if ON_WINDOWS:
+    try:
+        import win_unicode_console
+        HAVE_WIN_UNICODE_CONSOLE = True
+    except ImportError:
+        HAVE_WIN_UNICODE_CONSOLE = False
+
+    if HAVE_WIN_UNICODE_CONSOLE:
+        @pytest.fixture(autouse=True)
+        def disable_win_unicode_console(monkeypatch):
+            """ Disable win_unicode_console if it is present since it collides with
+            pytests ouptput capture"""
+            monkeypatch.setattr(win_unicode_console, 'enable', lambda: None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,11 +71,9 @@ def xonsh_builtins():
 if ON_WINDOWS:
     try:
         import win_unicode_console
-        HAVE_WIN_UNICODE_CONSOLE = True
     except ImportError:
-        HAVE_WIN_UNICODE_CONSOLE = False
-
-    if HAVE_WIN_UNICODE_CONSOLE:
+        pass
+    else:
         @pytest.fixture(autouse=True)
         def disable_win_unicode_console(monkeypatch):
             """ Disable win_unicode_console if it is present since it collides with

--- a/tests/test_dirstack_unc.py
+++ b/tests/test_dirstack_unc.py
@@ -23,6 +23,13 @@ from xonsh.dirstack import _unc_tempDrives
 HERE = os.path.abspath(os.path.dirname(__file__))
 PARENT = os.path.dirname(HERE)
 
+def drive_in_use(letter):
+    return ON_WINDOWS and os.system('vol {}: 2>nul>nul'.format(letter)) == 0
+
+pytestmark = pytest.mark.skipif(any(drive_in_use(l) for l in 'ywzx'),
+                                reason='Drive letters used by tests are '
+                                       'are already used by Windows.')
+
 
 @pytest.yield_fixture(scope="module")
 def shares_setup(tmpdir_factory):


### PR DESCRIPTION
This fixes some test problems I was having locally on windows. 

It skips the tests in 'test_dirstack_unc.py' if drive names are already mapped for other things in windows. 

It also disables `win_unicode_console` if that is installed. The module collides with pytests caputure functionality causing some test to error. 
