### PR TITLE
Add FileNotFoundError exception to the handler returning None

### DIFF
--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -18,7 +18,7 @@ def _get_git_branch(q):
             ['git', 'branch'],
             stderr=subprocess.DEVNULL
         )).splitlines()
-    except (subprocess.CalledProcessError, OSError):
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         q.put(None)
     else:
         for branch in branches:
@@ -64,8 +64,8 @@ def get_hg_branch(root=None):
                                        stderr=subprocess.DEVNULL)
     except subprocess.TimeoutExpired:
         return subprocess.TimeoutExpired(['hg'], timeout)
-    except subprocess.CalledProcessError:
-        # not in repo
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # not in repo or command not in PATH
         return None
     else:
         root = xt.decode_bytes(root).strip()
@@ -147,7 +147,7 @@ def _git_dirty_working_directory(q, include_untracked):
         else:
             cmd.append('--untracked-files=no')
         status = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
-    except (subprocess.CalledProcessError, OSError):
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         q.put(None)
     if status is not None:
         return q.put(bool(status))


### PR DESCRIPTION
After installing de9e1686353ec1d7a76e76e2c43185406de88e73 I got

    FileNotFoundError: [Errno 2] No such file or directory: 'hg'

at every new shell instance. This is due to the fact that my tools are in /opt/local since I'm using MacPorts on macOS but at the time the subprocess is called in get_hg_branch() PATH is just

    PATH=/usr/bin:/bin:/usr/sbin:/sbin

I'm adding FileNotFoundError to the None case handler of subprocess.check_output calls where needed, one of those already had the exception.

The rationale is that if the tool is missing then just return None like if there wasn't a repository at all.