### PR TITLE
Fix WHITE color keyword

### DIFF
--- a/news/ansiwhite.rst
+++ b/news/ansiwhite.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+* ``WHITE``  color keyword now means lightgray and ``INTENSE_WHITE`` commpletely white
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+**Security:** None

--- a/news/ansiwhite.rst
+++ b/news/ansiwhite.rst
@@ -8,6 +8,6 @@
 
 **Removed:** None
 
-**Fixed:** 
+**Fixed:** None
 
 **Security:** None

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -720,12 +720,12 @@ def _default_style():
             Color.INTENSE_GREEN: '#ansigreen',
             Color.INTENSE_PURPLE: '#ansifuchsia',
             Color.INTENSE_RED: '#ansired',
-            Color.INTENSE_WHITE: '#ansilightgray',
+            Color.INTENSE_WHITE: '#ansiwhite',
             Color.INTENSE_YELLOW: '#ansiyellow',
             Color.NO_COLOR: 'noinherit',
             Color.PURPLE: '#ansipurple',
             Color.RED: '#ansidarkred',
-            Color.WHITE: '#ansiwhite',
+            Color.WHITE: '#ansilightgray',
             Color.YELLOW: '#ansibrown',
         }
     elif ON_WINDOWS and 'CONEMUANSI' not in os.environ:
@@ -743,12 +743,12 @@ def _default_style():
             Color.INTENSE_GREEN: '#44FF44',
             Color.INTENSE_PURPLE: '#FF44FF',
             Color.INTENSE_RED: '#FF4444',
-            Color.INTENSE_WHITE: '#888888',
+            Color.INTENSE_WHITE: '#FFFFFF',
             Color.INTENSE_YELLOW: '#FFFF44',
             Color.NO_COLOR: 'noinherit',
             Color.PURPLE: '#AA00AA',
             Color.RED: '#AA0000',
-            Color.WHITE: '#FFFFFF',
+            Color.WHITE: '#888888',
             Color.YELLOW: '#AAAA00',
         }
     else:
@@ -763,12 +763,12 @@ def _default_style():
             Color.INTENSE_GREEN: '#00FF00',
             Color.INTENSE_PURPLE: '#FF00FF',
             Color.INTENSE_RED: '#FF0000',
-            Color.INTENSE_WHITE: '#aaaaaa',
+            Color.INTENSE_WHITE: '#ffffff',
             Color.INTENSE_YELLOW: '#FFFF55',
             Color.NO_COLOR: 'noinherit',
             Color.PURPLE: '#AA00AA',
             Color.RED: '#AA0000',
-            Color.WHITE: '#ffffff',
+            Color.WHITE: '#aaaaaa',
             Color.YELLOW: '#ffff00',
         }
     _expand_style(style)


### PR DESCRIPTION
This fixes hopefully the last inconsistency in the color keywords. Now `WHITE` corresponds to a light gray color (`#ansilightgray`) and `INTENSE_WHITE` to a pure white color (`#ansiwhite`) 

Just as is specified here: https://en.wikipedia.org/wiki/ANSI_escape_code

![image](https://cloud.githubusercontent.com/assets/1038978/20230682/758be56c-a85d-11e6-9fb0-5a0c0d9a15bc.png)
