### PR TITLE
hold off on release docs until next release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,13 @@ script:
       make html;
       cd ..;
       doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs dev;
-      git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
-      cd docs;
-      make html;
-      cd ..;
-      doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs .;
     else
       py.test --timeout=10;
     fi
+
+# This block should be inserted after line 52 for the next release.
+#      git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
+#      cd docs;
+#      make html;
+#      cd ..;
+#      doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs .;

--- a/news/doctr.rst
+++ b/news/doctr.rst
@@ -1,7 +1,6 @@
 **Added:**
 
 * Use `doctr <https://drdoctr.github.io/doctr/>`_ to deploy dev docs to github pages
-* Use `doctr <https://drdoctr.github.io/doctr/>`_ to deploy latest release docs to github pages
 
 **Changed:** None
 


### PR DESCRIPTION
Ok, last one for now (I hope).  dev docs are working as planned, available here: https://xonsh.github.io/xonsh-docs/dev/

release docs won't work until the next release is pushed, since, of course, the previous releases don't have the encrypted deploy key available to them since I just added it.  I've commented out the relevant parts of the `.travis.yml` to be enabled after the next release, which should stop the test failures on Travis.