### PR TITLE
Improved bash completions

### DIFF
--- a/news/improved-bash-completions.rst
+++ b/news/improved-bash-completions.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a bug where the bash completer raised an exception when using Python 3.6.
+
+**Security:** None
+

--- a/news/improved-bash-completions.rst
+++ b/news/improved-bash-completions.rst
@@ -13,4 +13,3 @@
 * Fixed a bug where the bash completer raised an exception when using Python 3.6.
 
 **Security:** None
-

--- a/news/improved-bash-completions.rst
+++ b/news/improved-bash-completions.rst
@@ -1,4 +1,6 @@
-**Added:** None
+**Added:**
+
+* The ``$BASH_COMPLETIONS`` environment variable now supports multiple valid paths.
 
 **Changed:** None
 

--- a/news/improved-bash-completions.rst
+++ b/news/improved-bash-completions.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* The ``$BASH_COMPLETIONS`` environment variable now supports multiple valid paths.
+* The ``$BASH_COMPLETIONS`` environment variable now supports multiple valid paths as well as directories.
 
 **Changed:** None
 

--- a/tests/bash_completion.d/foo
+++ b/tests/bash_completion.d/foo
@@ -1,0 +1,14 @@
+_foo() 
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="--bar --baz --qux"
+
+    if [[ ${cur} == -* ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+complete -F _foo foo

--- a/tests/bash_completion.d/spam
+++ b/tests/bash_completion.d/spam
@@ -1,0 +1,14 @@
+_spam() 
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="--egg --bacon --sausage --spam"
+
+    if [[ ${cur} == -* ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+complete -F _spam spam

--- a/tests/test_bash_completers.py
+++ b/tests/test_bash_completers.py
@@ -1,0 +1,18 @@
+"""Tests delegation to bash completers"""
+import pytest
+import os
+
+from xonsh.environ import Env
+
+from xonsh.completers.bash import complete_from_bash
+
+COMPLETION_DIR = os.path.join(os.path.dirname(__file__), 'bash_completion.d')
+COMPLETION_FILE = os.path.join(COMPLETION_DIR, 'spam')
+
+def test_single_completion_file(xonsh_builtins):
+    """This tests an issue surfacing in Python 3.6:
+    commonprefix() only works on indexable arguments, see http://bugs.python.org/issue28527
+    """
+    xonsh_builtins.__xonsh_env__ = Env(BASH_COMPLETIONS=[COMPLETION_FILE])
+    completions = complete_from_bash('spam --', 'spam --', 5, 5, None)
+    assert completions == ({'--bacon ', '--sausage ', '--egg ', '--spam '}, 2)

--- a/tests/test_bash_completers.py
+++ b/tests/test_bash_completers.py
@@ -7,12 +7,19 @@ from xonsh.environ import Env
 from xonsh.completers.bash import complete_from_bash
 
 COMPLETION_DIR = os.path.join(os.path.dirname(__file__), 'bash_completion.d')
-COMPLETION_FILE = os.path.join(COMPLETION_DIR, 'spam')
+COMPLETION_FILE1 = os.path.join(COMPLETION_DIR, 'spam')
+COMPLETION_FILE2 = os.path.join(COMPLETION_DIR, 'foo')
 
 def test_single_completion_file(xonsh_builtins):
     """This tests an issue surfacing in Python 3.6:
     commonprefix() only works on indexable arguments, see http://bugs.python.org/issue28527
     """
-    xonsh_builtins.__xonsh_env__ = Env(BASH_COMPLETIONS=[COMPLETION_FILE])
+    xonsh_builtins.__xonsh_env__ = Env(BASH_COMPLETIONS=[COMPLETION_FILE1])
     completions = complete_from_bash('spam --', 'spam --', 5, 5, None)
     assert completions == ({'--bacon ', '--sausage ', '--egg ', '--spam '}, 2)
+
+def test_multiple_completion_files(xonsh_builtins):
+    """Tests if all sources available in the environment are used, not just the first one"""
+    xonsh_builtins.__xonsh_env__ = Env(BASH_COMPLETIONS=[COMPLETION_FILE1, COMPLETION_FILE2])
+    completions = complete_from_bash('foo --', 'foo --', 5, 5, None)
+    assert completions == ({'--bar ', '--baz ', '--qux '}, 2)

--- a/tests/test_bash_completers.py
+++ b/tests/test_bash_completers.py
@@ -23,3 +23,11 @@ def test_multiple_completion_files(xonsh_builtins):
     xonsh_builtins.__xonsh_env__ = Env(BASH_COMPLETIONS=[COMPLETION_FILE1, COMPLETION_FILE2])
     completions = complete_from_bash('foo --', 'foo --', 5, 5, None)
     assert completions == ({'--bar ', '--baz ', '--qux '}, 2)
+
+def test_completion_dir(xonsh_builtins):
+    """Tests if a whole directory gets parsed as well"""
+    xonsh_builtins.__xonsh_env__ = Env(BASH_COMPLETIONS=[COMPLETION_DIR])
+    foo_completions = complete_from_bash('foo --', 'foo --', 5, 5, None)
+    assert foo_completions == ({'--bar ', '--baz ', '--qux '}, 2)
+    spam_completions = complete_from_bash('spam --', 'spam --', 5, 5, None)
+    assert spam_completions == ({'--bacon ', '--sausage ', '--egg ', '--spam '}, 2)

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -121,6 +121,8 @@ def _get_completions_source():
     completers = builtins.__xonsh_env__.get('BASH_COMPLETIONS', ())
     sources = []
     for path in map(pathlib.Path, completers):
-        if path.is_file():
+        if path.is_dir():
+            sources += (f for f in path.iterdir() if f.is_file())
+        elif path.is_file():
             sources.append(path)
     return '\n'.join('source "{}"'.format(source.as_posix()) for source in sources)

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -98,7 +98,7 @@ def complete_from_bash(prefix, line, begidx, endidx, ctx):
 
     out = out.splitlines()
     complete_stmt = out[0]
-    out = set(out[1:])
+    out = list(set(out[1:]))
 
     # From GNU Bash document: The results of the expansion are prefix-matched
     # against the word being completed

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -119,7 +119,8 @@ def complete_from_bash(prefix, line, begidx, endidx, ctx):
 
 def _get_completions_source():
     completers = builtins.__xonsh_env__.get('BASH_COMPLETIONS', ())
+    sources = []
     for path in map(pathlib.Path, completers):
         if path.is_file():
-            return 'source "{}"'.format(path.as_posix())
-    return None
+            sources.append(path)
+    return '\n'.join('source "{}"'.format(source.as_posix()) for source in sources)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -362,8 +362,10 @@ def DEFAULT_DOCS():
         'displayed suggestion. Only usable with ``$SHELL_TYPE=prompt_toolkit.``'),
     'BASH_COMPLETIONS': VarDocs(
         'This is a list (or tuple) of strings that specifies where the '
-        '``bash_completion`` script may be found. '
-        'All valid paths will be used. For better performance, '
+        '``bash_completion`` scripts may be found. '
+        'All valid paths will be used. Paths that point to directories cause all '
+        'directory entries to be used. '
+        'For better performance, '
         'bash-completion v2.x is recommended since it lazy-loads individual '
         'completion scripts. '
         'For both bash-completion v1.x and v2.x, paths of individual completion '

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -363,7 +363,7 @@ def DEFAULT_DOCS():
     'BASH_COMPLETIONS': VarDocs(
         'This is a list (or tuple) of strings that specifies where the '
         '``bash_completion`` script may be found. '
-        'The first valid path will be used. For better performance, '
+        'All valid paths will be used. For better performance, '
         'bash-completion v2.x is recommended since it lazy-loads individual '
         'completion scripts. '
         'For both bash-completion v1.x and v2.x, paths of individual completion '


### PR DESCRIPTION
Python 3.6 breaks bash completions because now os.path.commonprefix expects an indexable argument.

This change fixes that and extends the functionality of $BASH_COMPLETIONS:
* Added tests for the bash completer
* All valid files in $BASH_COMPLETIONS are used instead of just the first one
* Paths to directories cause the whole directory to be imported
