### PR TITLE
Patch setup:install_jupyter_root to respect the root param

### DIFF
--- a/news/jupyter-install-root.rst
+++ b/news/jupyter-install-root.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Jupyter kernel installation now respects the setuptools ``root`` parameter.
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,10 @@ def install_jupyter_hook(prefix=None, root=None):
         print('  root: {0!r}'.format(root))
         print('  prefix: {0!r}'.format(prefix))
         print('  as user: {0}'.format(user))
+        if root and prefix:
+            # os.path.join isn't used since prefix is probably absolute
+            prefix = root + prefix
+            print('  combined prefix {0!r}'.format(prefix))
         KernelSpecManager().install_kernel_spec(
             d, 'xonsh', user=user, replace=True, prefix=prefix)
 


### PR DESCRIPTION
`install_jupyter_hook(prefix, root)` doesn't honour the `root` parameter (since `KernelSpecManager.install_kernel_spec` has only a `prefix` option). When `root` is set (eg, distribution builds), this results in the jupyter kernel being installed in the wrong place.

