### PR TITLE
Readline wizard usability fixes

### DIFF
--- a/news/rlwiz.rst
+++ b/news/rlwiz.rst
@@ -1,0 +1,18 @@
+**Added:** None
+
+**Changed:**
+
+* ``Shell.stype`` has been renamed to ``Shell.shell_type``.
+* The configuration wizard now displays the proper control sequence to leave
+  the wizard at the to start of the wizard itself. Note that this is Ctrl+D for
+  readline and Ctrl+C for prompt-toolkit.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``Shell.shell_type`` is now properly set to the same value as ``$SHELL_TYPE``.
+
+**Security:** None

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -110,7 +110,6 @@ class Shell(object):
         """
         self.execer = execer
         self.ctx = {} if ctx is None else ctx
-        self.stype = shell_type
         env = builtins.__xonsh_env__
         # build history backend before creating shell
         builtins.__xonsh_history__ = hist = xhm.construct_history(
@@ -138,7 +137,7 @@ class Shell(object):
                               'supported. Please update prompt-toolkit. Using '
                               'readline instead.')
                 shell_type = 'readline'
-        env['SHELL_TYPE'] = shell_type
+        self.shell_type = env['SHELL_TYPE'] = shell_type
         # actually make the shell
         if shell_type == 'none':
             from xonsh.base_shell import BaseShell as shell_class

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -167,6 +167,16 @@ ENVVAR_MESSAGE = """
 ENVVAR_PROMPT = "{BOLD_GREEN}>>>{NO_COLOR} "
 
 
+def make_exit_message():
+    """Creates a message for how to exit the wizard."""
+    shell_type = builtins.__xonsh_shell__.shell_type
+    keyseq = 'Ctrl-D' if shell_type == 'readline' else 'Ctrl-C'
+    msg = 'To exit the wizard at any time, press {BOLD_UNDERLINE_CYAN}'
+    msg += keyseq + '{NO_COLOR}.\n'
+    m = wiz.Message(message=msg)
+    return m
+
+
 def make_envvar(name):
     """Makes a StoreNonEmpty node for an environment variable."""
     env = builtins.__xonsh_env__
@@ -266,6 +276,7 @@ def make_xonfig_wizard(default_file=None, confirm=False):
     """
     w = wiz.Wizard(children=[
         wiz.Message(message=WIZARD_HEAD),
+        make_exit_message(),
         wiz.Load(default_file=default_file, check=True),
         wiz.Message(message=WIZARD_FS),
         make_fs_wiz(),
@@ -314,6 +325,7 @@ def _wizard(ns):
         try:
             pv.visit()
         except (KeyboardInterrupt, Exception):
+            print()
             print_exception()
 
 


### PR DESCRIPTION
This is an attempt to address #956. It turns out there is an underlying issue with readline that eats Ctrl+C in Python (see https://bugs.python.org/issue24266).  Unfortunately, the fix - which has already been merged in - is only applicable to readline v7, which most people are not on yet. 

So as a usability fix, the wizard now prints the correct command to exit. This depends on the shell backend.

Additionally, the fixes another minor issue with the shell type not being set correctly on the shell class.