### PR TITLE
add support for windows drives in subsequence matching

### DIFF
--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -267,7 +267,7 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
             if p[0] == '':
                 basedir = ('', )
                 p = p[1:]
-            elif re.match(RE_WIN_DRIVE, p[0]):
+            elif xp.ON_WINDOWS and re.match(RE_WIN_DRIVE, p[0]):
                 basedir = (re.match(RE_WIN_DRIVE, p[0]).group(), )
                 p = p[1:]
             else:

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -1,4 +1,5 @@
 import os
+import re
 import ast
 import builtins
 
@@ -17,6 +18,7 @@ def CHARACTERS_NEED_QUOTES():
         cnq.append('%')
     return cnq
 
+RE_WIN_DRIVE = xl.LazyObject(lambda: re.compile('\w:'), globals(), 'RE_WIN_DRIVE')
 
 def _path_from_partial_string(inp, pos=None):
     if pos is None:
@@ -264,6 +266,9 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
         if len(p) != 0:
             if p[0] == '':
                 basedir = ('', )
+                p = p[1:]
+            elif re.match(RE_WIN_DRIVE, p[0]):
+                basedir = (re.match(RE_WIN_DRIVE, p[0]).group(), )
                 p = p[1:]
             else:
                 basedir = None


### PR DESCRIPTION
Subsequence matching was crawling up a directory tree and looking for an empty base, but on windows it's going to be a drive letter.  

pinging @astronouth7303 to see if this works.