### PR TITLE
History fix - use tss instead of buffer

### DIFF
--- a/news/hist-tss-fix.rst
+++ b/news/hist-tss-fix.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed an issue that using sqlite history backend does not kill unfinished
+  jobs when quitting xonsh with a second "exit".
+
+**Security:** None

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -277,8 +277,8 @@ def clean_jobs():
         if builtins.__xonsh_all_jobs__:
             global _last_exit_time
             hist = builtins.__xonsh_history__
-            if hist is not None and hist.buffer:
-                last_cmd_start = builtins.__xonsh_history__.buffer[-1]['ts'][0]
+            if hist is not None and len(hist.tss) > 0:
+                last_cmd_start = hist.tss[-1][0]
             else:
                 last_cmd_start = None
 


### PR DESCRIPTION
Fixed an issue with sqlite history backend that a second "exit" do not kill all the unfinished jobs when exiting xonsh.

Very minor one, so I guess no news items is needed.