### PR TITLE
New PTK menu style

### DIFF
--- a/news/ptk_menu.rst
+++ b/news/ptk_menu.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+* The style for the prompt toolkit completion menu is now lightgray/darkgray instead of turquoise/teal
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* The scroll bars in the PTK completions menus are back. 
+
+**Security:** None

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -452,8 +452,8 @@ class XonshStyle(Style):
         if 'CONEMUANSI' not in env:
             # Auto suggest needs to be a darker shade to be distinguishable
             # from the default color
-            self.styles[Token.AutoSuggestion] = '#444444'
-            self._smap.update(expand_gray_colors_for_cmd_exe(self._smap))
+            if not hasattr(pygments.style, 'ansicolors'):
+                self.styles[Token.AutoSuggestion] = '#444444'
             if env.get('INTENSIFY_COLORS_ON_WIN', False):
                 has_ansi = hasattr(pygments.style, 'ansicolors')
                 newcolors = intensify_colors_for_cmd_exe(self._smap, ansi=has_ansi)

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -476,21 +476,25 @@ def xonsh_style_proxy(styler):
 
 if hasattr(pygments.style, 'ansicolors'):
     PTK_STYLE = {
-        Token.Menu.Completions.Completion.Current: 'bg:#ansiturquoise  #ansiblack',
-        Token.Menu.Completions.Completion: 'bg:#ansiteal #ansiwhite',
-        Token.Menu.Completions.ProgressButton: 'bg:#ansidarkgray',
-        Token.Menu.Completions.ProgressBar: 'bg:#ansiturquoise',
+        Token.Menu.Completions: 'bg:#ansilightgray #ansiblack',
+        Token.Menu.Completions.Completion: '',
+        Token.Menu.Completions.Completion.Current: 'bg:#ansidarkgray #ansiwhite',
+        Token.Scrollbar: 'bg:#ansidarkgray',
+        Token.Scrollbar.Button: 'bg:#ansiblack',
+        Token.Scrollbar.Arrow: 'bg:#ansiblack #ansiwhite bold',
         Token.AutoSuggestion: '#ansidarkgray',
-        Token.Aborted: '#ansilightgray',
+        Token.Aborted: '#ansidarkgray',
     }
 else:
     PTK_STYLE = {
-        Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
-        Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
-        Token.Menu.Completions.ProgressButton: 'bg:#003333',
-        Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
+        Token.Menu.Completions: 'bg:#888888 #000000',
+        Token.Menu.Completions.Completion: '',
+        Token.Menu.Completions.Completion.Current: 'bg:#555555 #ffffff',
+        Token.Scrollbar: 'bg:#555555',
+        Token.Scrollbar.Button: 'bg:#000000',
+        Token.Scrollbar.Arrow: 'bg:#000000 #ffffff bold',
         Token.AutoSuggestion: '#666666',
-        Token.Aborted: '#888888',
+        Token.Aborted: '#666666',
     }
 
 if hasattr(pygments.style, 'ansicolors'):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -450,10 +450,11 @@ class XonshStyle(Style):
         env = builtins.__xonsh_env__
         # Ensure we are not using ConEmu
         if 'CONEMUANSI' not in env:
-            # Auto suggest needs to be a darker shade to be distinguishable
-            # from the default color
             if not hasattr(pygments.style, 'ansicolors'):
+                # Auto suggest needs to be a darker shade to be distinguishable
+                # from the default color
                 self.styles[Token.AutoSuggestion] = '#444444'
+                self._smap.update(expand_gray_colors_for_cmd_exe(self._smap))
             if env.get('INTENSIFY_COLORS_ON_WIN', False):
                 has_ansi = hasattr(pygments.style, 'ansicolors')
                 newcolors = intensify_colors_for_cmd_exe(self._smap, ansi=has_ansi)


### PR DESCRIPTION
This updates the PTK styles to bring the scrollbar back. PTK expect it to defined by the styles  `Token.Scrollbar` and `Token.Scrollbar.Button`. 

It also updates the toolbar styles to more neutral lightgray/darkgray color, instead of the previous turquoise/teal colors. This is a of course a matter of taste, but it is more in line with the default colors in prompt toolkit. 

![image](https://cloud.githubusercontent.com/assets/1038978/20033779/63807cb0-a3a9-11e6-862e-80fa6765d8c3.png)

Let me know what you think. 
