### PR TITLE
new threadable prediction lookup

### DIFF
--- a/news/lookup.rst
+++ b/news/lookup.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Threadable predicition for subprocesses will now consult both the command
+  as it was typed in and any resolved aliases.
+
+**Security:** None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -676,7 +676,9 @@ def _update_last_spec(last):
     if callable_alias:
         pass
     else:
-        thable = builtins.__xonsh_commands_cache__.predict_threadable(last.cmd)
+        cmds_cache = builtins.__xonsh_commands_cache__
+        thable = (cmds_cache.predict_threadable(last.args) and
+                  cmds_cache.predict_threadable(last.cmd))
         if captured and thable:
             last.cls = PopenThread
         elif not thable:

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -217,7 +217,7 @@ class CommandsCache(cabc.Mapping):
     def default_predictor(self, name, cmd0):
         if ON_POSIX:
             return self.default_predictor_readbin(name, cmd0,
-                                                  timeout=.1,
+                                                  timeout=0.1,
                                                   failure=predict_true)
         else:
             return predict_true
@@ -375,6 +375,7 @@ def default_threadable_predictors():
         'weechat': predict_help_ver,
         'xo': predict_help_ver,
         'xonsh': predict_shell,
+        'xon.sh': predict_shell,
         'zsh': predict_shell,
     }
     return predictors


### PR DESCRIPTION
This is an alternative to #2206 and should address  #2198 #220. Thanks to @gforsyth and @mitnk for pointing this out