### PR TITLE
Wrapping Triple Quotes for Subprocs

### DIFF
--- a/news/q.rst
+++ b/news/q.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Multiline strings can now be written in subprocess mode.
+
+**Security:** None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1792,6 +1792,9 @@ def test_comment_only():
 def test_echo_slash_question():
     check_xonsh_ast({}, '![echo /?]', False)
 
+def test_bad_quotes():
+    with pytest.raises(SyntaxError):
+        check_xonsh_ast({}, '![echo """hello]', False)
 
 def test_redirect():
     assert check_xonsh_ast({}, '$[cat < input.txt]', False)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -360,6 +360,9 @@ LOGICAL_LINE_CASES = [
 14 \\
 + 2
 """, 1, '14 + 2', 2),
+('''x = """wow
+mom"""
+''', 0, 'x = """wow\nmom"""', 2),
 ]
 
 @pytest.mark.parametrize('src, idx, exp_line, exp_n', LOGICAL_LINE_CASES)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -24,7 +24,7 @@ from xonsh.tools import (
     is_string_seq, pathsep_to_seq, seq_to_pathsep, is_nonstring_seq_of_strings,
     pathsep_to_upper_seq, seq_to_upper_pathsep, expandvars, is_int_as_str, is_slice_as_str,
     ensure_timestamp, get_portions, is_balanced, subexpr_before_unbalanced,
-    swap_values, get_logical_line, replace_logical_line
+    swap_values, get_logical_line, replace_logical_line, check_quotes,
     )
 from xonsh.environ import Env
 
@@ -208,6 +208,11 @@ def test_subproc_toks_hello_mom_second():
     assert exp == obs
 
 
+def test_subproc_toks_hello_bad_quotes():
+    with pytest.raises(SyntaxError):
+        obs = subproc_toks('echo """hello', lexer=LEXER, returnline=True)
+
+
 def test_subproc_toks_comment():
     exp = None
     obs = subproc_toks('# I am a comment', lexer=LEXER, returnline=True)
@@ -352,6 +357,17 @@ def test_replace_logical_line(src, idx, exp_line, exp_n):
     obs = '\n'.join(lines).replace('\\\n', '').strip()
     assert exp == obs
 
+
+@pytest.mark.parametrize('inp, exp', [
+    ('f(1,10),x.y', True),
+    ('"x"', True),
+    ("'y'", True),
+    ('b"x"', True),
+    ("r'y'", True),
+])
+def test_check_quotes(inp, exp):
+    obs = check_quotes(inp)
+    assert exp is obs
 
 @pytest.mark.parametrize('inp', [
     'f(1,10),x.y',

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -208,9 +208,24 @@ def test_subproc_toks_hello_mom_second():
     assert exp == obs
 
 
-def test_subproc_toks_hello_bad_quotes():
-    with pytest.raises(SyntaxError):
-        obs = subproc_toks('echo """hello', lexer=LEXER, returnline=True)
+def test_subproc_toks_hello_bad_leading_triple_quotes():
+    obs = subproc_toks('echo """hello', lexer=LEXER, returnline=True)
+    assert obs is None
+
+
+def test_subproc_toks_hello_bad_trailing_single_quotes():
+    obs = subproc_toks('echo hello"', lexer=LEXER, returnline=True)
+    assert obs is None
+
+
+def test_subproc_toks_hello_bad_leading_triple_quotes():
+    obs = subproc_toks('echo """hello', lexer=LEXER, returnline=True)
+    assert obs is None
+
+
+def test_subproc_toks_hello_bad_trailing_triple_quotes():
+    obs = subproc_toks('echo hello"""', lexer=LEXER, returnline=True)
+    assert obs is None
 
 
 def test_subproc_toks_comment():
@@ -368,6 +383,7 @@ def test_replace_logical_line(src, idx, exp_line, exp_n):
 def test_check_quotes(inp, exp):
     obs = check_quotes(inp)
     assert exp is obs
+
 
 @pytest.mark.parametrize('inp', [
     'f(1,10),x.y',

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -228,6 +228,13 @@ def test_subproc_toks_hello_bad_trailing_triple_quotes():
     assert obs is None
 
 
+def test_subproc_toks_hello_mom_triple_quotes_nl():
+    s = 'echo """hello\nmom"""'
+    exp = '![{0}]'.format(s)
+    obs = subproc_toks(s, lexer=LEXER, returnline=True)
+    assert exp == obs
+
+
 def test_subproc_toks_comment():
     exp = None
     obs = subproc_toks('# I am a comment', lexer=LEXER, returnline=True)
@@ -379,6 +386,7 @@ def test_replace_logical_line(src, idx, exp_line, exp_n):
     ("'y'", True),
     ('b"x"', True),
     ("r'y'", True),
+    ('"""hello\nmom"""', True),
 ])
 def test_check_quotes(inp, exp):
     obs = check_quotes(inp)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -208,8 +208,8 @@ def test_subproc_toks_hello_mom_second():
     assert exp == obs
 
 
-def test_subproc_toks_hello_bad_leading_triple_quotes():
-    obs = subproc_toks('echo """hello', lexer=LEXER, returnline=True)
+def test_subproc_toks_hello_bad_leading_single_quotes():
+    obs = subproc_toks('echo "hello', lexer=LEXER, returnline=True)
     assert obs is None
 
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -19,6 +19,7 @@ from xonsh.platform import PYTHON_VERSION_INFO
 from xonsh.tokenize import SearchPath, StringPrefix
 from xonsh.lazyasd import LazyObject
 from xonsh.parsers.context_check import check_contexts
+from xonsh.tools import check_quotes
 
 RE_SEARCHPATH = LazyObject(lambda: re.compile(SearchPath), globals(),
                            'RE_SEARCHPATH')
@@ -2505,25 +2506,7 @@ class BaseParser(object):
         """
         if not isinstance(p, ast.Str):
             return p
-        s = p.s
-        if s.startswith('"""'):
-            ok = s.endswith('"""')
-        elif s.endswith('"""'):
-            ok = s.startswith('"""')
-        elif s.startswith("'''"):
-            ok = s.endswith("'''")
-        elif s.endswith("'''"):
-            ok = s.startswith("'''")
-        elif s.startswith('"'):
-            ok = s.endswith('"')
-        elif s.endswith('"'):
-            ok = s.startswith('"')
-        elif s.startswith("'"):
-            ok = s.endswith("'")
-        elif s.endswith("'"):
-            ok = s.startswith("'")
-        else:
-            ok = True
+        ok = check_quotes(p.s)
         if not ok:
             msg = ("Subprocess tokes must have matching begining and ending "
                    "quotes, if they start or end with quotes, got {0}")

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2516,12 +2516,14 @@ class BaseParser(object):
 
     def p_subproc_atoms_single(self, p):
         """subproc_atoms : subproc_atom"""
-        p[0] = [self._check_quotes(p[1])]
+        p[0] = [p[1]]
+        #p[0] = [self._check_quotes(p[1])]
 
     def p_subproc_atoms_many(self, p):
         """subproc_atoms : subproc_atoms WS subproc_atom"""
         p1 = p[1]
-        p1.append(self._check_quotes(p[3]))
+        p1.append(p[3])
+        #p1.append(self._check_quotes(p[3]))
         p[0] = p1
 
     #

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2517,13 +2517,11 @@ class BaseParser(object):
     def p_subproc_atoms_single(self, p):
         """subproc_atoms : subproc_atom"""
         p[0] = [p[1]]
-        #p[0] = [self._check_quotes(p[1])]
 
     def p_subproc_atoms_many(self, p):
         """subproc_atoms : subproc_atoms WS subproc_atom"""
         p1 = p[1]
         p1.append(p[3])
-        #p1.append(self._check_quotes(p[3]))
         p[0] = p1
 
     #

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2500,20 +2500,6 @@ class BaseParser(object):
         cliargs = self._subproc_cliargs(p[3], lineno=self.lineno, col=self.col)
         p[0] = p1 + [p[2], cliargs]
 
-    def _check_quotes(self, p):
-        """Make sure that subproc atoms begin and end with matching quotes,
-        if they begin or end in quotes.
-        """
-        if not isinstance(p, ast.Str):
-            return p
-        ok = check_quotes(p.s)
-        if not ok:
-            msg = ("Subprocess tokes must have matching begining and ending "
-                   "quotes, if they start or end with quotes, got {0}")
-            msg = msg.format(s)
-            self._parse_error(msg, self.currloc(lineno=p.lineno, column=p.lexpos))
-        return p
-
     def p_subproc_atoms_single(self, p):
         """subproc_atoms : subproc_atom"""
         p[0] = [p[1]]

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -19,7 +19,7 @@ from xonsh.platform import PYTHON_VERSION_INFO
 from xonsh.tokenize import SearchPath, StringPrefix
 from xonsh.lazyasd import LazyObject
 from xonsh.parsers.context_check import check_contexts
-from xonsh.tools import check_quotes
+
 
 RE_SEARCHPATH = LazyObject(lambda: re.compile(SearchPath), globals(),
                            'RE_SEARCHPATH')

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1592,7 +1592,7 @@ terminating quotes)"""
 def RE_COMPLETE_STRING():
     ptrn = ('^' + _RE_STRING_START + '(?P<quote>' + "|".join(_STRINGS) + ')' +
             '.*?(?P=quote)$')
-    return re.compile(ptrn)
+    return re.compile(ptrn, re.DOTALL)
 
 
 def check_for_partial_string(x):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -377,9 +377,9 @@ def check_quotes(s):
 
 
 def _have_open_triple_quotes(s):
-    if s.count('"""')%2 == 1:
+    if s.count('"""') % 2 == 1:
         open_triple = '"""'
-    elif s.count("'''")%2 == 1:
+    elif s.count("'''") % 2 == 1:
         open_triple = "'''"
     else:
         open_triple = False

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -319,7 +319,7 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
             else:
                 tok.lexpos = len(line)
             break
-        elif isinstance(tok.value, str) and not check_quotes(tok.value):
+        elif check_bad_str_token(tok):
             return
     else:
         if len(toks) > 0 and toks[-1].type in END_TOK_TYPES:
@@ -346,6 +346,16 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
     if returnline:
         rtn = line[:beg] + rtn + line[end:]
     return rtn
+
+
+def check_bad_str_token(tok):
+    """Checks if a token is a bad string."""
+    if tok.type == 'ERRORTOKEN' and tok.value == 'EOF in multi-line string':
+        return True
+    elif isinstance(tok.value, str) and not check_quotes(tok.value):
+        return True
+    else:
+        return False
 
 
 def check_quotes(s):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -376,6 +376,16 @@ def check_quotes(s):
     return ok
 
 
+def _have_open_triple_quotes(s):
+    if s.count('"""')%2 == 1:
+        open_triple = '"""'
+    elif s.count("'''")%2 == 1:
+        open_triple = "'''"
+    else:
+        open_triple = False
+    return open_triple
+
+
 def get_logical_line(lines, idx):
     """Returns a single logical line (i.e. one without line continuations)
     from a list of lines.  This line should begin at index idx. This also
@@ -385,10 +395,15 @@ def get_logical_line(lines, idx):
     n = 1
     nlines = len(lines)
     line = lines[idx]
-    while line.endswith('\\') and idx < nlines:
+    open_triple = _have_open_triple_quotes(line)
+    while (line.endswith('\\') or open_triple) and idx < nlines:
         n += 1
         idx += 1
-        line = line[:-1] + lines[idx]
+        if line.endswith('\\'):
+            line = line[:-1] + lines[idx]
+        else:
+            line = line + '\n' + lines[idx]
+        open_triple = _have_open_triple_quotes(line)
     return line, n
 
 


### PR DESCRIPTION
This PR contains a number of fixes for wrapping subprocesses that happen to have partially open triple quotes. This is in an attempt to fix #1152.