### PR TITLE
Fixed xonfig raising error when xonsh is not installed from source

### DIFF
--- a/news/xonfig-fix.rst
+++ b/news/xonfig-fix.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed xonfig raising error when xonsh is not installed from source.
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,6 @@ def dirty_version():
     try:
         _, N, sha = _version.strip().split('-')
     except ValueError:  # tag name may contain "-"
-        open('xonsh/dev.githash', 'w').close()
         print('failed to parse git version', file=sys.stderr)
         return False
     sha = sha.strip('g')

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import builtins
+import xonsh.platform as xp
+
+
+def test_githash_value_error(monkeypatch):
+    @contextmanager
+    def mocked_open(*args):
+        yield MagicMock(read=lambda: 'abc123')
+    monkeypatch.setattr(builtins, 'open', mocked_open)
+    sha, date_ = xp.githash()
+    assert date_ is None
+    assert sha is None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -174,12 +174,15 @@ def pathbasename(p):
 def githash():
     """Returns a tuple contains two strings: the hash and the date."""
     install_base = os.path.dirname(__file__)
+    githash_file = '{}/dev.githash'.format(install_base)
+    if not os.path.exists(githash_file):
+        return None, None
     sha = None
     date_ = None
     try:
-        with open('{}/dev.githash'.format(install_base), 'r') as f:
+        with open(githash_file) as f:
             sha, date_ = f.read().strip().split('|')
-    except FileNotFoundError:
+    except ValueError:
         pass
     return sha, date_
 


### PR DESCRIPTION
Found xonfig is broken when I was trying 0.5.0 in a clean env..

Sorry @scopatz, maybe you could do a 0.5.1 release for it soon?