### PR TITLE
Add `xip` alias

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -126,6 +126,12 @@ Provides an interface to printing lines of source code prior to their execution.
 .. command-help:: xonsh.tracer.tracermain
 
 
+``xip``
+=================
+Runs the ``pip`` package manager for xonsh itself. Useful for installations where xonsh is in an
+isolated environment (eg homebrew). Pronounced "kip".
+
+
 ``xonfig``
 =================
 Manages xonsh configuration information.

--- a/news/xip.rst
+++ b/news/xip.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Add alias ``xip`` ("kip") so that xonsh's Python environment (whatever that is) can be modified.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -410,7 +410,8 @@ def make_default_aliases():
         'ipynb': ['jupyter', 'notebook', '--no-browser'],
         'which': xxw.which,
         'xontrib': xontribs_main,
-        'completer': xca.completer_alias
+        'completer': xca.completer_alias,
+        'xip': [sys.executable, '-m', 'pip'],
     }
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -387,14 +387,18 @@ def detect_xip_alias():
     if not getattr(sys, 'executable', None):
         return lambda args, stdin=None: ("", "Sorry, unable to run pip on your system (missing sys.executable)", 1)
 
+    basecmd = [sys.executable, '-m', 'pip']
     try:
-        if not os.access(os.path.dirname(sys.executable), os.W_OK):
-            return ['sudo', sys.executable, '-m', 'pip']
+        if ON_WINDOWS:
+            # XXX: Does windows have an installation mode that requires UAC?
+            return basecmd
+        elif not os.access(os.path.dirname(sys.executable), os.W_OK):
+            return ['sudo', *basecmd]
         else:
-            return [sys.executable, '-m', 'pip']
+            return basecmd
     except Exception:
         # Something freaky happened, return something that'll probably work
-        return [sys.executable, '-m', 'pip']
+        return basecmd
 
 
 def make_default_aliases():

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -380,6 +380,23 @@ def showcmd(args, stdin=None):
         sys.displayhook(args)
 
 
+def detect_xip_alias():
+    """
+    Determines the correct invokation to get xonsh's pip
+    """
+    if not getattr(sys, 'executable', None):
+        return lambda args, stdin=None: ("", "Sorry, unable to run pip on your system (missing sys.executable)", 1)
+
+    try:
+        if not os.access(os.path.dirname(sys.executable), os.W_OK):
+            return ['sudo', sys.executable, '-m', 'pip']
+        else:
+            return [sys.executable, '-m', 'pip']
+    except Exception:
+        # Something freaky happened, return something that'll probably work
+        return [sys.executable, '-m', 'pip']
+
+
 def make_default_aliases():
     """Creates a new default aliases dictionary."""
     default_aliases = {
@@ -411,7 +428,7 @@ def make_default_aliases():
         'which': xxw.which,
         'xontrib': xontribs_main,
         'completer': xca.completer_alias,
-        'xip': [sys.executable, '-m', 'pip'],
+        'xip': detect_xip_alias(),
     }
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -393,7 +393,7 @@ def detect_xip_alias():
             # XXX: Does windows have an installation mode that requires UAC?
             return basecmd
         elif not os.access(os.path.dirname(sys.executable), os.W_OK):
-            return ['sudo', *basecmd]
+            return ['sudo'] + basecmd
         else:
             return basecmd
     except Exception:


### PR DESCRIPTION
Allows easily calling `pip` for xonsh itself. Fixes #2110.

* [x] Automatically call `sudo` if needed.
* [ ] Tests