### PR TITLE
added commit date in xonfig

### DIFF
--- a/news/xonfig-commit-date.rst
+++ b/news/xonfig-commit-date.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+* xonfig now contains the latest git commit date if xonsh installed
+  from source.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/xonfig-commit-date.rst
+++ b/news/xonfig-commit-date.rst
@@ -1,4 +1,4 @@
-**Added:** None
+**Added:**
 
 * xonfig now contains the latest git commit date if xonsh installed
   from source.

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ def dirty_version():
         return False
     sha = sha.strip('g')
     replace_version(N)
-    _cmd = ['git', 'show', '--format=%cd', '--date=local', sha]
+    _cmd = ['git', 'show', '-s', '--format=%cd', '--date=local', sha]
     try:
         _date = subprocess.check_output(_cmd)
         _date = _date.decode('ascii')

--- a/setup.py
+++ b/setup.py
@@ -129,8 +129,17 @@ def dirty_version():
         return False
     sha = sha.strip('g')
     replace_version(N)
+    _cmd = ['git', 'show', '--format=%cd', '--date=local', sha]
+    try:
+        _date = subprocess.check_output(_cmd)
+        _date = _date.decode('ascii')
+        # remove weekday name for a shorter string
+        _date = ' '.join(_date.split()[1:])
+    except:
+        _date = ''
+        print('failed to get commit date', file=sys.stderr)
     with open('xonsh/dev.githash', 'w') as f:
-        f.write(sha)
+        f.write('{}|{}'.format(sha, _date))
     print('wrote git version: ' + sha, file=sys.stderr)
     return True
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -172,6 +172,7 @@ def pathbasename(p):
 
 @functools.lru_cache(1)
 def githash():
+    """Returns a tuple contains two strings: the hash and the date."""
     install_base = os.path.dirname(__file__)
     sha = None
     date_ = None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -173,14 +173,14 @@ def pathbasename(p):
 @functools.lru_cache(1)
 def githash():
     install_base = os.path.dirname(__file__)
+    sha = None
+    date_ = None
     try:
         with open('{}/dev.githash'.format(install_base), 'r') as f:
-            sha = f.read().strip()
-        if not sha:
-            sha = None
+            sha, date_ = f.read().strip().split('|')
     except FileNotFoundError:
-        sha = None
-    return sha
+        pass
+    return sha, date_
 
 
 #

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -345,7 +345,12 @@ def _info(ns):
         ply.__version__ = '3.8'
     data = [
         ('xonsh', XONSH_VERSION),
-        ('Git SHA', githash()),
+    ]
+    hash_, date_ = githash()
+    if hash_:
+        data.append(('Git SHA', hash_))
+        data.append(('Commit Date', date_))
+    data.extend([
         ('Python', '{}.{}.{}'.format(*PYTHON_VERSION_INFO)),
         ('PLY', ply.__version__),
         ('have readline', is_readline_available()),
@@ -353,7 +358,8 @@ def _info(ns):
         ('shell type', env.get('SHELL_TYPE')),
         ('pygments', pygments_version()),
         ('on posix', bool(ON_POSIX)),
-        ('on linux', ON_LINUX)]
+        ('on linux', ON_LINUX),
+    ])
     if ON_LINUX:
         data.append(('distro', linux_distro()))
     data.extend([


### PR DESCRIPTION
I feel this info would be helpful for xonsh developers. Does this make sense to you?

```
$ xonfig
+------------------+---------------------+
| xonsh            | 0.4.7.dev1734       |
| Git SHA          | f78a0e1             |
| Commit Date      | Nov 2 01:44:25 2016 |
| Python           | 3.5.1               |
| PLY              | 3.9                 |
| have readline    | True                |
| prompt toolkit   | 1.0.0               |
| shell type       | readline            |
| pygments         | 2.1.3               |
| on posix         | True                |
| on linux         | True                |
| distro           | debian              |
| on darwin        | False               |
| on windows       | False               |
| on cygwin        | False               |
| is superuser     | False               |
| default encoding | utf-8               |
| xonsh encoding   | utf-8               |
| encoding errors  | surrogateescape     |
+------------------+---------------------+
```