### PR TITLE
Fix pygment lexer when used by third party programs

### DIFF
--- a/news/pygment_plugin_fix.rst
+++ b/news/pygment_plugin_fix.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a bug when the pygments plugin was used by third party editors etc. 
+
+**Security:** None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -50,10 +50,11 @@ class CommandsCache(cabc.Mapping):
          name on Windows as a list, conserving the ordering in `PATHEXT`.
          Returns a list as `name` being the only item in it on other platforms."""
         if ON_WINDOWS:
+            pathext = builtins.__xonsh_env__.get(['PATHEXT'],['.EXE','.BAT','.CMD'])
             name = name.upper()
             return [
                 name + ext
-                for ext in ([''] + builtins.__xonsh_env__['PATHEXT'])
+                for ext in ([''] + pathext)
             ]
         else:
             return [name]

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -50,7 +50,7 @@ class CommandsCache(cabc.Mapping):
          name on Windows as a list, conserving the ordering in `PATHEXT`.
          Returns a list as `name` being the only item in it on other platforms."""
         if ON_WINDOWS:
-            pathext = builtins.__xonsh_env__.get('PATHEXT', ['.EXE','.BAT','.CMD'])
+            pathext = builtins.__xonsh_env__.get('PATHEXT')
             name = name.upper()
             return [
                 name + ext

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -50,7 +50,7 @@ class CommandsCache(cabc.Mapping):
          name on Windows as a list, conserving the ordering in `PATHEXT`.
          Returns a list as `name` being the only item in it on other platforms."""
         if ON_WINDOWS:
-            pathext = builtins.__xonsh_env__.get(['PATHEXT'],['.EXE','.BAT','.CMD'])
+            pathext = builtins.__xonsh_env__.get('PATHEXT', ['.EXE','.BAT','.CMD'])
             name = name.upper()
             return [
                 name + ext

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -26,12 +26,6 @@ from xonsh.lazyasd import LazyObject, LazyDict
 from xonsh.tools import (ON_WINDOWS, intensify_colors_for_cmd_exe,
                          expand_gray_colors_for_cmd_exe)
                          
-# If the lexor is loaded as a pygment plugin, we have to mock  
-# __xonsh_env__ and __xonsh_commands_cache__ 
-if not hasattr(builtins, '__xonsh_commands_cache__'):
-    if not hasattr(builtins, '__xonsh_env__'):
-        setattr(builtins, '__xonsh_env__', {})
-    setattr(builtins, '__xonsh_commands_cache__', CommandsCache())
 
 load_module_in_background('pkg_resources', debug='XONSH_DEBUG',
                           replacements={'pygments.plugin': 'pkg_resources'})
@@ -77,6 +71,15 @@ class XonshLexer(PythonLexer):
     filenames = ['*.xsh', '*xonshrc']
 
     def __init__(self, *args, **kwargs):
+        # If the lexor is loaded as a pygment plugin, we have to mock  
+        # __xonsh_env__ and __xonsh_commands_cache__ 
+        if not hasattr(builtins, '__xonsh_env__'):
+            setattr(builtins, '__xonsh_env__', {})
+            if ON_WINDOWS:
+                pathext = os.environ.get('PATHEXT', ['.EXE', '.BAT', '.CMD'])
+                builtins.__xonsh_env__['PATHEXT'] = pathext.split(os.pathsep)
+        if not hasattr(builtins, '__xonsh_commands_cache__'):
+            setattr(builtins, '__xonsh_commands_cache__', CommandsCache())
         _ = builtins.__xonsh_commands_cache__.all_commands
         super().__init__(*args, **kwargs)
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -21,11 +21,17 @@ from pygments.style import Style
 from pygments.styles import get_style_by_name
 import pygments.util
 
+from xonsh.commands_cache import CommandsCache
 from xonsh.lazyasd import LazyObject, LazyDict
 from xonsh.tools import (ON_WINDOWS, intensify_colors_for_cmd_exe,
                          expand_gray_colors_for_cmd_exe)
-from xonsh.tokenize import SearchPath
-
+                         
+# If the lexor is loaded as a pygment plugin, we have to mock  
+# __xonsh_env__ and __xonsh_commands_cache__ 
+if not hasattr(builtins, '__xonsh_commands_cache__'):
+    if not hasattr(builtins, '__xonsh_env__'):
+        setattr(builtins, '__xonsh_env__', {})
+    setattr(builtins, '__xonsh_commands_cache__', CommandsCache())
 
 load_module_in_background('pkg_resources', debug='XONSH_DEBUG',
                           replacements={'pygments.plugin': 'pkg_resources'})
@@ -38,7 +44,7 @@ def _command_is_valid(cmd):
 
 
 def _command_is_autocd(cmd):
-    if not builtins.__xonsh_env__.get('AUTO_CD'):
+    if not builtins.__xonsh_env__.get('AUTO_CD', False):
         return False
     cmd_abspath = os.path.abspath(os.path.expanduser(cmd))
     return os.path.isdir(cmd_abspath)


### PR DESCRIPTION
This fixes crash when using the pygment plugin from third-party programs. 

It happens because `__xonsh__commands__cache__` and `__xonsh_env__` are not available unless it is used from xonsh. 

In Spyder I got the follow error when opening a '.xsh' file: 
```
...
 File "C:\Users\mel\Anaconda3\lib\site-packages\spyder\utils\syntaxhighlighters.py", line 989, in guess_pygments_highlighter
    lexer = get_lexer_for_filename(filename)
  File "C:\Users\mel\Anaconda3\lib\site-packages\pygments\lexers\__init__.py", line 150, in get_lexer_for_filename
    return res(**options)
  File "C:\Users\mel\Anaconda3\lib\site-packages\pygments\lexer.py", line 582, in __call__
    return type.__call__(cls, *args, **kwds)
  File "c:\users\mel\documents\xonsh\xonsh\pyghooks.py", line 74, in __init__
    _ = builtins.__xonsh_commands_cache__.all_commands
AttributeError: module 'builtins' has no attribute '__xonsh_commands_cache__'
``` 

Although this PR fixes the immediate problem, the syntax highlighting looks a bit wonky in Spyder. 

![image](https://cloud.githubusercontent.com/assets/1038978/19066952/31588274-8a1c-11e6-958d-161e88454556.png)

Probably a separate issue. 



