### PR TITLE
Fix async comprehension on 3.6

### DIFF
--- a/tests/tools.py
+++ b/tests/tools.py
@@ -94,15 +94,15 @@ def check_parse(input):
 
 def nodes_equal(x, y):
     __tracebackhide__ = True
-    assert type(x) == type(y)
+    assert type(x) == type(y) , "Ast nodes do not have the same type: '%s' != '%s' " % (type(x), type(y))
     if isinstance(x, (ast.Expr, ast.FunctionDef, ast.ClassDef)):
-        assert x.lineno == y.lineno
-        assert x.col_offset == y.col_offset
+        assert x.lineno == y.lineno, "Ast nodes do not have the same line number : %s != %s" % (x.lineno, y.lineno)
+        assert x.col_offset == y.col_offset, "Ast nodes do not have the same column offset number : %s != %s" % (x.col_offset, y.col_offset)
     for (xname, xval), (yname, yval) in zip(ast.iter_fields(x),
                                             ast.iter_fields(y)):
-        assert xname == yname
-        assert type(xval) == type(yval)
+        assert xname == yname, "Ast nodes fields differ : %s (of type %s) != %s (of type %s)" % (xname, type(xval), yname, type(yval))
+        assert type(xval) == type(yval), "Ast nodes fields differ : %s (of type %s) != %s (of type %s)" % (xname, type(xval), yname, type(yval))
     for xchild, ychild in zip(ast.iter_child_nodes(x),
                               ast.iter_child_nodes(y)):
-        assert nodes_equal(xchild, ychild)
+        assert nodes_equal(xchild, ychild) , "Ast node children differs"
     return True

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -6,8 +6,10 @@ from xonsh.platform import PYTHON_VERSION_INFO
 
 @lazyobject
 def Parser():
-    if PYTHON_VERSION_INFO < (3, 5, 0):
-        from xonsh.parsers.v34 import Parser as p
-    else:
+    if PYTHON_VERSION_INFO > (3, 6):
+        from xonsh.parsers.v36 import Parser as p
+    elif PYTHON_VERSION_INFO > (3, 5):
         from xonsh.parsers.v35 import Parser as p
+    else:
+        from xonsh.parsers.v34 import Parser as p
     return p

--- a/xonsh/parsers/v36.py
+++ b/xonsh/parsers/v36.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""Implements the xonsh parser for Python v3.6."""
+import xonsh.ast as ast
+from xonsh.parsers.v35 import Parser as ThreeFiveParser
+from xonsh.parsers.base import store_ctx, ensure_has_elts
+
+
+class Parser(ThreeFiveParser):
+    """A Python v3.6 compliant parser for the xonsh language."""
+
+    def p_comp_for(self, p):
+        """comp_for : FOR exprlist IN or_test comp_iter_opt"""
+        targs, it, p5 = p[2], p[4], p[5]
+        if len(targs) == 1:
+            targ = targs[0]
+        else:
+            targ = ensure_has_elts(targs)
+        store_ctx(targ)
+        # only difference with base should be the is_async=0
+        comp = ast.comprehension(target=targ, iter=it, ifs=[], is_async=0)
+        comps = [comp]
+        p0 = {'comps': comps}
+        if p5 is not None:
+            comps += p5.get('comps', [])
+            comp.ifs += p5.get('if', [])
+        p[0] = p0
+


### PR DESCRIPTION
Seem simple enough, and avoid writing a full 3.6 parser for now. 

-- 

I tried to modify the parser to actually recognize actual `async for` comprehensions, but the lexer insist on seeing async as a NAME instead of an async token and thus refuses to match the `async_comp_for` rule...