### PR TITLE
Tracer fixes

### DIFF
--- a/news/tracer.rst
+++ b/news/tracer.rst
@@ -1,0 +1,17 @@
+**Added:**
+
+* The ``trace`` will automatically disable color printing when
+  stdout is not a TTY or stdout is captured.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* The ``trace`` utility will now correctly color output and not
+  print extraneous newlines when called in a script.
+
+**Security:** None

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -92,6 +92,7 @@ class DummyEnv(MutableMapping):
 
     DEFAULTS = {
         'XONSH_DEBUG': 1,
+        'XONSH_COLOR_STYLE': 'default',
     }
 
     def __init__(self, *args, **kwargs):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -48,7 +48,7 @@ def sp(cmd):
 
 
 class DummyStyler():
-    styles = defaultdict(None.__class__)
+    styles = defaultdict(str)
 
 
 class DummyBaseShell(BaseShell):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -353,11 +353,12 @@ def xonfig(args, stdin=None):
 
 
 @unthreadable
-def trace(args, stdin=None):
+def trace(args, stdin=None, stdout=None, stderr=None, spec=None):
     """Runs the xonsh tracer utility."""
     from xonsh.tracer import tracermain  # lazy import
     try:
-        return tracermain(args)
+        return tracermain(args, stdin=stdin, stdout=stdout,
+                          stderr=stderr, spec=spec)
     except SystemExit:
         pass
 

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -16,6 +16,7 @@ from xonsh.completer import Completer
 from xonsh.prompt.base import multiline_prompt, PromptFormatter
 from xonsh.events import events
 from xonsh.shell import transform_command
+from xonsh.lazyimps import pygments, pyghooks
 
 if ON_WINDOWS:
     import ctypes
@@ -475,19 +476,32 @@ class BaseShell(object):
         self.settitle()
         return p
 
-    def format_color(self, string, **kwargs):
-        """Formats the colors in a string. This base implmentation does not
-        actually do any coloring, but just returns the string directly.
+    def format_color(self, string, hide=False, force_string=False, **kwargs):
+        """Formats the colors in a string. This base implmentation colors based
+        on ANSI color codes
         """
-        return string
+        style = builtins.__xonsh_env__.get('XONSH_COLOR_STYLE')
+        return ansi_partial_color_format(string, hide=hide, style=style)
 
-    def print_color(self, string, **kwargs):
-        """Prints a string in color. This base implmentation does not actually
-        do any coloring, but just prints the string directly.
+    def print_color(self, string, hide=False, **kwargs):
+        """Prints a string in color. This base implmentation will color based
+        ANSI color codes if a string was given as input. If a list of token
+        pairs is given, it will color based on pygments, if available. If
+        pygments is not available, it will print a colorless string.
         """
-        if not isinstance(string, str):
-            string = ''.join([x for _, x in string])
-        print(string, **kwargs)
+        if isinstance(string, str):
+            s = self.format_color(string, hide=hide)
+        elif HAS_PYGMENTS:
+            # assume this is a list of (Token, str) tuples and format it
+            env = builtins.__xonsh_env__
+            self.styler.style_name = env.get('XONSH_COLOR_STYLE')
+            style_proxy = pyghooks.xonsh_style_proxy(self.styler)
+            formatter = pyghooks.XonshTerminal256Formatter(style=style_proxy)
+            s = pygments.format(string, formatter).rstrip()
+        else:
+            # assume this is a list of (Token, str) tuples and remove color
+            s = ''.join([x for _, x in string])
+        print(s, **kwargs)
 
     def color_style_names(self):
         """Returns an iterable of all available style names."""

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -17,6 +17,7 @@ from xonsh.prompt.base import multiline_prompt, PromptFormatter
 from xonsh.events import events
 from xonsh.shell import transform_command
 from xonsh.lazyimps import pygments, pyghooks
+from xonsh.ansi_colors import ansi_partial_color_format
 
 if ON_WINDOWS:
     import ctypes


### PR DESCRIPTION
This updates tracer to correctly print colors and not print extra newline in a headless shell. This should address #960.  The script I was using as a test is:

**test.xsh**
```
#!/usr/bin/env xonsh

trace on
print("yo")
42 + 42
trace off
```

This seems to work in the following cases:

```console
scopatz@artemis ~/temp $ ./test.xsh 
test.xsh:4:print("yo")
yo
test.xsh:5:42 + 42
test.xsh:6:trace off
scopatz@artemis ~/temp $ x = $(./test.xsh); x
'test.xsh:4:print("yo")\nyo\ntest.xsh:5:42 + 42\ntest.xsh:6:trace off\n'
scopatz@artemis ~/temp $ ./test.xsh | less
```