### PR TITLE
[RFC] Events keywords

### DIFF
--- a/docs/tutorial_events.rst
+++ b/docs/tutorial_events.rst
@@ -22,12 +22,15 @@ This will add a line to a file every time the current directory changes (due to 
 or several other commands)::
 
     @events.on_chdir
-    def add_to_file(newdir):
+    def add_to_file(olddir, newdir, **kw):
         with open(g`~/.dirhist`[0], 'a') as dh:
             print(newdir, file=dh)
 
 The exact arguments passed and returns expected vary from event to event; see the 
 `event list <events.html>`_ for the details.
+
+Note that the event system is keyword only. Event handlers must match argument names and must have a
+``**kw`` as protection against future changes.
 
 Can I use this, too?
 ====================

--- a/news/events-keywords.rst
+++ b/news/events-keywords.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Events are now keyword arguments only
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_base_shell.py
+++ b/tests/test_base_shell.py
@@ -27,7 +27,7 @@ def test_pwd_tracks_cwd(xonsh_builtins, xonsh_execer, tmpdir_factory, monkeypatc
 
 def test_transform(xonsh_builtins):
     @xonsh_builtins.events.on_transform_command
-    def spam2egg(cmd):
+    def spam2egg(cmd, **_):
         if cmd == 'spam':
             return 'egg'
         else:

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -75,9 +75,9 @@ def test_cdpath_events(xonsh_builtins, tmpdir):
 
     ev = None
     @xonsh_builtins.events.on_chdir
-    def handler(old, new):
+    def handler(olddir, newdir, **kw):
         nonlocal ev
-        ev = old, new
+        ev = olddir, newdir
 
     old_dir = os.getcwd()
     try:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,7 +13,7 @@ def test_event_calling(events):
     called = False
 
     @events.on_test
-    def _(spam):
+    def _(spam, **_):
         nonlocal called
         called = spam
 
@@ -26,13 +26,13 @@ def test_event_returns(events):
     called = 0
 
     @events.on_test
-    def on_test():
+    def on_test(**_):
         nonlocal called
         called += 1
         return 1
 
     @events.on_test
-    def second():
+    def second(**_):
         nonlocal called
         called += 1
         return 2
@@ -47,7 +47,7 @@ def test_validator(events):
     called = None
 
     @events.on_test
-    def first(n):
+    def first(n, **_):
         nonlocal called
         called += 1
         return False
@@ -57,7 +57,7 @@ def test_validator(events):
         return n == 'spam'
 
     @events.on_test
-    def second(n):
+    def second(n, **_):
         nonlocal called
         called += 1
         return False
@@ -83,7 +83,7 @@ def test_transmogrify(events):
     events.doc('on_test', docstring)
 
     @events.on_test
-    def func():
+    def func(**_):
         pass
 
     assert isinstance(events.on_test, Event)
@@ -102,7 +102,7 @@ def test_transmogrify_by_string(events):
     events.doc('on_test', docstring)
 
     @events.on_test
-    def func():
+    def func(**_):
         pass
 
     assert isinstance(events.on_test, Event)
@@ -121,7 +121,7 @@ def test_load(events):
     called = 0
 
     @events.on_test
-    def on_test():
+    def on_test(**_):
         nonlocal called
         called += 1
 
@@ -131,7 +131,7 @@ def test_load(events):
     assert called == 1
 
     @events.on_test
-    def second():
+    def second(**_):
         nonlocal called
         called += 1
 
@@ -142,7 +142,7 @@ def test_load_2nd_call(events):
     called = 0
 
     @events.on_test
-    def on_test():
+    def on_test(**_):
         nonlocal called
         called += 1
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -17,7 +17,7 @@ def test_event_calling(events):
         nonlocal called
         called = spam
 
-    events.on_test.fire("eggs")
+    events.on_test.fire(spam="eggs")
 
     assert called == "eggs"
 
@@ -63,11 +63,11 @@ def test_validator(events):
         return False
 
     called = 0
-    events.on_test.fire('egg')
+    events.on_test.fire(n='egg')
     assert called == 1
 
     called = 0
-    events.on_test.fire('spam')
+    events.on_test.fire(n='spam')
     assert called == 2
 
 

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -20,12 +20,12 @@ def test_crud(xonsh_builtins, tmpdir):
     last_event = None
 
     @xonsh_builtins.events.vox_on_create
-    def create(name):
+    def create(name, **_):
         nonlocal last_event
         last_event = 'create', name
 
     @xonsh_builtins.events.vox_on_delete
-    def delete(name):
+    def delete(name, **_):
         nonlocal last_event
         last_event = 'delete', name
 
@@ -59,12 +59,12 @@ def test_activate(xonsh_builtins, tmpdir):
     last_event = None
 
     @xonsh_builtins.events.vox_on_activate
-    def activate(name):
+    def activate(name, **_):
         nonlocal last_event
         last_event = 'activate', name
 
     @xonsh_builtins.events.vox_on_deactivate
-    def deactivate(name):
+    def deactivate(name, **_):
         nonlocal last_event
         last_event = 'deactivate', name
 

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -309,7 +309,7 @@ class BaseShell(object):
         if code is None:
             return
 
-        events.on_precommand.fire(src)
+        events.on_precommand.fire(cmd=src)
 
         env = builtins.__xonsh_env__
         hist = builtins.__xonsh_history__  # pylint: disable=no-member

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -372,7 +372,7 @@ class BaseShell(object):
             builtins.__xonsh_env__['PWD'] = cwd      # track it now
             if old is not None:
                 builtins.__xonsh_env__['OLDPWD'] = old  # and update $OLDPWD like dirstack.
-            events.on_chdir.fire(old, cwd)              # fire event after cwd actually changed.
+            events.on_chdir.fire(olddir=old, newdir=cwd)              # fire event after cwd actually changed.
 
     def push(self, line):
         """Pushes a line onto the buffer and compiles the code in a way that

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -355,10 +355,10 @@ class BaseShell(object):
         else:
             info['out'] = tee_out + '\n' + last_out
         events.on_postcommand.fire(
-            info['inp'],
-            info['rtn'],
-            info.get('out', None),
-            info['ts']
+            cmd=info['inp'],
+            rtn=info['rtn'],
+            out=info.get('out', None),
+            ts=info['ts']
             )
         if hist is not None:
             hist.append(info)

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -149,7 +149,7 @@ def _change_working_directory(newdir):
 
     # Fire event if the path actually changed
     if old != env['PWD']:
-        events.on_chdir.fire(old, env['PWD'])
+        events.on_chdir.fire(olddir=old, newdir=env['PWD'])
 
 
 def _try_cdpath(apath):

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -26,6 +26,7 @@ def debug_level():
     else:
         return 0  # Optimize for speed, not guarenteed correctness
 
+
 class AbstractEvent(collections.abc.MutableSet, abc.ABC):
     """
     A given event that handlers can register against.

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -16,7 +16,7 @@ from xonsh.tools import print_exception
 
 
 def has_kwargs(func):
-    return any(p.kind == inspect.VAR_KEYWORD for p in inspect.signature(func).parameters.values())
+    return any(p.kind == p.VAR_KEYWORD for p in inspect.signature(func).parameters.values())
 
 
 def debug_level():

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -48,7 +48,12 @@ class PromptToolkitShell(BaseShell):
         self.key_bindings_manager = KeyBindingManager(**key_bindings_manager_args)
         load_xonsh_bindings(self.key_bindings_manager)
         # This assumes that PromptToolkitShell is a singleton
-        events.on_ptk_create.fire(self.prompter, self.history, self.pt_completer, self.key_bindings_manager)
+        events.on_ptk_create.fire(
+            prompter=self.prompter,
+            history=self.history,
+            completer=self.pt_completer,
+            bindings=self.key_bindings_manager,
+        )
 
     def singleline(self, store_in_history=True, auto_suggest=None,
                    enable_history_search=True, multiline=True, **kwargs):

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -38,7 +38,7 @@ Fires just before a command is executed.
 events.doc('on_postcommand', """
 on_postcommand(cmd: str, rtn: int, out: str or None, ts: list) -> None
 
-Fires just after a command is executed.
+Fires just after a command is executed. The arguments are the same as history.
 """)
 
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -50,7 +50,7 @@ def transform_command(src, show_diff=True):
     raw = src
     while src != lst:
         lst = src
-        srcs = events.on_transform_command.fire(src)
+        srcs = events.on_transform_command.fire(cmd=src)
         for s in srcs:
             if s != lst:
                 src = s

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -2,7 +2,7 @@
 
 
 @events.on_transform_command
-def bash_preproc(cmd):
+def bash_preproc(cmd, **kw):
     if not __xonsh_history__.inps:
         if cmd.strip() == '!!':
             return ''

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -143,7 +143,7 @@ class Vox(collections.abc.Mapping):
             env_path,
             system_site_packages=system_site_packages, symlinks=symlinks,
             with_pip=with_pip)
-        events.vox_on_create.fire(name)
+        events.vox_on_create.fire(name=name)
 
     def upgrade(self, name, *, symlinks=False, with_pip=True):
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
@@ -288,7 +288,7 @@ class Vox(collections.abc.Mapping):
         if 'PYTHONHOME' in env:
             type(self).oldvars['PYTHONHOME'] = env.pop('PYTHONHOME')
 
-        events.vox_on_activate.fire(name)
+        events.vox_on_activate.fire(name=name)
 
     def deactivate(self):
         """
@@ -307,7 +307,7 @@ class Vox(collections.abc.Mapping):
 
         env.pop('VIRTUAL_ENV')
 
-        events.vox_on_deactivate.fire(env_name)
+        events.vox_on_deactivate.fire(name=env_name)
         return env_name
 
     def __delitem__(self, name):
@@ -328,4 +328,4 @@ class Vox(collections.abc.Mapping):
             pass
         shutil.rmtree(env_path)
 
-        events.vox_on_delete.fire(name)
+        events.vox_on_delete.fire(name=name)


### PR DESCRIPTION
In discussing the future of command transformation, I realized that history backends might want to log the pre- and post-transformation commands. But changing the signature of `on_precommand` will break  existing users.

So, moving forward, I propose that events are keyword-argument only, and that all handlers have a `**kw` against future expansion. (There is precedent for this. Django--and the PyDispatch it was based on--does the same thing.)

* [x] Implement in core usage
* [x] Update documentation
* [x] News