### PR TITLE
Unify History APIs - inps, rtns, etc.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -51,20 +51,61 @@ def test_hist_flush(hist, xonsh_builtins):
     hf = hist.flush()
     assert hf is None
     xonsh_builtins.__xonsh_env__['HISTCONTROL'] = set()
-    hist.append({'joco': 'still alive'})
+    hist.append({'inp': 'still alive?', 'rtn': 0, 'out': 'yes'})
     hf = hist.flush()
     assert hf is not None
     while hf.is_alive():
         pass
     with LazyJSON(hist.filename) as lj:
-        obs = lj['cmds'][0]['joco']
-    assert 'still alive' == obs
+        assert len(lj['cmds']) == 1
+        cmd = lj['cmds'][0]
+        assert cmd['inp'] == 'still alive?'
+        assert not cmd.get('out', None)
+
+
+def test_hist_flush_with_store_stdout(hist, xonsh_builtins):
+    """Verify explicit flushing of the history works."""
+    hf = hist.flush()
+    assert hf is None
+    xonsh_builtins.__xonsh_env__['HISTCONTROL'] = set()
+    xonsh_builtins.__xonsh_env__['XONSH_STORE_STDOUT'] = True
+    hist.append({'inp': 'still alive?', 'rtn': 0, 'out': 'yes'})
+    hf = hist.flush()
+    assert hf is not None
+    while hf.is_alive():
+        pass
+    with LazyJSON(hist.filename) as lj:
+        assert len(lj['cmds']) == 1
+        assert lj['cmds'][0]['inp'] == 'still alive?'
+        assert lj['cmds'][0]['out'].strip() == 'yes'
+
+
+def test_hist_flush_with_hist_control(hist, xonsh_builtins):
+    """Verify explicit flushing of the history works."""
+    hf = hist.flush()
+    assert hf is None
+    xonsh_builtins.__xonsh_env__['HISTCONTROL'] = 'ignoredups,ignoreerr'
+    hist.append({'inp': 'ls foo1', 'rtn': 0})
+    hist.append({'inp': 'ls foo1', 'rtn': 1})
+    hist.append({'inp': 'ls foo1', 'rtn': 0})
+    hist.append({'inp': 'ls foo2', 'rtn': 2})
+    hist.append({'inp': 'ls foo3', 'rtn': 0})
+    hf = hist.flush()
+    assert hf is not None
+    while hf.is_alive():
+        pass
+    assert len(hist.buffer) == 0
+    with LazyJSON(hist.filename) as lj:
+        cmds = list(lj['cmds'])
+        assert len(cmds) == 2
+        assert [x['inp'] for x in cmds] == ['ls foo1', 'ls foo3']
+        assert [x['rtn'] for x in cmds] == [0, 0]
 
 
 def test_cmd_field(hist, xonsh_builtins):
     # in-memory
     xonsh_builtins.__xonsh_env__['HISTCONTROL'] = set()
-    hf = hist.append({'rtn': 1})
+    hf = hist.append({'inp': 'ls foo', 'rtn': 1})
     assert hf is None
     assert 1 == hist.rtns[0]
     assert 1 == hist.rtns[-1]
@@ -116,62 +157,71 @@ def test_histcontrol(hist, xonsh_builtins):
 
     # An error, buffer remains empty
     hist.append({'inp': 'ls foo', 'rtn': 2})
-    assert len(hist.buffer) == 0
+    assert len(hist.buffer) == 1
     assert hist.rtns[-1] == 2
+    assert hist.inps[-1] == 'ls foo'
 
     # Success
     hist.append({'inp': 'ls foobazz', 'rtn': 0})
-    assert len(hist.buffer) == 1
+    assert len(hist.buffer) == 2
     assert 'ls foobazz' == hist.buffer[-1]['inp']
     assert 0 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == 0
+    assert hist.inps[-1] == 'ls foobazz'
 
     # Error
     hist.append({'inp': 'ls foo', 'rtn': 2})
-    assert len(hist.buffer) == 1
-    assert 'ls foobazz' == hist.buffer[-1]['inp']
-    assert 0 == hist.buffer[-1]['rtn']
+    assert len(hist.buffer) == 3
+    assert 'ls foo' == hist.buffer[-1]['inp']
+    assert 2 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == 2
+    assert hist.inps[-1] == 'ls foo'
 
     # File now exists, success
     hist.append({'inp': 'ls foo', 'rtn': 0})
-    assert len(hist.buffer) == 2
+    assert len(hist.buffer) == 4
     assert 'ls foo' == hist.buffer[-1]['inp']
     assert 0 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == 0
+    assert hist.inps[-1] == 'ls foo'
 
     # Success
     hist.append({'inp': 'ls', 'rtn': 0})
-    assert len(hist.buffer) == 3
+    assert len(hist.buffer) == 5
     assert 'ls' == hist.buffer[-1]['inp']
     assert 0 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == 0
+    assert hist.inps[-1] == 'ls'
 
     # Dup
     hist.append({'inp': 'ls', 'rtn': 0})
-    assert len(hist.buffer) == 3
+    assert len(hist.buffer) == 6
     assert hist.rtns[-1] == 0
+    assert hist.inps[-1] == 'ls'
 
     # Success
     hist.append({'inp': '/bin/ls', 'rtn': 0})
-    assert len(hist.buffer) == 4
+    assert len(hist.buffer) == 7
     assert '/bin/ls' == hist.buffer[-1]['inp']
     assert 0 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == 0
+    assert hist.inps[-1] == '/bin/ls'
 
     # Error
     hist.append({'inp': 'ls bazz', 'rtn': 1})
-    assert len(hist.buffer) == 4
-    assert '/bin/ls' == hist.buffer[-1]['inp']
-    assert 0 == hist.buffer[-1]['rtn']
+    assert len(hist.buffer) == 8
+    assert 'ls bazz' == hist.buffer[-1]['inp']
+    assert 1 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == 1
+    assert hist.inps[-1] == 'ls bazz'
 
     # Error
     hist.append({'inp': 'ls bazz', 'rtn': -1})
-    assert len(hist.buffer) == 4
-    assert '/bin/ls' == hist.buffer[-1]['inp']
-    assert 0 == hist.buffer[-1]['rtn']
+    assert len(hist.buffer) == 9
+    assert 'ls bazz' == hist.buffer[-1]['inp']
+    assert -1 == hist.buffer[-1]['rtn']
     assert hist.rtns[-1] == -1
+    assert hist.inps[-1] == 'ls bazz'
 
 
 @pytest.mark.parametrize('args', [ '-h', '--help', 'show -h', 'show --help'])

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -296,7 +296,7 @@ class JsonHistory(History):
         self.tss = JsonCommandField('ts', self)
         self.inps = JsonCommandField('inp', self)
         self.outs = JsonCommandField('out', self)
-        self.rtns = JsonCommandField('rtn', self)
+        self.rtns = []
 
     def __len__(self):
         return self._len
@@ -314,6 +314,7 @@ class JsonHistory(History):
         hf : JsonHistoryFlusher or None
             The thread that was spawned to flush history
         """
+        self.rtns.append(cmd.get('rtn', 0))
         opts = builtins.__xonsh_env__.get('HISTCONTROL')
         if ('ignoredups' in opts and len(self) > 0 and
                 cmd['inp'] == self.inps[-1]):

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -176,9 +176,21 @@ class JsonHistoryFlusher(threading.Thread):
 
     def dump(self):
         """Write the cached history to external storage."""
+        opts = builtins.__xonsh_env__.get('HISTCONTROL')
+        last_inp = None
+        cmds = []
+        for cmd in self.buffer:
+            if 'ignoredups' in opts and cmd['inp'] == last_inp:
+                # Skipping dup cmd
+                continue
+            if 'ignoreerr' in opts and cmd['rtn'] != 0:
+                # Skipping failed cmd
+                continue
+            cmds.append(cmd)
+            last_inp = cmd['inp']
         with open(self.filename, 'r', newline='\n') as f:
             hist = xlj.LazyJSON(f).load()
-        hist['cmds'].extend(self.buffer)
+        hist['cmds'].extend(cmds)
         if self.at_exit:
             hist['ts'][1] = time.time()  # apply end time
             hist['locked'] = False
@@ -296,7 +308,7 @@ class JsonHistory(History):
         self.tss = JsonCommandField('ts', self)
         self.inps = JsonCommandField('inp', self)
         self.outs = JsonCommandField('out', self)
-        self.rtns = []
+        self.rtns = JsonCommandField('rtn', self)
 
     def __len__(self):
         return self._len
@@ -314,16 +326,6 @@ class JsonHistory(History):
         hf : JsonHistoryFlusher or None
             The thread that was spawned to flush history
         """
-        self.rtns.append(cmd.get('rtn', 0))
-        opts = builtins.__xonsh_env__.get('HISTCONTROL')
-        if ('ignoredups' in opts and len(self) > 0 and
-                cmd['inp'] == self.inps[-1]):
-            # Skipping dup cmd
-            return None
-        elif 'ignoreerr' in opts and cmd['rtn'] != 0:
-            # Skipping failed cmd
-            return None
-
         self.buffer.append(cmd)
         self._len += 1  # must come before flushing
         if len(self.buffer) >= self.buffersize:
@@ -364,7 +366,7 @@ class JsonHistory(History):
         """
         Returns all history as found in XONSH_DATA_DIR.
 
-        return format: (cmd, start_time, index)
+        yeild format: {'inp': cmd, 'rtn': 0, ...}
         """
         while self.gc and self.gc.is_alive():
             time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer


### PR DESCRIPTION
Since sqlite history backend was just added, it's time to unify the history APIs a bit I think. In this PR I want to make behaviors of `inps`, `tss`, `outs`, and especially `rtns` consistent between history backends.

<del>Haven't dig deep, but it seems that we can remove class `JsonCommandField` and put the ``__getitem__`` logics in `JsonHistory` and only make `inps` searchable.</del>

Ideas on this?
