### PR TITLE
Use SetConsoleTitleW() on Windows

### DIFF
--- a/news/win-setconsoletitle.rst
+++ b/news/win-setconsoletitle.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Use ``SetConsoleTitleW()`` on Windows instead of a process call.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -16,6 +16,11 @@ from xonsh.completer import Completer
 from xonsh.prompt.base import multiline_prompt, partial_format_prompt
 from xonsh.events import events
 
+if ON_WINDOWS:
+    import ctypes
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleTitleW.argtypes = [ctypes.c_wchar_p]
+
 
 class _TeeOut(object):
     """Tees stdout into the original sys.stdout and another buffer."""
@@ -288,8 +293,7 @@ class BaseShell(object):
             return
         t = partial_format_prompt(t)
         if ON_WINDOWS and 'ANSICON' not in env:
-            t = escape_windows_cmd_string(t)
-            os.system('title {}'.format(t))
+            kernel32.SetConsoleTitleW(t)
         else:
             with open(1, 'wb', closefd=False) as f:
                 # prevent xonsh from answering interative questions


### PR DESCRIPTION
Closes #1753.

This should improve performance (yay one less process to wait on) and potentially improve security (There aren't known issues with the Windows escaping, but shell escaping isn't always clean...)

`kernel32` could be made to be lazy, but it'll be used as part of the first prompt anyway, and since it's already loaded into the process, I'm not sure significant time would be saved.