### PR TITLE
Timings between prompts

### DIFF
--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -295,7 +295,7 @@ def setup_timings():
         @events.on_post_prompt
         def timing_on_post_prompt(**kw):
             global _timings
-            _timings = {'on_post_prompt': 0.0}
+            _timings = {'on_post_prompt': clock()}
 
         @events.on_pre_prompt
         def timing_on_pre_prompt(**kw):


### PR DESCRIPTION
A small bug crept in yesterday that prevented the timings to used for commands etc. 

With this fixed, the timing feature can also be used to measure time between prompts:

```
snail@sea ~ $ x = $(echo "hallo world")
 Debug level: 0
|----------------|-----------|-----------|
|Event name      | Time (s)  | Delta (s) |
|----------------|-----------|-----------|
|on_post_prompt  |   0.000   |   0.000   |
|on_precommand   |   0.005   |   0.005   |
|on_postcommand  |   0.031   |   0.026   |
|on_pre_prompt   |   0.380   |   0.349   |
|----------------|-----------|-----------|
snail@sea ~ $
```
