### PR TITLE
Adding some tests back

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 flake8-max-line-length = 180
 flake8-ignore =
     *.py E122

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 flake8-max-line-length = 180
 flake8-ignore =
     *.py E122

--- a/tests/test_history_sqlite.py
+++ b/tests/test_history_sqlite.py
@@ -161,3 +161,25 @@ def test_histcontrol(hist, xonsh_builtins):
     assert '/bin/ls' == items[-1]['inp']
     assert 0 == items[-1]['rtn']
     assert -1 == hist.rtns[-1]
+
+
+@pytest.mark.parametrize('index, exp', [
+    (-1, ('grep from me', 'out', 0, (5, 6))),
+    (1, ('cat hello kitty', 'out', 0, (1, 2))),
+    (slice(1, 3), [('cat hello kitty', 'out', 0, (1, 2)),
+                   ('abc', 'out', 0, (2, 3))]),
+])
+def test_history_getitem(index, exp, hist, xonsh_builtins):
+    xonsh_builtins.__xonsh_env__['HISTCONTROL'] = set()
+    xonsh_builtins.__xonsh_env__['XONSH_STORE_STDOUT'] = True
+    attrs = ('inp', 'out', 'rtn', 'ts')
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        entry = {k: v for k, v in zip(attrs, [cmd, 'out', 0, (ts, ts + 1)])}
+        hist.append(entry)
+
+    entry = hist[index]
+    if isinstance(entry, list):
+        assert [(e.cmd, e.out, e.rtn, e.ts) for e in entry] == exp
+    else:
+        assert (entry.cmd, entry.out, entry.rtn, entry.ts) == exp


### PR DESCRIPTION
Adding some tests back, which was removed in #2109 (which, BTW, is a good one!)

Though it was the same test code for json and sqlite, but we need duplicate it in `test_history_sqlite.py` and `test_history.py` since they use different `hist` feature one for json and one for sqlite. Since there's two built-in backend, we have to cover them both :)

cc @laerus 