### PR TITLE
Add ansi-color codes to the default style

### DIFF
--- a/news/ansi_colors.rst
+++ b/news/ansi_colors.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+* The default style will now use the color keywords (#ansired, #ansidarkred) 
+  to set colors that follow the terminal color schemes. Currently, this requires
+  prompt_toolkit master (>1.0.8) and pygments master (2.2) to work correctly. 
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -719,7 +719,7 @@ def _default_style():
             Color.INTENSE_YELLOW: '#ansiyellow',
             Color.NO_COLOR: 'noinherit',
             Color.PURPLE: '#ansipurple',
-            Color.RED: '#ansdarkired',
+            Color.RED: '#ansidarkred',
             Color.WHITE: '#ansiwhite',
             Color.YELLOW: '#ansibrown',
         }

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -455,7 +455,9 @@ class XonshStyle(Style):
             self.styles[Token.AutoSuggestion] = '#444444'
             self._smap.update(expand_gray_colors_for_cmd_exe(self._smap))
             if env.get('INTENSIFY_COLORS_ON_WIN', False):
-                self._smap.update(intensify_colors_for_cmd_exe(self._smap))
+                has_ansi = hasattr(pygments.style, 'ansicolors')
+                newcolors = intensify_colors_for_cmd_exe(self._smap, ansi=has_ansi) 
+                self._smap.update(newcolors)
 
 
 def xonsh_style_proxy(styler):
@@ -474,8 +476,8 @@ def xonsh_style_proxy(styler):
 
 if hasattr(pygments.style, 'ansicolors'):
     PTK_STYLE = {
-        Token.Menu.Completions.Completion.Current: 'bg:#ansiturquoise #ansiblack',
-        Token.Menu.Completions.Completion: 'bg:#ansiteal #ansiwhite',
+        Token.Menu.Completions.Completion.Current: 'bg:#ansiteal #ansiblack',
+        Token.Menu.Completions.Completion: 'bg:#ansiturquoise #ansiwhite',
         Token.Menu.Completions.ProgressButton: 'bg:#ansidarkgray',
         Token.Menu.Completions.ProgressBar: 'bg:#ansiteal',
         Token.AutoSuggestion: '#ansidarkgray',
@@ -486,7 +488,7 @@ else:
         Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
         Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
         Token.Menu.Completions.ProgressButton: 'bg:#003333',
-        Token.Menu.Completions.ProgressBar: 'bg:#ansiturquoise',
+        Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
         Token.AutoSuggestion: '#666666',
         Token.Aborted: '#888888',
     }
@@ -494,7 +496,7 @@ else:
 if hasattr(pygments.style, 'ansicolors'):
     XONSH_BASE_STYLE = LazyObject(lambda: {
         Whitespace: '#ansilightgray',
-        Comment: 'underline #ansiturquoise',
+        Comment: 'underline #ansiteal',
         Comment.Preproc: 'underline #ansibrown',
         Keyword: 'bold #ansidarkgreen',
         Keyword.Pseudo: 'nobold',
@@ -705,23 +707,23 @@ def _bw_style():
 def _default_style():
     if hasattr(pygments.style, 'ansicolors'):
         style = {
-            Color.BLACK: '#ansidarkgray',
-            Color.BLUE: '#ansiblue',
-            Color.CYAN: '#ansiturquoise',
-            Color.GREEN: '#ansigreen',
-            Color.INTENSE_BLACK: '#ansiblack',
-            Color.INTENSE_BLUE: '#ansidarkblue',
-            Color.INTENSE_CYAN: '#ansiteal',
-            Color.INTENSE_GREEN: '#ansidarkgreen',
-            Color.INTENSE_PURPLE: '#ansipurple',
-            Color.INTENSE_RED: '#ansidarkred',
+            Color.BLACK: '#ansiblack',
+            Color.BLUE: '#ansidarkblue',
+            Color.CYAN: '#ansiteal',
+            Color.GREEN: '#ansidarkgreen',
+            Color.INTENSE_BLACK: '#ansidarkgray',
+            Color.INTENSE_BLUE: '#ansiblue',
+            Color.INTENSE_CYAN: '#ansiturquoise',
+            Color.INTENSE_GREEN: '#ansigreen',
+            Color.INTENSE_PURPLE: '#ansifuchsia',
+            Color.INTENSE_RED: '#ansired',
             Color.INTENSE_WHITE: '#ansilightgray',
-            Color.INTENSE_YELLOW: '#ansibrown',
+            Color.INTENSE_YELLOW: '#ansiyellow',
             Color.NO_COLOR: 'noinherit',
-            Color.PURPLE: '#ansifuchsia',
-            Color.RED: '#ansired',
+            Color.PURPLE: '#ansipurple',
+            Color.RED: '#ansdarkired',
             Color.WHITE: '#ansiwhite',
-            Color.YELLOW: '#ansiyellow',
+            Color.YELLOW: '#ansibrown',
             }
     elif ON_WINDOWS and 'CONEMUANSI' not in os.environ:
         # These colors must match the color specification

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -425,10 +425,13 @@ class XonshStyle(Style):
             value = 'default'
             builtins.__xonsh_env__['XONSH_COLOR_STYLE'] = value
         cmap = STYLES[value]
-        try:
-            self._smap = get_style_by_name(value)().styles.copy()
-        except (ImportError, pygments.util.ClassNotFound):
+        if value == 'default':
             self._smap = XONSH_BASE_STYLE.copy()
+        else:
+            try:
+                self._smap = get_style_by_name(value)().styles.copy()
+            except (ImportError, pygments.util.ClassNotFound):
+                self._smap = XONSH_BASE_STYLE.copy()
         compound = CompoundColorMap(ChainMap(self.trap, cmap, PTK_STYLE, self._smap))
         self.styles = ChainMap(self.trap, cmap, PTK_STYLE, self._smap, compound)
         self._style_name = value
@@ -469,55 +472,111 @@ def xonsh_style_proxy(styler):
     return XonshStyleProxy
 
 
-PTK_STYLE = {
-    Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
-    Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
-    Token.Menu.Completions.ProgressButton: 'bg:#003333',
-    Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
-    Token.AutoSuggestion: '#666666',
-    Token.Aborted: '#888888',
-}
+if hasattr(pygments.style, 'ansicolors'):
+    PTK_STYLE = {
+        Token.Menu.Completions.Completion.Current: 'bg:#ansiturquoise #ansiblack',
+        Token.Menu.Completions.Completion: 'bg:#ansiteal #ansiwhite',
+        Token.Menu.Completions.ProgressButton: 'bg:#ansidarkgray',
+        Token.Menu.Completions.ProgressBar: 'bg:#ansiteal',
+        Token.AutoSuggestion: '#ansidarkgray',
+        Token.Aborted: '#ansilightgray',
+    }
+else:
+    PTK_STYLE = {
+        Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
+        Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
+        Token.Menu.Completions.ProgressButton: 'bg:#003333',
+        Token.Menu.Completions.ProgressBar: 'bg:#ansiturquoise',
+        Token.AutoSuggestion: '#666666',
+        Token.Aborted: '#888888',
+    }
 
-XONSH_BASE_STYLE = LazyObject(lambda: {
-    Whitespace: '#008080',
-    Comment: 'underline',
-    Comment.Preproc: 'underline',
-    Keyword: 'bold',
-    Keyword.Pseudo: '#008000',
-    Keyword.Type: '',
-    Operator: '#008080',
-    Operator.Word: 'bold',
-    Name.Builtin: '',
-    Name.Function: '#000080',
-    Name.Class: 'bold',
-    Name.Namespace: 'bold',
-    Name.Exception: 'bold',
-    Name.Variable: '#008080',
-    Name.Constant: '#800000',
-    Name.Label: '#808000',
-    Name.Entity: 'bold',
-    Name.Attribute: '#008080',
-    Name.Tag: 'bold',
-    Name.Decorator: '#008080',
-    String: '',
-    String.Doc: 'underline',
-    String.Interpol: 'bold',
-    String.Escape: 'bold',
-    String.Regex: '',
-    String.Symbol: '',
-    String.Other: '#008000',
-    Number: '#800000',
-    Generic.Heading: 'bold',
-    Generic.Subheading: 'bold',
-    Generic.Deleted: '#800000',
-    Generic.Inserted: '#008000',
-    Generic.Error: 'bold',
-    Generic.Emph: 'underline',
-    Generic.Prompt: 'bold',
-    Generic.Output: '#008080',
-    Generic.Traceback: '#800000',
-    Error: '#800000',
+if hasattr(pygments.style, 'ansicolors'):
+    XONSH_BASE_STYLE = LazyObject(lambda: {
+        Whitespace: '#ansilightgray',
+        Comment: 'underline #ansiturquoise',
+        Comment.Preproc: 'underline #ansibrown',
+        Keyword: 'bold #ansidarkgreen',
+        Keyword.Pseudo: 'nobold',
+        Keyword.Type: 'nobold #ansidarkred',
+        Operator: '#ansidarkgray',
+        Operator.Word: 'bold #ansipurple',
+        Name.Builtin: '#ansidarkgreen',
+        Name.Function: '#ansiblue',
+        Name.Class: 'bold #ansiblue',
+        Name.Namespace: 'bold #ansiblue',
+        Name.Exception: 'bold #ansired',
+        Name.Variable: '#ansidarkblue',
+        Name.Constant: '#ansidarkred',
+        Name.Label: '#ansiyellow',
+        Name.Entity: 'bold #ansilightgray',
+        Name.Attribute: '#ansiyellow',
+        Name.Tag: 'bold #ansidarkgreen',
+        Name.Decorator: '#ansifuchsia',
+        String: '#ansired',
+        String.Doc: 'underline',
+        String.Interpol: 'bold #ansipurple',
+        String.Escape: 'bold #ansibrown',
+        String.Regex: '#ansipurple',
+        String.Symbol: '#ansibrown',
+        String.Other: '#ansidarkgreen',
+        Number: '#ansidarkgray',
+        Generic.Heading: 'bold #ansidarkblue',
+        Generic.Subheading: 'bold #ansipurple',
+        Generic.Deleted: '#ansidarkred',
+        Generic.Inserted: '#ansigreen',
+        Generic.Error: 'bold #ansired',
+        Generic.Emph: 'underline',
+        Generic.Prompt: 'bold #ansidarkblue',
+        Generic.Output: '#ansidarkblue',
+        Generic.Traceback: '#ansidarkblue',
+        Error: '#ansired',
+        }, globals(), 'XONSH_BASE_STYLE')
+else:
+    XONSH_BASE_STYLE = LazyObject(lambda: {
+        Whitespace: "#bbbbbb",
+        Comment: "italic #408080",
+        Comment.Preproc: "noitalic #BC7A00",
+        Keyword: "bold #008000",
+        Keyword.Pseudo: "nobold",
+        Keyword.Type:   "nobold #B00040",
+        Operator:   "#666666",
+        Operator.Word:  "bold #AA22FF",
+        Name.Builtin: "#008000",
+        Name.Function: "#0000FF",
+        Name.Class: "bold #0000FF",
+        Name.Namespace: "bold #0000FF",
+        Name.Exception: "bold #D2413A",
+        Name.Variable: "#19177C",
+        Name.Constant: "#880000",
+        Name.Label: "#A0A000",
+        Name.Entity: "bold #999999",
+        Name.Attribute: "#7D9029",
+        Name.Tag: "bold #008000",
+        Name.Decorator: "#AA22FF",
+        String: "#BA2121",
+        String.Doc: "italic",
+        String.Interpol: "bold #BB6688",
+        String.Escape: "bold #BB6622",
+        String.Regex: "#BB6688",
+        String.Symbol: "#19177C",
+        String.Other: "#008000",
+        Number: "#666666",
+        Generic.Heading: "bold #000080",
+        Generic.Subheading: "bold #800080",
+        Generic.Deleted: "#A00000",
+        Generic.Inserted: "#00A000",
+        Generic.Error: "#FF0000",
+        Generic.Emph: "italic",
+        Generic.Strong: "bold",
+        Generic.Prompt: "bold #000080",
+        Generic.Output: "#888",
+        Generic.Traceback: "#04D",
+        Error: "border:#FF0000"
     }, globals(), 'XONSH_BASE_STYLE')
+
+
+
 
 KNOWN_COLORS = LazyObject(lambda: frozenset([
     'BACKGROUND_BLACK',

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -456,7 +456,7 @@ class XonshStyle(Style):
             self._smap.update(expand_gray_colors_for_cmd_exe(self._smap))
             if env.get('INTENSIFY_COLORS_ON_WIN', False):
                 has_ansi = hasattr(pygments.style, 'ansicolors')
-                newcolors = intensify_colors_for_cmd_exe(self._smap, ansi=has_ansi) 
+                newcolors = intensify_colors_for_cmd_exe(self._smap, ansi=has_ansi)
                 self._smap.update(newcolors)
 
 
@@ -576,8 +576,6 @@ else:
         Generic.Traceback: "#04D",
         Error: "border:#FF0000"
     }, globals(), 'XONSH_BASE_STYLE')
-
-
 
 
 KNOWN_COLORS = LazyObject(lambda: frozenset([
@@ -724,7 +722,7 @@ def _default_style():
             Color.RED: '#ansdarkired',
             Color.WHITE: '#ansiwhite',
             Color.YELLOW: '#ansibrown',
-            }
+        }
     elif ON_WINDOWS and 'CONEMUANSI' not in os.environ:
         # These colors must match the color specification
         # in prompt_toolkit, so the colors are converted
@@ -747,7 +745,7 @@ def _default_style():
             Color.RED: '#AA0000',
             Color.WHITE: '#FFFFFF',
             Color.YELLOW: '#AAAA00',
-            }
+        }
     else:
         style = {
             Color.BLACK: '#000000',
@@ -767,7 +765,7 @@ def _default_style():
             Color.RED: '#AA0000',
             Color.WHITE: '#ffffff',
             Color.YELLOW: '#ffff00',
-            }
+        }
     _expand_style(style)
     return style
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1343,7 +1343,7 @@ def _get_color_indexes(style_map):
             yield token, index, rgb
 
 
-def intensify_colors_for_cmd_exe(style_map, replace_colors=None):
+def intensify_colors_for_cmd_exe(style_map, replace_colors=None, ansi=False):
     """Returns a modified style to where colors that maps to dark
        colors are replaced with brighter versions. Also expands the
        range used by the gray colors
@@ -1355,14 +1355,26 @@ def intensify_colors_for_cmd_exe(style_map, replace_colors=None):
             (stype == 'best' and not has_prompt_toolkit())):
         return modified_style
     if replace_colors is None:
-        replace_colors = {1: '#44ffff',  # subst blue with bright cyan
-                          2: '#44ff44',  # subst green with bright green
-                          4: '#ff4444',  # subst red with bright red
-                          5: '#ff44ff',  # subst magenta with bright magenta
-                          6: '#ffff44',  # subst yellow with bright yellow
-                          9: '#00aaaa',  # subst intense blue (hard to read)
-                                         # with dark cyan (which is readable)
-                          }
+        if ansi:
+            replace_colors = {
+                1: '#ansiturquoise', # subst blue with bright cyan
+                2: '#ansigreen',     # subst green with bright green
+                4: '#ansired',       # subst red with bright red
+                5: '#ansifuchsia',   # subst magenta with bright magenta
+                6: '#ansiyellow',    # subst yellow with bright yellow
+                9: '#ansiteal',      # subst intense blue (hard to read)
+                                     # with dark cyan (which is readable)
+            }
+        else:
+            replace_colors = {
+                1: '#44ffff',  # subst blue with bright cyan
+                2: '#44ff44',  # subst green with bright green
+                4: '#ff4444',  # subst red with bright red
+                5: '#ff44ff',  # subst magenta with bright magenta
+                6: '#ffff44',  # subst yellow with bright yellow
+                9: '#00aaaa',  # subst intense blue (hard to read)
+                               # with dark cyan (which is readable)
+            }
     for token, idx, _ in _get_color_indexes(style_map):
         if idx in replace_colors:
             modified_style[token] = replace_colors[idx]

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1357,13 +1357,13 @@ def intensify_colors_for_cmd_exe(style_map, replace_colors=None, ansi=False):
     if replace_colors is None:
         if ansi:
             replace_colors = {
-                1: '#ansiturquoise', # subst blue with bright cyan
-                2: '#ansigreen',     # subst green with bright green
-                4: '#ansired',       # subst red with bright red
-                5: '#ansifuchsia',   # subst magenta with bright magenta
-                6: '#ansiyellow',    # subst yellow with bright yellow
-                9: '#ansiteal',      # subst intense blue (hard to read)
-                                     # with dark cyan (which is readable)
+                1: '#ansiturquoise',  # subst blue with bright cyan
+                2: '#ansigreen',      # subst green with bright green
+                4: '#ansired',        # subst red with bright red
+                5: '#ansifuchsia',    # subst magenta with bright magenta
+                6: '#ansiyellow',     # subst yellow with bright yellow
+                9: '#ansiteal',       # subst intense blue (hard to read)
+                                      # with dark cyan (which is readable)
             }
         else:
             replace_colors = {


### PR DESCRIPTION
This PR updates the PTK styles. So now we don't use pygments when the style is set to 'default'. Instead,  we use the `XONSH_BASE_STYLE` dict, which has been updated to match the default pygments style. 

This has the advantage that we can make a version with ansi color code names. 
See this issue: https://github.com/xonsh/xonsh/issues/1821

At the moment, this is a WIP because I think there is a bug in prompt-toolkit which swap the dark and light ansi color names on Windows. https://github.com/jonathanslenders/python-prompt-toolkit/pull/408 

So I think we should wait until that is fixed. 
