### PR TITLE
Link the events tutorial and the events references

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,5 +1,5 @@
 Core Events
 ===========
-The following events are defined by xonsh itself.
+The following events are defined by xonsh itself. For more information about events, see `the events tutorial <tutorial_events.html>`_.
 
 .. include:: eventsbody

--- a/docs/tutorial_events.rst
+++ b/docs/tutorial_events.rst
@@ -45,8 +45,10 @@ Yes! It's even easy! In your xontrib, you just have to do something like::
 
 This will enable users to call ``help(events.myxontrib_on_spam)`` and get useful output.
 
-Under the Hood
-==============
+Further Reading
+===============
+
+For a complete list of available events, see `the events reference <events.html>`_.
 
 If you want to know more about the gory details of what makes events tick, see 
 `Advanced Events <advanced_events.html>`_.


### PR DESCRIPTION
Because they really should be cross-linked.

(Docs-only change. No news.)