### PR TITLE
prompt user to install xontribs on error

### DIFF
--- a/news/prompt_xontrib_install.rst
+++ b/news/prompt_xontrib_install.rst
@@ -1,0 +1,14 @@
+**Added:** 
+
+* Prompt user to install xontrib package if they try to load an uninstalled 
+  xontrib
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -112,7 +112,7 @@ class Shell(object):
             names = builtins.__xonsh_config__.get('xontribs', ())
             for name in names:
                 update_context(name, ctx=self.ctx)
-            if update_context.bad_imports:
+            if hasattr(update_context, 'bad_imports'):
                 prompt_xontrib_install(update_context.bad_imports)
                 del update_context.bad_imports
             # load run control files

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -5,7 +5,7 @@ import random
 import builtins
 import warnings
 
-from xonsh.xontribs import update_context
+from xonsh.xontribs import update_context, prompt_xontrib_install
 from xonsh.environ import xonshrc_context
 from xonsh.execer import Execer
 from xonsh.platform import (best_shell_type, has_prompt_toolkit,
@@ -112,6 +112,9 @@ class Shell(object):
             names = builtins.__xonsh_config__.get('xontribs', ())
             for name in names:
                 update_context(name, ctx=self.ctx)
+            if update_context.bad_imports:
+                prompt_xontrib_install(update_context.bad_imports)
+                del update_context.bad_imports
             # load run control files
             env = builtins.__xonsh_env__
             rc = env.get('XONSHRC') if rc is None else rc

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -32,7 +32,7 @@ def xontrib_context(name):
     if spec is None:
         with warnings.catch_warnings():
             warnings.simplefilter('default', ImportWarning)
-            warnings.warn('could not find xontrib module {0!r}'.format(name),
+            warnings.warn(prompt_xontrib_install(name),
                           ImportWarning)
         return {}
     m = importlib.import_module(spec.name)
@@ -42,6 +42,17 @@ def xontrib_context(name):
     else:
         ctx = {k: getattr(m, k) for k in dir(m) if not k.startswith('_')}
     return ctx
+
+
+def prompt_xontrib_install(name):
+    """Returns a formatted string with name of xontrib package to prompt user"""
+    md = xontrib_metadata()
+    install_str = ('xontrib "{xontrib}" is not installed.  \n'
+                   'To install it run \n'
+                   '    pip install {package}')
+    for xontrib in md['xontribs']:
+        if xontrib['name'] == name:
+            return install_str.format(xontrib=name, package=xontrib['package'])
 
 
 def update_context(name, ctx=None):

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -64,7 +64,7 @@ def prompt_xontrib_install(names):
 #                   'To install it run \n'
 #                   '    pip install {package}')
 
-def update_context(name, ctx=None, missing_specs=[]):
+def update_context(name, ctx=None):
     """Updates a context in place from a xontrib. If ctx is not provided,
     then __xonsh_ctx__ is updated.
     """
@@ -72,8 +72,9 @@ def update_context(name, ctx=None, missing_specs=[]):
         ctx = builtins.__xonsh_ctx__
     modctx = xontrib_context(name)
     if modctx == {}:
-        missing_specs.append(name)
-    return ctx.update(modctx)
+        return False
+    ctx.update(modctx)
+    return True
 
 
 @functools.lru_cache()
@@ -91,7 +92,9 @@ def _load(ns):
     for name in ns.names:
         if ns.verbose:
             print('loading xontrib {0!r}'.format(name))
-        update_context(name, ctx=ctx, missing_specs=missing_specs)
+        res = update_context(name, ctx=ctx)
+        if not res:
+            missing_specs.append(name)
     print(missing_specs)
     if missing_specs:
         prompt_xontrib_install(missing_specs)


### PR DESCRIPTION
As per recent discussions on gitter, a simple addition to the load-failure warning in `xontribs.py` to prompt the user to install the appropriate xontrib package