### PR TITLE
use doctr to also manage release docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,12 @@ script:
       make html;
       cd ..;
       doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs dev;
+      git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
+      cd docs;
+      make html;
+      cd ..;
+      doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs .;
     else
       py.test --timeout=10;
     fi
 
-# This block should be inserted after line 52 for the next release.
-#      git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
-#      cd docs;
-#      make html;
-#      cd ..;
-#      doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
       doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs dev;
       git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
       cd docs;
+      make clean;
       make html;
       cd ..;
       doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs .;


### PR DESCRIPTION
now that we have a release that contains the encrypted deploy key, we
can also have doctr always push the most recent release docs to
`xonsh-docs`.

there may be more fiddling to do to get a documentation selector
working but this is a start

Usual caveat that we won't know if this is working until it's merged, but if anyone spots any obvious problems in the yaml logic, let me know.