### PR TITLE
Prevent main proc from stopping

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -6,6 +6,7 @@ import enum
 import argparse
 import builtins
 import contextlib
+import signal
 import traceback
 
 from xonsh import __version__
@@ -340,6 +341,11 @@ def main(argv=None):
 
 def main_xonsh(args):
     """Main entry point for xonsh cli."""
+    def func_sig_ttin_ttou(n, f):
+        pass
+    signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
+    signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+
     events.on_post_init.fire()
     env = builtins.__xonsh_env__
     shell = builtins.__xonsh_shell__

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -341,10 +341,11 @@ def main(argv=None):
 
 def main_xonsh(args):
     """Main entry point for xonsh cli."""
-    def func_sig_ttin_ttou(n, f):
-        pass
-    signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
-    signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+    if not ON_WINDOWS:
+        def func_sig_ttin_ttou(n, f):
+            pass
+        signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
+        signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
 
     events.on_post_init.fire()
     env = builtins.__xonsh_env__

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -838,7 +838,10 @@ class PopenThread(threading.Thread):
         new[LFLAG] |= termios.ECHO | termios.ICANON
         new[CC][termios.VMIN] = 1
         new[CC][termios.VTIME] = 0
-        termios.tcsetattr(self.stdin_fd, termios.TCSANOW, new)
+        try:
+            termios.tcsetattr(self.stdin_fd, termios.TCSANOW, new)
+        except termios.error:
+            print_exception()
 
     #
     # Dispatch methods

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -841,7 +841,7 @@ class PopenThread(threading.Thread):
         try:
             termios.tcsetattr(self.stdin_fd, termios.TCSANOW, new)
         except termios.error:
-            print_exception()
+            pass
 
     #
     # Dispatch methods


### PR DESCRIPTION
Try fixes #2196. The current committed code actually fixed the stuck issue, but, obviously, is not the correct way.

The correct way I think should be 1) "not read from stdin or write to stdout/stderr when hand out the terminal" and/or 2) "do not settcattr when should not".