### PR TITLE
Restore bash git completions on Windows

### DIFF
--- a/news/fix_win_git_completions.rst
+++ b/news/fix_win_git_completions.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix regression where bash git completions where not loaded 
+  automatically when GitForWindows is installed. 
+
+**Security:** None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -279,7 +279,10 @@ def BASH_COMPLETIONS_DEFAULT():
                '/usr/local/etc/bash_completion')  # v1.x
     elif ON_WINDOWS and git_for_windows_path():
         bcd = (os.path.join(git_for_windows_path(),
-                            'usr\\share\\bash-completion'), )
+                            'usr\\share\\bash-completion'),
+               os.path.join(git_for_windows_path(),
+                            'mingw64\\share\\git\\completion\\'
+                            'git-completion.bash'))
     else:
         bcd = ()
     return bcd


### PR DESCRIPTION
I noticed that git completions had stopped working for me on windows. I haven't figure when it happen. Maybe xonsh or maybe a restructure of Git For Windows. 

Anyway, this fix makes it work again by adding the `` 'GitForWidnows\\mingw64\\share\\git\\completion\\git-completion.bash'` to the default completion list. 