### PR TITLE
ignore vc aliases in command_cache

### DIFF
--- a/news/vc_alias_fix.rst
+++ b/news/vc_alias_fix.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed issue wherein if ``git`` or (presumably) ``hg`` are aliased, then branch
+  information no longer appears in the ``$PROMPT``
+
+**Security:** None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -14,7 +14,11 @@ import collections.abc as cabc
 
 from xonsh.platform import ON_WINDOWS, ON_POSIX, pathbasename
 from xonsh.tools import executables_in
-from xonsh.lazyasd import lazyobject
+from xonsh.lazyasd import lazyobject, LazyObject
+
+
+IGNORE_ALIAS_CMDS = LazyObject(lambda: frozenset(['git', 'hg']), globals(),
+                               'IGNORE_ALIAS_CMDS')
 
 
 class CommandsCache(cabc.Mapping):
@@ -104,6 +108,11 @@ class CommandsCache(cabc.Mapping):
             if cmd not in allcmds:
                 key = cmd.upper() if ON_WINDOWS else cmd
                 allcmds[key] = (cmd, True)
+        for key in IGNORE_ALIAS_CMDS:
+            if key in allcmds:
+                key = key.upper() if ON_WINDOWS else key
+                pathkey, _ = allcmds[key]
+                allcmds[key] = (pathkey, False)
         self._cmds_cache = allcmds
         return allcmds
 

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -14,11 +14,7 @@ import collections.abc as cabc
 
 from xonsh.platform import ON_WINDOWS, ON_POSIX, pathbasename
 from xonsh.tools import executables_in
-from xonsh.lazyasd import lazyobject, LazyObject
-
-
-IGNORE_ALIAS_CMDS = LazyObject(lambda: frozenset(['git', 'hg']), globals(),
-                               'IGNORE_ALIAS_CMDS')
+from xonsh.lazyasd import lazyobject
 
 
 class CommandsCache(cabc.Mapping):
@@ -83,7 +79,7 @@ class CommandsCache(cabc.Mapping):
         cache_valid = path_hash == self._path_checksum
         self._path_checksum = path_hash
         # did aliases change?
-        alss = getattr(builtins, 'aliases', set())
+        alss = getattr(builtins, 'aliases', dict())
         al_hash = hash(frozenset(alss))
         cache_valid = cache_valid and al_hash == self._alias_checksum
         self._alias_checksum = al_hash
@@ -103,16 +99,11 @@ class CommandsCache(cabc.Mapping):
             # entries at the back.
             for cmd in executables_in(path):
                 key = cmd.upper() if ON_WINDOWS else cmd
-                allcmds[key] = (os.path.join(path, cmd), cmd in alss)
+                allcmds[key] = (os.path.join(path, cmd), alss.get(key, None))
         for cmd in alss:
             if cmd not in allcmds:
                 key = cmd.upper() if ON_WINDOWS else cmd
-                allcmds[key] = (cmd, True)
-        for key in IGNORE_ALIAS_CMDS:
-            if key in allcmds:
-                key = key.upper() if ON_WINDOWS else key
-                pathkey, _ = allcmds[key]
-                allcmds[key] = (pathkey, False)
+                allcmds[key] = (cmd, None)
         self._cmds_cache = allcmds
         return allcmds
 
@@ -151,14 +142,32 @@ class CommandsCache(cabc.Mapping):
         """A lazy value getter."""
         return self._cmds_cache.get(self.cached_name(key), default)
 
-    def locate_binary(self, name):
-        """Locates an executable on the file system using the cache."""
+    def locate_binary(self, name, ignore_alias=False):
+        """Locates an executable on the file system using the cache.
+
+        Arguments
+        ---------
+        name : str
+                name of binary to search for
+        ignore_alias : bool, optional
+                Force return of binary path even if alias of ``name`` exists
+                (default ``False``)
+        """
         # make sure the cache is up to date by accessing the property
         _ = self.all_commands
-        return self.lazy_locate_binary(name)
+        return self.lazy_locate_binary(name, ignore_alias)
 
-    def lazy_locate_binary(self, name):
-        """Locates an executable in the cache, without checking its validity."""
+    def lazy_locate_binary(self, name, ignore_alias=False):
+        """Locates an executable in the cache, without checking its validity.
+
+        Arguments
+        ---------
+        name : str
+                name of binary to search for
+        ignore_alias : bool, optional
+                Force return of binary path even if alias of ``name`` exists
+                (default ``False``)
+        """
         possibilities = self.get_possible_names(name)
         if ON_WINDOWS:
             # Windows users expect to be able to execute files in the same
@@ -170,8 +179,11 @@ class CommandsCache(cabc.Mapping):
         cached = next((cmd for cmd in possibilities if cmd in self._cmds_cache),
                       None)
         if cached:
-            (path, is_alias) = self._cmds_cache[cached]
-            return path if not is_alias else None
+            (path, alias) = self._cmds_cache[cached]
+            if not alias or ignore_alias:
+                return path
+            else:
+                return None
         elif os.path.isfile(name) and name != pathbasename(name):
             return name
 

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -103,7 +103,7 @@ class CommandsCache(cabc.Mapping):
         for cmd in alss:
             if cmd not in allcmds:
                 key = cmd.upper() if ON_WINDOWS else cmd
-                allcmds[key] = (cmd, None)
+                allcmds[key] = (cmd, True)
         self._cmds_cache = allcmds
         return allcmds
 

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -123,11 +123,11 @@ def current_branch():
     cmds = builtins.__xonsh_commands_cache__
     # check for binary only once
     if cmds.is_empty():
-        has_git = bool(cmds.locate_binary('git'))
-        has_hg = bool(cmds.locate_binary('hg'))
+        has_git = bool(cmds.locate_binary('git', ignore_alias=True))
+        has_hg = bool(cmds.locate_binary('hg', ignore_alias=True))
     else:
-        has_git = bool(cmds.lazy_locate_binary('git'))
-        has_hg = bool(cmds.lazy_locate_binary('hg'))
+        has_git = bool(cmds.lazy_locate_binary('git', ignore_alias=True))
+        has_hg = bool(cmds.lazy_locate_binary('hg', ignore_alias=True))
     if has_git:
         branch = get_git_branch()
     if not branch and has_hg:


### PR DESCRIPTION
I don't *think* this will have any side effects.

When we build the ``$PROMPT``, we lazily check for ``git`` and ``hg``
binaries to see if we should generate a ``<branch>`` field.

At the same time ``lazy_locate_binary`` doesn't return the path to a
command if it detects that that command is an alias (since aliases won't
have a path).

In the case that ``git`` or ``hg`` is aliased (the specific case here
was replacing ``git`` with ``hub``), ``lazy_locate_binary`` will return
``None`` because the command is an alias.

This breaks the logic in the branch detection. We don't want to change
the logic in the branch detection since there are many potential impacts
on prompt generation speed, which makes for a bad user experience.

So, this is a mildly ugly hack, but it's the best option I could come up
with in order to preserve prompt speed and still keep the branch
information available for this slightly weird edge case.

I'm all ears to alternative solutions.

Should resolve #2135 