### PR TITLE
update info print of debug level

### DIFF
--- a/news/xonsh-debug-level.rst
+++ b/news/xonsh-debug-level.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Updated the effectivity of ``$XONSH_DEBUG`` on debug messages.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -618,9 +618,9 @@ def DEFAULT_DOCS():
         'Sets the xonsh debugging level. This may be an integer or a boolean. '
         'Setting this variable prior to stating xonsh to ``1`` or ``True`` '
         'will supress amalgamated imports. Setting it to ``2`` will get some '
-        'basic information like code transformation, command replacement. '
+        'basic information like input transformation, command replacement. '
         'With ``3`` or a higher number will make more debugging information '
-        'presented, like PLY debug messages.',
+        'presented, like PLY parsing messages.',
         configurable=False),
     'XONSH_DATA_DIR': VarDocs(
         'This is the location where xonsh data files are stored, such as '

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -298,7 +298,7 @@ def DEFAULT_VALUES():
         'XONSH_COLOR_STYLE': 'default',
         'XONSH_CONFIG_DIR': xonsh_config_dir,
         'XONSH_DATA_DIR': xonsh_data_dir,
-        'XONSH_DEBUG': False,
+        'XONSH_DEBUG': 0,
         'XONSH_ENCODING': DEFAULT_ENCODING,
         'XONSH_ENCODING_ERRORS': 'surrogateescape',
         'XONSH_HISTORY_BACKEND': 'json',
@@ -615,10 +615,13 @@ def DEFAULT_DOCS():
         'This is the location where xonsh configuration information is stored.',
         configurable=False, default="``$XDG_CONFIG_HOME/xonsh``"),
     'XONSH_DEBUG': VarDocs(
-        'Sets the xonsh debugging level. This may be an integer or a boolean, '
-        'with higher values cooresponding to higher debuging levels and more '
-        'information presented. Setting this variable prior to stating xonsh '
-        'will supress amalgamated imports.', configurable=False),
+        'Sets the xonsh debugging level. This may be an integer or a boolean. '
+        'Setting this variable prior to stating xonsh to ``1`` or ``True`` '
+        'will supress amalgamated imports. Setting it to ``2`` will get some '
+        'basic information like code transformation, command replacement. '
+        'With ``3`` or a higher number will make more debugging information '
+        'presented, like PLY debug messages.',
+        configurable=False),
     'XONSH_DATA_DIR': VarDocs(
         'This is the location where xonsh data files are stored, such as '
         'history.', default="``$XDG_DATA_HOME/xonsh``"),

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -221,7 +221,7 @@ class Execer(object):
                     # anything
                     raise original_error
                 else:
-                    if self.debug_level:
+                    if self.debug_level > 1:
                         msg = ('{0}:{1}:{2}{3} - {4}\n'
                                '{0}:{1}:{2}{3} + {5}')
                         mstr = '' if maxcol is None else ':' + str(maxcol)

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -54,7 +54,7 @@ class Execer(object):
             filename = self.filename
         if not transform:
             return self.parser.parse(input, filename=filename, mode=mode,
-                                     debug_level=(self.debug_level > 1))
+                                     debug_level=(self.debug_level > 2))
 
         # Parsing actually happens in a couple of phases. The first is a
         # shortcut for a context-free parser. Normally, all subprocess
@@ -161,7 +161,7 @@ class Execer(object):
                 tree = self.parser.parse(input,
                                          filename=filename,
                                          mode=mode,
-                                         debug_level=(self.debug_level > 1))
+                                         debug_level=(self.debug_level > 2))
                 parsed = True
             except IndentationError as e:
                 if original_error is None:

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -584,7 +584,7 @@ def load_foreign_aliases(shells=None, config=None, issue_warning=True):
             shaliases = {} if shaliases is None else shaliases
             for alias in set(shaliases) & set(xonsh_aliases):
                 del shaliases[alias]
-                if builtins.__xonsh_env__.get('XONSH_DEBUG', False) > 1:
+                if builtins.__xonsh_env__.get('XONSH_DEBUG') > 1:
                     print('aliases: ignoring alias {!r} of shell {!r} '
                           'which tries to override xonsh alias.'
                           ''.format(alias, shell['shell']),

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -584,7 +584,7 @@ def load_foreign_aliases(shells=None, config=None, issue_warning=True):
             shaliases = {} if shaliases is None else shaliases
             for alias in set(shaliases) & set(xonsh_aliases):
                 del shaliases[alias]
-                if builtins.__xonsh_env__.get('XONSH_DEBUG'):
+                if builtins.__xonsh_env__.get('XONSH_DEBUG', False) > 1:
                     print('aliases: ignoring alias {!r} of shell {!r} '
                           'which tries to override xonsh alias.'
                           ''.format(alias, shell['shell']),

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -49,7 +49,7 @@ def fire_precommand(src, show_diff=True):
             print_exception('Modifcations to source input took more than '
                             'the recursion limit number of interations to '
                             'converge.')
-    debug_level = builtins.__xonsh_env__.get('XONSH_DEBUG', 0)
+    debug_level = builtins.__xonsh_env__.get('XONSH_DEBUG')
     if show_diff and debug_level > 1 and src != raw:
         sys.stderr.writelines(difflib.unified_diff(
             raw.splitlines(keepends=True),

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -49,7 +49,8 @@ def fire_precommand(src, show_diff=True):
             print_exception('Modifcations to source input took more than '
                             'the recursion limit number of interations to '
                             'converge.')
-    if show_diff and builtins.__xonsh_env__.get('XONSH_DEBUG') and src != raw:
+    debug_level = builtins.__xonsh_env__.get('XONSH_DEBUG', 0)
+    if show_diff and debug_level > 1 and src != raw:
         sys.stderr.writelines(difflib.unified_diff(
             raw.splitlines(keepends=True),
             src.splitlines(keepends=True),

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -21,7 +21,7 @@
     "you might find them useful if you have strong muscle memory.\n\n",
     "**Warning:** This xontrib may modify user command line input to implement ",
     "its behavior. To see the modifications as they are applied (in unified diff",
-    "format), please set ``$XONSH_DEBUG = True``."]
+    "format), please set ``$XONSH_DEBUG`` to ``2`` or higher."]
  },
  {"name": "distributed",
   "package": "xonsh",

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -3,4 +3,6 @@
 
 @events.on_precommand
 def bash_preproc(cmd):
+    if len(__xonsh_history__) == 0:
+        return cmd
     return cmd.replace('!!', __xonsh_history__.inps[-1].strip())

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -3,6 +3,8 @@
 
 @events.on_precommand
 def bash_preproc(cmd):
-    if len(__xonsh_history__) == 0:
+    if not __xonsh_history__.inps:
+        if cmd.strip() == '!!':
+            return ''
         return cmd
     return cmd.replace('!!', __xonsh_history__.inps[-1].strip())


### PR DESCRIPTION
There are debug level `+-` outputs with commands like `history info` when `$XONSH_DEBUG = 1`. I believe these outputs should be printed with a higher debug level as the other places of `execer.py` related with `self.debug_level`.

no news items is needed.