### PR TITLE
Expand user for non-default data directories

### DIFF
--- a/news/expand_user.rst
+++ b/news/expand_user.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Bug where non-default locations for ``XDG_DATA_HOME`` and ``XONSH_DATA_DIR``
+  would not expand ``~`` into the home directory
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -184,7 +184,7 @@ DEFAULT_TITLE = '{current_job:{} | }{user}@{hostname}: {cwd} | xonsh'
 @default_value
 def xonsh_data_dir(env):
     """Ensures and returns the $XONSH_DATA_DIR"""
-    xdd = os.path.join(env.get('XDG_DATA_HOME'), 'xonsh')
+    xdd = os.path.expanduser(os.path.join(env.get('XDG_DATA_HOME'), 'xonsh'))
     os.makedirs(xdd, exist_ok=True)
     return xdd
 
@@ -192,7 +192,7 @@ def xonsh_data_dir(env):
 @default_value
 def xonsh_config_dir(env):
     """Ensures and returns the $XONSH_CONFIG_DIR"""
-    xcd = os.path.join(env.get('XDG_CONFIG_HOME'), 'xonsh')
+    xcd = os.path.expanduser(os.path.join(env.get('XDG_CONFIG_HOME'), 'xonsh'))
     os.makedirs(xcd, exist_ok=True)
     return xcd
 


### PR DESCRIPTION
Attempt to fix #1782.  
We were using `expanduser` on the default values but if non-default values are specified in `config.json` then `expanduser` isn't run on them and a bunch of spurious `~` directories might be created.  