### PR TITLE
Add a vox custom prompt section

### DIFF
--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -74,3 +74,16 @@ To see all available commands, run ``vox help``, ``vox --help``, or ``vox -h``::
 
         vox help (-h, --help)
             Show help
+
+
+``virtualenv`` like prompt
+--------------------------
+Although it's included in the default prompt, you can customize your prompt
+to automatically update in the same way as ``virtualenv``.
+
+Simply add the ``'{env_name}'`` variable to your ``$PROMPT``::
+
+    $PROMPT = '{env_name: {}}' + restofmyprompt
+
+Note that you do **not** need to load the ``vox`` xontrib for this to work.
+For more details see :ref:`customprompt`.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1338,6 +1338,8 @@ completion for the commands themselves.
 xonsh also provides a means of modifying the behavior of the tab completer.  More
 detail is available on the `Tab Completion page <tutorial_completers.html>`_.
 
+.. _customprompt:
+
 Customizing the Prompt
 ======================
 Customizing the prompt by modifying ``$PROMPT`` is probably the most common


### PR DESCRIPTION
Aids those of use who like custom prompts but also want the same
prompt behaviour as `virtualenv`.

Resolves #2090