### PR TITLE
Cleanup refactor

### DIFF
--- a/news/cleanup_refactor.rst
+++ b/news/cleanup_refactor.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:**
+
+* Removed doubly defined methods in subproc refactor
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -6,8 +6,8 @@ import sys
 import time
 import builtins
 
-from xonsh.tools import (XonshError, escape_windows_cmd_string, print_exception,
-                         DefaultNotGiven, check_for_partial_string)
+from xonsh.tools import (XonshError, print_exception, DefaultNotGiven,
+                         check_for_partial_string)
 from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
@@ -156,13 +156,6 @@ class _TeeStd(io.TextIOBase):
         loc = self.std.tell()
         self.std.seek(loc + len(s))
         return s
-
-    def write(self, s):
-        """Write a string to both streams and return the length written to the
-        in-memory stream.
-        """
-        self.std.write(s)
-        return self.mem.write(s)
 
 
 class Tee:


### PR DESCRIPTION
This is the first of two PRs -- this one is more important than the other.  

We still allow failures on Travis, which means we haven't had any flake checks running (or they run, but don't really get reported).  This should obviously be changed.  

After manually checking on my local machine, I discovered some issues with the recent refactor, like doubly defined methods.  

This removes those in what I hope is the correct way.  Tests still pass locally and I think it's ok, but I would really appreciate it if everyone could try out their edge cases to make sure this behaves the same as master (or hell, even better?)

Next PR will just be simple flake cleanups removing unused imports, etc...