### PR TITLE
Add xontrib-vi-mode-prompt

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -85,6 +85,11 @@
   "package": "xontrib-powerline",
   "url": "https://github.com/santagada/xontrib-powerline",
   "description": ["Powerline for Xonsh shell"]
+ },
+ {"name": "prompt_vi_mode",
+  "package": "xontrib-prompt-vi-mode",
+  "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
+  "description": ["vi-mode status formatter for xonsh prompt"]
  }
  ],
  "packages": {
@@ -179,6 +184,13 @@
    "url": "https://github.com/meatballs/xontrib-thefuck",
    "install": {
     "pip": "pip install xontrib-thefuck"
+   }
+  },
+  "xontrib-prompt-vi-mode": {
+   "license": "MIT",
+   "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
+   "install": {
+    "pip": "pip install xontrib-prompt-vi-mode"
    }
   }
  }


### PR DESCRIPTION
Add xontrib-vi-mode-prompt

xontrib-vi-mode-prompt is a vi-mode status formatter for xonsh prompt.

Homepage: https://github.com/t184256/xontrib-prompt-vi-mode

As it depends on xonsh/xonsh/pull/1761,
I've branched it off t184256/xonsh/reeval-prompt-on-keypress.

I hope I did that right, correct me if I didn't or if I must rebase it onto something else.