### PR TITLE
provide core events for started and finished commands

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -792,6 +792,7 @@ def run_subproc(cmds, captured=False):
     Lastly, the captured argument affects only the last real command.
     """
     specs = cmds_to_specs(cmds, captured=captured)
+    events.on_command_started.fire(cmd=specs)
     captured = specs[-1].captured
     procs = []
     proc = pipeline_group = None


### PR DESCRIPTION
The purpose of the new events is to make it easy for users to detect executed commands, before and after the fact, as they are seen by the OS, after all the xonsh magic has been done.

It's just a working example. There are at least two rough edges I am aware of:

* the name of the two events is confusing; we need better names
* the "before" event just passes over the internal representation of the command - the purpose of these events is to offer a simple hooking point for basic needs, so I would prefer a quick and dirty access to the command(s) as lists of strings with the commands and their parameters

I have experience with formal languages, but my idiomatic python is rusty (pun intended) and I've never written a shell, so any advice is welcome.