### PR TITLE
Cmd cache lookup on windows

### DIFF
--- a/news/cmd_cache_lookup_on_win.rst
+++ b/news/cmd_cache_lookup_on_win.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Fix bug where know commands where not highlighed on windows.
+* Fixed completer showing executable in upper case on windows.  
+
+**Security:** None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def xonsh_builtins():
     """Mock out most of the builtins xonsh attributes."""
     builtins.__xonsh_env__ = {}
     if ON_WINDOWS:
-        builtins.__xonsh_env__['PATHEXT'] = ['.EXE','.BAT','.CMD']
+        builtins.__xonsh_env__['PATHEXT'] = ['.EXE', '.BAT', '.CMD']
     builtins.__xonsh_ctx__ = {}
     builtins.__xonsh_shell__ = DummyShell()
     builtins.__xonsh_help__ = lambda x: x

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ def xonsh_execer(monkeypatch):
 def xonsh_builtins():
     """Mock out most of the builtins xonsh attributes."""
     builtins.__xonsh_env__ = {}
+    if ON_WINDOWS:
+        builtins.__xonsh_env__['PATHEXT'] = ['.EXE','.BAT','.CMD']
     builtins.__xonsh_ctx__ = {}
     builtins.__xonsh_shell__ = DummyShell()
     builtins.__xonsh_help__ = lambda x: x

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1118,7 +1118,7 @@ def test_expand_case_matching(inp, exp):
     assert exp == obs
 
 
-def test_commands_cache_lazy():
+def test_commands_cache_lazy(xonsh_builtins):
     cc = CommandsCache()
     assert not cc.lazyin('xonsh')
     assert 0 == len(list(cc.lazyiter()))

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -29,7 +29,7 @@ class CommandsCache(cabc.Mapping):
         for cmd, (path, is_alias) in self.all_commands.items():
             if ON_WINDOWS and not is_alias:
                 # All comand keys are stored in uppercase on Windows.
-                # This ensures the original command name is returned.   
+                # This ensures the original command name is returned.
                 cmd = os.path.basename(path)
             yield cmd
 
@@ -100,12 +100,12 @@ class CommandsCache(cabc.Mapping):
         update the cache. It just says whether the value is known *now*. This
         may not reflect precisely what is on the $PATH.
         """
-        keys = self.get_possible_names(key)
-        cached = next((k for k in keys if k in self._cmds_cache), None)
-        if cached is not None:
-            return True
+        if ON_WINDOWS:
+            keys = self.get_possible_names(key)
+            cached_key = next((k for k in keys if k in self._cmds_cache), None)
+            return cached_key is not None
         else:
-            return False        
+            return key in self._cmds_cache
 
     def lazyiter(self):
         """Returns an iterator over the current cache contents without the

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -22,16 +22,23 @@ class CommandsCache(cabc.Mapping):
         self._path_mtime = -1
 
     def __contains__(self, key):
-        return key in self.all_commands
+        _ = self.all_commands
+        return self.lazyin(key)
 
     def __iter__(self):
-        return iter(self.all_commands)
+        for cmd, (path, is_alias) in self.all_commands.items():
+            if ON_WINDOWS and not is_alias:
+                # All comand keys are stored in uppercase on Windows.
+                # This ensures the original command name is returned.   
+                cmd = os.path.basename(path)
+            yield cmd
 
     def __len__(self):
         return len(self.all_commands)
 
     def __getitem__(self, key):
-        return self.all_commands[key]
+        _ = self.all_commands
+        return self.lazyget(key)
 
     def is_empty(self):
         """Returns whether the cache is populated or not."""
@@ -93,7 +100,12 @@ class CommandsCache(cabc.Mapping):
         update the cache. It just says whether the value is known *now*. This
         may not reflect precisely what is on the $PATH.
         """
-        return key in self._cmds_cache
+        keys = self.get_possible_names(key)
+        cached = next((k for k in keys if k in self._cmds_cache), None)
+        if cached is not None:
+            return True
+        else:
+            return False        
 
     def lazyiter(self):
         """Returns an iterator over the current cache contents without the
@@ -111,6 +123,10 @@ class CommandsCache(cabc.Mapping):
 
     def lazyget(self, key, default=None):
         """A lazy value getter."""
+        if ON_WINDOWS:
+            keys = self.get_possible_names(key)
+            cached_key = next((k for k in keys if k in self._cmds_cache), None)
+            key = cached_key if cached_key is not None else key
         return self._cmds_cache.get(key, default)
 
     def locate_binary(self, name):


### PR DESCRIPTION
This PR fixes the issue in #1702 which arise because keys in the command_cache are stored in uppercase on Windows. 

It add functionality on windows to the `CommandsCache` such that look up with with a valid command git/Git/git.exe/GIT.EXE all work the same. This fixes the highlight valid commands issue

It also adapts the iterator method of the `CommandsCache` such that it returns the originally cased command instead of the uppercase key. This fixes the command completer showing commands in upper case. 

![image](https://cloud.githubusercontent.com/assets/1038978/18380106/1b2b6f70-7676-11e6-9fd3-cc527ba7c584.png)



