### PR TITLE
Fix for windows quoting issue with machines

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -915,19 +915,25 @@ def test_escape_windows_cmd_string(st, esc):
     assert esc == obs
 
 
-@pytest.mark.parametrize('st, esc', [
-    ('', '""'),
-    ('foo', 'foo'),
+@pytest.mark.parametrize('st, esc, forced', [
+    ('', '""', None),
+    ('foo', 'foo', '"foo"'),
     (r'arg1 "hallo, "world""  "\some\path with\spaces")',
-     r'"arg1 \"hallo, \"world\"\"  \"\some\path with\spaces\")"'),
+     r'"arg1 \"hallo, \"world\"\"  \"\some\path with\spaces\")"', None),
     (r'"argument"2" argument3 argument4',
-     r'"\"argument\"2\" argument3 argument4"'),
-    (r'"\foo\bar bar\foo\" arg',
-     r'"\"\foo\bar bar\foo\\\" arg"')
+     r'"\"argument\"2\" argument3 argument4"', None),
+    (r'"\foo\bar bar\foo\" arg', r'"\"\foo\bar bar\foo\\\" arg"', None),
+    (r'\\machine\dir\file.bat', r'\\machine\dir\file.bat', r'"\\machine\dir\file.bat"'),
+    (r'"\\machine\dir space\file.bat"', r'"\"\\machine\dir space\file.bat\""', None)
 ])
-def test_argvquote(st, esc):
+def test_argvquote(st, esc, forced):
     obs = argvquote(st)
     assert esc == obs
+    
+    if forced is None:
+        forced = esc
+    obs = argvquote(st, force=True)
+    assert forced == obs
 
 
 @pytest.mark.parametrize('inp', ['no string here', ''])

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -747,16 +747,23 @@ def argvquote(arg, force=False):
         n_backslashes = 0
         cmdline = '"'
         for c in arg:
+            if c == "\\":
+                # first count the number of current backslashes
+                n_backslashes += 1
+                continue
             if c == '"':
+                # Escape all backslashes and the following double quotation mark
                 cmdline += (n_backslashes * 2 + 1) * '\\'
             else:
+                # backslashes are not special here
                 cmdline += n_backslashes * '\\'
-            if c != '\\':
-                cmdline += c
-                n_backslashes = 0
-            else:
-                n_backslashes += 1
-        return cmdline + n_backslashes * 2 * '\\' + '"'
+            n_backslashes = 0
+            cmdline += c
+        # Escape all backslashes, but let the terminating
+        # double quotation mark we add below be interpreted
+        # as a metacharacter
+        cmdline += + n_backslashes * 2 * '\\' + '"'
+        return cmdline
 
 
 def on_main_thread():


### PR DESCRIPTION
The problem is that `argvquote(r'\\machine\dir\file.bat', force=True)` returns a wrongly quoted string: `"\\\machine\dir\file.bat"` (note the three instead of two `\` in the beginning). This fix adds a testcase for such paths and reimplements the mentioned algorithm in argvquote more closely.

CC: @melund