### PR TITLE
Hack a rel=canonical in the templates.

### DIFF
--- a/docs/_templates_overwrite/layout.html
+++ b/docs/_templates_overwrite/layout.html
@@ -1,0 +1,6 @@
+{% extends '!layout.html' %}
+
+{% block extrahead %}
+    {{ super() }}
+    <link rel="canonical" href="http://xon.sh/{{pagename}}.html"/>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,7 @@ if not on_rtd:
 
     # Add any paths that contain custom themes here, relative to this directory.
     html_theme_path = ["_theme", csp.get_theme_dir()]
+    templates_path = ["_templates_overwrite"]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
We do not want non-canonical versions of xonsh docs to be indexed. OR at
least they should point to the canonical version.

Technically we should even try to have the stable version under a
/stable/ url (to leave us with some freedom of changing things) So that
later we can replace stable with X.y and have a version switcher.

-- 
From experience with the IPython docs. 