### PR TITLE
Tutorial: fix stdin handling in anonymous aliases

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -504,7 +504,7 @@ result is automatically converted to a string. For example,
     4
     >>> echo @([42, 'yo'])
     42 yo
-    >>> echo "hello" | @(lambda a, s=None: s.strip() + " world\n")
+    >>> echo "hello" | @(lambda a, s=None: s.read().strip() + " world\n")
     hello world
 
 This syntax can be used inside of a captured or uncaptured subprocess, and can
@@ -1256,7 +1256,7 @@ as aliases, by wrapping them in ``@()``.  For example:
 
     >>> @(_banana)
     'My spoon is tooo big!'
-    >>> echo "hello" | @(lambda args, stdin=None: stdin.strip() + args[0]) world
+    >>> echo "hello" | @(lambda args, stdin=None: ' '.join([stdin.read().strip(), *args]) + '\n') world
     hello world
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1256,7 +1256,7 @@ as aliases, by wrapping them in ``@()``.  For example:
 
     >>> @(_banana)
     'My spoon is tooo big!'
-    >>> echo "hello" | @(lambda args, stdin=None: ' '.join([stdin.read().strip(), *args]) + '\n') world
+    >>> echo "hello" | @(lambda args, stdin=None: stdin.read().strip() + ' ' + args[0] + '\n') world
     hello world
 
 


### PR DESCRIPTION
In Xonsh 0.5.1, an alias function's `stdin` argument receives a `_io.TextIOWrapper` object, which cannot be stripped or be treated as a string as-is. We have to `.read()` it first and then `.strip()` the resulting string instead.

Also, fix the second lambda to output the space and EOL correctly.