### PR TITLE
1kb

### DIFF
--- a/news/1kb.rst
+++ b/news/1kb.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Tee'd reads now occur in 1kb chunks, rather than character-by-character.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -180,7 +180,6 @@ class NonBlockingFDReader(QueueReader):
         self.thread.start()
 
 
-
 def populate_buffer(reader, fd, buffer, chunksize):
     """Reads bytes from the file descriptor and copies them into a buffer.
     The reads happend in parallel, using pread(), and is thus only


### PR DESCRIPTION
This PR provides about a 75% reduction in speed from master, and doesn't *seem* to break anything.

Using @laerus's script (slightly modified)

**prof.xsh**

```
import time

cd /usr/bin
outs = set()
start = time.time()
for i in range(100):
    outs.add($(ls))
print('command took: {} seconds'.format(time.time() - start))
print('difference in outs:', len(outs) - 1)
```

With this I am seeing:

|                     | command took [s] | difference in outs |
|---------------------|------------------|--------------------|
| 3545358a4b (master) | 20.03104758      | 17                 |
| 495d04f             | 4.724117279      | 0                  |
| 5aec225             | 4.678267479      | 0                  |

The problem before hand was that before hand we were reading from the pipe byte-by-byte.  This generated a lot of overhead in system calls.  Performance seems to level off above 100 byte reads on my machine, but I think that 1 kb is a typical amount, so I am going with that here.  

Also added some refactor to reduce duplicated code.