### PR TITLE
print jobs when interactive

### DIFF
--- a/news/ji.rst
+++ b/news/ji.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* Job control info when foregrounding or backgrounding jobs will now
+  only be displayed when xonsh is in interactive mode.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -244,7 +244,7 @@ def add_job(info):
     info['status'] = "running"
     tasks.appendleft(num)
     builtins.__xonsh_all_jobs__[num] = info
-    if info['bg']:
+    if info['bg'] and builtins.__xonsh_env__.get('XONSH_INTERACTIVE'):
         print_one_job(num)
 
 
@@ -358,7 +358,8 @@ def fg(args, stdin=None):
     job = get_task(tid)
     job['bg'] = False
     job['status'] = "running"
-    print_one_job(tid)
+    if builtins.__xonsh_env__.get('XONSH_INTERACTIVE'):
+        print_one_job(tid)
     pipeline = job['pipeline']
     pipeline.resume(job)
 


### PR DESCRIPTION
This PR only prints job info when in interactive mode when preforming backgrounding and foregrounding tasks.  The `jobs` command will always display, of course. This addresses part of what is in #1174.