### PR TITLE
Revised spell miss (overwite -> overwrite)

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -248,7 +248,7 @@ def source_foreign(args, stdin=None, stdout=None, stderr=None):
     for k, v in fsaliases.items():
         if k in baliases and v == baliases[k]:
             continue  # no change from original
-        elif ns.overwite_aliases or k not in baliases:
+        elif ns.overwrite_aliases or k not in baliases:
             baliases[k] = v
         else:
             msg = ('Skipping application of {0!r} alias from {1!r} '


### PR DESCRIPTION
It causes an exception when `source-bash foo/bin/activate` to activate python virtual environment in my terminal (Mac OS X 10.11.2).

The content of the exception is here.
```python
AttributeError: 'Namespace' object has no attribute 'overwite_aliases'
```

It seems this value `overwite` is not used in other place (I grepped this), so I changed.

I don't write test for this. but `source-bash` does work well to me.