### PR TITLE
Make history show all sorted

### DIFF
--- a/news/history-sort.rst
+++ b/news/history-sort.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Made ``history show`` result sorted.
+* Fixed issue that ``history gc`` does not delete empty history files.
+
+**Security:** None

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -2,7 +2,6 @@
 """Implements the xonsh history object."""
 import os
 import sys
-import glob
 import json
 import time
 import uuid
@@ -70,12 +69,16 @@ def _gc_bytes_to_rmfiles(hsize, files):
     return rmfiles
 
 
-def _get_history_files(reverse=False):
+def _get_history_files(sort=True, reverse=False):
+    """Find and return the history files. Optionally sort files by
+        modify time.
+    """
     data_dir = builtins.__xonsh_env__.get('XONSH_DATA_DIR')
     data_dir = expanduser_abs_path(data_dir)
     files = [os.path.join(data_dir, f) for f in os.listdir(data_dir)
              if f.startswith('xonsh-') and f.endswith('.json')]
-    files.sort(key=lambda x: os.path.getmtime(x), reverse=reverse)
+    if sort:
+        files.sort(key=lambda x: os.path.getmtime(x), reverse=reverse)
     return files
 
 
@@ -120,20 +123,22 @@ class HistoryGC(threading.Thread):
         """Find and return the history files. Optionally locked files may be
         excluded.
 
-        This is sorted by the last closed time. Returns a list of (timestamp,
-        file) tuples.
+        This is sorted by the last closed time. Returns a list of
+        (timestamp, number of cmds, file name) tuples.
         """
         # pylint: disable=no-member
         env = getattr(builtins, '__xonsh_env__', None)
         if env is None:
             return []
-        xdd = env.get('XONSH_DATA_DIR')
-        xdd = expanduser_abs_path(xdd)
 
-        fs = [f for f in glob.iglob(os.path.join(xdd, 'xonsh-*.json'))]
+        fs = _get_history_files(sort=False)
         files = []
         for f in fs:
             try:
+                if os.path.getsize(f) == 0:
+                    # collect empty files (for gc)
+                    files.append((time.time(), 0, f))
+                    continue
                 lj = LazyJSON(f, reopen=False)
                 if only_unlocked and lj['locked']:
                     continue


### PR DESCRIPTION
In this PR, I want to make the history sorted. It still work in progress, but I open it here for comments.

Currently when you run `history show all -t | head`, `history show all -t | tail`, xonsh mess up the order of results (when you have tons of history files). The first commit is sorting them by modify time. Maybe sorting by `ts` attr of cmds is more accurate but needs more work or sacrifice the performance. Ideas on this?

Also fixed a small issue on deleting empty history files.