### PR TITLE
import xonsh.main to fix events docs generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ from xonsh import __version__ as XONSH_VERSION
 from xonsh.environ import DEFAULT_DOCS, Env
 from xonsh.xontribs import xontrib_metadata
 from xonsh.events import events
+from xonsh import main
 from xonsh.commands_cache import CommandsCache
 
 sys.path.insert(0, os.path.dirname(__file__))


### PR DESCRIPTION
sphinx will implicitly import main, but not before we call
`make_events()`, so only `on_chdir` shows up on the events listing.
explicitly importing `xonsh.main` fixes this up so all of the available
events are documented properly.