### PR TITLE
use ptk-specific `push` when executing commands

### DIFF
--- a/news/fix_multiline_execution.rst
+++ b/news/fix_multiline_execution.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* multiline syntax error in PTK shell due to buffer not being reset
+
+**Security:** None

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -21,6 +21,7 @@ from xonsh.ptk.history import PromptToolkitHistory
 from xonsh.ptk.key_bindings import load_xonsh_bindings
 from xonsh.ptk.shortcuts import Prompter
 from xonsh.events import events
+from xonsh.shell import fire_precommand
 
 
 events.transmogrify('on_ptk_create', 'LoadEvent')
@@ -110,6 +111,7 @@ class PromptToolkitShell(BaseShell):
         if self.need_more_lines:
             return None, code
         src = ''.join(self.buffer)
+        src = fire_precommand(src)
         try:
             code = self.execer.compile(src,
                                        mode='single',
@@ -127,6 +129,7 @@ class PromptToolkitShell(BaseShell):
         if intro:
             print(intro)
         auto_suggest = AutoSuggestFromHistory()
+        self.push = self._push
         while not builtins.__xonsh_exit__:
             try:
                 line = self.singleline(auto_suggest=auto_suggest)


### PR DESCRIPTION
When events were introduced, the PTK shell's `_push` was left behind.
This is the cause of #2036 as the buffer isn't cleared between separate
prompt inputs, leading to very, very strange behavior.

This restores the use of the PTK `_push` that properly resets the buffer
if the AST fails to compile and also adds in the precommand src
transformation so that the bashisms xontrib still works as expected.