### PR TITLE
Build docs on 3.5 otherwise we'll never caught failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: python
 matrix:
     include:
         - os: linux
+          python: 3.5
+          env:
+            - BUILD_DOCS=true
+        - os: linux
           python: "nightly"
           env:
             - RUN_COVERAGE=true
-            - BUILD_DOCS=true
         - os: osx
           language: generic
           env: PYTHON="3.4" MINICONDA_OS="MacOSX"
@@ -16,7 +19,7 @@ matrix:
         - python: "nightly"
 
 before_install:
-  - if [[ ! "$TRAVIS_PYTHON_VERSION" == "nightly" ]]; then
+  - if [[ ! "$TRAVIS_PYTHON_VERSION" == "nightly" && ! $BUILD_DOCS ]]; then
       URL="https://repo.continuum.io/miniconda/Miniconda3-latest-${MINICONDA_OS}-x86_64.sh";
       wget "${URL}" -O miniconda.sh;
       bash miniconda.sh -b -p $HOME/miniconda;
@@ -28,28 +31,27 @@ before_install:
     fi
 
 install:
-  - if [[ ! "$TRAVIS_PYTHON_VERSION" == "nightly" ]]; then
+  - if [[ $BUILD_DOCS = true ]]; then
+      python setup.py install;
+      pip install -r requirements-docs.txt;
+      pip install pygments prompt_toolkit ply psutil ipykernel matplotlib;
+    elif [[ ! "$TRAVIS_PYTHON_VERSION" == "nightly" ]]; then
       conda create -q -n test_env python=${PYTHON} pygments prompt_toolkit ply pytest pytest-timeout psutil;
       source activate test_env;
       python setup.py install;
     else
       pip install -r requirements-tests.txt;
     fi
-  - if [[ $BUILD_DOCS = true ]]; then
-      python setup.py install;
-      pip install -r requirements-docs.txt;
-    fi
 
 
 script:
-  - if [[ $RUN_COVERAGE = true ]]; then
+  - if [[ $BUILD_DOCS = true ]]; then
+      cd docs;
+      make html;
+    elif [[ $RUN_COVERAGE = true ]]; then
       py.test --flake8 --cov=. --timeout=10;
     else
       py.test --timeout=10;
-    fi
-  - if [[ $BUILD_DOCS = true ]]; then
-        cd docs;
-        make html;
     fi
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ from xonsh import __version__ as XONSH_VERSION
 from xonsh.environ import DEFAULT_DOCS, Env
 from xonsh.xontribs import xontrib_metadata
 from xonsh.events import events
+from xonsh.commands_cache import CommandsCache
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -384,4 +385,4 @@ make_events()
 
 builtins.__xonsh_history__ = None
 builtins.__xonsh_env__ = {}
-builtins.__xonsh_commands_cache__ = {}
+builtins.__xonsh_commands_cache__ = CommandsCache()

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -38,7 +38,7 @@ def _command_is_valid(cmd):
 
 
 def _command_is_autocd(cmd):
-    if not builtins.__xonsh_env__['AUTO_CD']:
+    if not builtins.__xonsh_env__.get('AUTO_CD'):
         return False
     cmd_abspath = os.path.abspath(os.path.expanduser(cmd))
     return os.path.isdir(cmd_abspath)


### PR DESCRIPTION
Fix docs building and move docs building to a non-allow-failure version of Python.