### PR TITLE
Windows non-threadable fix

### DIFF
--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -108,7 +108,7 @@ class CommandsCache(cabc.Mapping):
         return allcmds
 
     def cached_name(self, name):
-        """Returns the name that would appear in the cache, if it was exists."""
+        """Returns the name that would appear in the cache, if it exists."""
         if name is None:
             return None
         cached = pathbasename(name)
@@ -171,6 +171,7 @@ class CommandsCache(cabc.Mapping):
         thread, rather than the main thread.
         """
         name = self.cached_name(cmd[0])
+        predictors = self.threadable_predictors
         if ON_WINDOWS:
             # On all names (keys) are stored in upper case so instead
             # we get the original cmd or alias name
@@ -179,7 +180,11 @@ class CommandsCache(cabc.Mapping):
                 return True
             else:
                 name = pathbasename(path)
-        predictor = self.threadable_predictors[name]
+            if name not in predictors:
+                pre, ext = os.path.splitext(name)
+                if pre in predictors:
+                    predictors[name] = predictors[pre]
+        predictor = predictors[name]
         return predictor(cmd[1:])
 
 #
@@ -249,7 +254,6 @@ def default_threadable_predictors():
         'bash': predict_shell,
         'csh': predict_shell,
         'clear': predict_false,
-        'clear.exe': predict_false,
         'cls': predict_false,
         'cmd': predict_shell,
         'fish': predict_shell,

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -161,7 +161,7 @@ def pathsplit(p):
 
 def pathbasename(p):
     """This is a safe version of os.path.basename(), which does not work on
-    input without a drive.
+    input without a drive.  This version does.
     """
     return pathsplit(p)[-1]
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1463,8 +1463,6 @@ class CommandPipeline:
         if stdout is not None and \
                 not isinstance(stdout, (io.BytesIO, NonBlockingFDReader)):
             stdout = NonBlockingFDReader(stdout.fileno(), timeout=timeout)
-        #print("stdout", stdout, safe_readable(stdout))
-        #import pdb; pdb.set_trace()
         if not stdout or not safe_readable(stdout):
             # we get here if the process is not threadable or the
             # class is the real Popen

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1463,8 +1463,10 @@ class CommandPipeline:
         if stdout is not None and \
                 not isinstance(stdout, (io.BytesIO, NonBlockingFDReader)):
             stdout = NonBlockingFDReader(stdout.fileno(), timeout=timeout)
+        #print("stdout", stdout, safe_readable(stdout))
+        #import pdb; pdb.set_trace()
         if not stdout or not safe_readable(stdout):
-            # we get here if the process is not bacgroundable or the
+            # we get here if the process is not threadable or the
             # class is the real Popen
             wait_for_active_job()
             proc.wait()


### PR DESCRIPTION
This should address the issues with less, vim, etc and other non-threadable commands on Windows. @melund  and @BYK, would you mind taking a look please?  

This issue with `git diff` and other similar threadable commands are more deeply seeded with alternate mode. I am looking in to them now.