### PR TITLE
carriage return on the first prompt to properly capture all input

### DIFF
--- a/news/resetline.rst
+++ b/news/resetline.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* The first prompt will no longer print in the middle of the line if the user has
+  already started typing.
+
+**Security:** None

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -172,7 +172,7 @@ class PromptToolkitShell(BaseShell):
         toks = partial_color_tokenize(p)
         if self._first_prompt:
             carriage_return()
-            self._first_message = False
+            self._first_prompt = False
         self.settitle()
         return toks
 

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -10,7 +10,7 @@ from prompt_toolkit.shortcuts import print_tokens
 from prompt_toolkit.styles import PygmentsStyle, style_from_dict
 
 from xonsh.base_shell import BaseShell
-from xonsh.tools import print_exception
+from xonsh.tools import print_exception, carriage_return
 from xonsh.ptk.completer import PromptToolkitCompleter
 from xonsh.ptk.history import PromptToolkitHistory
 from xonsh.ptk.key_bindings import load_xonsh_bindings
@@ -36,6 +36,7 @@ class PromptToolkitShell(BaseShell):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._first_prompt = True
         self.prompter = Prompter()
         self.history = PromptToolkitHistory()
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
@@ -169,6 +170,9 @@ class PromptToolkitShell(BaseShell):
         except Exception:  # pylint: disable=broad-except
             print_exception()
         toks = partial_color_tokenize(p)
+        if self._first_prompt:
+            carriage_return()
+            self._first_message = False
         self.settitle()
         return toks
 

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -27,7 +27,7 @@ from xonsh.ansi_colors import (ansi_partial_color_format, ansi_color_style_names
                                ansi_color_style)
 from xonsh.prompt.base import multiline_prompt
 from xonsh.tools import (print_exception, check_for_partial_string, to_bool,
-                         columnize)
+                         columnize, carriage_return)
 from xonsh.platform import ON_WINDOWS, ON_CYGWIN, ON_DARWIN, ON_POSIX
 from xonsh.lazyimps import pygments, pyghooks
 from xonsh.events import events
@@ -132,6 +132,8 @@ def setup_readline():
         except Exception:
             # this seems to fail with libedit
             print_exception('xonsh: could not load readline default init file.')
+    # properly reset intput typed before the first prompt
+    readline.set_startup_hook(carriage_return)
 
 
 def teardown_readline():

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1847,3 +1847,8 @@ def uncapturable(f):
     """
     f.__xonsh_capturable__ = False
     return f
+
+
+def carriage_return():
+    """Writes a carriage return to stdout, and nothing else."""
+    print('\r', flush=True, end='')


### PR DESCRIPTION
This should address #959 for both ptk and readline.