### PR TITLE
Fix the regression introduced by #2235 concerning the `$PWD` change

### DIFF
--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -375,12 +375,15 @@ class BaseShell(object):
         """Check if the cwd changed out from under us."""
         env = builtins.__xonsh_env__
         cwd = os.getcwd()
-        if 'PWD' in env and os.path.realpath(cwd) != os.path.realpath(env['PWD']):
-            old = env['PWD']  # working directory changed without updating $PWD
-            env['PWD'] = cwd  # track it now
-            if old is not None:
-                env['OLDPWD'] = old  # and update $OLDPWD like dirstack.
-            events.on_chdir.fire(olddir=old, newdir=cwd)  # fire event after cwd actually changed.
+        if 'PWD' not in env:
+            # $PWD is missing from env, recreate it
+            env['PWD'] = cwd
+        elif os.path.realpath(cwd) != os.path.realpath(env['PWD']):
+            # The working directory has changed without updating $PWD, fix this
+            old = env['PWD']
+            env['PWD'] = cwd
+            env['OLDPWD'] = old
+            events.on_chdir.fire(olddir=old, newdir=cwd)
 
     def push(self, line):
         """Pushes a line onto the buffer and compiles the code in a way that


### PR DESCRIPTION
Before 72d04e (#2235), the `_fix_cwd` function was having a side effect to reset the `$PWD` environment variable if it was deleted. As #2235 changed this behviour in order to handle symlinks, this implicit side effect is gone.

This commit reintroduce the reset of the `$PWD` environment variable from `_fix_cwd`, but explicitely so it wont be missed again :-)

    «Explicit is better than implicit.» [Tim Peters]

Close #2236