### PR TITLE
try,finally in xonsh_builtins fixture

### DIFF
--- a/news/conftest-xonsh_builtins.rst
+++ b/news/conftest-xonsh_builtins.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* ``xonsh_builtins`` fixture in conftest now uses try-finally block for more isolation
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,25 +48,27 @@ def xonsh_builtins():
     # Unlike all the other stuff, this has to refer to the "real" one because all modules that would
     # be firing events on the global instance.
     builtins.events = events
-    yield builtins
-    del builtins.__xonsh_env__
-    del builtins.__xonsh_ctx__
-    del builtins.__xonsh_shell__
-    del builtins.__xonsh_help__
-    del builtins.__xonsh_glob__
-    del builtins.__xonsh_exit__
-    del builtins.__xonsh_superhelp__
-    del builtins.__xonsh_regexpath__
-    del builtins.__xonsh_expand_path__
-    del builtins.__xonsh_subproc_captured__
-    del builtins.__xonsh_subproc_uncaptured__
-    del builtins.__xonsh_ensure_list_of_strs__
-    del builtins.XonshBlockError
-    del builtins.evalx
-    del builtins.execx
-    del builtins.compilex
-    del builtins.aliases
-    del builtins.events
+    try:
+        yield builtins
+    finally:
+        del builtins.__xonsh_env__
+        del builtins.__xonsh_ctx__
+        del builtins.__xonsh_shell__
+        del builtins.__xonsh_help__
+        del builtins.__xonsh_glob__
+        del builtins.__xonsh_exit__
+        del builtins.__xonsh_superhelp__
+        del builtins.__xonsh_regexpath__
+        del builtins.__xonsh_expand_path__
+        del builtins.__xonsh_subproc_captured__
+        del builtins.__xonsh_subproc_uncaptured__
+        del builtins.__xonsh_ensure_list_of_strs__
+        del builtins.XonshBlockError
+        del builtins.evalx
+        del builtins.execx
+        del builtins.compilex
+        del builtins.aliases
+        del builtins.events
 
 
 if ON_WINDOWS:


### PR DESCRIPTION
this came up in [comment](https://github.com/xonsh/xonsh/pull/1735#issuecomment-247352575)

not tested yet if that's the case but this seems more safe

not sure if this is excessive, maybe pytest handles that anyway

there is also this usual suspect

```
Exception ignored in: <bound method Execer.__del__ of <xonsh.execer.Execer object at 0x7f2bd3fd9a20>>
Traceback (most recent call last):
  File "/home/laerus/projects/xonsh/xonsh/execer.py", line 46, in __del__
  File "/home/laerus/projects/xonsh/xonsh/built_ins.py", line 1000, in unload_builtins
  File "/usr/lib/python3.5/abc.py", line 187, in __instancecheck__
AttributeError: 'NoneType' object has no attribute '_abc_invalidation_counter'
```