### PR TITLE
prompt formatting error handling + refactor

### DIFF
--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -13,7 +13,7 @@ from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
                              update_cache, run_compiled_code)
 from xonsh.completer import Completer
-from xonsh.environ import multiline_prompt, partial_format_prompt
+from xonsh.prompt.base import multiline_prompt, partial_format_prompt
 from xonsh.events import events
 
 

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -94,11 +94,12 @@ def _failover_template_format(template):
 
 def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
     """Formats a xonsh prompt template string."""
-    try:
-        return _partial_format_prompt_main(template=template,
-                                           formatter_dict=formatter_dict)
-    except Exception:
-        return _failover_template_format(template)
+    # try:
+    return _partial_format_prompt_main(template=template,
+                                       formatter_dict=formatter_dict)
+    # except Exception:
+    #     print("EXCEPTING")
+    #     return _failover_template_format(template)
 
 
 def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):
@@ -109,7 +110,7 @@ def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):
     colon = ':'
     expl = '!'
     toks = []
-    for literal, field, spec, conv in string.Formatter().parse(template):
+    for literal, field, spec, conv in _FORMATTER.parse(template):
         toks.append(literal)
         if field is None:
             continue
@@ -119,7 +120,13 @@ def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):
             toks.append(val)
         elif field in fmtter:
             v = fmtter[field]
-            val = v() if callable(v) else v
+            try:
+                val = v() if callable(v) else v
+            except Exception as err:
+                print('prompt: error: field {!r} raised: {!r}'
+                      ''.format(field, err))
+                toks.append('(ERROR:{})'.format(field))
+                continue
             val = _format_value(val, spec, conv)
             toks.append(val)
         else:

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Base prompt, provides FORMATTER_DICT"""
+"""Base prompt, provides FORMATTER_DICT and prompt related functions"""
 
 import os
 import socket
+import string
 
 import xonsh.lazyasd as xl
 import xonsh.tools as xt
@@ -18,6 +19,7 @@ from xonsh.prompt.vc_branch import (
     current_branch, branch_color, branch_bg_color
 )
 from xonsh.prompt.gitstatus import gitstatus_prompt
+from xonsh.platform import ON_WINDOWS, ON_CYGWIN
 
 
 FORMATTER_DICT = xl.LazyObject(lambda: dict(
@@ -36,3 +38,142 @@ FORMATTER_DICT = xl.LazyObject(lambda: dict(
     vte_new_tab_cwd=vte_new_tab_cwd,
     gitstatus=gitstatus_prompt,
 ), globals(), 'FORMATTER_DICT')
+
+
+def default_prompt():
+    """Creates a new instance of the default prompt."""
+    if ON_CYGWIN:
+        dp = ('{env_name:{} }{BOLD_GREEN}{user}@{hostname}'
+              '{BOLD_BLUE} {cwd} {prompt_end}{NO_COLOR} ')
+    elif ON_WINDOWS:
+        dp = ('{env_name:{} }'
+              '{BOLD_INTENSE_GREEN}{user}@{hostname}{BOLD_INTENSE_CYAN} '
+              '{cwd}{branch_color}{curr_branch: {}}{NO_COLOR} '
+              '{BOLD_INTENSE_CYAN}{prompt_end}{NO_COLOR} ')
+    else:
+        dp = ('{env_name:{} }'
+              '{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
+              '{cwd}{branch_color}{curr_branch: {}}{NO_COLOR} '
+              '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
+    return dp
+
+
+@xt.lazyobject
+def DEFAULT_PROMPT():
+    return default_prompt()
+
+def _get_fmtter(formatter_dict=None):
+    if formatter_dict is None:
+        fmtter = builtins.__xonsh_env__.get('FORMATTER_DICT', FORMATTER_DICT)
+    else:
+        fmtter = formatter_dict
+    return fmtter
+
+
+def _failover_template_format(template):
+    if callable(template):
+        try:
+            # Exceptions raises from function of producing $PROMPT
+            # in user's xonshrc should not crash xonsh
+            return template()
+        except Exception:
+            print_exception()
+            return '$ '
+    return template
+
+
+def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
+    """Formats a xonsh prompt template string."""
+    try:
+        return _partial_format_prompt_main(template=template,
+                                           formatter_dict=formatter_dict)
+    except Exception:
+        return _failover_template_format(template)
+
+
+def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):
+    template = template() if callable(template) else template
+    fmtter = _get_fmtter(formatter_dict)
+    bopen = '{'
+    bclose = '}'
+    colon = ':'
+    expl = '!'
+    toks = []
+    for literal, field, spec, conv in string.Formatter.parse(template):
+        print("FORMATTING")
+        toks.append(literal)
+        if field is None:
+            continue
+        elif field.startswith('$'):
+            val = builtins.__xonsh_env__[field[1:]]
+            val = _format_value(val, spec, conv)
+            toks.append(val)
+        elif field in fmtter:
+            v = fmtter[field]
+            val = v() if callable(v) else v
+            val = _format_value(val, spec, conv)
+            toks.append(val)
+        else:
+            toks.append(bopen)
+            toks.append(field)
+            if conv is not None and len(conv) > 0:
+                toks.append(expl)
+                toks.append(conv)
+            if spec is not None and len(spec) > 0:
+                toks.append(colon)
+                toks.append(spec)
+            toks.append(bclose)
+    return ''.join(toks)
+
+
+
+@xt.lazyobject
+def RE_HIDDEN(): \
+    return re.compile('\001.*?\002')
+
+
+def multiline_prompt(curr=''):
+    """Returns the filler text for the prompt in multiline scenarios."""
+    line = curr.rsplit('\n', 1)[1] if '\n' in curr else curr
+    line = RE_HIDDEN.sub('', line)  # gets rid of colors
+    # most prompts end in whitespace, head is the part before that.
+    head = line.rstrip()
+    headlen = len(head)
+    # tail is the trailing whitespace
+    tail = line if headlen == 0 else line.rsplit(head[-1], 1)[1]
+    # now to constuct the actual string
+    dots = builtins.__xonsh_env__.get('MULTILINE_PROMPT')
+    dots = dots() if callable(dots) else dots
+    if dots is None or len(dots) == 0:
+        return ''
+    tokstr = format_color(dots, hide=True)
+    baselen = 0
+    basetoks = []
+    for x in tokstr.split('\001'):
+        pre, sep, post = x.partition('\002')
+        if len(sep) == 0:
+            basetoks.append(('', pre))
+            baselen += len(pre)
+        else:
+            basetoks.append(('\001' + pre + '\002', post))
+            baselen += len(post)
+    if baselen == 0:
+        return format_color('{NO_COLOR}' + tail, hide=True)
+    toks = basetoks * (headlen // baselen)
+    n = headlen % baselen
+    count = 0
+    for tok in basetoks:
+        slen = len(tok[1])
+        newcount = slen + count
+        if slen == 0:
+            continue
+        elif newcount <= n:
+            toks.append(tok)
+        else:
+            toks.append((tok[0], tok[1][:n-count]))
+        count = newcount
+        if n <= count:
+            break
+    toks.append((format_color('{NO_COLOR}', hide=True), tail))
+    rtn = ''.join(itertools.chain.from_iterable(toks))
+    return rtn

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -13,7 +13,7 @@ from pygments.token import Token
 
 from xonsh.base_shell import BaseShell
 from xonsh.tools import print_exception
-from xonsh.environ import partial_format_prompt
+from xonsh.prompt.base import partial_format_prompt
 from xonsh.pyghooks import (XonshLexer, partial_color_tokenize,
                             xonsh_style_proxy)
 from xonsh.ptk.completer import PromptToolkitCompleter

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -24,7 +24,7 @@ from xonsh.lazyjson import LazyJSON
 from xonsh.lazyasd import LazyObject
 from xonsh.base_shell import BaseShell
 from xonsh.ansi_colors import ansi_partial_color_format, ansi_color_style_names, ansi_color_style
-from xonsh.environ import partial_format_prompt, multiline_prompt
+from xonsh.prompt.base import partial_format_prompt, multiline_prompt
 from xonsh.tools import print_exception
 from xonsh.platform import ON_WINDOWS, ON_CYGWIN, ON_DARWIN
 from xonsh.lazyimps import pygments, pyghooks

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -17,7 +17,7 @@ except ImportError:
 
 import xonsh.wizard as wiz
 from xonsh import __version__ as XONSH_VERSION
-from xonsh.environ import is_template_string
+from xonsh.prompt.base import is_template_string
 from xonsh.platform import (is_readline_available, ptk_version,
                             PYTHON_VERSION_INFO, pygments_version, ON_POSIX, ON_LINUX, linux_distro,
                             ON_DARWIN, ON_WINDOWS, ON_CYGWIN, DEFAULT_ENCODING, githash)


### PR DESCRIPTION
#1731 

this is a first draft, the error message can be more friendly/informative,
ideas are appreciated.

moved functions that deal with prompt formatting from `environ` to `prompt.base`