### PR TITLE
print out exception msg when do fail-back

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -285,8 +285,7 @@ def _failback_to_other_shells(argv, err):
             foreign_shell = line
             break
     if foreign_shell:
-        traceback.print_tb(err.__traceback__)
-        print('{}: {}'.format(err.__class__.__name__, err), file=sys.stderr)
+        traceback.print_exc()
         print('Xonsh encountered an issue during launch', file=sys.stderr)
         print('Failback to {}'.format(foreign_shell), file=sys.stderr)
         os.execlp(foreign_shell, foreign_shell)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -286,6 +286,7 @@ def _failback_to_other_shells(argv, err):
             break
     if foreign_shell:
         traceback.print_tb(err.__traceback__)
+        print('{}: {}'.format(err.__class__.__name__, err), file=sys.stderr)
         print('Xonsh encountered an issue during launch', file=sys.stderr)
         print('Failback to {}'.format(foreign_shell), file=sys.stderr)
         os.execlp(foreign_shell, foreign_shell)


### PR DESCRIPTION
Missed some info from previous PR.

This PR will turn this:
```
Last login: Wed Dec 21 21:28:23 on ttys010
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17829, in main
    return main_xonsh(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17836, in main_xonsh
    args = premain(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17775, in premain
    builtins.__xonsh_shell__ = Shell(**shell_kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17001, in __init__
    from xonsh.ptk.shell import PromptToolkitShell as shell_class
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/ptk/shell.py", line 11, in <module>
    import pygments
```

to this (added the last line of exception info):
```
Last login: Wed Dec 21 21:28:23 on ttys010
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17829, in main
    return main_xonsh(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17836, in main_xonsh
    args = premain(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17775, in premain
    builtins.__xonsh_shell__ = Shell(**shell_kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/__amalgam__.py", line 17001, in __init__
    from xonsh.ptk.shell import PromptToolkitShell as shell_class
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/xonsh/ptk/shell.py", line 11, in <module>
    import pygments
ImportError: No module named 'pygments'
```

no news item needed.