### PR TITLE
Fix ON_ANACONDA

### DIFF
--- a/news/conda-forge.rst
+++ b/news/conda-forge.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix failure to detect an Anaconda python distribution if the python was install from the conda-forge channel.   
+
+**Security:** None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -62,7 +62,7 @@ ON_BSD = LazyBool(lambda: ON_FREEBSD or ON_NETBSD,
 PYTHON_VERSION_INFO = sys.version_info[:3]
 """ Version of Python interpreter as three-value tuple. """
 ON_ANACONDA = LazyBool(
-    lambda: any(s in sys.version for s in {'Anaconda', 'Continuum'}),
+    lambda: any(s in sys.version for s in {'Anaconda', 'Continuum', 'conda-forge'}),
     globals(), 'ON_ANACONDA')
 """ ``True`` if executed in an Anaconda instance, else ``False``. """
 CAN_RESIZE_WINDOW = LazyBool(lambda: hasattr(signal, 'SIGWINCH'),


### PR DESCRIPTION
The ON_ANACONDA returned false when python was installed from the conda-forge branch. 