### PR TITLE
pin mpl to 1.5.3 for tests

### DIFF
--- a/.circle_miniconda.sh
+++ b/.circle_miniconda.sh
@@ -1,10 +1,10 @@
 if [[ $CIRCLE_NODE_INDEX == 0 ]]
 then
-    conda create -q -n test_env python=3.4 pygments prompt_toolkit ply pytest pytest-timeout psutil numpy matplotlib
+    conda create -q -n test_env python=3.4 pygments prompt_toolkit ply pytest pytest-timeout psutil numpy matplotlib=1.5.3
 fi
 
 
 if [[ $CIRCLE_NODE_INDEX == 1 ]]
 then
-    conda create -q -n test_env python=3.5 pygments prompt_toolkit ply pytest pytest-timeout psutil numpy matplotlib
+    conda create -q -n test_env python=3.5 pygments prompt_toolkit ply pytest pytest-timeout psutil numpy matplotlib=1.5.3
 fi


### PR DESCRIPTION
Pinning matplotlib to 1.5.3 avoids the test failures on CircleCI for now. We'll have to update the `mpl` xontrib to work with matplotlib v2.0 soon