### PR TITLE
fix xontrib prompt for empty list

### DIFF
--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -112,7 +112,7 @@ class Shell(object):
             names = builtins.__xonsh_config__.get('xontribs', ())
             for name in names:
                 update_context(name, ctx=self.ctx)
-            if hasattr(update_context, 'bad_imports'):
+            if getattr(update_context, 'bad_imports', None):
                 prompt_xontrib_install(update_context.bad_imports)
                 del update_context.bad_imports
             # load run control files


### PR DESCRIPTION
I got xontrib prompt info from nothing:

```
Last login: Thu Oct 20 14:23:11 on ttys005
The following xontribs are enabled but not installed:

To install them run
    pip install
xonsh $ xontrib list
distributed         installed      not-loaded
mpl                 installed      not-loaded
vox                 installed      loaded
prompt_ret_code     installed      not-loaded
xo                  not-installed  not-loaded
apt_tabcomplete     not-installed  not-loaded
docker_tabcomplete  not-installed  not-loaded
scrapy_tabcomplete  not-installed  not-loaded
vox_tabcomplete     not-installed  not-loaded
autoxsh             not-installed  not-loaded
xonda               not-installed  not-loaded
avox                not-installed  not-loaded
z                   not-installed  not-loaded
powerline           not-installed  not-loaded
prompt_vi_mode      not-installed  not-loaded
```