### PR TITLE
Add support for path-yielding backticks

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -953,6 +953,20 @@ The following example shows the form of these functions:
     ['aa', 'aaa', 'aab', 'aabb']
 
 
+Path Output
+-----------
+
+Using the ``p`` modifier with either regex or glob backticks changes the
+return type from a list of strings to a list of :class:`pathlib.Path` objects:
+
+.. code-block:: xonshcon
+
+    >>> p`.*`
+    [Path('foo'), Path('bar')]
+    >>> [x for x in pg`**` if x.is_symlink()]
+    [Path('a_link')]
+
+
 Help & Superhelp with ``?`` & ``??``
 =====================================================
 From IPython, xonsh allows you to inspect objects with question marks.

--- a/news/path-backticks.rst
+++ b/news/path-backticks.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+* Backticks for regex or glob searches now support an additional modifier
+  ``p``, which causes them to return Path objects instead of strings.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -191,7 +191,7 @@ def test_single_bytes_literal():
 
 def test_regex_globs():
     for i in ('.*', r'\d*', '.*#{1,2}'):
-        for p in ('', 'r', 'g', '@somethingelse'):
+        for p in ('', 'r', 'g', '@somethingelse', 'p', 'pg'):
             c = '{}`{}`'.format(p,i)
             assert check_token(c, ['SEARCHPATH', c, 0])
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1615,6 +1615,15 @@ def test_ls_glob():
 def test_gbacktick():
     check_xonsh_ast({}, 'print(g`.*`)', False)
 
+def test_pbacktrick():
+    check_xonsh_ast({}, 'print(p`.*`)', False)
+
+def test_pgbacktick():
+    check_xonsh_ast({}, 'print(pg`.*`)', False)
+
+def test_prbacktick():
+    check_xonsh_ast({}, 'print(pr`.*`)', False)
+
 def test_ls_glob_octothorpe():
     check_xonsh_ast({}, '$(ls g`#[Ff]+i*LE` -l)', False)
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -13,6 +13,7 @@ import types
 import shlex
 import signal
 import atexit
+import pathlib
 import inspect
 import builtins
 import itertools
@@ -150,16 +151,19 @@ def globsearch(s):
                     sort_result=glob_sorted)
 
 
-def pathsearch(func, s, pymode=False):
+def pathsearch(func, s, pymode=False, pathobj=False):
     """
     Takes a string and returns a list of file paths that match (regex, glob,
-    or arbitrary search function).
+    or arbitrary search function). If pathobj=True, the return is a list of
+    pathlib.Path objects instead of strings.
     """
     if (not callable(func) or
             len(inspect.signature(func).parameters) != 1):
         error = "%r is not a known path search function"
         raise XonshError(error % func)
     o = func(s)
+    if pathobj and pymode:
+        o = list(map(pathlib.Path, o))
     no_match = [] if pymode else [s]
     return o if len(o) != 0 else no_match
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -129,15 +129,19 @@ def xonsh_pathsearch(pattern, pymode=False, lineno=None, col=None):
     searchfunc, pattern = RE_SEARCHPATH.match(pattern).groups()
     pattern = ast.Str(s=pattern, lineno=lineno,
                       col_offset=col)
-    if searchfunc in {'r', ''}:
-        func = '__xonsh_regexsearch__'
-    elif searchfunc == 'g':
+    pathobj = False
+    if searchfunc.startswith('@'):
+        func = searchfunc[1:]
+    elif 'g' in searchfunc:
         func = '__xonsh_globsearch__'
+        pathobj = 'p' in searchfunc
     else:
-        func = searchfunc[1:]  # remove the '@' character
+        func = '__xonsh_regexsearch__'
+        pathobj = 'p' in searchfunc
     func = ast.Name(id=func, ctx=ast.Load(), lineno=lineno,
                     col_offset=col)
-    return xonsh_call('__xonsh_pathsearch__', args=[func, pattern, pymode],
+    pathobj = ast.NameConstant(value=pathobj, lineno=lineno, col_offset=col)
+    return xonsh_call('__xonsh_pathsearch__', args=[func, pattern, pymode, pathobj],
                       lineno=lineno, col=col)
 
 

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -221,7 +221,7 @@ String = group(StringPrefix + r"'[^\n'\\]*(?:\\.[^\n'\\]*)*'",
                StringPrefix + r'"[^\n"\\]*(?:\\.[^\n"\\]*)*"')
 
 # Xonsh-specific Syntax
-SearchPath = r"((?:[rg]|@\w*)?)`([^\n`\\]*(?:\\.[^\n`\\]*)*)`"
+SearchPath = r"((?:[rgp]+|@\w*)?)`([^\n`\\]*(?:\\.[^\n`\\]*)*)`"
 
 # Because of leftmost-then-longest match semantics, be sure to put the
 # longest operators first (e.g., if = came before ==, == would get


### PR DESCRIPTION
This is a split of #1862 containing only the path backticks part.