### PR TITLE
Allow the TTY to be insane if there is no shell

### DIFF
--- a/news/insane.rst
+++ b/news/insane.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed an issue with commands that background themselves (such as
+  ``gpg-connect-agent``) not being able to be run from within xonshrc.
+
+**Security:** None

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -171,7 +171,7 @@ else:
         # Return when there are no foreground active task
         if active_task is None:
             _give_terminal_to(_shell_pgrp)  # give terminal back to the shell
-            if backgrounded:
+            if backgrounded and hasattr(builtins, '__xonsh_shell__'):
                 # restoring sanity could probably be called whenever we return
                 # control to the shell. But it only seems to matter after a
                 # ^Z event. This *has* to be called after we give the terminal


### PR DESCRIPTION
See gitter discussion: https://gitter.im/xonsh/xonsh?at=5897635df045df0a220c2aa6