### PR TITLE
Track wd1

### DIFF
--- a/news/base_shell_fire_chdir_event.rst
+++ b/news/base_shell_fire_chdir_event.rst
@@ -8,6 +8,6 @@
 
 **Fixed:**
 
-* cd . and cd <singleCharacter> now work.  Fix indexerror in AUTO_PUSHD case, too.
+* now fires chdir event if OS change in working directory is detected.
 
 **Security:** None

--- a/tests/test_base_shell.py
+++ b/tests/test_base_shell.py
@@ -25,4 +25,7 @@ def test_pwd_tracks_cwd(xonsh_builtins, xonsh_execer, tmpdir_factory, monkeypatc
 
     assert os.path.abspath(os.getcwd()) == os.path.abspath(asubdir)
     assert os.path.abspath(os.getcwd()) == os.path.abspath(xonsh_builtins.__xonsh_env__['PWD'])
+    assert 'OLDPWD' in xonsh_builtins.__xonsh_env__
+    assert os.path.abspath(cur_wd) == os.path.abspath(xonsh_builtins.__xonsh_env__['OLDPWD'])
+
 

--- a/tests/test_dirstack_unc.py
+++ b/tests/test_dirstack_unc.py
@@ -10,14 +10,11 @@ import subprocess
 
 import builtins
 import pytest
-
 from xonsh import dirstack
 from xonsh.environ import Env
 from xonsh.built_ins import load_builtins
 from xonsh.dirstack import DIRSTACK
-
 from xonsh.platform import ON_WINDOWS
-
 from xonsh.dirstack import _unc_tempDrives
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -275,4 +272,3 @@ def test_uncpushd_unc_check():
     # emminently suited to mocking, but I don't know how
     # need to verify unc_check_enabled correct whether values set in HKCU or HKLM
     pass
-

--- a/tests/test_dirstack_unc.py
+++ b/tests/test_dirstack_unc.py
@@ -34,8 +34,8 @@ for d in 'zyxwvuts':
     if not drive_in_use(d):
         TEMP_DRIVE.append(d + ':')
 pytestmark = pytest.mark.skipif(len(TEMP_DRIVE) < MAX_TEMP_DRIVES,
-                                    reason='Too many drive letters needed by tests '
-                                   'are already used by Windows.')
+                                reason='Too many drive letters are already used by Windows to run the tests.')
+
 
 @pytest.yield_fixture(scope="module")
 def shares_setup(tmpdir_factory):
@@ -139,7 +139,7 @@ def test_uncpushd_push_to_same_share(xonsh_builtins):
 
 @pytest.mark.skipif( not ON_WINDOWS, reason="Windows-only UNC functionality")
 def test_uncpushd_push_other_push_same(xonsh_builtins):
-    """push to a, then to b. verify is w:, skipping already used y:
+    """push to a, then to b. verify drive letter is TEMP_DRIVE[2], skipping already used TEMP_DRIVE[1]
        Then push to a again. Pop (check b unmapped and a still mapped), pop, pop (check a is unmapped)"""
     xonsh_builtins.__xonsh_env__ = Env(CDPATH=PARENT, PWD=HERE)
 

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -14,6 +14,7 @@ from xonsh.codecache import (should_use_cache, code_cache_name,
                              update_cache, run_compiled_code)
 from xonsh.completer import Completer
 from xonsh.environ import multiline_prompt, partial_format_prompt
+from xonsh.events import events
 
 
 class _TeeOut(object):
@@ -180,7 +181,13 @@ class BaseShell(object):
             ts1 = ts1 or time.time()
             self._append_history(inp=src, ts=[ts0, ts1], tee_out=tee.getvalue())
             tee.close()
-            builtins.__xonsh_env__['PWD'] = os.getcwd()        # track any change in working directory
+            cwd = os.getcwd()
+            if cwd != builtins.__xonsh_env__['PWD']:
+                old = builtins.__xonsh_env__['PWD']             # working directory changed without updating $PWD
+                builtins.__xonsh_env__['PWD'] = cwd             # track it now
+                if old is not None:
+                    builtins.__xonsh_env__['OLDPWD'] = old      # and update $OLDPWD like dirstack.
+                events.on_chdir.fire(old, cwd)                  # fire event after cwd actually changed.
         if builtins.__xonsh_exit__:  # pylint: disable=no-member
             return True
 

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -51,7 +51,7 @@ def _unc_check_enabled()->bool:
     return False if wval else True
 
 
-def _is_unc_path( some_path)->bool:
+def _is_unc_path(some_path)->bool:
     """True if path starts with 2 backward (or forward, due to python path hacking) slashes."""
     return len(some_path) > 1 and some_path[0] == some_path[1] and some_path[0] in (os.sep, os.altsep)
 

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -217,7 +217,7 @@ def cd(args, stdin=None):
     # now, push the directory onto the dirstack if AUTO_PUSHD is set
     if cwd is not None and env.get('AUTO_PUSHD'):
         pushd(['-n', '-q', cwd])
-        if ON_WINDOWS and (d[0] == d[1]) and (d[0] in (os.sep, os.altsep)):
+        if ON_WINDOWS and len(d) > 1 and (d[0] == d[1]) and (d[0] in (os.sep, os.altsep)):
             d = _unc_map_temp_drive(d)
     _change_working_directory(d)
     return None, None, 0


### PR DESCRIPTION
Fires chdir event when OS level change in working directory is detected (based on discussion in #1666).
Also fixes indexerror in cd(['.'] and AUTO_PUSHD on Windows (extension of fix from #1667).