### PR TITLE
[RFC] moved unthreadable etc decorators to tools

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1276,11 +1276,11 @@ Usually, callable alias commands will be run in a separate thread so that
 they may be run in the background.  However, some aliases may need to be
 executed on the thread that they were called from. This is mostly useful for
 debuggers and profilers. To make an alias run in the foreground, decorate its
-function with the ``xonsh.proc.unthreadable`` decorator.
+function with the ``xonsh.tools.unthreadable`` decorator.
 
 .. code-block:: python
 
-    from xonsh.proc import unthreadable
+    from xonsh.tools import unthreadable
 
     @unthreadable
     def _mycmd(args, stdin=None):
@@ -1297,12 +1297,12 @@ Thus the callable alias can't be captured without dire consequences (tm).
 To prevent this, you can declare a callable alias uncapturable. This is mostly
 useful for aliases that then open up text editors, pagers, or the like.
 To make an alias uncapturable, decorate its
-function with the ``xonsh.proc.uncapturable`` decorator. This is probably
+function with the ``xonsh.tools.uncapturable`` decorator. This is probably
 best used in conjunction with the ``unthreadable`` decorator.  For example:
 
 .. code-block:: python
 
-    from xonsh.proc import unthreadable, uncapturable
+    from xonsh.tools import unthreadable, uncapturable
 
     @uncapturable
     @unthreadable

--- a/news/move-tools.rst
+++ b/news/move-tools.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* Moved decorators ``unthreadable``, ``foreground``, ``uncapturable`` from
+  ``xonsh.proc`` to ``xonsh.tools``.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/move-tools.rst
+++ b/news/move-tools.rst
@@ -2,7 +2,7 @@
 
 **Changed:**
 
-* Moved decorators ``unthreadable``, ``foreground``, ``uncapturable`` from
+* Moved decorators ``unthreadable``, ``uncapturable`` from
   ``xonsh.proc`` to ``xonsh.tools``.
 
 **Deprecated:** None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -148,7 +148,7 @@ with open('tttt', 'w') as fp:
 """, '      1       3      24\n' if ON_WINDOWS else " 1  4 16 <stdin>\n", 0),
 # test unthreadable alias (which should trigger a ProcPoxy call)
 ("""
-from xonsh.proc import unthreadable
+from xonsh.tools import unthreadable
 
 @unthreadable
 def _f():

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -15,7 +15,7 @@ from xonsh.foreign_shells import foreign_shell_data
 from xonsh.jobs import jobs, fg, bg, clean_jobs
 from xonsh.platform import (ON_ANACONDA, ON_DARWIN, ON_WINDOWS, ON_FREEBSD,
                             ON_NETBSD)
-from xonsh.proc import foreground
+from xonsh.tools import foreground
 from xonsh.replay import replay_main
 from xonsh.timings import timeit_alias
 from xonsh.tools import argvquote, escape_windows_cmd_string, to_bool

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -15,7 +15,7 @@ from xonsh.foreign_shells import foreign_shell_data
 from xonsh.jobs import jobs, fg, bg, clean_jobs
 from xonsh.platform import (ON_ANACONDA, ON_DARWIN, ON_WINDOWS, ON_FREEBSD,
                             ON_NETBSD)
-from xonsh.tools import foreground
+from xonsh.tools import unthreadable
 from xonsh.replay import replay_main
 from xonsh.timings import timeit_alias
 from xonsh.tools import argvquote, escape_windows_cmd_string, to_bool
@@ -350,7 +350,7 @@ def xonfig(args, stdin=None):
     return xonfig_main(args)
 
 
-@foreground
+@unthreadable
 def trace(args, stdin=None):
     """Runs the xonsh tracer utility."""
     from xonsh.tracer import tracermain  # lazy import

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -31,6 +31,8 @@ from xonsh.tools import (redirect_stdout, redirect_stderr, print_exception,
 from xonsh.lazyasd import lazyobject, LazyObject
 from xonsh.jobs import wait_for_active_job
 from xonsh.lazyimps import fcntl, termios, _winapi, msvcrt, winutils
+# these decorators are imported for users back-compatible
+from xonsh.tools import unthreadable, foreground, uncapturable
 
 
 @lazyobject
@@ -1586,26 +1588,6 @@ class ProcProxy(object):
         while not hasattr(self, name):
             time.sleep(1e-7)
         return getattr(self, name)
-
-
-def unthreadable(f):
-    """Decorator that specifies that a callable alias should be run only
-    on the main thread process. This is often needed for debuggers and profilers.
-    """
-    f.__xonsh_threadable__ = False
-    return f
-
-
-foreground = unthreadable
-
-
-def uncapturable(f):
-    """Decorator that specifies that a callable alias should not be run with
-    any capturing. This is often needed if the alias call interactive subprocess,
-    like pagers and text editors.
-    """
-    f.__xonsh_capturable__ = False
-    return f
 
 
 @lazyobject

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -32,7 +32,7 @@ from xonsh.lazyasd import lazyobject, LazyObject
 from xonsh.jobs import wait_for_active_job
 from xonsh.lazyimps import fcntl, termios, _winapi, msvcrt, winutils
 # these decorators are imported for users back-compatible
-from xonsh.tools import unthreadable, foreground, uncapturable
+from xonsh.tools import unthreadable, foreground, uncapturable  # NOQA
 
 
 @lazyobject

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -32,7 +32,10 @@ from xonsh.lazyasd import lazyobject, LazyObject
 from xonsh.jobs import wait_for_active_job
 from xonsh.lazyimps import fcntl, termios, _winapi, msvcrt, winutils
 # these decorators are imported for users back-compatible
-from xonsh.tools import unthreadable, foreground, uncapturable  # NOQA
+from xonsh.tools import unthreadable, uncapturable  # NOQA
+
+# foreground has be deprecated
+foreground = unthreadable
 
 
 @lazyobject

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1773,3 +1773,24 @@ def columnize(elems, width=80, newline='\n'):
     lines = [row_t.format(row=row, w=colwidths) for row in
              itertools.zip_longest(*data, fillvalue='')]
     return lines
+
+
+def unthreadable(f):
+    """Decorator that specifies that a callable alias should be run only
+    on the main thread process. This is often needed for debuggers and
+    profilers.
+    """
+    f.__xonsh_threadable__ = False
+    return f
+
+
+foreground = unthreadable
+
+
+def uncapturable(f):
+    """Decorator that specifies that a callable alias should not be run with
+    any capturing. This is often needed if the alias call interactive
+    subprocess, like pagers and text editors.
+    """
+    f.__xonsh_capturable__ = False
+    return f

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1784,9 +1784,6 @@ def unthreadable(f):
     return f
 
 
-foreground = unthreadable
-
-
 def uncapturable(f):
     """Decorator that specifies that a callable alias should not be run with
     any capturing. This is often needed if the alias call interactive

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -1,6 +1,6 @@
 """Matplotlib xontribution."""
 
-from xonsh.proc import foreground as foreground
+from xonsh.tools import foreground
 
 __all__ = ()
 

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -1,11 +1,11 @@
 """Matplotlib xontribution."""
 
-from xonsh.tools import foreground
+from xonsh.tools import unthreadable
 
 __all__ = ()
 
 
-@foreground
+@unthreadable
 def mpl(args, stdin=None):
     """Hooks to matplotlib"""
     from xontrib.mplhooks import show


### PR DESCRIPTION
Moved decorators `unthreadable`, `foreground`, `uncapturable` from `xonsh.proc` to `xonsh.tools`. Because,

- Can reduce potential circle imports, since proc.py have more deps. (major reason)
- These decorators have no deps, and all one/two line of code, suitable in tools.py
- `xonsh.tools` is more suitable than `xonsh.proc` for using by xonsh itself or xonsh users

ideas?

cc @scopatz 