### PR TITLE
docs: Fixed git_dirty_working_directory location

### DIFF
--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -31,7 +31,7 @@ The following snippet reimplements the formatter also to include untracked files
 
 .. code-block:: xonshcon
 
-    >>> from xonsh.environ import git_dirty_working_directory
+    >>> from xonsh.prompt.vc_branch import git_dirty_working_directory
     >>> $FORMATTER_DICT['branch_color'] = lambda: ('{BOLD_INTENSE_RED}'
                                                    if git_dirty_working_directory(include_untracked=True)
                                                    else '{BOLD_INTENSE_GREEN}')


### PR DESCRIPTION
The xonshrc example imported `git_dirty_working_directory` still from
`xonsh.environ`. Now its located in `xonsh.prompt.vc_branch`.