### PR TITLE
fix signal hook issue

### DIFF
--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -730,7 +730,7 @@ class PopenThread(threading.Thread):
 
     def _signal_winch(self, signum, frame):
         """Signal handler for SIGWINCH - window size has changed."""
-        self.proc.send_signal(signal.SIGWINCH)
+        self.send_signal(signal.SIGWINCH)
         self._set_pty_size()
 
     def _set_pty_size(self):

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -525,6 +525,7 @@ class PopenThread(threading.Thread):
         else:
             self.stdin_fd = stdin.fileno()
         self.store_stdin = env.get('XONSH_STORE_STDIN')
+        self.timeout = env.get('XONSH_PROC_FREQUENCY')
         self.in_alt_mode = False
         self.stdin_mode = None
         # stdout setup
@@ -570,7 +571,6 @@ class PopenThread(threading.Thread):
             self.stdin = io.BytesIO()
             self.stdout = io.BytesIO()
             self.stderr = io.BytesIO()
-        self.timeout = env.get('XONSH_PROC_FREQUENCY')
         self.suspended = False
         self.prevs_are_closed = False
         self.start()


### PR DESCRIPTION
An addition fix for #1954, fixes issue like following:

```
$ Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/bin/xonsh", line 3, in <module>
    main()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/main.py", line 221, in main
    shell.shell.cmdloop()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/readline_shell.py", line 399, in cmdloop
    self._cmdloop(intro=intro)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/readline_shell.py", line 359, in _cmdloop
    line = self.singleline()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/readline_shell.py", line 249, in singleline
    rtn = input(self.prompt)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/proc.py", line 733, in _signal_winch
    self.proc.send_signal(signal.SIGWINCH)
AttributeError: 'NoneType' object has no attribute 'send_signal'
```

no news item needed.