### PR TITLE
Handle if WSL bash misbehaves on Windows

### DIFF
--- a/news/wsl_bash.rst
+++ b/news/wsl_bash.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Handle a bug where Bash On Windows causes platform.windows_bash_command() 
+  to raise CalledProcessError.
+
+**Security:** None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -304,15 +304,15 @@ def windows_bash_command():
     if bash_on_path:
         try:
             out = subprocess.check_output([bash_on_path, '--version'],
-                                      stderr=subprocess.PIPE,
-                                      universal_newlines=True)
+                                          stderr=subprocess.PIPE,
+                                          universal_newlines=True)
         except subprocess.CalledProcessError:
             bash_works = False
         else:
             # Check if Bash is from the "Windows Subsystem for Linux" (WSL)
             # which can't be used by xonsh foreign-shell/completer
             bash_works = 'pc-linux-gnu' not in out.splitlines()[0]
-        
+
         if bash_works:
             wbc = bash_on_path
         else:

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -299,22 +299,28 @@ def windows_bash_command():
     # Check that bash is on path otherwise try the default directory
     # used by Git for windows
     wbc = 'bash'
-    bash_on_path = builtins.__xonsh_commands_cache__.lazy_locate_binary('bash',
-                                                                        ignore_alias=True)
+    cmd_cache = builtins.__xonsh_commands_cache__
+    bash_on_path = cmd_cache.lazy_locate_binary('bash', ignore_alias=True)
     if bash_on_path:
-        # Check if Bash is from the "Windows Subsystem for Linux" (WSL)
-        # which can't be used by xonsh foreign-shell/completer
-        out = subprocess.check_output([bash_on_path, '--version'],
+        try:
+            out = subprocess.check_output([bash_on_path, '--version'],
                                       stderr=subprocess.PIPE,
                                       universal_newlines=True)
-        if 'pc-linux-gnu' in out.splitlines()[0]:
+        except subprocess.CalledProcessError:
+            bash_works = False
+        else:
+            # Check if Bash is from the "Windows Subsystem for Linux" (WSL)
+            # which can't be used by xonsh foreign-shell/completer
+            bash_works = 'pc-linux-gnu' not in out.splitlines()[0]
+        
+        if bash_works:
+            wbc = bash_on_path
+        else:
             gfwp = git_for_windows_path()
             if gfwp:
                 bashcmd = os.path.join(gfwp, 'bin\\bash.exe')
                 if os.path.isfile(bashcmd):
                     wbc = bashcmd
-        else:
-            wbc = bash_on_path
     return wbc
 
 #


### PR DESCRIPTION
This should address #2224, where @ericmharris reported that `Windows subsystem for Linux` (WSL) bash did not return a correct version string. 

