### PR TITLE
some munging speed ups

### DIFF
--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -62,6 +62,7 @@ ALTERNATE_MODE_FLAGS = LazyObject(
 RE_HIDDEN_BYTES = LazyObject(lambda: re.compile(b'(\001.*?\002)'),
                              globals(), 'RE_HIDDEN')
 
+
 @lazyobject
 def RE_VT100_ESCAPE():
     return re.compile(b'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')


### PR DESCRIPTION
I have rearranged some of the string and bytes munging of output to yield a faster runtimes in the test case given in #1932 and #1938. This is about a 25% performance improvement over the sleepless branch, and takes < 6% of the runtime of the original.

|                       | command took [s] | difference in outs |
|-----------------------|------------------|--------------------|
| 3545358a4b (master)   | 20.03104758      | 17                 |
| 5aec225 (1kb)         | 4.678267479      | 0                  |
| 8603909be (sleepless) | 1.552735806      | 0                  |
| b5d63ce               | 1.150137424      | 0                  |

My remaining ideas that don't involve optional external dependencies or writing a regular expression library haven't panned out.  They all added to the runtime, sometimes significantly. There is probably more profiling and fine tuning that can be done, but I would like to work on something other than run_subproc eventually too :)