### PR TITLE
Fix which prints 

### DIFF
--- a/news/which_returns.rst
+++ b/news/which_returns.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Fixed the meassage printed when which is unable to find the command. 
+
+**Security:** None

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -97,7 +97,10 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
 
     pargs = parser.parse_args(args)
     verbose = pargs.verbose or pargs.all
-    captured = spec.captured in xproc.STDOUT_CAPTURE_KINDS
+    if spec is not None:
+        captured = spec.captured in xproc.STDOUT_CAPTURE_KINDS
+    else:
+        captured = False
     if pargs.plain:
         verbose = False
     if xp.ON_WINDOWS:
@@ -138,12 +141,12 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         print('{} not in '.format(', '.join(failures)),
               file=stderr, end='')
         if pargs.all:
-            print('globals or ')
+            print('globals or ', file=stderr, end='')
         print('$PATH', file=stderr, end='')
         if not pargs.skip:
             print(' or xonsh.builtins.aliases',
                   file=stderr, end='')
-        print('', end='\n')
+        print('', file=stderr, end='\n')
         return len(failures)
 
 


### PR DESCRIPTION
So I am just opening  a new PR for the `which` stuff, which wasn't addressed in @scopatz's #1803 PR

This fixes the print statements when `which` doesn't find any matches, and ensures they go to stderr. 