### PR TITLE
additional fixes for tab completion with spaces in readline

### DIFF
--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -269,6 +269,12 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             offset = begidx - _s
             begidx = _s
             endidx -= 1
+        elif (_s is not None and
+                _e is not None and
+                not any(i == ' ' for i in line[_e:begidx])):
+            line = line[:_e] + line[_e+1:]
+            offset = begidx - _s
+            begidx = _s
         if self.completer is None:
             x = []
         else:


### PR DESCRIPTION
I think #1896 fixed some things partially w.r.t. tab completion in readline with spaces, but it seemed to cause other issues for me when:
- the first completion resulted in a fully-quoted directory, and
- I hit tab again to continue completing

I believe this patch should fix that behavior.
