### PR TITLE
more entries in threadable predictors

### DIFF
--- a/news/thread_pred.rst
+++ b/news/thread_pred.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+* added ``mvim``, ``pacman`` and ``nano`` to threadable predictors default-dict (all 
+  rely on ncurses)
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -264,6 +264,8 @@ def default_threadable_predictors():
         'more': predict_help_ver,
         'mvim': predict_help_ver,
         'mutt': predict_help_ver,
+        'nano': predict_help_ver,
+        'pacman': predict_help_ver,
         'scp': predict_false,
         'sh': predict_shell,
         'ssh': predict_false,

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -262,6 +262,7 @@ def default_threadable_predictors():
         'less': predict_help_ver,
         'man': predict_help_ver,
         'more': predict_help_ver,
+        'mvim': predict_help_ver,
         'mutt': predict_help_ver,
         'scp': predict_false,
         'sh': predict_shell,


### PR DESCRIPTION
I know this is just a bandaid, but for now we can cover a lot of commonly used programs until we come up with a robust way to predict these things.  Also, `pacman` and `macvim` will let us close out at least two issues.