### PR TITLE
Tests python shebangs

### DIFF
--- a/news/tests-python-shebangs.rst
+++ b/news/tests-python-shebangs.rst
@@ -6,7 +6,7 @@
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
 
 * ``tests/bin/{cat,pwd,wc}`` shebang changed to python3
 

--- a/news/tests-python-shebangs.rst
+++ b/news/tests-python-shebangs.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+* ``tests/bin/{cat,pwd,wc}`` shebang changed to python3
+
+**Security:** None

--- a/tests/bin/cat
+++ b/tests/bin/cat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 with open(sys.argv[-1]) as f:
     for line in f:

--- a/tests/bin/pwd
+++ b/tests/bin/pwd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 x = os.getcwd()
 print(x)

--- a/tests/bin/wc
+++ b/tests/bin/wc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 if len(sys.argv) == 1:


### PR DESCRIPTION
These files contain python3 syntax, which causes the associated tests to fail on a system for which `/usr/bin/python` is python2.