### PR TITLE
Sleepless

### DIFF
--- a/news/rs.rst
+++ b/news/rs.rst
@@ -48,6 +48,8 @@
   ```while True: sleep 1``.
 * Fix for stdin redirects.
 * Backgrounding works with ``$XONSH_STORE_STDOUT``
+* ``PopenThread`` blocks its thread from finishing until command has completed
+  or process is suspended.
 * Added a minimum time buffer time for command pipelines to check for
   if previous commands have executed successfully.  This is helpful
   for pipelines where the last command takes a long time to start up,

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -426,7 +426,8 @@ class SubprocSpec:
         self.captured_stderr = None
 
     def __str__(self):
-        s = self.cls.__name__ + '(' + str(self.cmd) + ', '
+        s = self.__class__.__name__ + '(' + str(self.cmd) + ', '
+        s += self.cls.__name__ + ', '
         kws = [n + '=' + str(getattr(self, n)) for n in self.kwnames]
         s += ', '.join(kws) + ')'
         return s

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -115,7 +115,10 @@ class HistoryGC(threading.Thread):
         file) tuples.
         """
         # pylint: disable=no-member
-        xdd = builtins.__xonsh_env__.get('XONSH_DATA_DIR')
+        env = getattr(builtins, '__xonsh_env__', None)
+        if env is None:
+            return []
+        xdd = env.get('XONSH_DATA_DIR')
         xdd = expanduser_abs_path(xdd)
 
         fs = [f for f in glob.iglob(os.path.join(xdd, 'xonsh-*.json'))]

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -606,8 +606,8 @@ class PopenThread(threading.Thread):
         if self.suspended:
             return
         # close files to send EOF to non-blocking reader.
-        self.orig_stdout.close()
-        self.orig_stderr.close()
+        safe_fdclose(self.orig_stdout)
+        safe_fdclose(self.orig_stderr)
         # read in the remaining data in a blocking fashion.
         while not procout.is_fully_read() or not procerr.is_fully_read():
             self._read_write(procout, stdout, sys.__stdout__)

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -183,13 +183,11 @@ def populate_fd_queue(reader, fd, queue):
             c = os.read(fd, 1024)
         except OSError:
             reader.closed = True
-            #print("EOF")
             break
         if c:
             queue.put(c)
         else:
             reader.closed = True
-            #print("empty line")
             break
 
 
@@ -594,12 +592,12 @@ class PopenThread(threading.Thread):
             j = self._read_write(procerr, stderr, sys.__stderr__)
             if self.suspended:
                 break
-            #elif self.in_alt_mode:
-            #    if i + j == 0:
-            #        cnt = min(cnt + 1, 1000)
-            #    else:
-            #        cnt = 1
-            #    time.sleep(self.timeout * cnt)
+            elif self.in_alt_mode:
+                if i + j == 0:
+                    cnt = min(cnt + 1, 1000)
+                else:
+                    cnt = 1
+                time.sleep(self.timeout * cnt)
             #elif self.prevs_are_closed:
             #    break
             #else:

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -96,7 +96,7 @@ class QueueReader:
         """
         return self.closed and (self.thread is None or
                                 not self.thread.is_alive()) \
-                           and self.queue.empty()
+               and self.queue.empty()
 
     def read_queue(self):
         """Reads a single chunk from the queue. This is blocking if

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -94,9 +94,9 @@ class QueueReader:
         """Returns whether or not the queue is fully read and the reader is
         closed.
         """
-        return self.closed and (self.thread is None or
-                                not self.thread.is_alive()) \
-               and self.queue.empty()
+        return (self.closed
+                and (self.thread is None or not self.thread.is_alive())
+                and self.queue.empty())
 
     def read_queue(self):
         """Reads a single chunk from the queue. This is blocking if

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -608,8 +608,8 @@ class PopenThread(threading.Thread):
         if self.suspended:
             return
         # close files to send EOF to non-blocking reader.
-        # capout & caperr seem to be needed only by Windows, while 
-        # orig_stdout & orig_stderr are need by posix and Windows. 
+        # capout & caperr seem to be needed only by Windows, while
+        # orig_stdout & orig_stderr are need by posix and Windows.
         # Probably best to close them all. Also, order seems to matter here,
         # with orig_* needed to be closed before cap*
         safe_fdclose(self.orig_stdout)


### PR DESCRIPTION
Here are some more performance improvements for running subprocesses. Using the same example script from #1932, I am now seeing,

|                     | command took [s] | difference in outs |
|---------------------|------------------|--------------------|
| 3545358a4b (master) | 20.03104758      | 17                 |
| 5aec225 (1kb)       | 4.678267479      | 0                  |
| 8603909be           | 1.552735806      | 0                  |

The two main points here are that:

1. the PopenThread now does a proper blocking read after the process has ended, which should prevent losing data, and 
2. Many sleep() calls have been replaced with a proper usage of queue, which used operating system mutexes, locking, etc under the covers to timeout instead of Python's relatively expensive sleep().

There is still more to do. I think that the CommandPipeline.iterread() could also get rid of its sleep() in the inner loop and replace it with a queue (sometimes).  Other than that, we'd need to move to Cython, find faster regexes, etc get faster my preliminary profiling tells me.