### PR TITLE
Add $XONSH_UPDATE_PROMPT_ON_KEYPRESS option

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -160,6 +160,7 @@ def DEFAULT_ENSURERS():
     'XONSH_STORE_STDIN': (is_bool, to_bool, bool_to_str),
     'XONSH_TRACEBACK_LOGFILE': (is_logfile_opt, to_logfile_opt, logfile_opt_to_str),
     'XONSH_DATETIME_FORMAT': (is_string, ensure_string, ensure_string),
+    'UPDATE_PROMPT_ON_KEYPRESS': (is_bool, to_bool, bool_to_str),
     }
 
 
@@ -300,6 +301,7 @@ def DEFAULT_VALUES():
         'XONSH_STORE_STDOUT': False,
         'XONSH_TRACEBACK_LOGFILE': None,
         'XONSH_DATETIME_FORMAT': '%Y-%m-%d %H:%M',
+        'UPDATE_PROMPT_ON_KEYPRESS': False,
     }
     if hasattr(locale, 'LC_MESSAGES'):
         dv['LC_MESSAGES'] = locale.setlocale(locale.LC_MESSAGES)
@@ -672,6 +674,10 @@ def DEFAULT_DOCS():
     'XONSH_DATETIME_FORMAT': VarDocs(
         'The format that is used for ``datetime.strptime()`` in various places'
         'i.e the history timestamp option'),
+    'UPDATE_PROMPT_ON_KEYPRESS': VarDocs(
+        'Disables caching the prompt between commands, '
+        'so that it would be reevaluated on each keypress. '
+        'Disabled by default because of the incurred performance penalty.'),
     }
 
 

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -58,10 +58,14 @@ class PromptToolkitShell(BaseShell):
         multicolumn = (completions_display == 'multi')
         self.styler.style_name = env.get('XONSH_COLOR_STYLE')
         completer = None if completions_display == 'none' else self.pt_completer
-        prompt_tokens = self.prompt_tokens(None)
-        get_prompt_tokens = lambda cli: prompt_tokens
-        rprompt_tokens = self.rprompt_tokens(None)
-        get_rprompt_tokens = lambda cli: rprompt_tokens
+        if not env.get('UPDATE_PROMPT_ON_KEYPRESS'):
+            prompt_tokens_cached = self.prompt_tokens(None)
+            get_prompt_tokens = lambda cli: prompt_tokens_cached
+            rprompt_tokens_cached = self.rprompt_tokens(None)
+            get_rprompt_tokens = lambda cli: rprompt_tokens_cached
+        else:
+            get_prompt_tokens = self.prompt_tokens
+            get_rprompt_tokens = self.rprompt_tokens
         with self.prompter:
             prompt_args = {
                     'mouse_support': mouse_support,


### PR DESCRIPTION
$XONSH_UPDATE_PROMPT_ON_KEYPRESS = True (False by default)
disables prompt caching, so that it will be reevaluated on each keypress.
It is crucial, e.g. for exposing vi-input-mode to the prompt (see #1048).
Performance with slow prompts will probably suffer.