### PR TITLE
fix for aliases that start with a comma

### DIFF
--- a/news/fix_comma_alias.rst
+++ b/news/fix_comma_alias.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Aliases that begin with a comma now complete correctly (no spurious comma)
+
+**Security:** None

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -39,7 +39,8 @@ def complete_python(prefix, line, start, end, ctx):
     """
     rtn = _complete_python(prefix, line, start, end, ctx)
     if not rtn:
-        prefix = re.split(r'\(|=|{|\[|,', prefix)[-1]
+        prefix = (re.split(r'\(|=|{|\[|,', prefix)[-1] if not
+                  prefix.startswith(',') else prefix)
         start = line.find(prefix)
         rtn = _complete_python(prefix, line, start, end, ctx)
         return rtn, len(prefix)


### PR DESCRIPTION
For 0.4.7 I added in logic to split on commas so that completion worked
inline with comma separated terms.  This inadvertently broke completion
behavior for aliases starting with a comma.  The rest of the characters
that we split on aren't valid syntax for beginning an alias, but commas
are.