### PR TITLE
Allow activation of virtual environments in relative directories.

### DIFF
--- a/news/vox-reldir.rst
+++ b/news/vox-reldir.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* `vox activate` now accepts relative directories.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/vox-reldir.rst
+++ b/news/vox-reldir.rst
@@ -2,7 +2,7 @@
 
 **Changed:**
 
-* `vox activate` now accepts relative directories.
+* ``vox activate`` now accepts relative directories.
 
 **Deprecated:** None
 

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -3,9 +3,11 @@
 import builtins
 import stat
 import os
+import pytest
 from xontrib.voxapi import Vox
 
 from tools import skip_if_on_conda
+from xonsh.platform import ON_WINDOWS
 
 
 @skip_if_on_conda
@@ -97,6 +99,7 @@ def test_path(xonsh_builtins, tmpdir):
     
     assert oldpath == xonsh_builtins.__xonsh_env__['PATH']
 
+
 @skip_if_on_conda
 def test_crud_subdir(xonsh_builtins, tmpdir):
     """
@@ -121,3 +124,24 @@ def test_crud_subdir(xonsh_builtins, tmpdir):
     del vox['spam/eggs']
 
     assert not tmpdir.join('spam', 'eggs').check()
+
+
+@skip_if_on_conda
+def test_crud_subdir(xonsh_builtins, tmpdir):
+    """
+    Creates a virtual environment, gets it, enumerates it, and then deletes it.
+    """
+    xonsh_builtins.__xonsh_env__['VIRTUALENV_HOME'] = str(tmpdir)
+
+    vox = Vox()
+    with pytest.raises(ValueError):
+        if ON_WINDOWS:
+            vox.create('Scripts')
+        else:
+            vox.create('bin')
+
+    with pytest.raises(ValueError):
+        if ON_WINDOWS:
+            vox.create('spameggs/Scripts')
+        else:
+            vox.create('spameggs/bin')


### PR DESCRIPTION
So that venvs made by other means (eg, `.venv`) are usable within xonsh.

(Also disallow the creation of venvs with reserved names.)

I'm pretty sure this is a good idea, but I'm not certain, so I wanted a second opinion.