### PR TITLE
Fix AttributeError: 'TextTranscodingWrapper' object has no attribute 'buffer' in stderr

### DIFF
--- a/news/fix_stderr_attribute_error.rst
+++ b/news/fix_stderr_attribute_error.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``proc.stream_stderr`` now handles stderr that doesn't have buffer attribute
+
+**Security:** None

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1547,9 +1547,16 @@ class CommandPipeline:
         """Streams lines to sys.stderr and the errors attribute."""
         if not lines:
             return
+        env = builtins.__xonsh_env__
+        enc = env.get('XONSH_ENCODING')
+        err = env.get('XONSH_ENCODING_ERRORS')
         b = b''.join(lines)
+        stderr_has_buffer = hasattr(sys.stderr, 'buffer')
         # write bytes to std stream
-        sys.stderr.buffer.write(b)
+        if stderr_has_buffer:
+            sys.stderr.buffer.write(b)
+        else:
+            sys.stderr.write(b.decode(encoding=enc, errors=err))
         sys.stderr.flush()
         # do some munging of the line before we save it to the attr
         b = RE_HIDDEN_BYTES.sub(b'', b)


### PR DESCRIPTION
I cannot provide a concise and reliable repro, but I kept tripping over it when making mistakes in ``git`` commands.  A sample follows below.  And I do not understand what this ``TextTranscodingWrapper`` is that stderr can sometimes be pointed to, so I have not tried to mock up a unit test.  However, I'm willing to do that if given some hints.

The fix was to copy some likely-looking code from ``proc.tee_stdout`` to ``proc.stream_stderr``.  At least it's not likely to break anything.

```cmd
======= n:\DevWork\work\xonsh
> python setup.py develop
running develop
Removed xonsh/parser_table.py
         --- snip ---
Installed n:\devwork\work\xonsh
Processing dependencies for xonsh==0.4.7
Finished processing dependencies for xonsh==0.4.7

======= n:\DevWork\work\xonsh
> xonsh
-------------------------- bobhy@BobHy-PC n:\DevWork\work\xonsh stderr_transcodingWrapper_buffer_error
$ git checkout stderr_transcodingWrapper_buffer_error
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "n:\DevWork\work\xonsh\xonsh\base_shell.py", line 288, in default
    if (term is None and not ON_WINDOWS) or term in ['dumb', 'eterm-color',
  File "n:\DevWork\work\xonsh\xonsh\codecache.py", line 65, in run_compiled_code
    func(code, glb, loc)
  File "<xonsh-code>", line 1, in <module>
  File "n:\DevWork\work\xonsh\xonsh\built_ins.py", line 830, in subproc_captured_hiddenobject
    locs : Mapping or None
  File "n:\DevWork\work\xonsh\xonsh\built_ins.py", line 798, in run_subproc
    The globals from the call site.
  File "n:\DevWork\work\xonsh\xonsh\proc.py", line 1592, in end
  File "n:\DevWork\work\xonsh\xonsh\proc.py", line 1526, in tee_stdout
  File "n:\DevWork\work\xonsh\xonsh\proc.py", line 1491, in iterraw
  File "n:\DevWork\work\xonsh\xonsh\proc.py", line 1552, in stream_stderr
AttributeError: 'TextTranscodingWrapper' object has no attribute 'buffer'
-------------------------- bobhy@BobHy-PC n:\DevWork\work\xonsh stderr_transcodingWrapper_buffer_error
$ exit
======= n:\DevWork\work\xonsh
> git checkout stderr_transcodingWrapper_buffer_error
M       requirements-docs.txt
Already on 'stderr_transcodingWrapper_buffer_error'

======= n:\DevWork\work\xonsh
