### PR TITLE
POC - hot pluggable completers

### DIFF
--- a/xonsh/completers/__init__.py
+++ b/xonsh/completers/__init__.py
@@ -14,6 +14,8 @@ else:
         _sys.modules['xonsh.completers.tools'] = __amalgam__
         xompletions = __amalgam__
         _sys.modules['xonsh.completers.xompletions'] = __amalgam__
+        xonsh = __amalgam__
+        _sys.modules['xonsh.completers.xonsh'] = __amalgam__
         _aliases = __amalgam__
         _sys.modules['xonsh.completers._aliases'] = __amalgam__
         commands = __amalgam__

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -2,6 +2,7 @@
 import collections
 
 from xonsh.completers.pip import complete_pip
+from xonsh.completers.xonsh import complete_xonsh
 from xonsh.completers.man import complete_from_man
 from xonsh.completers.bash import complete_from_bash
 from xonsh.completers.base import complete_base
@@ -21,6 +22,7 @@ def default_completers():
         ('base', complete_base),
         ('completer', complete_completer),
         ('skip', complete_skipper),
+        ('xonsh', complete_xonsh),
         ('pip', complete_pip),
         ('cd', complete_cd),
         ('rmdir', complete_rmdir),

--- a/xonsh/completers/xonsh.py
+++ b/xonsh/completers/xonsh.py
@@ -1,0 +1,42 @@
+import importlib.util
+import os.path
+import xonsh.tools as xt
+
+_XCX_MODULES = []
+
+
+def _xcx_load_complete_modules():
+    dir_ = xt.expanduser_abs_path('~/.xonsh/completers')
+    if not os.path.isdir(dir_):
+        return
+    for f in os.listdir(dir_):
+        if not f.endswith('.py'):
+            continue
+        full_path = os.path.join(dir_, f)
+        if not os.path.isfile(full_path):
+            continue
+        name = f.split('.')[0]
+        spec = importlib.util.spec_from_file_location(
+            "xonsh.completers.xonsh_{}".format(name), full_path)
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        _XCX_MODULES.append(m)
+
+
+def complete_xonsh(prefix, line, begidx, endidx, ctx):
+    try:
+        cmd = line.strip().split()[0]
+    except IndexError:
+        return
+    if not cmd:
+        return
+    for m in _XCX_MODULES:
+        if not m.__name__.endswith(cmd):
+            continue
+        result = m.complete(prefix, line, begidx, endidx, ctx)
+        if result is not None:
+            return result
+    return
+
+
+_xcx_load_complete_modules()


### PR DESCRIPTION
I think instead of alway implementing a next completer and add it to xonsh codebase, we can make completers writing easy as bash completion scripts. You can put as many as new scripts as your want, bash will load them all. Program author then could pack a xonsh-myapp.py as its completer script for xonsh like they will do for bash.

This PR is a quick & dirty POC, without safe check or anything. Just put it here to collect ideas.

With a PR like this, xonsh users can drop their completer files into `~/.xonsh/completers/`, and they will just work. This will be even convenient than xontrib. Demo files would be:

file: **~/.xonsh/completers/foo.py**:
```
def complete(prefix, line, begidx, endidx, ctx):
    if not line.startswith('foo'):
        return
    L = ['bar', 'baz']
    return {x for x in L if x.startswith(prefix)}
```

file: **~/.xonsh/completers/brew.py**:
```
def complete(prefix, line, begidx, endidx, ctx):
    if not line.startswith('brew'):
        return
    L = ['install', 'info', 'uninstall']
    return {x for x in L if x.startswith(prefix)}
```
