### PR TITLE
Xonsh startup loading refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tests/lexer_table.py
 tests/parser_table.py
 tests/lexer_test_table.py
 tests/parser_test_table.py
+tests/testfile
 build/
 dist/
 xonsh.egg-info/

--- a/news/lr.rst
+++ b/news/lr.rst
@@ -18,7 +18,11 @@
 * The ``--config-path`` command line option is now deprecated in favor of
   ``--rc``.
 
-**Removed:** None
+**Removed:**
+
+* ``xonsh.environ.DEFAULT_XONSHRC`` has been removed due to deprecation.
+  For this value, please check the environment instead, or call
+  ``xonsh.environ.default_xonshrc(env)``.
 
 **Fixed:** None
 

--- a/news/lr.rst
+++ b/news/lr.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* New ``--rc`` command line option allows users to specify paths to run control
+  files from the command line. This includes both xonsh-based and JSON-based
+  configuration.
+
+**Changed:**
+
+* ``$XONSHRC`` and related configuration variables now accept JSON-based
+  static configuration file names as elements. This unifies the two methods
+  of run control to a single entry point and loading system.
+* The ``xonsh.shell.Shell()`` class now requires that an Execer instance
+  be explicitly provided to its init method. This class is no longer
+  responsible for creating an execer an its deprendencies.
+
+**Deprecated:**
+
+* The ``--config-path`` command line option is now deprecated in favor of
+  ``--rc``.
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def xonsh_execer(monkeypatch):
     """Initiate the Execer with a mocked nop `load_builtins`"""
     monkeypatch.setattr(xonsh.built_ins, 'load_builtins',
                         lambda *args, **kwargs: None)
-    execer = Execer(login=False, unload=False)
+    execer = Execer(unload=False)
     builtins.__xonsh_execer__ = execer
     return execer
 
@@ -74,19 +74,28 @@ def xonsh_builtins(xonsh_events):
     # be firing events on the global instance.
     builtins.events = xonsh_events
     yield builtins
-    del builtins.__xonsh_env__
+    if hasattr(builtins, '__xonsh_env__'):
+        del builtins.__xonsh_env__
     del builtins.__xonsh_ctx__
     del builtins.__xonsh_shell__
-    del builtins.__xonsh_help__
-    del builtins.__xonsh_glob__
-    del builtins.__xonsh_exit__
-    del builtins.__xonsh_superhelp__
+    if hasattr(builtins, '__xonsh_help__'):
+        del builtins.__xonsh_help__
+    if hasattr(builtins, '__xonsh_glob__'):
+        del builtins.__xonsh_glob__
+    if hasattr(builtins, '__xonsh_exit__'):
+        del builtins.__xonsh_exit__
+    if hasattr(builtins, '__xonsh_superhelp__'):
+        del builtins.__xonsh_superhelp__
     del builtins.__xonsh_regexpath__
-    del builtins.__xonsh_expand_path__
-    del builtins.__xonsh_stdout_uncaptured__
-    del builtins.__xonsh_stderr_uncaptured__
+    if hasattr(builtins, '__xonsh_expand_path__'):
+        del builtins.__xonsh_expand_path__
+    if hasattr(builtins, '__xonsh_stdout_uncaptured__'):
+        del builtins.__xonsh_stdout_uncaptured__
+    if hasattr(builtins, '__xonsh_stderr_uncaptured__'):
+        del builtins.__xonsh_stderr_uncaptured__
     del builtins.__xonsh_subproc_captured__
-    del builtins.__xonsh_subproc_uncaptured__
+    if hasattr(builtins, '__xonsh_subproc_uncaptured__'):
+        del builtins.__xonsh_subproc_uncaptured__
     del builtins.__xonsh_ensure_list_of_strs__
     del builtins.__xonsh_commands_cache__
     del builtins.__xonsh_all_jobs__

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,8 @@ def xonsh_builtins(xonsh_events):
     del builtins.__xonsh_ensure_list_of_strs__
     del builtins.__xonsh_commands_cache__
     del builtins.__xonsh_all_jobs__
-    del builtins.__xonsh_history__
+    if hasattr(builtins, '__xonsh_history__'):
+        del builtins.__xonsh_history__
     del builtins.__xonsh_enter_macro__
     del builtins.evalx
     del builtins.execx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import os
 
 import pytest
 
-import xonsh.built_ins
-
 from xonsh.built_ins import ensure_list_of_strs, enter_macro
 from xonsh.execer import Execer
 from xonsh.jobs import tasks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,8 @@ def source_path():
 @pytest.fixture
 def xonsh_execer(monkeypatch):
     """Initiate the Execer with a mocked nop `load_builtins`"""
-    monkeypatch.setattr(xonsh.built_ins, 'load_builtins',
-                        lambda *args, **kwargs: None)
+    monkeypatch.setattr('xonsh.built_ins.load_builtins.__code__',
+                        (lambda *args, **kwargs: None).__code__)
     execer = Execer(unload=False)
     builtins.__xonsh_execer__ = execer
     return execer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,8 @@ def xonsh_builtins(xonsh_events):
     yield builtins
     if hasattr(builtins, '__xonsh_env__'):
         del builtins.__xonsh_env__
-    del builtins.__xonsh_ctx__
+    if hasattr(builtins, '__xonsh_ctx__'):
+        del builtins.__xonsh_ctx__
     del builtins.__xonsh_shell__
     if hasattr(builtins, '__xonsh_help__'):
         del builtins.__xonsh_help__

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -6,16 +6,16 @@ import builtins
 import pytest
 
 from xonsh import imphooks
+from xonsh.execer import Execer
 from xonsh.environ import Env
-from xonsh.built_ins import load_builtins, unload_builtins
+from xonsh.built_ins import unload_builtins
 
 imphooks.install_hook()
 
 
 @pytest.yield_fixture(autouse=True)
-def imp_env(xonsh_execer):
-    """Call `load_builtins` with `xonsh_execer`"""
-    load_builtins(execer=xonsh_execer)
+def imp_env():
+    execer = Execer(unload=False)
     builtins.__xonsh_env__ = Env({'PATH': [], 'PATHEXT': []})
     yield
     unload_builtins()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ def Shell(*args, **kwargs):
 
 
 @pytest.fixture
-def shell(xonsh_builtins, monkeypatch):
+def shell(xonsh_builtins, xonsh_execer, monkeypatch):
     """Xonsh Shell Mock"""
     monkeypatch.setattr(xonsh.main, 'Shell', Shell)
 
@@ -62,7 +62,7 @@ def test_premain_interactive__with_file_argument(shell):
 
 
 @pytest.mark.parametrize('case', ['----', '--hep', '-TT', '--TTTT'])
-def test_premain_invalid_arguments(case, shell, capsys):
+def test_premain_invalid_arguments(shell, case, capsys):
     with pytest.raises(SystemExit):
         xonsh.main.premain([case])
     assert 'unrecognized argument' in capsys.readouterr()[1]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -7,6 +7,7 @@ import builtins
 import pytest
 
 from xonsh.shell import Shell
+from xonsh.execer import Execer
 from xonsh.replay import Replayer
 
 from tools import skip_if_on_darwin
@@ -18,7 +19,9 @@ HISTDIR = os.path.join(os.path.dirname(__file__), 'histories')
 @pytest.yield_fixture(scope='module', autouse=True)
 def ctx():
     """Create a global Shell instance to use in all the test."""
-    builtins.__xonsh_shell__ = Shell({'PATH': []})
+    ctx = {'PATH': []}
+    execer = Execer(xonsh_ctx=ctx)
+    builtins.__xonsh_shell__ = Shell(execer=execer, ctx=ctx)
     yield
     del builtins.__xonsh_shell__
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -23,7 +23,7 @@ VER_MAJOR_MINOR = sys.version_info[:2]
 VER_FULL = sys.version_info[:3]
 ON_DARWIN = (platform.system() == 'Darwin')
 ON_WINDOWS = (platform.system() == 'Windows')
-ON_CONDA = True in [conda in pytest.__file__ for conda
+ON_CONDA = True in [conda in pytest.__file__.lower() for conda
                     in ['anaconda', 'miniconda']]
 ON_TRAVIS = 'TRAVIS' in os.environ and 'CI' in os.environ
 TEST_DIR = os.path.dirname(__file__)

--- a/xonsh/__init__.py
+++ b/xonsh/__init__.py
@@ -60,14 +60,20 @@ else:
         _sys.modules['xonsh.dirstack'] = __amalgam__
         inspectors = __amalgam__
         _sys.modules['xonsh.inspectors'] = __amalgam__
+        shell = __amalgam__
+        _sys.modules['xonsh.shell'] = __amalgam__
         timings = __amalgam__
         _sys.modules['xonsh.timings'] = __amalgam__
         xonfig = __amalgam__
         _sys.modules['xonsh.xonfig'] = __amalgam__
+        base_shell = __amalgam__
+        _sys.modules['xonsh.base_shell'] = __amalgam__
         environ = __amalgam__
         _sys.modules['xonsh.environ'] = __amalgam__
         tracer = __amalgam__
         _sys.modules['xonsh.tracer'] = __amalgam__
+        readline_shell = __amalgam__
+        _sys.modules['xonsh.readline_shell'] = __amalgam__
         replay = __amalgam__
         _sys.modules['xonsh.replay'] = __amalgam__
         aliases = __amalgam__
@@ -78,14 +84,8 @@ else:
         _sys.modules['xonsh.execer'] = __amalgam__
         imphooks = __amalgam__
         _sys.modules['xonsh.imphooks'] = __amalgam__
-        shell = __amalgam__
-        _sys.modules['xonsh.shell'] = __amalgam__
-        base_shell = __amalgam__
-        _sys.modules['xonsh.base_shell'] = __amalgam__
         main = __amalgam__
         _sys.modules['xonsh.main'] = __amalgam__
-        readline_shell = __amalgam__
-        _sys.modules['xonsh.readline_shell'] = __amalgam__
         del __amalgam__
     except ImportError:
         pass

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -26,7 +26,6 @@ from xonsh.lazyasd import LazyObject, lazyobject
 from xonsh.inspectors import Inspector
 from xonsh.aliases import Aliases, make_default_aliases
 from xonsh.environ import Env, default_env, locate_binary
-from xonsh.foreign_shells import load_foreign_aliases
 from xonsh.jobs import add_job
 from xonsh.platform import ON_POSIX, ON_WINDOWS
 from xonsh.proc import (

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1124,14 +1124,14 @@ def enter_macro(obj, raw_block, glbs, locs):
     return obj
 
 
-def load_builtins(execer=None, config=None, login=False, ctx=None):
+def load_builtins(execer=None, ctx=None):
     """Loads the xonsh builtins into the Python builtins. Sets the
     BUILTINS_LOADED variable to True.
     """
     global BUILTINS_LOADED
     # private built-ins
     builtins.__xonsh_config__ = {}
-    builtins.__xonsh_env__ = Env(default_env(config=config, login=login))
+    builtins.__xonsh_env__ = Env(default_env())
     builtins.__xonsh_help__ = helper
     builtins.__xonsh_superhelp__ = superhelper
     builtins.__xonsh_pathsearch__ = pathsearch
@@ -1174,8 +1174,6 @@ def load_builtins(execer=None, config=None, login=False, ctx=None):
     # Need this inline/lazy import here since we use locate_binary that
     # relies on __xonsh_env__ in default aliases
     builtins.default_aliases = builtins.aliases = Aliases(make_default_aliases())
-    if login:
-        builtins.aliases.update(load_foreign_aliases(issue_warning=False))
     builtins.__xonsh_history__ = None
     atexit.register(_lastflush)
     for sig in AT_EXIT_SIGNALS:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -9,7 +9,6 @@ import textwrap
 import locale
 import builtins
 import warnings
-import traceback
 import contextlib
 import collections
 import collections.abc as cabc
@@ -1160,15 +1159,14 @@ def xonsh_script_run_control(filename, ctx, env, execer=None, login=True):
             run_script_with_cache(filename, execer, ctx)
         loaded = True
     except SyntaxError as err:
-        msg = '{0}\nsyntax error in xonsh run control file {1!r}: {2!s}'
-        print_exception(msg.format(exc, filename, err))
+        msg = 'syntax error in xonsh run control file {0!r}: {1!s}'
+        print_exception(msg.format(filename, err))
         loaded = False
     except Exception as err:
-        msg = '{0}\nerror running xonsh run control file {1!r}: {2!s}'
-        print_exception(msg.format(exc, filename, err))
+        msg = 'error running xonsh run control file {0!r}: {1!s}'
+        print_exception(msg.format(filename, err))
         loaded = False
     return loaded
-
 
 
 def default_env(env=None):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -249,9 +249,6 @@ def default_xonshrc(env):
     return dxrc
 
 
-DEFAULT_XONSHRC = LazyObject(default_xonshrc, globals(), 'DEFAULT_XONSHRC')
-
-
 # Default values should generally be immutable, that way if a user wants
 # to set them they have to do a copy and write them to the environment.
 # try to keep this sorted.

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -16,7 +16,7 @@ class Execer(object):
     """Executes xonsh code in a context."""
 
     def __init__(self, filename='<xonsh-code>', debug_level=0, parser_args=None,
-                 unload=True, config=None, login=True, xonsh_ctx=None):
+                 unload=True, xonsh_ctx=None, scriptcache=True, cacheall=False):
         """Parameters
         ----------
         filename : str, optional
@@ -27,18 +27,24 @@ class Execer(object):
             Arguments to pass down to the parser.
         unload : bool, optional
             Whether or not to unload xonsh builtins upon deletion.
-        config : str, optional
-            Path to configuration file.
         xonsh_ctx : dict or None, optional
             Xonsh xontext to load as builtins.__xonsh_ctx__
+        scriptcache : bool, optional
+            Whether or not to use a precompiled bytecode cache when execing
+            code, default: True.
+        cacheall : bool, optional
+            Whether or not to cache all xonsh code, and not just files. If this
+            is set to true, it will cache command line input too, default: False.
         """
         parser_args = parser_args or {}
         self.parser = Parser(**parser_args)
         self.filename = filename
         self.debug_level = debug_level
         self.unload = unload
+        self.scriptcache = scriptcache
+        self.cacheall = cacheall
         self.ctxtransformer = CtxAwareTransformer(self.parser)
-        load_builtins(execer=self, config=config, login=login, ctx=xonsh_ctx)
+        load_builtins(execer=self, ctx=xonsh_ctx)
 
     def __del__(self):
         if self.unload:

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -90,11 +90,12 @@ class Shell(object):
     readline version of shell should be used.
     """
 
-    def __init__(self, ctx=None, shell_type=None, config=None, rc=None,
-                 **kwargs):
+    def __init__(self, execer, ctx=None, shell_type=None, **kwargs):
         """
         Parameters
         ----------
+        execer : Execer
+            An execer instance capable of running xonsh code.
         ctx : Mapping, optional
             The execution context for the shell (e.g. the globals namespace).
             If none, this is computed by loading the rc files. If not None,
@@ -103,16 +104,10 @@ class Shell(object):
         shell_type : str, optional
             The shell type to start, such as 'readline', 'prompt_toolkit',
             or 'random'.
-        config : str, optional
-            Path to configuration file.
-        rc : list of str, optional
-            Sequence of paths to run control files.
         """
-        self.login = kwargs.get('login', True)
+        self.execer = execer
+        self.ctx = {} if ctx is None else ctx
         self.stype = shell_type
-        self._init_environ(ctx, config, rc,
-                           kwargs.get('scriptcache', True),
-                           kwargs.get('cacheall', False))
         env = builtins.__xonsh_env__
         # build history backend before creating shell
         builtins.__xonsh_history__ = hist = xhm.construct_history(
@@ -160,28 +155,3 @@ class Shell(object):
     def __getattr__(self, attr):
         """Delegates calls to appropriate shell instance."""
         return getattr(self.shell, attr)
-
-    def _init_environ(self, ctx, config, rc, scriptcache, cacheall):
-        self.ctx = {} if ctx is None else ctx
-        debug = to_bool_or_int(os.getenv('XONSH_DEBUG', '0'))
-        events.on_timingprobe.fire(name='pre_execer_init')
-        self.execer = Execer(config=config, login=self.login, xonsh_ctx=self.ctx,
-                             debug_level=debug)
-        events.on_timingprobe.fire(name='post_execer_init')
-        self.execer.scriptcache = scriptcache
-        self.execer.cacheall = cacheall
-        if self.stype != 'none' or self.login:
-            # load xontribs from config file
-            names = builtins.__xonsh_config__.get('xontribs', ())
-            for name in names:
-                update_context(name, ctx=self.ctx)
-            if getattr(update_context, 'bad_imports', None):
-                prompt_xontrib_install(update_context.bad_imports)
-                del update_context.bad_imports
-            # load run control files
-            env = builtins.__xonsh_env__
-            rc = env.get('XONSHRC') if rc is None else rc
-            events.on_pre_rc.fire()
-            self.ctx.update(xonshrc_context(rcfiles=rc, execer=self.execer, initial=self.ctx))
-            events.on_post_rc.fire()
-        self.ctx['__name__'] = '__main__'

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """The xonsh shell"""
-import os
 import sys
 import random
 import time
@@ -8,12 +7,9 @@ import difflib
 import builtins
 import warnings
 
-from xonsh.xontribs import update_context, prompt_xontrib_install
-from xonsh.environ import xonshrc_context
-from xonsh.execer import Execer
 from xonsh.platform import (best_shell_type, has_prompt_toolkit,
                             ptk_version_is_supported)
-from xonsh.tools import XonshError, to_bool_or_int, print_exception
+from xonsh.tools import XonshError, print_exception
 from xonsh.events import events
 import xonsh.history.main as xhm
 


### PR DESCRIPTION
This refactor of the loading system linearizes the setup of xonsh. The Shell class is now no longer responsible for creating an execer and loading the rc files. Additionally, it unifies the load path for xonsh-lang rc files and the JSON-based static configuration files. Lastly, this PR should address #870.