### PR TITLE
Fix "Fork me on GitHub" ribbons.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -266,4 +266,10 @@ Helpful Links
 
 .. raw:: html
 
-    <a href="https://github.com/xonsh/xonsh"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
+    <a href="https://github.com/xonsh/xonsh" style="position: absolute; top: 0; right: 0; border: 0;" id="forkmeongithub"><img src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
+
+    <style>
+    #forkmeongithub:hover {
+        background: none;
+    }
+    </style>


### PR DESCRIPTION
The current ribbon just don't react on click on some platform for
some reason. Mainly because the Image is in the corner, but not the
link.

This fixes it

Though it still look ugly on hi-dpi screen

One might want to consider a pure-css method like
https://simonwhitaker.github.io/github-fork-ribbon-css/

-- 

The hover style is not inline as ~ no browser support an inline hover style. 