### PR TITLE
Fix for alias resolution in threadable predition

### DIFF
--- a/news/wrongpred.rst
+++ b/news/wrongpred.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Threadable prediction was incorrectly based on the user input command, rather than
+  the version where aliases have been resolved. This has been corrected.
+
+**Security:** None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -676,7 +676,7 @@ def _update_last_spec(last):
     if callable_alias:
         pass
     else:
-        thable = builtins.__xonsh_commands_cache__.predict_threadable(last.args)
+        thable = builtins.__xonsh_commands_cache__.predict_threadable(last.cmd)
         if captured and thable:
             last.cls = PopenThread
         elif not thable:


### PR DESCRIPTION
This should address some of the issued pointed out in #2186