### PR TITLE
Skip existing foreign shell aliases

### DIFF
--- a/news/no-fs-over.rst
+++ b/news/no-fs-over.rst
@@ -1,0 +1,16 @@
+**Added:** None
+
+**Changed:**
+
+* Sourcing foreign shells will now safely skip applying aliases
+  with the same name as existing xonsh aliases by default.
+  This prevents accitidentally overwriting important xonsh standard
+  aliases, such as ``cd``.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -199,10 +199,14 @@ def _SOURCE_FOREIGN_PARSER():
     parser.add_argument('--seterrpostcmd', default=None, dest='seterrpostcmd',
                         help='command(s) to set exit-on-error after all'
                              'other commands.')
+    parser.add_argument('--overwrite-aliases', default=False, action='store_true',
+                        dest='overwrite_aliases',
+                        help='flag for whether or not sourced aliases should '
+                             'replace the current xonsh aliases.')
     return parser
 
 
-def source_foreign(args, stdin=None):
+def source_foreign(args, stdin=None, stdout=None, stderr=None):
     """Sources a file written in a foreign shell language."""
     ns = _SOURCE_FOREIGN_PARSER.parse_args(args)
     if ns.prevcmd is not None:
@@ -244,7 +248,13 @@ def source_foreign(args, stdin=None):
     for k, v in fsaliases.items():
         if k in baliases and v == baliases[k]:
             continue  # no change from original
-        baliases[k] = v
+        elif ns.overwite_aliases or k not in baliases:
+            baliases[k] = v
+        else:
+            msg = ('Skipping application of {0!r} alias from {1!r} '
+                   'since it shares a name with an existing xonsh alias. '
+                   'Use "--overwrite-alias" option to apply it anyway.')
+            print(msg.format(k, ns.shell), file=stderr)
 
 
 def source_alias(args, stdin=None):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1134,8 +1134,16 @@ def static_config_run_control(filename, ctx, env, execer=None, login=True):
         windows_foreign_env_fixes(foreign_env)
     foreign_env_fixes(foreign_env)
     env.update(foreign_env)
+    aliase = builtins.aliases
     foreign_aliases = load_foreign_aliases(config=filename, issue_warning=True)
-    builtins.aliases.update(foreign_aliases)
+    for k, v in foreign_aliases.items():
+        if k in aliases:
+            msg = ('Skipping application of {0!r} alias from foreign shell '
+                   '(loaded from {1!r}) since it shares a name with an '
+                   'existing xonsh alias.')
+            print(msg.format(k, filename))
+        else:
+            aliases[k] = v
     # load xontribs
     names = conf.get('xontribs', ())
     for name in names:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1134,7 +1134,7 @@ def static_config_run_control(filename, ctx, env, execer=None, login=True):
         windows_foreign_env_fixes(foreign_env)
     foreign_env_fixes(foreign_env)
     env.update(foreign_env)
-    aliase = builtins.aliases
+    aliases = builtins.aliases
     foreign_aliases = load_foreign_aliases(config=filename, issue_warning=True)
     for k, v in foreign_aliases.items():
         if k in aliases:


### PR DESCRIPTION
This PR adds some logic to skip existing foreign shell aliases. This should hopefully address #1064