### PR TITLE
Better completer display in prompt-toolkit

### DIFF
--- a/news/fix-ptk-completer.rst
+++ b/news/fix-ptk-completer.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Better completer display for long completions in prompt-toolkit
+
+**Security:** None

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -46,7 +46,7 @@ class PromptToolkitCompleter(Completer):
                                                 for a in completions])
                 # Find last split symbol, do not trim the last part 
                 while c_prefix:
-                    if c_prefix[-1] in r'/\.:@':
+                    if c_prefix[-1] in r'/\.:@,':
                         break
                     c_prefix = c_prefix[:-1]
 

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -44,7 +44,7 @@ class PromptToolkitCompleter(Completer):
                 # Find common prefix (strip quoting)
                 c_prefix = os.path.commonprefix([a.strip('\'"')
                                                 for a in completions])
-                # Find last split symbol, do not trim the last part 
+                # Find last split symbol, do not trim the last part
                 while c_prefix:
                     if c_prefix[-1] in r'/\.:@,':
                         break

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -4,7 +4,7 @@ import os
 import builtins
 
 from prompt_toolkit.layout.dimension import LayoutDimension
-from prompt_toolkit.completion import Completer, Completion, _commonprefix
+from prompt_toolkit.completion import Completer, Completion
 
 
 class PromptToolkitCompleter(Completer):
@@ -40,13 +40,20 @@ class PromptToolkitCompleter(Completer):
                     pass
                 elif len(os.path.commonprefix(completions)) <= len(prefix):
                     self.reserve_space()
-                c_prefix = _commonprefix([a.strip('\'/').rsplit('/', 1)[0]
-                                          for a in completions])
+
+                # Find common prefix (strip quoting)
+                c_prefix = os.path.commonprefix([a.strip('\'"')
+                                                for a in completions])
+                # Find last split symbol, do not trim the last part 
+                while c_prefix:
+                    if c_prefix[-1] in r'/\.:@':
+                        break
+                    c_prefix = c_prefix[:-1]
+
                 for comp in completions:
-                    if comp.endswith('/') and not c_prefix.startswith('/'):
-                        c_prefix = ''
-                    display = comp[len(c_prefix):].lstrip('/')
-                    yield Completion(comp, -l, display=display)
+                    # do not display quote
+                    disp = comp.strip('\'"')[len(c_prefix):]
+                    yield Completion(comp, -l, display=disp)
 
     def reserve_space(self):
         cli = builtins.__xonsh_shell__.shell.prompter.cli


### PR DESCRIPTION
This is a followup for #1643 

Before: 
<img width="935" alt="screen shot 2016-09-02 at 23 54 09" src="https://cloud.githubusercontent.com/assets/1308450/18210123/a4eec5ac-7169-11e6-9d76-11aa5249f0c2.png">
<img width="1100" alt="screen shot 2016-09-02 at 23 55 19" src="https://cloud.githubusercontent.com/assets/1308450/18210128/aae1894a-7169-11e6-840f-0eb838351594.png">
<img width="821" alt="screen shot 2016-09-02 at 23 53 45" src="https://cloud.githubusercontent.com/assets/1308450/18210132/add51a9a-7169-11e6-9846-84550016dd59.png">
<img width="132" alt="screen shot 2016-09-03 at 00 00 52" src="https://cloud.githubusercontent.com/assets/1308450/18210135/af643be8-7169-11e6-8fa5-58538ff8ff18.png">
<img width="136" alt="screen shot 2016-09-03 at 00 09 47" src="https://cloud.githubusercontent.com/assets/1308450/18210379/c90b44f0-716a-11e6-9bb3-825b9f29245c.png">


---

After:

<img width="703" alt="screen shot 2016-09-02 at 23 54 21" src="https://cloud.githubusercontent.com/assets/1308450/18210139/b4a50312-7169-11e6-98e8-3c0d4efa417f.png">
<img width="985" alt="screen shot 2016-09-02 at 23 55 31" src="https://cloud.githubusercontent.com/assets/1308450/18210145/b9ad4f2c-7169-11e6-815f-b83a1b2f7213.png">
<img width="587" alt="screen shot 2016-09-02 at 23 53 27" src="https://cloud.githubusercontent.com/assets/1308450/18210149/bbfc8bda-7169-11e6-8a22-75a4796dad74.png">
<img width="159" alt="screen shot 2016-09-02 at 23 50 03" src="https://cloud.githubusercontent.com/assets/1308450/18210169/d3e1a03c-7169-11e6-8809-99acc266ffbd.png">
<img width="173" alt="screen shot 2016-09-03 at 00 09 59" src="https://cloud.githubusercontent.com/assets/1308450/18210382/ce1871a2-716a-11e6-9890-3ba23e3efb85.png">

