### PR TITLE
Tutorial: Rephrase Bash/Xonsh comparison warning concerning backticks

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -909,7 +909,7 @@ Other than the regex matching, this functions in the same way as normal
 globbing.  For more information, please see the documentation for the ``re``
 module in the Python standard library.
 
-.. warning:: Backticks have very different meanings in Xonsh vs. Bash.  In
+.. warning:: In Xonsh, the meaning of backticks is very different from their meaning in Bash.  In
              Bash, backticks mean to run a captured subprocess ``$()``.
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -911,7 +911,8 @@ module in the Python standard library.
 
 .. warning:: In Xonsh, the meaning of backticks is very different from their
              meaning in Bash.
-             In Bash, backticks mean to run a captured subprocess ``$()``.
+             In Bash, backticks mean to run a captured subprocess
+	     (``$()`` in Xonsh).
 
 
 Normal Globbing

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -909,7 +909,7 @@ Other than the regex matching, this functions in the same way as normal
 globbing.  For more information, please see the documentation for the ``re``
 module in the Python standard library.
 
-.. warning:: This backtick syntax has very different semantics from that of Bash.  In
+.. warning:: Backticks have very different meanings in Xonsh vs. Bash.  In
              Bash, backticks mean to run a captured subprocess ``$()``.
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -909,8 +909,9 @@ Other than the regex matching, this functions in the same way as normal
 globbing.  For more information, please see the documentation for the ``re``
 module in the Python standard library.
 
-.. warning:: In Xonsh, the meaning of backticks is very different from their meaning in Bash.  In
-             Bash, backticks mean to run a captured subprocess ``$()``.
+.. warning:: In Xonsh, the meaning of backticks is very different from their
+             meaning in Bash.
+             In Bash, backticks mean to run a captured subprocess ``$()``.
 
 
 Normal Globbing

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -909,7 +909,7 @@ Other than the regex matching, this functions in the same way as normal
 globbing.  For more information, please see the documentation for the ``re``
 module in the Python standard library.
 
-.. warning:: This backtick syntax has very different from that of Bash.  In
+.. warning:: This backtick syntax has very different semantics from that of Bash.  In
              Bash, backticks mean to run a captured subprocess ``$()``.
 
 


### PR DESCRIPTION
to fix its grammar and increase its clarity