### PR TITLE
Fix context-manager tests on 3.6

### DIFF
--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -236,38 +236,38 @@ def test_block_func_trailing_triple_string():
 # Functor tests
 #
 
-X2_WITH = ('x = 1\n'
+X2_WITH = ('{var} = 1\n'
            'with Functor() as f:\n'
            '{body}'
-           'x += 1\n'
+           '{var} += 1\n'
            '{calls}\n'
            )
 
 def test_functor_oneline_onecall_class():
-    body = ('    global x\n'
-            '    x += 42\n')
+    body = ('    global y\n'
+            '    y += 42\n')
     calls = 'f()'
-    s = X2_WITH.format(body=body, calls=calls)
+    s = X2_WITH.format(body=body, calls=calls, var='y')
     glbs = {'Functor': Functor}
     check_exec(s, glbs=glbs, locs=None)
-    block_checks_glb('f', glbs, body, {'x': 44})
+    block_checks_glb('f', glbs, body, {'y': 44})
 
 
 def test_functor_oneline_onecall_func():
-    body = ('    global x\n'
-            '    x += 42\n')
+    body = ('    global z\n'
+            '    z += 42\n')
     calls = 'f.func()'
-    s = X2_WITH.format(body=body, calls=calls)
+    s = X2_WITH.format(body=body, calls=calls, var='z')
     glbs = {'Functor': Functor}
     check_exec(s, glbs=glbs, locs=None)
-    block_checks_glb('f', glbs, body, {'x': 44})
+    block_checks_glb('f', glbs, body, {'z': 44})
 
 
 def test_functor_oneline_onecall_both():
     body = ('    global x\n'
             '    x += 42\n')
     calls = 'f()\nf.func()'
-    s = X2_WITH.format(body=body, calls=calls)
+    s = X2_WITH.format(body=body, calls=calls, var='x')
     glbs = {'Functor': Functor}
     check_exec(s, glbs=glbs, locs=None)
     block_checks_glb('f', glbs, body, {'x': 86})

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -94,15 +94,15 @@ def check_parse(input):
 
 def nodes_equal(x, y):
     __tracebackhide__ = True
-    assert type(x) == type(y)
+    assert type(x) == type(y) , "Ast nodes do not have the same type: '%s' != '%s' " % (type(x), type(y))
     if isinstance(x, (ast.Expr, ast.FunctionDef, ast.ClassDef)):
-        assert x.lineno == y.lineno
-        assert x.col_offset == y.col_offset
+        assert x.lineno == y.lineno, "Ast nodes do not have the same line number : %s != %s" % (x.lineno, y.lineno)
+        assert x.col_offset == y.col_offset, "Ast nodes do not have the same column offset number : %s != %s" % (x.col_offset, y.col_offset)
     for (xname, xval), (yname, yval) in zip(ast.iter_fields(x),
                                             ast.iter_fields(y)):
-        assert xname == yname
-        assert type(xval) == type(yval)
+        assert xname == yname, "Ast nodes fields differ : %s (of type %s) != %s (of type %s)" % (xname, type(xval), yname, type(yval))
+        assert type(xval) == type(yval), "Ast nodes fields differ : %s (of type %s) != %s (of type %s)" % (xname, type(xval), yname, type(yval))
     for xchild, ychild in zip(ast.iter_child_nodes(x),
                               ast.iter_child_nodes(y)):
-        assert nodes_equal(xchild, ychild)
+        assert nodes_equal(xchild, ychild) , "Ast node children differs"
     return True

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2,6 +2,7 @@
 """Implements the base xonsh parser."""
 import os
 import re
+import sys
 import time
 import textwrap
 from threading import Thread
@@ -2324,7 +2325,10 @@ class BaseParser(object):
         else:
             targ = ensure_has_elts(targs)
         store_ctx(targ)
-        comp = ast.comprehension(target=targ, iter=it, ifs=[])
+        if sys.version_info > (3,6):
+            comp = ast.comprehension(target=targ, iter=it, ifs=[], is_async=False)
+        else:
+            comp = ast.comprehension(target=targ, iter=it, ifs=[])
         comps = [comp]
         p0 = {'comps': comps}
         if p5 is not None:

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2326,7 +2326,7 @@ class BaseParser(object):
             targ = ensure_has_elts(targs)
         store_ctx(targ)
         if sys.version_info > (3,6):
-            comp = ast.comprehension(target=targ, iter=it, ifs=[], is_async=False)
+            comp = ast.comprehension(target=targ, iter=it, ifs=[], is_async=0)
         else:
             comp = ast.comprehension(target=targ, iter=it, ifs=[])
         comps = [comp]


### PR DESCRIPTION
Don't reuse variables names in tests.

Since http://bugs.python.org/issue27999, global after use is a
SyntaxError; reusing variable name in tests/test_contexts.py
lead to failure.

Should close #1718

--- 

On top of #1717 that fix other things and is necessary for tests to pass. 

