### PR TITLE
Import Events and Matplotlib Interactive Fixes

### DIFF
--- a/news/ie.rst
+++ b/news/ie.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* New events for hooking into the Python import process are now available.
+  You can now provide a handler for:
+
+  - ``on_import_pre_find_spec``
+  - ``on_import_post_find_spec``
+  - ``on_import_pre_create_module``
+  - ``on_import_post_create_module``
+  - ``on_import_pre_exec_module``
+  - ``on_import_post_exec_module``
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* The ``mpl`` xontrib has been updated to improve matplotlib
+  handling. If ``xontrib load mpl`` is run before matplotlib
+  is imported and xonsh is in ineteractive mode, matplotlib
+  will automatically enter interactive mode as well. Additionally,
+  ``pyplot.show()`` is patched in interactive mode to be non-blocking.
+  If a non-blocking show fails to draw the figre for some reason,
+  a regular blocking version is called.
+
+**Security:** None

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -10,7 +10,7 @@ from xonsh.execer import Execer
 from xonsh.environ import Env
 from xonsh.built_ins import unload_builtins
 
-imphooks.install_hook()
+imphooks.install_import_hooks()
 
 
 @pytest.yield_fixture(autouse=True)

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -14,7 +14,7 @@ from importlib.abc import MetaPathFinder, SourceLoader, Loader
 
 from xonsh.events import events
 from xonsh.execer import Execer
-from xonsh.platform import scandir, PYTHON_VERSION_INFO
+from xonsh.platform import scandir
 
 
 class XonshImportHook(MetaPathFinder, SourceLoader):

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -3,15 +3,18 @@
 
 This module registers the hooks it defines when it is imported.
 """
-import builtins
 import os
 import sys
 import types
+import builtins
+import contextlib
+import importlib
 from importlib.machinery import ModuleSpec
-from importlib.abc import MetaPathFinder, SourceLoader
+from importlib.abc import MetaPathFinder, SourceLoader, Loader
 
+from xonsh.events import events
 from xonsh.execer import Execer
-from xonsh.platform import scandir
+from xonsh.platform import scandir, PYTHON_VERSION_INFO
 
 
 class XonshImportHook(MetaPathFinder, SourceLoader):
@@ -93,16 +96,146 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
         return code
 
 
-def install_hook():
-    """
-    Install Xonsh import hook in `sys.metapath` in order for `.xsh` files to be
-    importable.
+#
+# Import events
+#
+events.doc('on_import_pre_find_spec', """
+on_import_pre_find_spec(fullname: str, path: str, target: module or None) -> None
 
-    Can safely be called many times, will be no-op if a xonsh import hook is
+Fires before any import find_spec() calls have been executed. The parameters
+here are the same as importlib.abc.MetaPathFinder.find_spec(). Namely,
+
+``fullname``: The full name of the module to import.
+``path``: None if a top-level import, otherwise the ``__path__`` of the parent
+          package.
+``target``: Target module used to make a better guess about the package spec.
+""")
+
+events.doc('on_import_post_find_spec', """
+on_import_post_find_spec(spec, fullname, path, target) -> None
+
+Fires after all import find_spec() calls have been executed. The parameters
+here the spec and the arguments importlib.abc.MetaPathFinder.find_spec(). Namely,
+
+``spec``: A ModuleSpec object if the spec was found, or None if it was not.
+``fullname``: The full name of the module to import.
+``path``: None if a top-level import, otherwise the ``__path__`` of the parent
+          package.
+``target``: Target module used to make a better guess about the package spec.
+""")
+
+events.doc('on_import_pre_create_module', """
+on_import_pre_create_module(spec: ModuleSpec) -> None
+
+Fires right before a module is created by its loader. The only parameter
+is the spec object. See importlib for more details.
+""")
+
+events.doc('on_import_post_create_module', """
+on_import_post_create_module(mod: Module, spec: ModuleSpec) -> None
+
+Fires after a module is created by its loader but before the loader returns it.
+The parameters here are the module object itself and the spec object.
+See importlib for more details.
+""")
+
+
+class XonshImportEventHook(MetaPathFinder):
+    """Implements the import hook for firing xonsh events on import."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fullname_stack = []
+
+    @contextlib.contextmanager
+    def append_stack(self, fullname):
+        """A context manager for appending and then removing a name from the
+        fullname stack.
+        """
+        self._fullname_stack.append(fullname)
+        yield
+        del self._fullname_stack[-1]
+
+    #
+    # MetaPathFinder methods
+    #
+    def find_spec(self, fullname, path, target=None):
+        """Finds the spec for a xonsh module if it exists."""
+        if fullname in reversed(self._fullname_stack):
+            # don't execute if we are already in the stack.
+            return None
+        npre = len(events.on_import_pre_find_spec)
+        npost = len(events.on_import_post_find_spec)
+        nprecreate = len(events.on_import_pre_create_module)
+        npostcreate = len(events.on_import_post_create_module)
+        if npre > 0:
+            events.on_import_pre_find_spec.fire(fullname=fullname, path=path,
+                                                target=target)
+        elif npost == 0 and nprecreate == 0 and npostcreate == 0:
+            # no events to fire, proceed normally and prevent recursion
+            return None
+        # now find the spec
+        with self.append_stack(fullname):
+            spec = importlib.util.find_spec(fullname)
+        # fire post event
+        if npost > 0:
+            events.on_import_post_find_spec.fire(spec=spec, fullname=fullname,
+                                                 path=path, target=target)
+        if nprecreate > 0 or npostcreate > 0:
+            spec.loader = XonshImportEventLoader(spec.loader)
+        return spec
+
+
+class XonshImportEventLoader(Loader):
+    """A class that dispatches loader calls to another loader and fires relevent
+    xonsh events.
+    """
+
+    def __init__(self, loader):
+        self.loader = loader
+
+    #
+    # Loader methods
+    #
+    def create_module(self, spec):
+        """Creates and returns the module object."""
+        events.on_import_pre_create_module.fire(spec=spec)
+        mod = self.loader.create_module(spec)
+        events.on_import_post_create_module.fire(mod=mod, spec=spec)
+        return mod
+
+    def exec_module(self, module):
+        """Executes the module in its own namespace."""
+        return self.loader.exec_module(module)
+
+    def load_module(self, fullname):
+        """Legacy module loading, provided for backwards compatability."""
+        return self.loader.load_module(fullname)
+
+    def module_repr(self, module):
+        """Legacy module repr, provided for backwards compatability."""
+        return self.loader.module_repr(module)
+
+
+def install_import_hooks():
+    """
+    Install Xonsh import hooks in ``sys.meta_path`` in order for ``.xsh`` files
+    to be importable and import events to be fired.
+
+    Can safely be called many times, will be no-op if xonsh import hooks are
     already present.
     """
+    found_imp = found_event = False
     for hook in sys.meta_path:
         if isinstance(hook, XonshImportHook):
-            break
-    else:
+            found_imp = True
+        elif isinstance(hook, XonshImportEventHook):
+            found_event = True
+    if not found_imp:
         sys.meta_path.append(XonshImportHook())
+    if not found_event:
+        sys.meta_path.insert(0, XonshImportEventHook())
+
+
+# alias to deprecated name
+install_hook = install_import_hooks

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -22,7 +22,7 @@ from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.codecache import run_script_with_cache, run_code_with_cache
 from xonsh.xonfig import xonfig_main
 from xonsh.lazyimps import pygments, pyghooks
-from xonsh.imphooks import install_hook
+from xonsh.imphooks import install_import_hooks
 from xonsh.events import events
 from xonsh.environ import xonshrc_context
 
@@ -222,7 +222,7 @@ def start_services(shell_kwargs):
     """Starts up the essential services in the proper order.
     This returns the envrionment instance as a convenience.
     """
-    install_hook()
+    install_import_hooks()
     # create execer, which loads builtins
     ctx = shell_kwargs.get('ctx', {})
     debug = to_bool_or_int(os.getenv('XONSH_DEBUG', '0'))

--- a/xonsh/pytest_plugin.py
+++ b/xonsh/pytest_plugin.py
@@ -5,11 +5,12 @@ import importlib
 from traceback import format_list, extract_tb
 
 import pytest
-from xonsh.imphooks import install_hook
+
+from xonsh.imphooks import install_import_hooks
 
 
 def pytest_configure(config):
-    install_hook()
+    install_import_hooks()
 
 
 def pytest_collection_modifyitems(items):

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -1,8 +1,9 @@
-"""Matplotlib xontribution."""
+"""Matplotlib xontribution. This xontrib should be loaded before matplotlib
+is imported.
+"""
 
 from xonsh.tools import unthreadable
 from xonsh.lazyasd import lazyobject
-import time
 
 
 __all__ = ()
@@ -33,16 +34,31 @@ def interactive_pyplot(module=None, **kwargs):
     if module.__name__ != 'matplotlib.pyplot' or \
        not __xonsh_env__.get('XONSH_INTERACTIVE'):
         return
+    # Since we are in interactive mode, let's monkey-patch plt.show
+    # to try to never block.
     module.ion()
     module._INSTALL_FIG_OBSERVER = False
+    plt_show = module.show
+
+    def xonsh_show(*args, **kwargs):
+        """This is a monkey patched version of matplotlib.pyplot.show()
+        for xonsh's interactive mode. First it tries non-blocking mode
+        (block=False). If for some reason this fails, it will run show
+        in normal bloking mode (block=True).
+        """
+        kwargs.update(block=False)
+        rtn = plt_show(*args, **kwargs)
+        figmanager = pylab_helpers.Gcf.get_active()
+        if figmanager is not None:
+            # unblocked mode failed, try blocking.
+            kwargs.update(block=True)
+            rtn = plt_show(*args, **kwargs)
+        return rtn
+
+    module.show = xonsh_show
 
     # register figure drawer
     @events.on_postcommand
     def redraw_mpl_figure(**kwargs):
         """Redraws the current matplotlib figure after each command."""
-        # module is pyplot
-        if module.isinteractive():
-            #print('redrawing')
-            #module.ioff()
-            pylab_helpers.Gcf.draw_all(force=True)
-            #module.ion()
+        pylab_helpers.Gcf.draw_all()

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -1,6 +1,9 @@
 """Matplotlib xontribution."""
 
 from xonsh.tools import unthreadable
+from xonsh.lazyasd import lazyobject
+import time
+
 
 __all__ = ()
 
@@ -13,3 +16,33 @@ def mpl(args, stdin=None):
 
 
 aliases['mpl'] = mpl
+
+
+@lazyobject
+def pylab_helpers():
+    try:
+        import matplotlib._pylab_helpers as m
+    except ImportError:
+        m = None
+    return m
+
+
+@events.on_import_post_exec_module
+def interactive_pyplot(module=None, **kwargs):
+    """This puts pyplot in interactive mode once it is imported."""
+    if module.__name__ != 'matplotlib.pyplot' or \
+       not __xonsh_env__.get('XONSH_INTERACTIVE'):
+        return
+    module.ion()
+    module._INSTALL_FIG_OBSERVER = False
+
+    # register figure drawer
+    @events.on_postcommand
+    def redraw_mpl_figure(**kwargs):
+        """Redraws the current matplotlib figure after each command."""
+        # module is pyplot
+        if module.isinteractive():
+            #print('redrawing')
+            #module.ioff()
+            pylab_helpers.Gcf.draw_all(force=True)
+            #module.ion()


### PR DESCRIPTION
This PR adds six new events for hooking into Python's import mechanism.  Now you can register a handler for before/after a module is search for, created, or exec'd. There are probably some pretty crazy abuses of this. 

The initial application of this is to help fix some of the interactivity issues with matplotlib. This should close out #1043. Some of the problems mentioned in that issue seemed to related to mpl v1.x and have since been fixed in mpl v2.x.  This PR tries to address the remaining problems.