### PR TITLE
Replaced backgroundable with threadable

### DIFF
--- a/news/not_backgroundable.rst
+++ b/news/not_backgroundable.rst
@@ -2,13 +2,15 @@
 
 **Changed:**
 
-* The following commands are, by deafult, predicted to be not backgroundable
+* The following commands are, by deafult, predicted to be not threadable
   in some circumastances:
 
     * bash
     * csh
     * clear
+    * clear.exe
     * cls
+    * cmd
     * fish
     * ksh
     * less

--- a/news/rs.rst
+++ b/news/rs.rst
@@ -28,6 +28,8 @@
 * Piping between processes now uses OS pipes.
 * ``$XONSH_STORE_STDIN`` now uses ``os.pread()`` rather than ``tee`` and a new
   file.
+* The implementation of the ``foreground()`` decorator has been moved to
+  ``unthreadable()``.
 
 **Deprecated:** None
 
@@ -37,7 +39,7 @@
   in favor of ``CommandPipeline`` and ``HiddenCommandPipeline``.
 * ``SimpleProcProxy`` and ``SimpleForegroundProcProxy`` have been removed
   in favor of a more general mechanism for dispatching callable aliases
-  implemented in the ``ProcProxy`` class.
+  implemented in the ``ProcProxyThread``  and ``ProcProxy`` classes.
 
 
 **Fixed:**

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -70,7 +70,7 @@ class DummyCommandsCache:
     def locate_binary(self, name):
         return os.path.join(os.path.dirname(__file__), 'bin', name)
 
-    def predict_backgroundable(self, cmd):
+    def predict_threadable(self, cmd):
         return True
 
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -912,7 +912,7 @@ def partial_proxy(f):
         raise XonshError(e.format(numargs))
 
 
-class ProcProxy(threading.Thread):
+class ProcProxyThread(threading.Thread):
     """
     Class representing a function to be run as a subprocess-mode command.
     """
@@ -1238,15 +1238,15 @@ class ProcProxy(threading.Thread):
 
 
 #
-# Foreground Process Proxies
+# Foreground Thread Process Proxies
 #
 
-class ForegroundProcProxy(object):
+class ProcProxy(object):
     """This is process proxy class that runs its alias functions on the
     same thread that it was called from, which is typically the main thread.
-    This prevents backgrounding the process, but enables debugger and
-    profiler tools (functions) be run on the same thread that they are
-    attempting to debug.
+    This prevents the process from runing on a background thread, but enables
+    debugger and profiler tools (functions) be run on the same thread that they
+    are attempting to debug.
     """
 
     def __init__(self, f, args, stdin=None, stdout=None, stderr=None,
@@ -1320,13 +1320,15 @@ class ForegroundProcProxy(object):
         return getattr(self, name)
 
 
-def foreground(f):
+def unthreadable(f):
     """Decorator that specifies that a callable alias should be run only
-    as a foreground process. This is often needed for debuggers and profilers.
+    on the main thread process. This is often needed for debuggers and profilers.
     """
-    f.__xonsh_backgroundable__ = False
+    f.__xonsh_threadable__ = False
     return f
 
+
+foreground = unthreadable
 
 @lazyobject
 def SIGNAL_MESSAGES():


### PR DESCRIPTION
This should make it more clear whether or not a process is run on a thread and will hopefully prevent confusion with backgrounding a process.