### PR TITLE
checkout HEAD before attempting second deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ script:
       doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs dev;
       git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
       cd docs;
-      make clean;
-      make html;
+      make clean html;
       cd ..;
+      git checkout HEAD;
       doctr deploy --deploy-repo xonsh/xonsh-docs --gh-pages-docs .;
     else
       py.test --timeout=10;


### PR DESCRIPTION
I think the errors that doctr encounters when pushing the second set of
docs has to do with trying to add to the gh-pages branch when we're
starting from non-HEAD location?

I'm hoping that by manually putting us back onto HEAD that this should
avoid that...

If this does work, it's probably worth putting into doctr itself.

Usually caveats that we can't test this until it's merged...