### PR TITLE
New implementation of XonshLexer for pygments

### DIFF
--- a/news/highlight-cmd.rst
+++ b/news/highlight-cmd.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Highlight valid command / executable as Keyword
+* Better syntax highlights in prompt-toolkit, including valid command / path highlighting, macro syntax highlighting, and more
 
 **Changed:** None
 

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -53,20 +53,20 @@ def test_py_print():
 
 
 def test_invalid_cmd():
-    check_token('ls-non-existance-cmd -al', [(Name, 'ls')])  # parse as python
-    check_token('![ls-non-existance-cmd -al]',
-                [(Error, 'ls-non-existance-cmd')])  # parse as error
+    check_token('non-existance-cmd -al', [(Name, 'non')])  # parse as python
+    check_token('![non-existance-cmd -al]',
+                [(Error, 'non-existance-cmd')])  # parse as error
     check_token('for i in range(10):', [(Keyword, 'for')])  # as py keyword
 
 
 def test_multi_cmd():
-    check_token('ls && ls', [(Keyword, 'ls'),
+    check_token('cd && cd', [(Keyword, 'cd'),
                              (Operator, '&&'),
-                             (Keyword, 'ls')])
-    check_token('ls || ls-non-existance-cmd', [(Keyword, 'ls'),
-                                               (Operator, '||'),
-                                               (Error, 'ls-non-existance-cmd')
-                                               ])
+                             (Keyword, 'cd')])
+    check_token('cd || non-existance-cmd', [(Keyword, 'cd'),
+                                            (Operator, '||'),
+                                            (Error, 'non-existance-cmd')
+                                            ])
 
 
 def test_nested():
@@ -75,11 +75,11 @@ def test_nested():
                                     (Punctuation, '('),
                                     (String.Double, 'hello'),
                                     (Punctuation, ')')])
-    check_token('print($(ls))', [(Keyword, 'print'),
+    check_token('print($(cd))', [(Keyword, 'print'),
                                  (Punctuation, '('),
                                  (Keyword, '$'),
                                  (Punctuation, '('),
-                                 (Keyword, 'ls'),
+                                 (Keyword, 'cd'),
                                  (Punctuation, ')'),
                                  (Punctuation, ')')])
     check_token('print(![echo "])"])', [(Keyword, 'print'),
@@ -95,7 +95,18 @@ def test_path():
     test_dir = os.path.join(HERE, 'xonsh-test-highlight-path')
     if not os.path.exists(test_dir):
         os.mkdir(test_dir)
-    check_token('ls {}'.format(test_dir), [(Keyword, 'ls'),
+    check_token('cd {}'.format(test_dir), [(Keyword, 'cd'),
                                            (Name.Builtin, test_dir)])
-    check_token('ls {}-xxx'.format(test_dir), [(Keyword, 'ls'),
-                                               (Text, '{}-xxx'.format(test_dir))])
+    check_token('cd {}-xxx'.format(test_dir), [(Keyword, 'cd'),
+                                               (Text,
+                                                '{}-xxx'.format(test_dir))
+                                               ])
+
+
+def test_backtick():
+    check_token(r'echo g`.*\w+`', [(String.Affix, 'g'),
+                                   (String.Backtick, '`'),
+                                   (String.Regex, '.'),
+                                   (String.Regex, '*'),
+                                   (String.Escape, r'\w'),
+                                   ])

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """Test XonshLexer for pygments"""
 
-import pytest
 import os
-from pygments.token import (Keyword, Name, Comment, String, Error, Number,
-                            Operator, Generic, Whitespace, Token, Punctuation,
-                            Text)
-from tools import (skip_if_on_unix, skip_if_on_windows)
+import pytest
+from pygments.token import (Keyword, Name, String, Error, Number,
+                            Operator, Punctuation, Text)
+from tools import skip_if_on_windows
 
 from xonsh.built_ins import load_builtins, unload_builtins
 from xonsh.pyghooks import XonshLexer
@@ -57,6 +56,8 @@ def test_invalid_cmd():
     check_token('![non-existance-cmd -al]',
                 [(Error, 'non-existance-cmd')])  # parse as error
     check_token('for i in range(10):', [(Keyword, 'for')])  # as py keyword
+    check_token('(1, )', [(Punctuation, '('),
+                          (Number.Integer, '1')])
 
 
 def test_multi_cmd():

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -60,13 +60,13 @@ def test_invalid_cmd():
 
 
 def test_multi_cmd():
-    check_token('cd && cd', [(Name.Builtin, 'cd'),
-                             (Operator, '&&'),
-                             (Name.Builtin, 'cd')])
-    check_token('cd || non-existance-cmd', [(Name.Builtin, 'cd'),
-                                            (Operator, '||'),
-                                            (Error, 'non-existance-cmd')
-                                            ])
+    check_token('type && type', [(Name.Builtin, 'type'),
+                                 (Operator, '&&'),
+                                 (Name.Builtin, 'type')])
+    check_token('type || non-existance-cmd', [(Name.Builtin, 'type'),
+                                              (Operator, '||'),
+                                              (Error, 'non-existance-cmd')
+                                              ])
 
 
 def test_nested():
@@ -75,13 +75,13 @@ def test_nested():
                                     (Punctuation, '('),
                                     (String.Double, 'hello'),
                                     (Punctuation, ')')])
-    check_token('print($(cd))', [(Keyword, 'print'),
-                                 (Punctuation, '('),
-                                 (Keyword, '$'),
-                                 (Punctuation, '('),
-                                 (Name.Builtin, 'cd'),
-                                 (Punctuation, ')'),
-                                 (Punctuation, ')')])
+    check_token('print($(type))', [(Keyword, 'print'),
+                                   (Punctuation, '('),
+                                   (Keyword, '$'),
+                                   (Punctuation, '('),
+                                   (Name.Builtin, 'type'),
+                                   (Punctuation, ')'),
+                                   (Punctuation, ')')])
     check_token('print(![echo "])"])', [(Keyword, 'print'),
                                         (Keyword, '!'),
                                         (Punctuation, '['),
@@ -95,12 +95,12 @@ def test_path():
     test_dir = os.path.join(HERE, 'xonsh-test-highlight-path')
     if not os.path.exists(test_dir):
         os.mkdir(test_dir)
-    check_token('cd {}'.format(test_dir), [(Name.Builtin, 'cd'),
-                                           (Name.Constant, test_dir)])
-    check_token('cd {}-xxx'.format(test_dir), [(Name.Builtin, 'cd'),
-                                               (Text,
-                                                '{}-xxx'.format(test_dir))
-                                               ])
+    check_token('type {}'.format(test_dir), [(Name.Builtin, 'type'),
+                                             (Name.Constant, test_dir)])
+    check_token('type {}-xxx'.format(test_dir), [(Name.Builtin, 'type'),
+                                                 (Text,
+                                                  '{}-xxx'.format(test_dir))
+                                                 ])
 
 
 def test_backtick():

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -37,12 +37,12 @@ def check_token(code, tokens):
 
 @skip_if_on_windows
 def test_ls():
-    check_token('ls -al', [(Keyword, 'ls')])
+    check_token('ls -al', [(Name.Builtin, 'ls')])
 
 
 @skip_if_on_windows
 def test_bin_ls():
-    check_token('/bin/ls -al', [(Keyword, '/bin/ls')])
+    check_token('/bin/ls -al', [(Name.Builtin, '/bin/ls')])
 
 
 def test_py_print():
@@ -60,17 +60,17 @@ def test_invalid_cmd():
 
 
 def test_multi_cmd():
-    check_token('cd && cd', [(Keyword, 'cd'),
+    check_token('cd && cd', [(Name.Builtin, 'cd'),
                              (Operator, '&&'),
-                             (Keyword, 'cd')])
-    check_token('cd || non-existance-cmd', [(Keyword, 'cd'),
+                             (Name.Builtin, 'cd')])
+    check_token('cd || non-existance-cmd', [(Name.Builtin, 'cd'),
                                             (Operator, '||'),
                                             (Error, 'non-existance-cmd')
                                             ])
 
 
 def test_nested():
-    check_token('echo @("hello")', [(Keyword, 'echo'),
+    check_token('echo @("hello")', [(Name.Builtin, 'echo'),
                                     (Keyword, '@'),
                                     (Punctuation, '('),
                                     (String.Double, 'hello'),
@@ -79,13 +79,13 @@ def test_nested():
                                  (Punctuation, '('),
                                  (Keyword, '$'),
                                  (Punctuation, '('),
-                                 (Keyword, 'cd'),
+                                 (Name.Builtin, 'cd'),
                                  (Punctuation, ')'),
                                  (Punctuation, ')')])
     check_token('print(![echo "])"])', [(Keyword, 'print'),
                                         (Keyword, '!'),
                                         (Punctuation, '['),
-                                        (Keyword, 'echo'),
+                                        (Name.Builtin, 'echo'),
                                         (String.Double, '"])"'),
                                         (Punctuation, ']')])
 
@@ -95,9 +95,9 @@ def test_path():
     test_dir = os.path.join(HERE, 'xonsh-test-highlight-path')
     if not os.path.exists(test_dir):
         os.mkdir(test_dir)
-    check_token('cd {}'.format(test_dir), [(Keyword, 'cd'),
-                                           (Name.Builtin, test_dir)])
-    check_token('cd {}-xxx'.format(test_dir), [(Keyword, 'cd'),
+    check_token('cd {}'.format(test_dir), [(Name.Builtin, 'cd'),
+                                           (Name.Constant, test_dir)])
+    check_token('cd {}-xxx'.format(test_dir), [(Name.Builtin, 'cd'),
                                                (Text,
                                                 '{}-xxx'.format(test_dir))
                                                ])

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -96,11 +96,8 @@ def test_nested():
                                            (Punctuation, ']')])
 
 
-def test_path():
-    HERE = os.path.abspath(os.path.dirname(__file__))
-    test_dir = os.path.join(HERE, 'xonsh-test-highlight-path')
-    if not os.path.exists(test_dir):
-        os.mkdir(test_dir)
+def test_path(tmpdir):
+    test_dir = str(tmpdir.mkdir('xonsh-test-highlight-path'))
     check_token('cd {}'.format(test_dir), [(Name.Builtin, 'cd'),
                                            (Name.Constant, test_dir)])
     check_token('cd {}-xxx'.format(test_dir), [(Name.Builtin, 'cd'),

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -88,12 +88,12 @@ def test_nested():
                                  (Name.Builtin, 'cd'),
                                  (Punctuation, ')'),
                                  (Punctuation, ')')])
-    check_token('print(![echo "])"])', [(Keyword, 'print'),
-                                        (Keyword, '!'),
-                                        (Punctuation, '['),
-                                        (Name.Builtin, 'echo'),
-                                        (String.Double, '"])"'),
-                                        (Punctuation, ']')])
+    check_token(r'print(![echo "])\""])', [(Keyword, 'print'),
+                                           (Keyword, '!'),
+                                           (Punctuation, '['),
+                                           (Name.Builtin, 'echo'),
+                                           (String.Double, r'"])\""'),
+                                           (Punctuation, ']')])
 
 
 def test_path():
@@ -108,6 +108,10 @@ def test_path():
                                                 '{}-xxx'.format(test_dir))
                                                ])
     check_token('cd X={}'.format(test_dir), [(Name.Constant, test_dir)])
+
+
+def test_subproc_args():
+    check_token('cd 192.168.0.1', [(Text, '192.168.0.1')])
 
 
 def test_backtick():

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -107,6 +107,7 @@ def test_path():
                                                (Text,
                                                 '{}-xxx'.format(test_dir))
                                                ])
+    check_token('cd X={}'.format(test_dir), [(Name.Constant, test_dir)])
 
 
 def test_backtick():

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -2,6 +2,8 @@
 """Test XonshLexer for pygments"""
 
 import os
+import builtins
+
 import pytest
 from pygments.token import (Keyword, Name, String, Error, Number,
                             Operator, Punctuation, Text)
@@ -14,6 +16,8 @@ from xonsh.pyghooks import XonshLexer
 @pytest.yield_fixture(autouse=True)
 def load_command_cache():
     load_builtins()
+    if 'cd' not in builtins.aliases:
+        builtins.aliases['cd'] = lambda *args, **kwargs: None
     yield
     unload_builtins()
 

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -9,6 +9,7 @@ from pygments.token import (Keyword, Name, String, Error, Number,
                             Operator, Punctuation, Text)
 from tools import skip_if_on_windows
 
+from xonsh.platform import ON_WINDOWS
 from xonsh.built_ins import load_builtins, unload_builtins
 from xonsh.pyghooks import XonshLexer
 
@@ -16,8 +17,9 @@ from xonsh.pyghooks import XonshLexer
 @pytest.yield_fixture(autouse=True)
 def load_command_cache():
     load_builtins()
-    if 'cd' not in builtins.aliases:
-        builtins.aliases['cd'] = lambda *args, **kwargs: None
+    if ON_WINDOWS:
+        for key in ('cd', 'bash'):
+            builtins.aliases[key] = lambda *args, **kwargs: None
     yield
     unload_builtins()
 

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -60,13 +60,13 @@ def test_invalid_cmd():
 
 
 def test_multi_cmd():
-    check_token('type && type', [(Name.Builtin, 'type'),
-                                 (Operator, '&&'),
-                                 (Name.Builtin, 'type')])
-    check_token('type || non-existance-cmd', [(Name.Builtin, 'type'),
-                                              (Operator, '||'),
-                                              (Error, 'non-existance-cmd')
-                                              ])
+    check_token('cd && cd', [(Name.Builtin, 'cd'),
+                             (Operator, '&&'),
+                             (Name.Builtin, 'cd')])
+    check_token('cd || non-existance-cmd', [(Name.Builtin, 'cd'),
+                                            (Operator, '||'),
+                                            (Error, 'non-existance-cmd')
+                                            ])
 
 
 def test_nested():
@@ -75,13 +75,13 @@ def test_nested():
                                     (Punctuation, '('),
                                     (String.Double, 'hello'),
                                     (Punctuation, ')')])
-    check_token('print($(type))', [(Keyword, 'print'),
-                                   (Punctuation, '('),
-                                   (Keyword, '$'),
-                                   (Punctuation, '('),
-                                   (Name.Builtin, 'type'),
-                                   (Punctuation, ')'),
-                                   (Punctuation, ')')])
+    check_token('print($(cd))', [(Keyword, 'print'),
+                                 (Punctuation, '('),
+                                 (Keyword, '$'),
+                                 (Punctuation, '('),
+                                 (Name.Builtin, 'cd'),
+                                 (Punctuation, ')'),
+                                 (Punctuation, ')')])
     check_token('print(![echo "])"])', [(Keyword, 'print'),
                                         (Keyword, '!'),
                                         (Punctuation, '['),
@@ -95,12 +95,12 @@ def test_path():
     test_dir = os.path.join(HERE, 'xonsh-test-highlight-path')
     if not os.path.exists(test_dir):
         os.mkdir(test_dir)
-    check_token('type {}'.format(test_dir), [(Name.Builtin, 'type'),
-                                             (Name.Constant, test_dir)])
-    check_token('type {}-xxx'.format(test_dir), [(Name.Builtin, 'type'),
-                                                 (Text,
-                                                  '{}-xxx'.format(test_dir))
-                                                 ])
+    check_token('cd {}'.format(test_dir), [(Name.Builtin, 'cd'),
+                                           (Name.Constant, test_dir)])
+    check_token('cd {}-xxx'.format(test_dir), [(Name.Builtin, 'cd'),
+                                               (Text,
+                                                '{}-xxx'.format(test_dir))
+                                               ])
 
 
 def test_backtick():

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Test XonshLexer for pygments"""
+
+import pytest
+import os
+from pygments.token import (Keyword, Name, Comment, String, Error, Number,
+                            Operator, Generic, Whitespace, Token, Punctuation,
+                            Text)
+from tools import (skip_if_on_unix, skip_if_on_windows)
+
+from xonsh.built_ins import load_builtins, unload_builtins
+from xonsh.pyghooks import XonshLexer
+
+
+@pytest.yield_fixture(autouse=True)
+def load_command_cache():
+    load_builtins()
+    yield
+    unload_builtins()
+
+
+def check_token(code, tokens):
+    """Make sure that all tokens appears in code in order"""
+    load_builtins()
+    lx = XonshLexer()
+    tks = list(lx.get_tokens(code))
+
+    for tk in tokens:
+        while tks:
+            if tk == tks[0]:
+                break
+            tks = tks[1:]
+        else:
+            msg = "Token {!r} missing: {!r}".format(tk,
+                                                    list(lx.get_tokens(code)))
+            pytest.fail(msg)
+            break
+
+
+@skip_if_on_windows
+def test_ls():
+    check_token('ls -al', [(Keyword, 'ls')])
+
+
+@skip_if_on_windows
+def test_bin_ls():
+    check_token('/bin/ls -al', [(Keyword, '/bin/ls')])
+
+
+def test_py_print():
+    check_token('print("hello")', [(Keyword, 'print'),
+                                   (String.Double, 'hello')])
+
+
+def test_invalid_cmd():
+    check_token('ls-non-existance-cmd -al', [(Name, 'ls')])  # parse as python
+    check_token('![ls-non-existance-cmd -al]',
+                [(Error, 'ls-non-existance-cmd')])  # parse as error
+    check_token('for i in range(10):', [(Keyword, 'for')])  # as py keyword
+
+
+def test_multi_cmd():
+    check_token('ls && ls', [(Keyword, 'ls'),
+                             (Operator, '&&'),
+                             (Keyword, 'ls')])
+    check_token('ls || ls-non-existance-cmd', [(Keyword, 'ls'),
+                                               (Operator, '||'),
+                                               (Error, 'ls-non-existance-cmd')
+                                               ])
+
+
+def test_nested():
+    check_token('echo @("hello")', [(Keyword, 'echo'),
+                                    (Keyword, '@'),
+                                    (Punctuation, '('),
+                                    (String.Double, 'hello'),
+                                    (Punctuation, ')')])
+    check_token('print($(ls))', [(Keyword, 'print'),
+                                 (Punctuation, '('),
+                                 (Keyword, '$'),
+                                 (Punctuation, '('),
+                                 (Keyword, 'ls'),
+                                 (Punctuation, ')'),
+                                 (Punctuation, ')')])
+    check_token('print(![echo "])"])', [(Keyword, 'print'),
+                                        (Keyword, '!'),
+                                        (Punctuation, '['),
+                                        (Keyword, 'echo'),
+                                        (String.Double, '"])"'),
+                                        (Punctuation, ']')])
+
+
+def test_path():
+    HERE = os.path.abspath(os.path.dirname(__file__))
+    test_dir = os.path.join(HERE, 'xonsh-test-highlight-path')
+    if not os.path.exists(test_dir):
+        os.mkdir(test_dir)
+    check_token('ls {}'.format(test_dir), [(Keyword, 'ls'),
+                                           (Name.Builtin, test_dir)])
+    check_token('ls {}-xxx'.format(test_dir), [(Keyword, 'ls'),
+                                               (Text, '{}-xxx'.format(test_dir))])

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -109,6 +109,9 @@ def test_path():
                                                ])
     check_token('cd X={}'.format(test_dir), [(Name.Constant, test_dir)])
 
+    with builtins.__xonsh_env__.swap(AUTO_CD=True):
+        check_token(test_dir, [(Name.Constant, test_dir)])
+
 
 def test_subproc_args():
     check_token('cd 192.168.0.1', [(Text, '192.168.0.1')])

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -20,7 +20,6 @@ def load_command_cache():
 
 def check_token(code, tokens):
     """Make sure that all tokens appears in code in order"""
-    load_builtins()
     lx = XonshLexer()
     tks = list(lx.get_tokens(code))
 

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -114,3 +114,19 @@ def test_backtick():
                                    (String.Regex, '*'),
                                    (String.Escape, r'\w'),
                                    ])
+
+
+def test_macro():
+    check_token(r'g!(42, *, 65)', [(Name, 'g'),
+                                   (Keyword, '!'),
+                                   (Punctuation, '('),
+                                   (Number.Integer, '42')])
+    check_token(r'echo! hello world', [(Name.Builtin, 'echo'),
+                                       (Keyword, '!'),
+                                       (String, "hello world")])
+    check_token(r'bash -c ! export var=42; echo $var',
+                [(Name.Builtin, 'bash'),
+                 (Text, '-c'),
+                 (Keyword, '!'),
+                 (String, 'export var=42; echo $var'),
+                 ])

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -91,7 +91,8 @@ class CommandsCache(cabc.Mapping):
         only_alias = (None, True)
         for cmd in alss:
             if cmd not in allcmds:
-                allcmds[cmd] = only_alias
+                key = cmd.upper() if ON_WINDOWS else cmd
+                allcmds[key] = only_alias
         self._cmds_cache = allcmds
         return allcmds
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -128,7 +128,6 @@ class XonshLexer(PythonLexer):
             (r'&|=', Punctuation),
             (r'\|', Punctuation, 'subproc_start'),
             (r'\s+', Text),
-            (r'\d+\b', Number),
             (r'[^=\s\[\]{}()$"\'`<&|;]+', subproc_arg_callback),
             (r'<', Text),
             (r'\$\w+', Name.Variable),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -101,7 +101,7 @@ class XonshLexer(PythonLexer):
             (r'({[0-9]+}|{[0-9]+,[0-9]+})\??', String.Regex),
             (r'\\([0-9]+|[AbBdDsSwWZabfnrtuUvx\\])', String.Escape),
             (r'`', String.Backtick, '#pop'),
-            (r'[^`]+', String.Backtick),
+            (r'[^`\.\^\$\*\+\?\[\]\|]+', String.Backtick),
         ],
         'root': [
             (r'\?', Keyword),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -54,7 +54,7 @@ def subproc_arg_callback(_, match):
         yield match.start(), Text, text
 
 
-COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`\\<&|;]+'
+COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`\\<&|;]+(?=\s|$|\)|\]|\})'
 
 
 class XonshLexer(PythonLexer):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -38,20 +38,19 @@ def _command_is_valid(cmd):
 
 
 def subproc_cmd_callback(_, match):
-    """Yield Keyword token if match contains valid command,
+    """Yield Builtin token if match contains valid command,
     otherwise fallback to fallback lexer.
     """
     cmd = match.group()
-    yield match.start(), Keyword if _command_is_valid(cmd) else Error, cmd
+    yield match.start(), Name.Builtin if _command_is_valid(cmd) else Error, cmd
 
 
 def subproc_arg_callback(_, match):
     """Check if match contains valid path"""
     text = match.group()
-    if os.path.exists(os.path.expanduser(text)):
-        yield match.start(), Name.Builtin, text
-    else:
-        yield match.start(), Text, text
+    yield (match.start(),
+           Name.Constant if os.path.exists(os.path.expanduser(text)) else Text,
+           text)
 
 
 COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`\\<&|;]+(?=\s|$|\)|\]|\})'
@@ -145,7 +144,7 @@ class XonshLexer(PythonLexer):
             cmd_is_valid = _command_is_valid(cmd)
 
             if cmd_is_valid:
-                yield m.start(2), Keyword, cmd
+                yield m.start(2), Name.Builtin, cmd
                 start = m.end(2)
                 state = ('subproc', )
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -53,7 +53,7 @@ def subproc_arg_callback(_, match):
            text)
 
 
-COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`\\<&|;]+(?=\s|$|\)|\]|\})'
+COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`\\<&|;!]+(?=\s|$|\)|\]|\}|!)'
 
 
 class XonshLexer(PythonLexer):
@@ -105,6 +105,7 @@ class XonshLexer(PythonLexer):
         ],
         'root': [
             (r'\?', Keyword),
+            (r'(?<=\w)!', Keyword),
             (r'\$\w+', Name.Variable),
             (r'\(', Punctuation, 'py_bracket'),
             (r'\{', Punctuation, 'py_curly_bracket'),
@@ -121,6 +122,8 @@ class XonshLexer(PythonLexer):
             (r'&&|\|\|', Operator, 'subproc_start'),
             (r'"(\\\\|\\[0-7]+|\\.|[^"\\])*"', String.Double),
             (r"'(\\\\|\\[0-7]+|\\.|[^'\\])*'", String.Single),
+            (r'(?<=\w|\s)!', Keyword, 'subproc_macro'),
+            (r'^!', Keyword, 'subproc_macro'),
             (r';', Punctuation, 'subproc_start'),
             (r'&', Punctuation),
             (r'\|', Punctuation, 'subproc_start'),
@@ -129,6 +132,10 @@ class XonshLexer(PythonLexer):
             (r'[^=\s\[\]{}()$"\'`<&|;]+', subproc_arg_callback),
             (r'<', Text),
             (r'\$\w+', Name.Variable),
+        ],
+        'subproc_macro': [
+            (r'(\s*)([^\n]+)', bygroups(Whitespace, String)),
+            (r'', Whitespace, '#pop'),
         ],
     }
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -60,7 +60,7 @@ def subproc_arg_callback(_, match):
            text)
 
 
-COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`\\<&|;!]+(?=\s|$|\)|\]|\}|!)'
+COMMAND_TOKEN_RE = r'[^=\s\[\]{}()$"\'`<&|;!]+(?=\s|$|\)|\]|\}|!)'
 
 
 class XonshLexer(PythonLexer):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -125,7 +125,7 @@ class XonshLexer(PythonLexer):
             (r'(?<=\w|\s)!', Keyword, 'subproc_macro'),
             (r'^!', Keyword, 'subproc_macro'),
             (r';', Punctuation, 'subproc_start'),
-            (r'&', Punctuation),
+            (r'&|=', Punctuation),
             (r'\|', Punctuation, 'subproc_start'),
             (r'\s+', Text),
             (r'\d+\b', Number),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -64,6 +64,10 @@ class XonshLexer(PythonLexer):
     aliases = ['xonsh', 'xsh']
     filenames = ['*.xsh', '*xonshrc']
 
+    def __init__(self, *args, **kwargs):
+        _ = builtins.__xonsh_commands_cache__.all_commands
+        super().__init__(*args, **kwargs)
+
     tokens = {
         'mode_switch_brackets': [
             (r'(\$)(\{)', bygroups(Keyword, Punctuation), 'py_curly_bracket'),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -126,7 +126,7 @@ class XonshLexer(PythonLexer):
             (r'\|', Punctuation, 'subproc_start'),
             (r'\s+', Text),
             (r'\d+\b', Number),
-            (r'[^=\s\[\]{}()$"\'`\\<&|;]+', subproc_arg_callback),
+            (r'[^=\s\[\]{}()$"\'`<&|;]+', subproc_arg_callback),
             (r'<', Text),
             (r'\$\w+', Name.Variable),
         ],

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -74,6 +74,8 @@ class XonshLexer(PythonLexer):
              ('subproc_bracket', 'subproc_start')),
             (r'([\!\$])(\[)', bygroups(Keyword, Punctuation),
              ('subproc_square_bracket', 'subproc_start')),
+            (r'(g?)(`)', bygroups(String.Affix, String.Backtick),
+             'backtick_re'),
         ],
         'subproc_bracket': [
             (r'\)', Punctuation, '#pop'),
@@ -91,6 +93,13 @@ class XonshLexer(PythonLexer):
             (r'\}', Punctuation, '#pop'),
             include('root'),
         ],
+        'backtick_re': [
+            (r'[\.\^\$\*\+\?\[\]\|]', String.Regex),
+            (r'({[0-9]+}|{[0-9]+,[0-9]+})\??', String.Regex),
+            (r'\\([0-9]+|[AbBdDsSwWZabfnrtuUvx\\])', String.Escape),
+            (r'`', String.Backtick, '#pop'),
+            (r'[^`]+', String.Backtick),
+        ],
         'root': [
             (r'\?', Keyword),
             (r'\$\w+', Name.Variable),
@@ -105,7 +114,6 @@ class XonshLexer(PythonLexer):
             (r'', Whitespace, '#pop'),
         ],
         'subproc': [
-            (SearchPath, String.Backtick),
             include('mode_switch_brackets'),
             (r'&&|\|\|', Operator, 'subproc_start'),
             (r'"(\\\\|\\[0-7]+|\\.|[^"\\])*"', String.Double),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -12,11 +12,7 @@ from collections.abc import MutableMapping
 # must come before pygments imports
 from xonsh.lazyasd import load_module_in_background
 
-load_module_in_background('pkg_resources', debug='XONSH_DEBUG',
-                          replacements={'pygments.plugin': 'pkg_resources'})
-
-from pygments.lexer import inherit, bygroups, using, this, include
-from pygments.lexers.shell import BashLexer
+from pygments.lexer import inherit, bygroups, include
 from pygments.lexers.agile import PythonLexer
 from pygments.token import (Keyword, Name, Comment, String, Error, Number,
                             Operator, Generic, Whitespace, Token, Punctuation,
@@ -29,6 +25,10 @@ from xonsh.lazyasd import LazyObject, LazyDict
 from xonsh.tools import (ON_WINDOWS, intensify_colors_for_cmd_exe,
                          expand_gray_colors_for_cmd_exe)
 from xonsh.tokenize import SearchPath
+
+
+load_module_in_background('pkg_resources', debug='XONSH_DEBUG',
+                          replacements={'pygments.plugin': 'pkg_resources'})
 
 
 def _command_is_valid(cmd):


### PR DESCRIPTION
This is successor of #1688 , hopefully this would resolve #985 #1663 and maybe #1038 later

BashLexer is removed because that's unnecessary and increases complexity. A large amount of keywords/builtins/syntax in BashLexer is invalid for xonsh's subprocess mode.

Dynamic highlighting for command and path is implemented.

---

Updates:

<img width="231" alt="screen shot 2016-09-12 at 12 00 02" src="https://cloud.githubusercontent.com/assets/1308450/18424302/bc5c84da-78e0-11e6-8209-3e9dfd5d489d.png">
<img width="368" alt="screen shot 2016-09-12 at 11 56 48" src="https://cloud.githubusercontent.com/assets/1308450/18424303/bd8c3724-78e0-11e6-9060-fc2150c0f704.png">
<img width="327" alt="screen shot 2016-09-12 at 11 59 12" src="https://cloud.githubusercontent.com/assets/1308450/18424304/bef33572-78e0-11e6-9350-87ca75dfcec4.png">
<img width="347" alt="screen shot 2016-09-12 at 12 00 18" src="https://cloud.githubusercontent.com/assets/1308450/18424307/c027162a-78e0-11e6-96f4-d75a9aecadc5.png">
<img width="259" alt="screen shot 2016-09-12 at 12 00 59" src="https://cloud.githubusercontent.com/assets/1308450/18424309/c31e7616-78e0-11e6-8de3-5a137d05038f.png">
