### PR TITLE
remove pacman from threadable predictors

### DIFF
--- a/news/not_backgroundable.rst
+++ b/news/not_backgroundable.rst
@@ -19,7 +19,6 @@
     * more
     * mutt
     * nano
-    * pacman
     * ranger
     * scp
     * sh

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -265,7 +265,6 @@ def default_threadable_predictors():
         'mvim': predict_help_ver,
         'mutt': predict_help_ver,
         'nano': predict_help_ver,
-        'pacman': predict_help_ver,
         'ranger': predict_help_ver,
         'scp': predict_false,
         'sh': predict_shell,


### PR DESCRIPTION
as reported in #1947, `pacman` in the `default_threadable_predictors`
disables capture of all `pacman` commands.