### PR TITLE
Make XONSH_HISTORY_BACKEND accept class type

### DIFF
--- a/news/hist-be-env.rst
+++ b/news/hist-be-env.rst
@@ -1,4 +1,4 @@
-**Added:** None
+**Added:**
 
 * The environment variable ``XONSH_HISTORY_BACKEND`` now also supports a
   value of class type.

--- a/news/hist-be-env.rst
+++ b/news/hist-be-env.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+* The environment variable ``XONSH_HISTORY_BACKEND`` now also supports a
+  value of class type.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/hist-be-env.rst
+++ b/news/hist-be-env.rst
@@ -1,7 +1,7 @@
 **Added:**
 
 * The environment variable ``XONSH_HISTORY_BACKEND`` now also supports a
-  value of class type.
+  value of class type or a History Backend instance.
 
 **Changed:** None
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests the json history backend."""
 # pylint: disable=protected-access
-import io
 import os
-import sys
 import shlex
 
 from xonsh.lazyjson import LazyJSON
+from xonsh.history.dummy import DummyHistory
 from xonsh.history.json import JsonHistory
-from xonsh.history.main import history_main, _xh_parse_args
+from xonsh.history.main import history_main, _xh_parse_args, construct_history
 
 import pytest
 
@@ -268,6 +267,20 @@ def test_parser_show(args, exp):
 def test_history_getitem(index, exp, hist, xonsh_builtins):
     xonsh_builtins.__xonsh_env__['HISTCONTROL'] = set()
     for ts,cmd in enumerate(CMDS):  # populate the shell history
-        hist.append({'inp': cmd, 'rtn': 0, 'ts':(ts+1, ts+1.5)})
-
+        hist.append({'inp': cmd, 'rtn': 0, 'ts':(ts + 1, ts + 1.5)})
     assert hist[index] == exp
+
+
+def test_construct_history_str(xonsh_builtins):
+    xonsh_builtins.__xonsh_env__['XONSH_HISTORY_BACKEND'] = 'dummy'
+    assert isinstance(construct_history(), DummyHistory)
+
+
+def test_construct_history_class(xonsh_builtins):
+    xonsh_builtins.__xonsh_env__['XONSH_HISTORY_BACKEND'] = DummyHistory
+    assert isinstance(construct_history(), DummyHistory)
+
+
+def test_construct_history_instance(xonsh_builtins):
+    xonsh_builtins.__xonsh_env__['XONSH_HISTORY_BACKEND'] = DummyHistory()
+    assert isinstance(construct_history(), DummyHistory)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -38,7 +38,7 @@ from xonsh.tools import (
     is_dynamic_cwd_width, to_dynamic_cwd_tuple, dynamic_cwd_tuple_to_str,
     is_logfile_opt, to_logfile_opt, logfile_opt_to_str, executables_in,
     is_nonstring_seq_of_strings, pathsep_to_upper_seq,
-    seq_to_upper_pathsep, print_color
+    seq_to_upper_pathsep, print_color, is_history_backend, to_itself,
 )
 import xonsh.prompt.base as prompt
 
@@ -176,7 +176,7 @@ def DEFAULT_ENSURERS():
     'XONSH_DEBUG': (always_false, to_debug, bool_or_int_to_str),
     'XONSH_ENCODING': (is_string, ensure_string, ensure_string),
     'XONSH_ENCODING_ERRORS': (is_string, ensure_string, ensure_string),
-    'XONSH_HISTORY_BACKEND': (is_string_or_callable, ensure_string, ensure_string),
+    'XONSH_HISTORY_BACKEND': (is_history_backend, to_itself, ensure_string),
     'XONSH_HISTORY_FILE': (is_string, ensure_string, ensure_string),
     'XONSH_HISTORY_SIZE': (is_history_tuple, to_history_tuple, history_tuple_to_str),
     'XONSH_LOGIN': (is_bool, to_bool, bool_to_str),
@@ -937,6 +937,7 @@ class Env(cabc.MutableMapping):
         if not ensurer.validate(val):
             val = ensurer.convert(val)
         # existing envvars can have any value including None
+
         old_value = self._d[key] if key in self._d else self._no_value
         self._d[key] = val
         if self.detypeable(val):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -176,7 +176,7 @@ def DEFAULT_ENSURERS():
     'XONSH_DEBUG': (always_false, to_debug, bool_or_int_to_str),
     'XONSH_ENCODING': (is_string, ensure_string, ensure_string),
     'XONSH_ENCODING_ERRORS': (is_string, ensure_string, ensure_string),
-    'XONSH_HISTORY_BACKEND': (is_string, ensure_string, ensure_string),
+    'XONSH_HISTORY_BACKEND': (is_string_or_callable, ensure_string, ensure_string),
     'XONSH_HISTORY_FILE': (is_string, ensure_string, ensure_string),
     'XONSH_HISTORY_SIZE': (is_history_tuple, to_history_tuple, history_tuple_to_str),
     'XONSH_LOGIN': (is_bool, to_bool, bool_to_str),
@@ -679,8 +679,10 @@ def DEFAULT_DOCS():
         '* ``XONSH_GITSTATUS_BEHIND``: ``↓·``\n'
     ),
     'XONSH_HISTORY_BACKEND': VarDocs(
-        'Set which history backend to use. Options are: ``json``, '
-        '``sqlite``, and ``dummy``. default is ``json``.'),
+        "Set which history backend to use. Options are: 'json', "
+        "'sqlite', and 'dummy'. The default is 'json'. "
+        '``XONSH_HISTORY_BACKEND`` also accepts a class type that inherits '
+        'from ``xonsh.history.base.History``.'),
     'XONSH_HISTORY_FILE': VarDocs(
         'Location of history file (deprecated).',
         configurable=False, default="``~/.xonsh_history``"),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -682,7 +682,7 @@ def DEFAULT_DOCS():
         "Set which history backend to use. Options are: 'json', "
         "'sqlite', and 'dummy'. The default is 'json'. "
         '``XONSH_HISTORY_BACKEND`` also accepts a class type that inherits '
-        'from ``xonsh.history.base.History``.'),
+        'from ``xonsh.history.base.History``, or its instance.'),
     'XONSH_HISTORY_FILE': VarDocs(
         'Location of history file (deprecated).',
         configurable=False, default="``~/.xonsh_history``"),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -937,7 +937,6 @@ class Env(cabc.MutableMapping):
         if not ensurer.validate(val):
             val = ensurer.convert(val)
         # existing envvars can have any value including None
-
         old_value = self._d[key] if key in self._d else self._no_value
         self._d[key] = val
         if self.detypeable(val):

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -4,7 +4,6 @@ import argparse
 import builtins
 import datetime
 import functools
-import inspect
 import json
 import os
 import sys
@@ -30,7 +29,7 @@ def construct_history(**kwargs):
     backend = env.get('XONSH_HISTORY_BACKEND')
     if isinstance(backend, str) and backend in HISTORY_BACKENDS:
         kls_history = HISTORY_BACKENDS[backend]
-    elif inspect.isclass(backend):
+    elif xt.is_class(backend):
         kls_history = backend
     elif isinstance(backend, History):
         return backend

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -4,6 +4,7 @@ import argparse
 import builtins
 import datetime
 import functools
+import inspect
 import json
 import os
 import sys
@@ -26,7 +27,9 @@ def construct_history(**kwargs):
     """Construct the history backend object."""
     env = builtins.__xonsh_env__
     backend = env.get('XONSH_HISTORY_BACKEND')
-    if backend not in HISTORY_BACKENDS:
+    if inspect.isclass(backend):
+        kls_history = backend
+    elif backend not in HISTORY_BACKENDS:
         print('Unknown history backend: {}. Using JSON version'.format(
             backend), file=sys.stderr)
         kls_history = JsonHistory

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -9,6 +9,7 @@ import json
 import os
 import sys
 
+from xonsh.history.base import History
 from xonsh.history.dummy import DummyHistory
 from xonsh.history.json import JsonHistory
 from xonsh.history.sqlite import SqliteHistory
@@ -27,14 +28,16 @@ def construct_history(**kwargs):
     """Construct the history backend object."""
     env = builtins.__xonsh_env__
     backend = env.get('XONSH_HISTORY_BACKEND')
-    if inspect.isclass(backend):
+    if isinstance(backend, str) and backend in HISTORY_BACKENDS:
+        kls_history = HISTORY_BACKENDS[backend]
+    elif inspect.isclass(backend):
         kls_history = backend
-    elif backend not in HISTORY_BACKENDS:
+    elif isinstance(backend, History):
+        return backend
+    else:
         print('Unknown history backend: {}. Using JSON version'.format(
             backend), file=sys.stderr)
         kls_history = JsonHistory
-    else:
-        kls_history = HISTORY_BACKENDS[backend]
     return kls_history(**kwargs)
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -921,7 +921,7 @@ def to_bool(x):
 
 
 def to_itself(x):
-    """Do not do conversion, returns to itself."""
+    """No conversion, returns itself."""
     return x
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -819,6 +819,11 @@ def is_string_or_callable(x):
     return is_string(x) or is_callable(x)
 
 
+def is_class(x):
+    """Tests if something is a class"""
+    return isinstance(x, type)
+
+
 def always_true(x):
     """Returns True"""
     return True
@@ -913,6 +918,11 @@ def to_bool(x):
         return False if x.lower() in _FALSES else True
     else:
         return bool(x)
+
+
+def to_itself(x):
+    """Do not do conversion, returns to itself."""
+    return x
 
 
 def bool_to_str(x):
@@ -1238,6 +1248,11 @@ def is_history_tuple(x):
             x[1].lower() in CANON_HISTORY_UNITS):
         return True
     return False
+
+
+def is_history_backend(x):
+    """Tests if something is a valid history backend."""
+    return is_string(x) or is_class(x) or isinstance(x, object)
 
 
 def is_dynamic_cwd_width(x):


### PR DESCRIPTION
Just a POC. Will continue if direction is ok.

With some changes like this would [simplify code in xonshrc](https://github.com/xonsh/xonsh/pull/2138#issuecomment-276942858) if the users want to [write their own history backend](https://github.com/xonsh/xonsh/pull/2138#issuecomment-276942858).