### PR TITLE
Add elision char at the end of cwd when the last dir is shortened

### DIFF
--- a/news/elision_char_at_the_end_of_last.rst
+++ b/news/elision_char_at_the_end_of_last.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* When ``$DYNAMIC_CWD_ELISION_CHAR`` is non empty and the last dir of cwd is too
+  long and shortened, the elision char is added at the end.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/prompt/cwd.py
+++ b/xonsh/prompt/cwd.py
@@ -80,5 +80,6 @@ def _dynamically_collapsed_pwd():
         # if there is not even a single separator we still
         # want to display at least the beginning of the directory
         if full.find(sep) == -1:
-            full = (truncature_char + sep + last)[0:int(target_width)]
+            full = (truncature_char + sep +
+                    last)[0:int(target_width) - len(truncature_char)] + truncature_char
     return full


### PR DESCRIPTION
With ``$DYNAMIC_CWD_ELISION_CHAR='…'``

Before:
```
jben@germinale /tmp $ mkdir i_love_writing_a_lot_of_useless_things_in_directory_names
jben@germinale /tmp $ cd i_love_writing_a_lot_of_useless_things_in_directory_names/
jben@germinale …/i_love_writing_a_lot_of_usele $                            
```
After:
```
jben@germinale /tmp $ mkdir i_love_writing_a_lot_of_useless_things_in_directory_names
jben@germinale /tmp $ cd i_love_writing_a_lot_of_useless_things_in_directory_names/
jben@germinale …/i_love_writing_a_lot_of_usel… $                            
```

[edit]: I had inverted before and after.