### PR TITLE
Fix readline path completion issues

### DIFF
--- a/news/fix-readline-completer.rst
+++ b/news/fix-readline-completer.rst
@@ -8,6 +8,6 @@
 
 **Fixed:**
 
-* Fixed readline completer issue when cmd alias contains space (e.g. ``ls``).
+* Fixed readline completer issues on paths with spaces
 
 **Security:** None

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -257,22 +257,21 @@ class ReadlineShell(BaseShell, cmd.Cmd):
 
     def completedefault(self, prefix, line, begidx, endidx):
         """Implements tab-completion for text."""
+        if self.completer is None:
+            return []
         rl_completion_suppress_append()  # this needs to be called each time
         _rebind_case_sensitive_completions()
         _s, _e, _q = check_for_partial_string(line)
-        if _s is not None:
+        if _s is not None and _e is not None and line.endswith(_q):
+            return []
+        if _s is not None and _e is None:
             mline = line[_s:]
         else:
             mline = line.rpartition(' ')[2]
         offs = len(mline) - len(prefix)
-        if self.completer is None:
-            x = []
-        else:
-            x = [(i[offs:] if " " in i[:-1] else i)
-                 for i in self.completer.complete(prefix, line,
-                                                  begidx, endidx,
-                                                  ctx=self.ctx)[0]]
-        return x
+        return [i[offs:] for i in self.completer.complete(prefix, line,
+                                                          begidx, endidx,
+                                                          ctx=self.ctx)[0]]
 
     # tab complete on first index too
     completenames = completedefault

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -262,10 +262,11 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         rl_completion_suppress_append()  # this needs to be called each time
         _rebind_case_sensitive_completions()
         _s, _e, _q = check_for_partial_string(line)
-        if _s is not None and _e is not None and line.endswith(_q):
-            return []
-        if _s is not None and _e is None:
-            mline = line[_s:]
+        if _s is not None:
+            if _e is not None and ' ' in line[_e:]:
+                mline = line.rpartition(' ')[2]
+            else:
+                mline = line[_s:]
         else:
             mline = line.rpartition(' ')[2]
         offs = len(mline) - len(prefix)


### PR DESCRIPTION
This fix following readline path completion issues on master:

```
# set up
$ mkdir -p '/tmp/path with spaces/ok'
$ mkdir -p '/tmp/path with spaces/pok'
$ mkdir -p '/tmp/foo'
$ mkdir -p '/tmp/foo bar'
```

```
# cases
$ cd '/tmp/foo <TAB>
$ ls '/tmp/foo'<TAB>
$ ls '/tmp/foo bar/'<TAB>
$ ls '/tmp/foo' /tmp/f<TAB>  # completion for second path param.
$ ls /tmp/p<TAB>
$ ls '/tmp/path with spaces/'o<TAB>
$ ls '/tmp/path with spaces/'po<TAB>
```