### PR TITLE
pip extras

### DIFF
--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -6,14 +6,21 @@ Xonsh currently has the following external dependencies,
 
     #. Python v3.4+
     #. PLY (optional, included with xonsh)
-    #. prompt-toolkit (optional, requires `pygments`): 
+
+Pip supports "extra" dependendcies in the form of ``xonsh[ptk,linux]``, where the list in the brackets identify the optional featues
+
+Xonsh currently has the following extras
+
+    #. ``ptk``: prompt-toolkit, `pygments`:
        *advanced readline library, syntax-highlighting, line-editing*
-    #. Jupyter (optional): *in-browser REPL, run xonsh in jupyter notebook*
-    #. setproctitle (optional): *change the title of terminal to reflect the current subprocess*
-    #. distro (optional): *linux specific platform information*
+    #. ``proctitle``: setproctitle: *change the title of terminal to reflect the current subprocess*
+    #. ``linux``: distro: *linux specific platform information*
+    #. ``mac``: gnureadline: *GNU's featureful version of readline*
+    #. ``win``: win_unicode_console: *enables the use of Unicode in windows consoles*
 
-*Documentation:*
+In addition, xonsh integrates with Jupyter, an in-browser REPL, enabling the use of xonsh in jupyter notebooks
 
-    #. `Sphinx <http://sphinx-doc.org/>`_ (which uses  `reStructuredText <http://sphinx-doc.org/rest.html>`_)
-    #. Numpydoc
-    #. Cloud Sphinx Theme
+Development Dependencies
+------------------------
+
+If you want to develop xonsh, it is extremely recommended to install the depdencies listed in `requirements-docs.txt <https://github.com/xonsh/xonsh/blob/master/requirements-docs.txt>`_ (to generate documentation) and `requirements-tests.txt <https://github.com/xonsh/xonsh/blob/master/requirements-tests.txt>`_ (to run the test suite).

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -143,7 +143,7 @@ Python's utf-8 unicode is not compatible with the default shell 'cmd.exe' on Win
 
 .. note:: Even with unicode support enabled the symbols available will depend on the font used in cmd.exe.
 
-The packages ``win_unicode_console`` can be installed using pip or conda.
+The packages ``win_unicode_console`` can be installed along with xonsh by using the package name ``xonsh[win]`` or separately using pip or conda.
 
 .. code-block:: bat
 

--- a/news/extras.rst
+++ b/news/extras.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* xonsh's optional dependencies may now be installed with the pip extras ``ptk``, ``proctitle``, ``linux``, ``mac``, and ``win``.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -316,6 +316,13 @@ def main():
             'pytest11': ['xonsh = xonsh.pytest_plugin']
         }
         skw['cmdclass']['develop'] = xdevelop
+        skw['extras_require'] = {
+            'ptk':  ['prompt-toolkit', 'pygments'],
+            'win': ['win_unicode_console'],
+            'mac': ['gnureadline'],
+            'linux': ['distro'],
+            'proctitle': ['setproctitle'],
+        }
     setup(**skw)
 
 


### PR DESCRIPTION
Declare all the optional dependencies in a set of pip extras to make them more easily installable.

The biggest thing that fixes is that pygments is now a documented dependency on its own.

The extras declared are `ptk`, `proctitle`, `linux`, `mac`, `win`.

Conda isn't included yet because I couldn't figure out how conda features work. If someone knows conda, please help?