### PR TITLE
Fix regression in lazy_locate_binary introduced by #1852

### DIFF
--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -161,7 +161,8 @@ class CommandsCache(cabc.Mapping):
         cached = next((cmd for cmd in possibilities if cmd in self._cmds_cache),
                       None)
         if cached:
-            return self._cmds_cache[cached][0]
+            (path, is_alias) = self._cmds_cache[cached]
+            return path if not is_alias else None
         elif os.path.isfile(name) and name != pathbasename(name):
             return name
 


### PR DESCRIPTION
I currently get this error when running aliases on windows.  ( `aliases['ls'] = ['ls', '--color']`)

```
snail@sea ~\Documents\xonsh $ ls
xonsh: subprocess mode: permission denied: ls
```

I introduced this bug in #1852. Sorry. Here is the fix. We need to explicitly check that a command is not an alias before returning the path in 'lazy_locate_binary()`. This is necessary since the orignal cased name of an alias is now saved in the first element of the command_cache tuple (i.e. the path element). 