### PR TITLE
raw path completer fixes

### DIFF
--- a/news/rawpath.rst
+++ b/news/rawpath.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed issues pertaining to completing from raw string paths.
+  This is particularly relevant to Windows, where raw strings
+  are instered in path completion.
+
+**Security:** None


### PR DESCRIPTION
This should enable more robust raw string path completers on windows. It should address the remaining issues in #983.