### PR TITLE
Which returns

### DIFF
--- a/news/which_returns.rst
+++ b/news/which_returns.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed regression in the return value of the ``which`` command. It now again returns a non-zero retun value if a command is not found.
+
+**Security:** None

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -141,7 +141,7 @@ def which(args, stdin=None, stdout=None, stderr=None):
         if not pargs.skip:
             print(' or xonsh.builtins.aliases',
                   file=stderr, end='')
-        print('', end='\n')
+        print('', file=stderr, end='\n')
         return len(failures)
 
 

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -160,6 +160,6 @@ class AWitchAWitch(argparse.Action):
         parser.exit()
 
 
-def which_main(args=None, stdin=None):
+def which_main(args, stdin, stdout, stderr):
     """This is the which command entry point."""
-    which(args, stdin=stdin)
+    return which(args, stdin, stdout, stderr)


### PR DESCRIPTION
This should fix the regression with `which` not giving the correct return code. See #1826 

Unfortunately, it also revealed another bug with streaming aliases, see #1828 . So `!(which)` will fail with this fix....