### PR TITLE
Macro Consistency

### DIFF
--- a/docs/tutorial_macros.rst
+++ b/docs/tutorial_macros.rst
@@ -234,7 +234,7 @@ There are six kinds of annotations that macros are able to interpret:
      - ``str``
      - ``'s'``, ``'str'``, or ``'string'``
      -
-     - Source code of argument as string.
+     - Source code of argument as string, *default*.
    * - AST
      - ``ast.AST``
      - ``'a'`` or ``'ast'``
@@ -249,7 +249,7 @@ There are six kinds of annotations that macros are able to interpret:
      - ``eval`` or ``None``
      - ``'v'`` or ``'eval'``
      -
-     - Evaluation of the argument, *default*.
+     - Evaluation of the argument.
    * - Exec
      - ``exec``
      - ``'x'`` or ``'exec'``
@@ -269,9 +269,9 @@ annotation type.
 Each argument may be annotated with its own individual type. Annotations
 may be provided as either objects or as the string flags seen in the above
 table. String flags are case-insensitive.
-If an argument does not have an annotation, ``eval`` is selected.
-This makes the macro call behave like a normal function call for
-arguments whose annotations are unspecified.  For example,
+If an argument does not have an annotation, ``str`` is selected.
+This makes the macro function call behave like the subprocess macros and
+context manager macros below. For example,
 
 .. code-block:: xonsh
 
@@ -280,7 +280,7 @@ arguments whose annotations are unspecified.  For example,
 
 In a macro call of ``func!()``,
 
-* ``a`` will be evaluated with ``eval`` since no annotation was provided,
+* ``a`` will be evaluated with ``str`` since no annotation was provided,
 * ``b`` will be parsed into a syntax tree node, and
 * ``c`` will be compiled into code object since the builtin ``compile()``
   function was used as the annotation.

--- a/news/consist.rst
+++ b/news/consist.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* Macro function arguments now default to ``str``, rather than ``eval``,
+  for consistentcy with other parts of the macro system.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -749,7 +749,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name='<arg>',
         kind, mode = kind
     if isinstance(kind, str):
         kind = _convert_kind_flag(kind)
-    if kind is str:
+    if kind is str or kind is None:
         return raw_arg  # short circut since there is nothing else to do
     # select from kind and convert
     execer = builtins.__xonsh_execer__
@@ -764,7 +764,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name='<arg>',
         mode = mode or 'eval'
         arg = execer.compile(raw_arg, mode=mode, glbs=glbs, locs=locs,
                              filename=filename)
-    elif kind is eval or kind is None:
+    elif kind is eval:
         arg = execer.eval(raw_arg, glbs=glbs, locs=locs, filename=filename)
     elif kind is exec:
         mode = mode or 'exec'
@@ -838,7 +838,7 @@ def call_macro(f, raw_args, glbs, locs):
             break
         kind = param.annotation
         if kind is empty or kind is None:
-            kind = eval
+            kind = str
         arg = convert_macro_arg(raw_arg, kind, glbs, locs, name=key,
                                 macroname=macroname)
         args.append(arg)


### PR DESCRIPTION
This changes macro function calls to default to strings, rather than eval.  This makes it more consistent with subprocess macros and context manager macros, which also default to strings.