### PR TITLE
Added jedi completions

### DIFF
--- a/news/jedi.rst
+++ b/news/jedi.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Added jedi completion to Python-mode completions.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/completers/__init__.py
+++ b/xonsh/completers/__init__.py
@@ -8,6 +8,8 @@ else:
         from xonsh.completers import __amalgam__
         completer = __amalgam__
         _sys.modules['xonsh.completers.completer'] = __amalgam__
+        jedi = __amalgam__
+        _sys.modules['xonsh.completers.jedi'] = __amalgam__
         pip = __amalgam__
         _sys.modules['xonsh.completers.pip'] = __amalgam__
         tools = __amalgam__

--- a/xonsh/completers/dirs.py
+++ b/xonsh/completers/dirs.py
@@ -1,3 +1,4 @@
+"""Completers for directory commands such as cd and rmdir."""
 from xonsh.completers.man import complete_from_man
 from xonsh.completers.path import complete_dir
 

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -6,6 +6,7 @@ from xonsh.completers.man import complete_from_man
 from xonsh.completers.bash import complete_from_bash
 from xonsh.completers.base import complete_base
 from xonsh.completers.path import complete_path
+from xonsh.completers.jedi import complete_jedi
 from xonsh.completers.dirs import complete_cd, complete_rmdir
 from xonsh.completers.python import (complete_python, complete_import,
                                      complete_python_mode)
@@ -19,6 +20,7 @@ def default_completers():
     return collections.OrderedDict([
         ('python_mode', complete_python_mode),
         ('base', complete_base),
+        ('jedi', complete_jedi),
         ('completer', complete_completer),
         ('skip', complete_skipper),
         ('pip', complete_pip),

--- a/xonsh/completers/jedi.py
+++ b/xonsh/completers/jedi.py
@@ -1,0 +1,18 @@
+"""Jedi-based completer for Python-mode."""
+import builtins
+
+import xonsh.platform as xp
+import xonsh.lazyimps as xlimps
+
+
+def complete_jedi(prefix, line, start, end, ctx):
+    """Jedi-based completer for Python-mode."""
+    if not xp.HAS_JEDI:
+        return set()
+    script = xlimps.jedi.api.Interpreter(line, [ctx], column=end)
+    if builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS'):
+        rtn = {x.name_with_symbols for x in script.completions()
+               if x.name_with_symbols.startswith(prefix)}
+    else:
+        rtn = {x.name_with_symbols for x in script.completions()}
+    return rtn

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -8,8 +8,10 @@ import collections.abc as cabc
 
 import xonsh.tools as xt
 import xonsh.lazyasd as xl
+import xonsh.platform as xp
 
 from xonsh.completers.tools import get_filter_function
+from xonsh.completers.jedi import complete_jedi
 
 
 @xl.lazyobject
@@ -63,6 +65,7 @@ def _complete_python(prefix, line, start, end, ctx):
             rtn |= attr_complete(prefix, ctx, filt)
         rtn |= {s for s in ctx if filt(s, prefix)}
     rtn |= {s for s in dir(builtins) if filt(s, prefix)}
+    rtn |= complete_jedi(prefix, line, start, end, ctx)
     return rtn
 
 
@@ -73,7 +76,7 @@ def complete_python_mode(prefix, line, start, end, ctx):
     if not (prefix.startswith('@(') or prefix.startswith('${')):
         return set()
     prefix_start = prefix[:2]
-    python_matches = complete_python(prefix[2:], line, start+2, end, ctx)
+    python_matches = complete_python(prefix[2:], line, start-2, end-2, ctx)
     if isinstance(python_matches, cabc.Sequence):
         python_matches = python_matches[0]
     return set(prefix_start + i for i in python_matches)

--- a/xonsh/lazyimps.py
+++ b/xonsh/lazyimps.py
@@ -1,7 +1,7 @@
 """Lazy imports that may apply across the xonsh package."""
 import importlib
 
-from xonsh.platform import ON_WINDOWS
+from xonsh.platform import ON_WINDOWS, HAS_JEDI
 from xonsh.lazyasd import LazyObject, lazyobject
 
 pygments = LazyObject(lambda: importlib.import_module('pygments'),
@@ -72,3 +72,12 @@ def winutils():
 @lazyobject
 def terminal256():
     return importlib.import_module('pygments.formatters.terminal256')
+
+
+@lazyobject
+def jedi():
+    if HAS_JEDI:
+        import jedi as m
+    else:
+        m = None
+    return m

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -90,6 +90,25 @@ def pygments_version():
     return v
 
 
+
+@lazybool
+def HAS_JEDI():
+    """``True`` if `jedi` is available, else ``False``."""
+    spec = importlib.util.find_spec('jedi')
+    return (spec is not None)
+
+
+@functools.lru_cache(1)
+def jedi_version():
+    """jedi.__version__ version if available, else None."""
+    if HAS_JEDI:
+        import jedi
+        v = jedi.__version__
+    else:
+        v = None
+    return v
+
+
 @functools.lru_cache(1)
 def has_prompt_toolkit():
     """ Tests if the `prompt_toolkit` is available. """

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -19,8 +19,9 @@ import xonsh.wizard as wiz
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.prompt.base import is_template_string
 from xonsh.platform import (is_readline_available, ptk_version,
-                            PYTHON_VERSION_INFO, pygments_version, ON_POSIX, ON_LINUX, linux_distro,
-                            ON_DARWIN, ON_WINDOWS, ON_CYGWIN, DEFAULT_ENCODING, githash)
+                            PYTHON_VERSION_INFO, pygments_version, ON_POSIX,
+                            ON_LINUX, linux_distro, ON_DARWIN, ON_WINDOWS,
+                            ON_CYGWIN, DEFAULT_ENCODING, githash, jedi_version)
 from xonsh.tools import (to_bool, is_string, print_exception, is_superuser,
                          color_style_names, print_color, color_style)
 from xonsh.xontribs import xontrib_metadata, find_xontrib
@@ -357,6 +358,7 @@ def _info(ns):
         ('prompt toolkit', ptk_version() or None),
         ('shell type', env.get('SHELL_TYPE')),
         ('pygments', pygments_version()),
+        ('jedi', jedi_version()),
         ('on posix', bool(ON_POSIX)),
         ('on linux', ON_LINUX),
     ])


### PR DESCRIPTION
This is an attempt to satisfy #344.  However, I am not sure that it really should go in (yet?) for a couple of reasons. 

1. Jedi seems super slow (like 15 ms for simple completions). I think this might be because it is built for a use case when there is a file being edited.  

2. The interpreter interface seems like an afterthought and somewhat buggy. For example if you dynamically define a function, jedi doesn't seem like it can complete kwargs from that function.

3. The only thing we really get from jedi is the function parameter names. Imports, attribute access, etc, we have other tools for.

All things said, I think this is a lot of extra parsing and another optional dependency for not a whole lot of differential value. Also it is hard/annoying to put this in a xontrib since to even get that differential value it has to hook into xonsh's existing python completer.

I think we could do better ourselves with a judicious use of inspect and `__xonsh_ctx__`. Let's keep this open, though, until we have an alternative.