### PR TITLE
fix pip completion

### DIFF
--- a/news/fix_pip_completer.rst
+++ b/news/fix_pip_completer.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``pip`` completion now filters results by prefix
+
+**Security:** None

--- a/xonsh/completers/pip.py
+++ b/xonsh/completers/pip.py
@@ -33,7 +33,8 @@ def complete_pip(prefix, line, begidx, endidx, ctx):
         except FileNotFoundError:
             return set()
         items = items.decode('utf-8').splitlines()
-        return set(i.split()[0] for i in items)
+        return set(i.split()[0] for i in items
+                   if i.split()[0].startswith(prefix))
 
     if (line_len > 1 and line.endswith(' ')) or line_len > 2:
         # "pip show " -> no complete (note space)


### PR DESCRIPTION
pip completion results for install/uninstall were returning the entire
list of installed packages in a given python install no matter the
contents of the completion prefix.

Now the results are filtered by a `startswith(prefix)`