### PR TITLE
stop travis if build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
       pip install -r requirements-tests.txt;
     fi
 
+before_script:
+  - rvm get head || true
 
 script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
 
 
 script:
+  - set -e
   - if [[ $BUILD_DOCS = true ]]; then
       cd docs;
       make html;

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -89,7 +89,7 @@ It will pick up the environment and any aliases.
 Tools for dealing with xonsh history. See `the history tutorial <tutorial_hist.html>`_
 for more information all the history command and all of its sub-commands.
 
-.. command-help:: xonsh.history.history_main
+.. command-help:: xonsh.history.main.history_main
 
 
 ``replay``


### PR DESCRIPTION
@asmeurer reported that travis doesn't stop a build if the docs fail to build unless there's a `set -e` in there.  Adding it in so that we don't accidentally push broken docs, potentially deleting what we have.