### PR TITLE
Windows Terminal ANSI color fixes

### DIFF
--- a/news/winterm.rst
+++ b/news/winterm.rst
@@ -1,0 +1,17 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Windows consoles will now automatically enable virtual terminal processing
+  with the readline shell, if available. This allows the full use of ANSI
+  escape sequences.
+* On the Windows readline shell, the teb-completion supression prompt will no
+  longer error out depending on what you press.
+
+**Security:** None

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -232,6 +232,10 @@ def rl_on_new_line():
         func = getattr(RL_LIB, name, None)
         if func is not None:
             break
+    else:
+        def print_for_newline():
+            print()
+        func = print_for_newline
     return func
 
 
@@ -304,10 +308,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         show_completions = to_bool(yn)
         print()
         if not show_completions:
-            if rl_on_new_line is None:
-                rl_on_new_line()
-            else:
-                print()
+            rl_on_new_line()
             return False
         w, h = shutil.get_terminal_size()
         lines = columnize(completions, width=w)

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -302,7 +302,10 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         show_completions = to_bool(yn)
         print()
         if not show_completions:
-            rl_on_new_line()
+            if rl_on_new_line is None:
+                rl_on_new_line()
+            else:
+                print()
             return False
         w, h = shutil.get_terminal_size()
         lines = columnize(completions, width=w)

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -29,7 +29,7 @@ from xonsh.prompt.base import multiline_prompt
 from xonsh.tools import (print_exception, check_for_partial_string, to_bool,
                          columnize)
 from xonsh.platform import ON_WINDOWS, ON_CYGWIN, ON_DARWIN, ON_POSIX
-from xonsh.lazyimps import pygments, pyghooks
+from xonsh.lazyimps import pygments, pyghooks, winutils
 from xonsh.events import events
 
 readline = None
@@ -126,6 +126,8 @@ def setup_readline():
         inputrc_name = os.path.join(os.path.expanduser('~'), inputrc_name)
     if (not ON_WINDOWS) and (not os.path.isfile(inputrc_name)):
         inputrc_name = '/etc/inputrc'
+    if ON_WINDOWS:
+        winutils.enable_virtual_terminal_processing()
     if os.path.isfile(inputrc_name):
         try:
             readline.read_init_file(inputrc_name)

--- a/xonsh/winutils.py
+++ b/xonsh/winutils.py
@@ -249,6 +249,14 @@ def set_console_mode(mode, fd=1):
     SetConsoleMode(hcon, mode)
 
 
+def enable_virtual_terminal_processing():
+    """Enables virtual terminal processing on Windows.
+    This inlcudes ANSI escape sequence interpretation.
+    See http://stackoverflow.com/a/36760881/2312428
+    """
+    SetConsoleMode(GetStdHandle(-11), 7)
+
+
 @lazyobject
 def COORD():
     if platform.has_prompt_toolkit():


### PR DESCRIPTION
This fixes the other bug in #2130, where ANSI color sequences don't display properly in windows terminals. cc @melund @laerus This builds on #2207, but shouldn't be a big deal