### PR TITLE
prompt mechanism refactor

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1361,7 +1361,7 @@ or ``{BOLD_BLUE}``.  Colors have the form shown below:
   can use!
 
 You can make use of additional variables beyond these by adding them to the
-``FORMATTER_DICT`` environment variable.  The values in this dictionary
+``PROMPT_FIELDS`` environment variable.  The values in this dictionary
 should be strings (which will be inserted into the prompt verbatim), or
 functions of no arguments (which will be called each time the prompt is
 generated, and the results of those calls will be inserted into the prompt).
@@ -1369,11 +1369,11 @@ For example:
 
 .. code-block:: console
 
-    snail@home ~ $ $FORMATTER_DICT['test'] = "hey"
+    snail@home ~ $ $PROMPT_FIELDS['test'] = "hey"
     snail@home ~ $ $PROMPT = "{test} {cwd} $ "
     hey ~ $
     hey ~ $ import random
-    hey ~ $ $FORMATTER_DICT['test'] = lambda: random.randint(1,9)
+    hey ~ $ $PROMPT_FIELDS['test'] = lambda: random.randint(1,9)
     3 ~ $
     5 ~ $
     2 ~ $
@@ -1387,7 +1387,7 @@ prefix.  For example:
     snail@home ~ $ $PROMPT = "{$LANG} >"
     en_US.utf8 >
 
-Note that some entries of the ``$FORMATTER_DICT`` are not always applicable, for
+Note that some entries of the ``$PROMPT_FIELDS`` are not always applicable, for
 example, ``curr_branch`` returns ``None`` if the current directory is not in a
 repository. The ``None`` will be interpreted as an empty string.
 

--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -32,7 +32,7 @@ The following snippet reimplements the formatter also to include untracked files
 .. code-block:: xonshcon
 
     >>> from xonsh.prompt.vc_branch import git_dirty_working_directory
-    >>> $FORMATTER_DICT['branch_color'] = lambda: ('{BOLD_INTENSE_RED}'
+    >>> $PROMPT_FIELDS['branch_color'] = lambda: ('{BOLD_INTENSE_RED}'
                                                    if git_dirty_working_directory(include_untracked=True)
                                                    else '{BOLD_INTENSE_GREEN}')
 

--- a/news/prompt.rst
+++ b/news/prompt.rst
@@ -1,0 +1,18 @@
+**Added:**
+
+* PromptFormatter class that holds all the related prompt methods
+* PromptFormatter caching when building the prompt
+
+**Changed:**
+
+* Renamed FORMATTER_DICT to PROMPT_FIELDS
+* BaseShell instantiates PromptFormatter
+* readline/ptk shells use PromptFormatter
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -5,7 +5,7 @@ from xonsh.prompt.base import PromptFormatter
 
 
 @pytest.fixture
-def formatter():
+def formatter(xonsh_builtins):
     return PromptFormatter()
 
 
@@ -84,7 +84,3 @@ def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
     assert exp == obs
     out, err = capsys.readouterr()
     assert 'prompt: error' in err
-
-
-def test_promptformatter():
-    pf = PromptFormatter()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from xonsh.environ import Env
@@ -84,3 +86,26 @@ def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
     assert exp == obs
     out, err = capsys.readouterr()
     assert 'prompt: error' in err
+
+
+def test_promptformatter_cache(formatter):
+    spam = Mock()
+    spam.return_value = 'eggs'
+    template = '{spam} and {spam}'
+    formatter_dict = {'spam': spam}
+
+    formatter(template, formatter_dict)
+
+    assert spam.call_count == 1
+
+
+def test_promptformmater_clears_cache(formatter):
+    spam = Mock()
+    spam.return_value = 'eggs'
+    template = '{spam} and {spam}'
+    formatter_dict = {'spam': spam}
+
+    formatter(template, formatter_dict)
+    formatter(template, formatter_dict)
+
+    assert spam.call_count == 2

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -39,7 +39,7 @@ def test_format_prompt(inp, exp, formatter_dict, formatter, xonsh_builtins):
     ('{{{a_string:{{{}}}}}}', '{{cats}}'),
     ('{{{none:{{{}}}}}}', '{}'),
 ])
-def test_format_prompt_with_format_spec(inp, exp, formatter_dict, 
+def test_format_prompt_with_format_spec(inp, exp, formatter_dict,
                                         formatter, xonsh_builtins):
     obs = formatter.format_prompt(template=inp, formatter_dict=formatter_dict)
     assert exp == obs
@@ -54,22 +54,22 @@ def test_format_prompt_with_broken_template(formatter, xonsh_builtins):
         assert 'user' in formatter.format_prompt(p)
 
 
-def test_format_prompt_with_broken_template_in_func(formatter, xonsh_builtins):
-    for p in (
-        lambda: '{user',
-        lambda: '{{user',
-        lambda: '{{user}',
-        lambda: '{user}{hostname',
-    ):
-        # '{{user' will be parsed to '{user'
-        assert 'user' in formatter.format_prompt(p)
+@pytest.mark.parametrize('inp', [
+    '{user',
+    '{{user',
+    '{{user}',
+    '{user}{hostname',
+    ])
+def test_format_prompt_with_broken_template_in_func(inp, formatter, xonsh_builtins):
+    # '{{user' will be parsed to '{user'
+    assert '{user' in formatter.format_prompt(lambda: inp)
 
 
 def test_format_prompt_with_invalid_func(formatter, xonsh_builtins):
     xonsh_builtins.__xonsh_env__ = Env()
 
     def p():
-        foo = bar  # raises exception
+        foo = bar  # raises exception # noqa
         return '{user}'
 
     assert isinstance(formatter.format_prompt(p), str)
@@ -84,3 +84,7 @@ def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
     assert exp == obs
     out, err = capsys.readouterr()
     assert 'prompt: error' in err
+
+
+def test_promptformatter():
+    pf = PromptFormatter()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -11,7 +11,7 @@ def formatter(xonsh_builtins):
     return PromptFormatter()
 
 
-@pytest.mark.parametrize('formatter_dict', [{
+@pytest.mark.parametrize('fields', [{
     'a_string': 'cat',
     'none': (lambda: None),
     'f': (lambda: 'wakka'),
@@ -21,12 +21,12 @@ def formatter(xonsh_builtins):
     ('my {none}{a_string}', 'my cat'),
     ('{f} jawaka', 'wakka jawaka'),
 ])
-def test_format_prompt(inp, exp, formatter_dict, formatter, xonsh_builtins):
-    obs = formatter(template=inp, formatter_dict=formatter_dict)
+def test_format_prompt(inp, exp, fields, formatter, xonsh_builtins):
+    obs = formatter(template=inp, fields=fields)
     assert exp == obs
 
 
-@pytest.mark.parametrize('formatter_dict', [{
+@pytest.mark.parametrize('fields', [{
     'a_string': 'cats',
     'a_number': 7,
     'empty': '',
@@ -41,9 +41,9 @@ def test_format_prompt(inp, exp, formatter_dict, formatter, xonsh_builtins):
     ('{{{a_string:{{{}}}}}}', '{{cats}}'),
     ('{{{none:{{{}}}}}}', '{}'),
 ])
-def test_format_prompt_with_format_spec(inp, exp, formatter_dict,
+def test_format_prompt_with_format_spec(inp, exp, fields,
                                         formatter, xonsh_builtins):
-    obs = formatter(template=inp, formatter_dict=formatter_dict)
+    obs = formatter(template=inp, fields=fields)
     assert exp == obs
 
 
@@ -81,8 +81,8 @@ def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
     xonsh_builtins.__xonsh_env__ = Env()
     template = 'tt {zerodiv} tt'
     exp = 'tt (ERROR:zerodiv) tt'
-    formatter_dict = {'zerodiv': lambda: 1/0}
-    obs = formatter(template, formatter_dict)
+    fields = {'zerodiv': lambda: 1/0}
+    obs = formatter(template, fields)
     assert exp == obs
     out, err = capsys.readouterr()
     assert 'prompt: error' in err
@@ -90,22 +90,20 @@ def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
 
 def test_promptformatter_cache(formatter):
     spam = Mock()
-    spam.return_value = 'eggs'
     template = '{spam} and {spam}'
-    formatter_dict = {'spam': spam}
+    fields = {'spam': spam}
 
-    formatter(template, formatter_dict)
+    formatter(template, fields)
 
     assert spam.call_count == 1
 
 
 def test_promptformmater_clears_cache(formatter):
     spam = Mock()
-    spam.return_value = 'eggs'
     template = '{spam} and {spam}'
-    formatter_dict = {'spam': spam}
+    fields = {'spam': spam}
 
-    formatter(template, formatter_dict)
-    formatter(template, formatter_dict)
+    formatter(template, fields)
+    formatter(template, fields)
 
     assert spam.call_count == 2

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -21,7 +21,7 @@ def formatter(xonsh_builtins):
     ('my {none}{a_string}', 'my cat'),
     ('{f} jawaka', 'wakka jawaka'),
 ])
-def test_format_prompt(inp, exp, fields, formatter, xonsh_builtins):
+def test_format_prompt(inp, exp, fields, formatter):
     obs = formatter(template=inp, fields=fields)
     assert exp == obs
 
@@ -41,13 +41,12 @@ def test_format_prompt(inp, exp, fields, formatter, xonsh_builtins):
     ('{{{a_string:{{{}}}}}}', '{{cats}}'),
     ('{{{none:{{{}}}}}}', '{}'),
 ])
-def test_format_prompt_with_format_spec(inp, exp, fields,
-                                        formatter, xonsh_builtins):
+def test_format_prompt_with_format_spec(inp, exp, fields, formatter):
     obs = formatter(template=inp, fields=fields)
     assert exp == obs
 
 
-def test_format_prompt_with_broken_template(formatter, xonsh_builtins):
+def test_format_prompt_with_broken_template(formatter):
     for p in ('{user', '{user}{hostname'):
         assert formatter(p) == p
 
@@ -62,7 +61,7 @@ def test_format_prompt_with_broken_template(formatter, xonsh_builtins):
     '{{user}',
     '{user}{hostname',
     ])
-def test_format_prompt_with_broken_template_in_func(inp, formatter, xonsh_builtins):
+def test_format_prompt_with_broken_template_in_func(inp, formatter):
     # '{{user' will be parsed to '{user'
     assert '{user' in formatter(lambda: inp)
 
@@ -98,7 +97,7 @@ def test_promptformatter_cache(formatter):
     assert spam.call_count == 1
 
 
-def test_promptformmater_clears_cache(formatter):
+def test_promptformatter_clears_cache(formatter):
     spam = Mock()
     template = '{spam} and {spam}'
     fields = {'spam': spam}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -20,7 +20,7 @@ def formatter(xonsh_builtins):
     ('{f} jawaka', 'wakka jawaka'),
 ])
 def test_format_prompt(inp, exp, formatter_dict, formatter, xonsh_builtins):
-    obs = formatter.format_prompt(template=inp, formatter_dict=formatter_dict)
+    obs = formatter(template=inp, formatter_dict=formatter_dict)
     assert exp == obs
 
 
@@ -41,17 +41,17 @@ def test_format_prompt(inp, exp, formatter_dict, formatter, xonsh_builtins):
 ])
 def test_format_prompt_with_format_spec(inp, exp, formatter_dict,
                                         formatter, xonsh_builtins):
-    obs = formatter.format_prompt(template=inp, formatter_dict=formatter_dict)
+    obs = formatter(template=inp, formatter_dict=formatter_dict)
     assert exp == obs
 
 
 def test_format_prompt_with_broken_template(formatter, xonsh_builtins):
     for p in ('{user', '{user}{hostname'):
-        assert formatter.format_prompt(p) == p
+        assert formatter(p) == p
 
     # '{{user' will be parsed to '{user'
     for p in ('{{user}', '{{user'):
-        assert 'user' in formatter.format_prompt(p)
+        assert 'user' in formatter(p)
 
 
 @pytest.mark.parametrize('inp', [
@@ -62,7 +62,7 @@ def test_format_prompt_with_broken_template(formatter, xonsh_builtins):
     ])
 def test_format_prompt_with_broken_template_in_func(inp, formatter, xonsh_builtins):
     # '{{user' will be parsed to '{user'
-    assert '{user' in formatter.format_prompt(lambda: inp)
+    assert '{user' in formatter(lambda: inp)
 
 
 def test_format_prompt_with_invalid_func(formatter, xonsh_builtins):
@@ -72,7 +72,7 @@ def test_format_prompt_with_invalid_func(formatter, xonsh_builtins):
         foo = bar  # raises exception # noqa
         return '{user}'
 
-    assert isinstance(formatter.format_prompt(p), str)
+    assert isinstance(formatter(p), str)
 
 
 def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
@@ -80,7 +80,7 @@ def test_format_prompt_with_func_that_raises(formatter, capsys, xonsh_builtins):
     template = 'tt {zerodiv} tt'
     exp = 'tt (ERROR:zerodiv) tt'
     formatter_dict = {'zerodiv': lambda: 1/0}
-    obs = formatter.format_prompt(template, formatter_dict)
+    obs = formatter(template, formatter_dict)
     assert exp == obs
     out, err = capsys.readouterr()
     assert 'prompt: error' in err

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -403,7 +403,7 @@ class BaseShell(object):
         t = env.get('TITLE')
         if t is None:
             return
-        t = self.prompt_formatter.format_prompt(t)
+        t = self.prompt_formatter(t)
         if ON_WINDOWS and 'ANSICON' not in env:
             kernel32.SetConsoleTitleW(t)
         else:
@@ -427,7 +427,7 @@ class BaseShell(object):
         env = builtins.__xonsh_env__  # pylint: disable=no-member
         p = env.get('PROMPT')
         try:
-            p = self.prompt_formatter.format_prompt(p)
+            p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         self.settitle()

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -13,7 +13,7 @@ from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
                              update_cache, run_compiled_code)
 from xonsh.completer import Completer
-from xonsh.prompt.base import multiline_prompt, partial_format_prompt
+from xonsh.prompt.base import multiline_prompt, PromptFormatter
 from xonsh.events import events
 
 if ON_WINDOWS:
@@ -235,6 +235,7 @@ class BaseShell(object):
         self.need_more_lines = False
         self.mlprompt = None
         self._styler = DefaultNotGiven
+        self.prompt_formatter = PromptFormatter()
 
     @property
     def styler(self):
@@ -402,7 +403,7 @@ class BaseShell(object):
         t = env.get('TITLE')
         if t is None:
             return
-        t = partial_format_prompt(t)
+        t = self.prompt_formatter.format_prompt(t)
         if ON_WINDOWS and 'ANSICON' not in env:
             kernel32.SetConsoleTitleW(t)
         else:
@@ -426,7 +427,7 @@ class BaseShell(object):
         env = builtins.__xonsh_env__  # pylint: disable=no-member
         p = env.get('PROMPT')
         try:
-            p = partial_format_prompt(p)
+            p = self.prompt_formatter.format_prompt(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         self.settitle()

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -844,6 +844,12 @@ class Env(cabc.MutableMapping):
     #
 
     def __getitem__(self, key):
+        # remove this block on next release
+        if key == 'FORMATTER_DICT':
+            print('PendingDeprecationWarning: FORMATTER_DICT is an alias of '
+                  'PROMPT_FIELDS and will be removed in the next release',
+                  file=sys.stderr)
+            return self['PROMPT_FIELDS']
         if key is Ellipsis:
             return self
         m = self.arg_regex.match(key)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -245,7 +245,7 @@ def DEFAULT_VALUES():
         'EXPAND_ENV_VARS': True,
         'FORCE_POSIX_PATHS': False,
         'FOREIGN_ALIASES_OVERRIDE': False,
-        'FORMATTER_DICT': dict(prompt.FORMATTER_DICT),
+        'PROMPT_FIELDS': dict(prompt.PROMPT_FIELDS),
         'FUZZY_PATH_COMPLETION': True,
         'GLOB_SORTED': True,
         'HISTCONTROL': set(),
@@ -424,11 +424,11 @@ def DEFAULT_DOCS():
         "``$XONSH_CONFIG_DIR/config.json`` in the 'env' section and not in "
         '``.xonshrc`` as loading of foreign aliases happens before'
         '``.xonshrc`` is parsed', configurable=True),
-    'FORMATTER_DICT': VarDocs(
+    'PROMPT_FIELDS': VarDocs(
         'Dictionary containing variables to be used when formatting $PROMPT '
         "and $TITLE. See 'Customizing the Prompt' "
         'http://xon.sh/tutorial.html#customizing-the-prompt',
-        configurable=False, default='``xonsh.prompt.FORMATTER_DICT``'),
+        configurable=False, default='``xonsh.prompt.PROMPT_FIELDS``'),
     'FUZZY_PATH_COMPLETION': VarDocs(
         "Toggles 'fuzzy' matching of paths for tab completion, which is only "
         "used as a fallback if no other completions succeed but can be used "
@@ -945,7 +945,7 @@ def locate_binary(name):
 
 BASE_ENV = LazyObject(lambda: {
     'BASH_COMPLETIONS': list(DEFAULT_VALUES['BASH_COMPLETIONS']),
-    'FORMATTER_DICT': dict(DEFAULT_VALUES['FORMATTER_DICT']),
+    'PROMPT_FIELDS': dict(DEFAULT_VALUES['PROMPT_FIELDS']),
     'XONSH_VERSION': XONSH_VERSION,
 }, globals(), 'BASE_ENV')
 

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Base prompt, provides FORMATTER_DICT and prompt related functions"""
+"""Base prompt, provides PROMPT_FIELDS and prompt related functions"""
 
 import builtins
 import itertools
@@ -37,7 +37,7 @@ class PromptFormatter:
     def __call__(self, template=DEFAULT_PROMPT, fields=None):
         """Formats a xonsh prompt template string."""
         if fields is None:
-            self.fields = builtins.__xonsh_env__.get('FORMATTER_DICT', FORMATTER_DICT)
+            self.fields = builtins.__xonsh_env__.get('PROMPT_FIELDS', PROMPT_FIELDS)
         else:
             self.fields = fields
         try:
@@ -87,7 +87,7 @@ class PromptFormatter:
 
 
 @xl.lazyobject
-def FORMATTER_DICT():
+def PROMPT_FIELDS():
     return dict(
         user=os.environ.get('USERNAME' if xp.ON_WINDOWS else 'USER', '<user>'),
         prompt_end='#' if xt.is_superuser() else '$',
@@ -193,7 +193,7 @@ def multiline_prompt(curr=''):
     return rtn
 
 
-def is_template_string(template, formatter_dict=None):
+def is_template_string(template, PROMPT_FIELDS=None):
     """Returns whether or not the string is a valid template."""
     template = template() if callable(template) else template
     try:
@@ -201,10 +201,10 @@ def is_template_string(template, formatter_dict=None):
     except ValueError:
         return False
     included_names.discard(None)
-    if formatter_dict is None:
-        fmtter = builtins.__xonsh_env__.get('FORMATTER_DICT', FORMATTER_DICT)
+    if PROMPT_FIELDS is None:
+        fmtter = builtins.__xonsh_env__.get('PROMPT_FIELDS', PROMPT_FIELDS)
     else:
-        fmtter = formatter_dict
+        fmtter = PROMPT_FIELDS
     known_names = set(fmtter.keys())
     return included_names <= known_names
 

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -30,7 +30,10 @@ def DEFAULT_PROMPT():
 
 
 class PromptFormatter:
-    """Class used by base_shell"""
+    """Class that holds all the related prompt formatting methods,
+    uses the ``PROMPT_FIELDS`` envvar (no color formatting).
+    """
+
     def __init__(self):
         self.cache = {}
 
@@ -42,11 +45,11 @@ class PromptFormatter:
             self.fields = fields
         try:
             prompt = self._format_prompt(template=template)
-            # keep cache only during building prompt
-            self.cache.clear()
-            return prompt
         except Exception:
             return _failover_template_format(template)
+        # keep cache only during building prompt
+        self.cache.clear()
+        return prompt
 
     def _format_prompt(self, template=DEFAULT_PROMPT):
         template = template() if callable(template) else template
@@ -69,7 +72,7 @@ class PromptFormatter:
             return _format_value(val, spec, conv)
         else:
             # color or unkown field, return as is
-            return '{{{}}}'.format(field)
+            return '{' + field + '}'
 
     def _get_field_value(self, field):
         field_value = self.fields[field]

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -24,6 +24,22 @@ from xonsh.prompt.vc_branch import (
 from xonsh.prompt.gitstatus import gitstatus_prompt
 
 
+@xt.lazyobject
+def DEFAULT_PROMPT():
+    return default_prompt()
+
+
+class PromptFormatter:
+    """Class used by base_shell"""
+    def format_prompt(self, template=DEFAULT_PROMPT, formatter_dict=None):
+        """Formats a xonsh prompt template string."""
+        try:
+            return _partial_format_prompt_main(template=template,
+                                               formatter_dict=formatter_dict)
+        except Exception:
+            return _failover_template_format(template)
+
+
 @xl.lazyobject
 def FORMATTER_DICT():
     return dict(
@@ -67,11 +83,6 @@ def default_prompt():
     return dp
 
 
-@xt.lazyobject
-def DEFAULT_PROMPT():
-    return default_prompt()
-
-
 def _get_fmtter(formatter_dict=None):
     if formatter_dict is None:
         fmtter = builtins.__xonsh_env__.get('FORMATTER_DICT', FORMATTER_DICT)
@@ -92,24 +103,15 @@ def _failover_template_format(template):
     return template
 
 
-def partial_format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
-    """Formats a xonsh prompt template string."""
-    try:
-        return _partial_format_prompt_main(template=template,
-                                           formatter_dict=formatter_dict)
-    except Exception:
-        return _failover_template_format(template)
-
-
 def _partial_format_prompt_main(template=DEFAULT_PROMPT, formatter_dict=None):
     template = template() if callable(template) else template
-    fmtter = _get_fmtter(formatter_dict)
-    bopen = '{'
-    bclose = '}'
-    colon = ':'
-    expl = '!'
     toks = []
     for literal, field, spec, conv in _FORMATTER.parse(template):
+        fmtter = _get_fmtter(formatter_dict)
+        bopen = '{'
+        bclose = '}'
+        colon = ':'
+        expl = '!'
         toks.append(literal)
         if field is None:
             continue

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -31,12 +31,16 @@ def DEFAULT_PROMPT():
 
 class PromptFormatter:
     """Class used by base_shell"""
+    def __init__(self):
+        self.cache = {}
 
     def __call__(self, template=DEFAULT_PROMPT, formatter_dict=None):
         """Formats a xonsh prompt template string."""
         try:
-            return self._format_prompt(template=template,
-                                       formatter_dict=formatter_dict)
+            prompt = self._format_prompt(template=template,
+                                         formatter_dict=formatter_dict)
+            self.cache.clear()
+            return prompt
         except Exception:
             return _failover_template_format(template)
 
@@ -69,8 +73,11 @@ class PromptFormatter:
 
     def _get_field_value(self, field, fmtter):
         field_value = fmtter[field]
+        if field_value in self.cache:
+            return self.cache[field_value]
         try:
             value = field_value() if callable(field_value) else field_value
+            self.cache[field_value] = value
         except Exception:
             print('prompt: error: on field {!r}'
                   ''.format(field), file=sys.stderr)

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -32,7 +32,7 @@ def DEFAULT_PROMPT():
 class PromptFormatter:
     """Class used by base_shell"""
 
-    def format_prompt(self, template=DEFAULT_PROMPT, formatter_dict=None):
+    def __call__(self, template=DEFAULT_PROMPT, formatter_dict=None):
         """Formats a xonsh prompt template string."""
         try:
             return _partial_format_prompt_main(template=template,

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -13,7 +13,6 @@ from pygments.token import Token
 
 from xonsh.base_shell import BaseShell
 from xonsh.tools import print_exception
-from xonsh.prompt.base import partial_format_prompt
 from xonsh.pyghooks import (XonshLexer, partial_color_tokenize,
                             xonsh_style_proxy)
 from xonsh.ptk.completer import PromptToolkitCompleter
@@ -138,7 +137,7 @@ class PromptToolkitShell(BaseShell):
         """Returns a list of (token, str) tuples for the current prompt."""
         p = builtins.__xonsh_env__.get('PROMPT')
         try:
-            p = partial_format_prompt(p)
+            p = self.prompt_formatter.format_prompt(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)
@@ -150,13 +149,13 @@ class PromptToolkitShell(BaseShell):
         prompt.
         """
         p = builtins.__xonsh_env__.get('RIGHT_PROMPT')
-        # partial_format_prompt does handle empty strings properly,
+        # self.prompt_formatter.format_prompt does handle empty strings properly,
         # but this avoids descending into it in the common case of
         # $RIGHT_PROMPT == ''.
         if isinstance(p, str) and len(p) == 0:
             return []
         try:
-            p = partial_format_prompt(p)
+            p = self.prompt_formatter.format_prompt(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)
@@ -167,13 +166,13 @@ class PromptToolkitShell(BaseShell):
         toolbar.
         """
         p = builtins.__xonsh_env__.get('BOTTOM_TOOLBAR')
-        # partial_format_prompt does handle empty strings properly,
+        # self.prompt_formatter.format_prompt does handle empty strings properly,
         # but this avoids descending into it in the common case of
         # $TOOLBAR == ''.
         if isinstance(p, str) and len(p) == 0:
             return []
         try:
-            p = partial_format_prompt(p)
+            p = self.prompt_formatter.format_prompt(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -137,7 +137,7 @@ class PromptToolkitShell(BaseShell):
         """Returns a list of (token, str) tuples for the current prompt."""
         p = builtins.__xonsh_env__.get('PROMPT')
         try:
-            p = self.prompt_formatter.format_prompt(p)
+            p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)
@@ -149,13 +149,13 @@ class PromptToolkitShell(BaseShell):
         prompt.
         """
         p = builtins.__xonsh_env__.get('RIGHT_PROMPT')
-        # self.prompt_formatter.format_prompt does handle empty strings properly,
+        # self.prompt_formatter does handle empty strings properly,
         # but this avoids descending into it in the common case of
         # $RIGHT_PROMPT == ''.
         if isinstance(p, str) and len(p) == 0:
             return []
         try:
-            p = self.prompt_formatter.format_prompt(p)
+            p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)
@@ -166,13 +166,13 @@ class PromptToolkitShell(BaseShell):
         toolbar.
         """
         p = builtins.__xonsh_env__.get('BOTTOM_TOOLBAR')
-        # self.prompt_formatter.format_prompt does handle empty strings properly,
+        # self.prompt_formatter does handle empty strings properly,
         # but this avoids descending into it in the common case of
         # $TOOLBAR == ''.
         if isinstance(p, str) and len(p) == 0:
             return []
         try:
-            p = self.prompt_formatter.format_prompt(p)
+            p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -420,7 +420,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         env = builtins.__xonsh_env__  # pylint: disable=no-member
         p = env.get('PROMPT')
         try:
-            p = self.prompt_formatter.format_prompt(p)
+            p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         hide = True if self._force_hide is None else self._force_hide

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -24,7 +24,7 @@ from xonsh.lazyjson import LazyJSON
 from xonsh.lazyasd import LazyObject
 from xonsh.base_shell import BaseShell
 from xonsh.ansi_colors import ansi_partial_color_format, ansi_color_style_names, ansi_color_style
-from xonsh.prompt.base import partial_format_prompt, multiline_prompt
+from xonsh.prompt.base import multiline_prompt
 from xonsh.tools import print_exception
 from xonsh.platform import ON_WINDOWS, ON_CYGWIN, ON_DARWIN
 from xonsh.lazyimps import pygments, pyghooks
@@ -420,7 +420,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         env = builtins.__xonsh_env__  # pylint: disable=no-member
         p = env.get('PROMPT')
         try:
-            p = partial_format_prompt(p)
+            p = self.prompt_formatter.format_prompt(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
         hide = True if self._force_hide is None else self._force_hide

--- a/xontrib/prompt_ret_code.xsh
+++ b/xontrib/prompt_ret_code.xsh
@@ -30,6 +30,5 @@ $PROMPT = $PROMPT.replace('{prompt_end}{NO_COLOR}',
                           '{ret_code_color}{ret_code}{prompt_end}{NO_COLOR}')
 
 
-$FORMATTER_DICT['ret_code_color'] = _ret_code_color
-$FORMATTER_DICT['ret_code'] = _ret_code
-
+$PROMPT_FIELDS['ret_code_color'] = _ret_code_color
+$PROMPT_FIELDS['ret_code'] = _ret_code


### PR DESCRIPTION
new PromptFormatter class

renamed `FORMATTER_DICT` to `PROMPT_FIELDS`

some caching when building the prompt (we can do better, some details on #1564)

(some shell refactoring on this matter would prolly come after this)