### PR TITLE
add weechat to default predictors (ncurses based)

### DIFF
--- a/news/command_cache_additions.rst
+++ b/news/command_cache_additions.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Added ``weechat`` to default predictors
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -281,6 +281,7 @@ def default_threadable_predictors():
         'view': predict_false,
         'vim': predict_false,
         'vimpager': predict_help_ver,
+        'weechat': predict_help_ver,
         'xo': predict_help_ver,
         'xonsh': predict_shell,
         'zsh': predict_shell,


### PR DESCRIPTION
this should fix weechat in xonsh, but the larger issues around ncurses based applications raised in #2056 remains