### PR TITLE
add missing newline in code block

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -120,6 +120,7 @@ in the CWD of the original TAB, this is because of a custom VTE interface. To
 fix this, please add ``{vte_new_tab_cwd}`` somewhere to you prompt:
 
 .. code-block:: xonsh
+
     $PROMPT = '{vte_new_tab_cwd}' + $PROMPT
 
 This will issue the proper escape sequence to the terminal without otherwise


### PR DESCRIPTION
What idiot didn't bother to check if this page in the docs was formatted
correctly?  Couldn't they be bothered to at least check that the docs
compiled without errors?

```
git blame
```

Oh.  It was me.

No news entry on this.