### PR TITLE
Fast hg branch

### DIFF
--- a/news/fast_hg_branch.rst
+++ b/news/fast_hg_branch.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+* ``prompt.vc.get_hg_branch`` now uses ``os.scandir`` to walk up the filetree
+  looking for a ``.hg`` directory. This results in (generally) faster branch
+  resolution compared to the subprocess call to ``hg root``.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -79,19 +79,6 @@ def get_hg_branch(root=None):
         root = q.get_nowait()
     except queue.Empty:
         return None
-#    if t.is_alive():
-#        return subprocess.TimeoutExpired(['hg'], timeout)
-
-#    try:
-#        root = subprocess.check_output(['hg', 'root'], timeout=timeout,
-#                                       stderr=subprocess.DEVNULL)
-#    except subprocess.TimeoutExpired:
-#        return subprocess.TimeoutExpired(['hg'], timeout)
-#    except (subprocess.CalledProcessError, FileNotFoundError):
-#        # not in repo or command not in PATH
-#        return None
-#    else:
-#        root = xt.decode_bytes(root).strip()
     if env.get('VC_HG_SHOW_BRANCH'):
         # get branch name
         branch_path = os.path.sep.join([root, '.hg', 'branch'])

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -52,6 +52,18 @@ def get_git_branch():
         branch = None
     return branch
 
+def _get_hg_root(q):
+    _curpwd = os.getcwd()
+    while True:
+        if any([b.name == '.hg' for b in os.scandir(_curpwd)]):
+            q.put(_curpwd)
+            break
+        else:
+            _oldpwd = _curpwd
+            _curpwd = os.path.split(_curpwd)[0]
+            if _oldpwd == _curpwd:
+                return False
+
 
 def get_hg_branch(root=None):
     """Try to get the mercurial branch of the current directory,
@@ -59,16 +71,27 @@ def get_hg_branch(root=None):
     """
     env = builtins.__xonsh_env__
     timeout = env['VC_BRANCH_TIMEOUT']
+    q = queue.Queue()
+    t = threading.Thread(target=_get_hg_root, args=(q,))
+    t.start()
+    t.join(timeout=timeout)
     try:
-        root = subprocess.check_output(['hg', 'root'], timeout=timeout,
-                                       stderr=subprocess.DEVNULL)
-    except subprocess.TimeoutExpired:
-        return subprocess.TimeoutExpired(['hg'], timeout)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        # not in repo or command not in PATH
+        root = q.get_nowait()
+    except queue.Empty:
         return None
-    else:
-        root = xt.decode_bytes(root).strip()
+#    if t.is_alive():
+#        return subprocess.TimeoutExpired(['hg'], timeout)
+
+#    try:
+#        root = subprocess.check_output(['hg', 'root'], timeout=timeout,
+#                                       stderr=subprocess.DEVNULL)
+#    except subprocess.TimeoutExpired:
+#        return subprocess.TimeoutExpired(['hg'], timeout)
+#    except (subprocess.CalledProcessError, FileNotFoundError):
+#        # not in repo or command not in PATH
+#        return None
+#    else:
+#        root = xt.decode_bytes(root).strip()
     if env.get('VC_HG_SHOW_BRANCH'):
         # get branch name
         branch_path = os.path.sep.join([root, '.hg', 'branch'])

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -52,6 +52,7 @@ def get_git_branch():
         branch = None
     return branch
 
+
 def _get_hg_root(q):
     _curpwd = os.getcwd()
     while True:


### PR DESCRIPTION
This needs more work, but I wanted folks to take a look at it (ping @ngoldbaum @laerus) to make sure I'm not missing any `hg` specific issues. 

Also, the usage of `$VC_BRANCH_TIMEOUT` will probably have to change (or be removed entirely)

Preliminary checks on my machine show something like a 1000x speed increase, which ain't too bad.

```
In [1]: import subprocess

In [2]: from xonsh.prompt.vc import _get_hg_root

In [3]: import queue

In [4]: pwd
Out[4]: '/home/gil/git/pygments-main/pygments/styles'

In [5]: subprocess.check_output(['hg', 'root'])
Out[5]: b'/home/gil/git/pygments-main\n'

In [6]: %timeit subprocess.check_output(['hg', 'root'])
10 loops, best of 3: 80.4 ms per loop

In [7]: q = queue.Queue()

In [8]: _get_hg_root(q)
   ...: q.get_nowait()
   ...: 
Out[8]: '/home/gil/git/pygments-main'

In [9]: %%timeit 
   ...: _get_hg_root(q)
   ...: q.get_nowait()
   ...: 
The slowest run took 6.81 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 65.4 µs per loop
```