### PR TITLE
add xontrib entry for click-tabcompleter

### DIFF
--- a/news/tabcomplete_for_click_apps.rst
+++ b/news/tabcomplete_for_click_apps.rst
@@ -1,4 +1,4 @@
-**Added:** None
+**Added:** 
 
 * Tab completion xontrib for python applications based on click framework.
 

--- a/news/tabcomplete_for_click_apps.rst
+++ b/news/tabcomplete_for_click_apps.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+* Tab completion xontrib for python applications based on click framework.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -71,6 +71,11 @@
   "url": "https://github.com/Granitas/xonsh-vox-tabcomplete",
   "description": ["Adds tabcomplete functionality to vox inside of xonsh."]
  },
+ {"name": "click_tabcomplete",
+  "package": "xonsh-click-tabcomplete",
+  "url": "https://github.com/Granitas/xonsh-click-tabcomplete",
+  "description": ["Adds tabcomplete functionality to click based python applications inside of xonsh."]
+ },
  {"name": "xo",
   "package": "exofrills",
   "url": "https://github.com/scopatz/xo",

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -160,13 +160,15 @@
    "url": "https://github.com/Granitosaurus/xonsh-vox-tabcomplete",
    "install": {
     "pip": "pip install xonsh-vox-tabcomplete"
-   },
+   }
+  },
   "xonsh-click-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
    "install": {
     "pip": "pip install xonsh-click-tabcomplete"
-   },
+   }
+  },
   "xonsh-autoxsh": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-autoxsh",

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -68,13 +68,8 @@
   },
  {"name": "vox_tabcomplete",
   "package": "xonsh-vox-tabcomplete",
-  "url": "https://github.com/Granitas/xonsh-vox-tabcomplete",
+  "url": "https://github.com/Granitosaurus/xonsh-vox-tabcomplete",
   "description": ["Adds tabcomplete functionality to vox inside of xonsh."]
- },
- {"name": "click_tabcomplete",
-  "package": "xonsh-click-tabcomplete",
-  "url": "https://github.com/Granitas/xonsh-click-tabcomplete",
-  "description": ["Adds tabcomplete functionality to click based python applications inside of xonsh."]
  },
  {"name": "xo",
   "package": "exofrills",
@@ -108,6 +103,11 @@
   "package": "xontrib-prompt-vi-mode",
   "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
   "description": ["vi-mode status formatter for xonsh prompt"]
+ },
+ {"name": "click_tabcomplete",
+  "package": "xonsh-click-tabcomplete",
+  "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
+  "description": ["Adds tabcomplete functionality to click based python applications inside of xonsh."]
  }
  ],
  "packages": {
@@ -157,9 +157,15 @@
    },
   "xonsh-vox-tabcomplete": {
    "license": "GPLv3",
-   "url": "https://github.com/Granitas/xonsh-vox-tabcomplete",
+   "url": "https://github.com/Granitosaurus/xonsh-vox-tabcomplete",
    "install": {
     "pip": "pip install xonsh-vox-tabcomplete"
+   },
+  "xonsh-click-tabcomplete": {
+   "license": "GPLv3",
+   "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
+   "install": {
+    "pip": "pip install xonsh-click-tabcomplete"
    }
   },
   "xonsh-autoxsh": {

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -166,8 +166,7 @@
    "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
    "install": {
     "pip": "pip install xonsh-click-tabcomplete"
-   }
-  },
+   },
   "xonsh-autoxsh": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-autoxsh",


### PR DESCRIPTION
Hi,

I've made a generic tabcompleter for applications based on [click](http://click.pocoo.org/5/) command line interface framework, which seems to be very popular for newer python applications.

Pypi: https://pypi.python.org/pypi?name=xonsh-click-tabcomplete
Github: https://github.com/Granitosaurus/xonsh-click-tabcomplete