### PR TITLE
get_hg_branch runs 'hg status' first

### DIFF
--- a/news/hg_branch.rst
+++ b/news/hg_branch.rst
@@ -2,7 +2,9 @@
 
 * The ``$VC_HG_SHOW_BRANCH`` environement variable to control whether to hide the hg branch in the prompt.
 
-**Changed:** None
+**Changed:**
+
+* ``get_hg_branch`` runs ``hg status`` first to check if we are in a repo
 
 **Deprecated:** None
 

--- a/xonsh/prompt/vc_branch.py
+++ b/xonsh/prompt/vc_branch.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Prompt formatter for simple version control branchs"""
+# pylint:disable=no-member, invalid-name
 
 import os
 import sys
@@ -64,10 +65,13 @@ def _get_parent_dir_for(path, dir_name, timeout):
             return path
         previous_path = path
         path, _ = os.path.split(path)
-    return (path == previous_path)
+    return path == previous_path
 
 
-def get_hg_branch(cwd=None, root=None):
+def get_hg_branch(root=None):
+    """Try to get the mercurial branch of the current directory,
+    return None if not in a repo or subprocess.TimeoutExpired if timed out.
+    """
     env = builtins.__xonsh_env__
     timeout = env['VC_BRANCH_TIMEOUT']
     # Bail if we are not in a repo or we timed out
@@ -76,11 +80,11 @@ def get_hg_branch(cwd=None, root=None):
                                  stdout=subprocess.DEVNULL,
                                  stderr=subprocess.DEVNULL)
     except subprocess.TimeoutExpired:
-        return subprocess.TimeoutExpired(['hg'], env['VC_BRANCH_TIMEOUT'])
+        return subprocess.TimeoutExpired(['hg'], timeout)
     else:
         if status == 255:
             return None
-    root = _get_parent_dir_for(cwd or env['PWD'], '.hg', timeout)
+    root = _get_parent_dir_for(env['PWD'], '.hg', timeout)
     if env.get('VC_HG_SHOW_BRANCH'):
         # get branch name
         branch_path = os.path.sep.join([root, '.hg', 'branch'])
@@ -198,7 +202,7 @@ def hg_dirty_working_directory():
         return None
 
 
-def dirty_working_directory(cwd=None):
+def dirty_working_directory():
     """Returns a boolean as to whether there are uncommitted files in version
     control repository we are inside. If this cannot be determined, returns
     None. Currently supports git and hg.


### PR DESCRIPTION
noticed while stracing xonsh that `get_hg_branch` is crawling all the way up to root dir to check if we
are in a repo, this can be slow if we are very deep in a dir tree.

```
$ pwd
/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p
```
part of strace on every prompt update:
```
...
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/l/m/n/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/l/m/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/l/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/k/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/j/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/i/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/h/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/g/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/f/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/e/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/d/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/c/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/b/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/a/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/lab/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/laerus/.hg", 0x7ffca79cef30) = -1 ENOENT (No such file or directory)
stat("/home/.hg", 0x7ffca79cef30)       = -1 ENOENT (No such file or directory)
stat("/.hg", 0x7ffca79cef30) 
...
```

instead we run `hg status` and check if the return code is 255 
which is the code when not in a mercurial repo.