### PR TITLE
Alt enter

### DIFF
--- a/news/alt_enter.rst
+++ b/news/alt_enter.rst
@@ -1,0 +1,16 @@
+**Added:**
+
+* Alt+Enter will execute a multiline code block irrespective of cursor position
+
+**Changed:**
+
+* All custom prompt_toolkit key binding filters now declared with the 
+  ``@Condition`` decorator
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -24,7 +24,6 @@ def carriage_return(b, cli, *, autoindent=True):
     - Line ends with backslash
     - Any text exists below cursor position (relevant when editing previous
     multiline blocks)
-
     """
     doc = b.document
     at_end_of_line = _is_blank(doc.current_line_after_cursor)

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -223,7 +223,7 @@ def load_xonsh_bindings(key_bindings_manager):
         b.accept_action.validate_and_handle(event.cli, b)
         xonsh_exit([])
 
-    @handle(Keys.ControlJ, filter=IsMultiline)
+    @handle(Keys.ControlJ, filter=IsMultiline())
     def multiline_carriage_return(event):
         """ Wrapper around carriage_return multiline parser """
         b = event.cli.current_buffer

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -244,6 +244,12 @@ def load_xonsh_bindings(key_bindings_manager):
         """Use <ESC> to cancel completion"""
         event.cli.current_buffer.cancel_completion()
 
+    @handle(Keys.Escape, Keys.ControlJ)
+    def execute_block_now(event):
+        """Execute a block of text irrespective of cursor position"""
+        b = event.cli.current_buffer
+        b.accept_action.validate_and_handle(event.cli, b)
+
     @handle(Keys.Left, filter=BeginningOfLine())
     def wrap_cursor_back(event):
         """Move cursor to end of previous line unless at beginning of

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -3,9 +3,8 @@
 import builtins
 
 from prompt_toolkit.enums import DEFAULT_BUFFER
-from prompt_toolkit.filters import (Condition, Filter, IsMultiline,
-                                    HasSelection, EmacsInsertMode,
-                                    ViInsertMode)
+from prompt_toolkit.filters import (Condition, IsMultiline, HasSelection,
+                                    EmacsInsertMode, ViInsertMode)
 from prompt_toolkit.keys import Keys
 from xonsh.aliases import xonsh_exit
 from xonsh.tools import ON_WINDOWS, check_for_partial_string

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -14,10 +14,8 @@ DEDENT_TOKENS = frozenset(['raise', 'return', 'pass', 'break', 'continue'])
 
 
 def carriage_return(b, cli, *, autoindent=True):
-    """
-    Preliminary parser to determine if 'Enter' key should send command to
-    the xonsh parser for execution or should insert a newline for continued
-    input.
+    """Preliminary parser to determine if 'Enter' key should send command to the
+    xonsh parser for execution or should insert a newline for continued input.
 
     Current 'triggers' for inserting a newline are:
     - Not on first line of buffer and line is non-empty
@@ -26,6 +24,7 @@ def carriage_return(b, cli, *, autoindent=True):
     - Line ends with backslash
     - Any text exists below cursor position (relevant when editing previous
     multiline blocks)
+
     """
     doc = b.document
     at_end_of_line = _is_blank(doc.current_line_after_cursor)
@@ -48,17 +47,14 @@ def carriage_return(b, cli, *, autoindent=True):
             doc.line_count > 1):
         b.newline(copy_margin=autoindent)
         b.delete_before_cursor(count=len(indent))
-    elif (not doc.on_first_line and
-            not current_line_blank):
+    elif (not doc.on_first_line and not current_line_blank):
         b.newline(copy_margin=autoindent)
     elif (doc.char_before_cursor == '\\' and
             not (not builtins.__xonsh_env__.get('FORCE_POSIX_PATHS') and
                  ON_WINDOWS)):
         b.newline(copy_margin=autoindent)
     elif (doc.find_next_word_beginning() is not None and
-            (any(not _is_blank(i)
-                 for i
-                 in doc.lines_from_current[1:]))):
+            (any(not _is_blank(i) for i in doc.lines_from_current[1:]))):
         b.newline(copy_margin=autoindent)
     elif not current_line_blank and not can_compile(doc.text):
         b.newline(copy_margin=autoindent)
@@ -66,6 +62,10 @@ def carriage_return(b, cli, *, autoindent=True):
         b.newline(copy_margin=autoindent)
     else:
         b.accept_action.validate_and_handle(cli, b)
+
+
+def _is_blank(l):
+    return len(l.strip()) == 0
 
 
 def can_compile(src):
@@ -290,7 +290,3 @@ def load_xonsh_bindings(key_bindings_manager):
         else:
             event.cli.start_completion(insert_common_part=True,
                                        select_first=False)
-
-
-def _is_blank(l):
-    return len(l.strip()) == 0


### PR DESCRIPTION
Enables Alt+Enter to force execute a code block in PTK irrespective of cursor position.

Also changes all of the filter definitions to be consistent and reordered the key_bindings file a bit to group things more sensibly.