### PR TITLE
ret_code should return None not '' when rc==0

### DIFF
--- a/news/ret_code_none.rst
+++ b/news/ret_code_none.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+* ``_ret_code`` function of ``prompt_ret_code`` xontrib return now ``None`` when
+  return code is 0 instead of empty string allowing more customization of prompt
+  format.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xontrib/prompt_ret_code.xsh
+++ b/xontrib/prompt_ret_code.xsh
@@ -23,7 +23,7 @@ def _ret_code():
         return_code = __xonsh_history__.rtns[-1]
         if return_code != 0:
             return '[{}]'.format(return_code)
-    return ''
+    return None
 
 
 $PROMPT = $PROMPT.replace('{prompt_end}{NO_COLOR}',


### PR DESCRIPTION
When the return code is 0, nothing is displayed in the prompt. Empty string was
returned. Returning None have the same behavior, but allows user to use the
syntax "{retcode:{} }" in the prompt for different spacing.