### PR TITLE
Fix bash completer: some files not showing in completion

### DIFF
--- a/news/fix_bash_completer.rst
+++ b/news/fix_bash_completer.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a bug where some files are not showing using bash completer
+
+**Security:** None

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -11,6 +11,25 @@ from xonsh.completers.path import _quote_paths
 BASH_COMPLETE_SCRIPT = r"""
 {sources}
 
+# Override some functions in bash-completion, do not quote for readline
+quote_readline()
+{{
+    echo "$1"
+}}
+
+_quote_readline_by_ref()
+{{
+    if [[ $1 == \'* ]]; then
+        # Leave out first character
+        printf -v $2 %s "${{1:1}}"
+    else
+        printf -v $2 %s "$1"
+    fi
+
+    [[ ${{!2}} == \$* ]] && eval $2=${{!2}}
+}}
+
+
 function _get_complete_statement {{
     complete -p {cmd} 2> /dev/null || echo "-F _minimal"
 }}


### PR DESCRIPTION
This fixes the issue that, if there's files and directories under `~/Downloads/`, typing `mv ~/Downloads/<TAB>` would only completes directories, but not files. This only happens for few commands and when the path starts with `~`.

----

Here's the long explanation:

So, basically, while xonsh is completing from `mv ~/Downloads/<TAB>`, it runs:

```
source "/usr/local/share/bash-completion/bash_completion"
# ... some other stuff
COMP_WORDS=(mv '~/Downloads/')
COMP_LINE='mv ~/Downloads/'
COMP_POINT=${#COMP_LINE}
COMP_COUNT=16
COMP_CWORD=1
_longopt mv '~/Downloads/' mv

for ((i=0;i<${#COMPREPLY[*]};i++)) do echo ${COMPREPLY[i]}; done
```

(`_longopt` is returned by `complete -p mv`)

Save the scripts in `test.sh` and run `bash test.sh` does not print files as expected. But running them line by line in bash DOES print those files. So I re-ran it using `bash -x` and found that the command that really matter is `compgen -f -X '' -- '\~/Downloads/'`. This command prints all files while running from interactive bash but fails while running from bash script.

So I digged into bash source code, found this:

in pcomplete.c line 751: 

```
      iscompgen = this_shell_builtin == compgen_builtin;
      iscompleting = RL_ISSTATE (RL_STATE_COMPLETING);
      
      if (iscompgen && iscompleting == 0 && rl_completion_found_quote == 0
	  && rl_filename_dequoting_function)
	{
	  /* Use rl_completion_quote_character because any single or
	     double quotes have been removed by the time TEXT makes it
	     here, and we don't want to remove backslashes inside
	     quoted strings. */
	  dfn = (*rl_filename_dequoting_function) ((char *)text, rl_completion_quote_character);
	}
```

And it turns out that, while running from bash script, `rl_filename_dequoting_function` is `NULL`. `rl_filename_dequoting_function` is set in baseline.c line 589, in `initialize_readline()`, which clearly is not called while not using readline (while running bash script).

So the problem is that `\~/Downloads/` should not be quoted since we are not using readline so bash would not de-quote it. There's two functions named `quote_readline` and `_quote_readline_by_ref` in `bash-completion` and here comes my solution...