### PR TITLE
Fix line continuations on windows

### DIFF
--- a/news/win_line_cont.rst
+++ b/news/win_line_cont.rst
@@ -1,4 +1,7 @@
-**Added:** None
+**Added:** 
+
+* Line continuation backslashes are respected on Windows in PTK shell if
+  the backspace is is preceded by a space. 
 
 **Changed:** None
 

--- a/news/win_line_cont.rst
+++ b/news/win_line_cont.rst
@@ -1,0 +1,16 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Fixed bug where trailing backspaces on windows paths could be interpreted 
+  as line continuations characters. Now line continuation characters must be
+  preceeded by a space on Windows. This only applies to interactive to ensure 
+  xonsh scripts are portable. 
+
+**Security:** None

--- a/news/win_line_cont.rst
+++ b/news/win_line_cont.rst
@@ -1,6 +1,6 @@
 **Added:** 
 
-* Line continuation backslashes are respected on Windows in PTK shell if
+* Line continuation backslashes are respected on Windows in the PTK shell if
   the backspace is is preceded by a space. 
 
 **Changed:** None
@@ -11,9 +11,9 @@
 
 **Fixed:** 
 
-* Fixed bug where trailing backspaces on windows paths could be interpreted 
+* Fixed bug where trailing backspaces on Windows paths could be interpreted
   as line continuations characters. Now line continuation characters must be
-  preceeded by a space on Windows. This only applies to interactive to ensure 
-  xonsh scripts are portable. 
+  preceded by a space on Windows. This only applies to xonsh in interactive
+  mode to ensure  scripts are portable. 
 
 **Security:** None

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -401,7 +401,6 @@ class BaseShell(object):
         """Compiles source code and returns the (possibly modified) source and
         a valid code object.
         """
-        import pdb;pdb.set_trace()
         _cache = should_use_cache(self.execer, 'single')
         if _cache:
             codefname = code_cache_name(src)

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -8,7 +8,7 @@ import builtins
 
 from xonsh.tools import (XonshError, print_exception, DefaultNotGiven,
                          check_for_partial_string, format_std_prepost,
-                         LINE_CONT_STR)
+                         LINE_CONTINUATION)
 from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
@@ -409,7 +409,7 @@ class BaseShell(object):
             if usecache:
                 self.reset_buffer()
                 return src, code
-        if src.endswith(str(LINE_CONT_STR)+'\n'):
+        if src.endswith(str(LINE_CONTINUATION)+'\n'):
             self.need_more_lines = True
             return src, None
         try:

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -409,7 +409,7 @@ class BaseShell(object):
             if usecache:
                 self.reset_buffer()
                 return src, code
-        if src.endswith(LINECONT+'\n'):
+        if src.endswith(LINE_CONT_STR+'\n'):
             self.need_more_lines = True
             return src, None
         try:

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -401,6 +401,7 @@ class BaseShell(object):
         """Compiles source code and returns the (possibly modified) source and
         a valid code object.
         """
+        import pdb;pdb.set_trace()
         _cache = should_use_cache(self.execer, 'single')
         if _cache:
             codefname = code_cache_name(src)
@@ -409,7 +410,7 @@ class BaseShell(object):
             if usecache:
                 self.reset_buffer()
                 return src, code
-        if src.endswith(LINE_CONT_STR+'\n'):
+        if src.endswith(str(LINE_CONT_STR)+'\n'):
             self.need_more_lines = True
             return src, None
         try:

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -7,7 +7,8 @@ import time
 import builtins
 
 from xonsh.tools import (XonshError, print_exception, DefaultNotGiven,
-                         check_for_partial_string, format_std_prepost)
+                         check_for_partial_string, format_std_prepost,
+                         LINE_CONT_STR)
 from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
@@ -408,7 +409,7 @@ class BaseShell(object):
             if usecache:
                 self.reset_buffer()
                 return src, code
-        if src.endswith('\\\n'):
+        if src.endswith(LINECONT+'\n'):
             self.need_more_lines = True
             return src, None
         try:

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -8,7 +8,7 @@ from prompt_toolkit.filters import (Condition, IsMultiline, HasSelection,
 from prompt_toolkit.keys import Keys
 
 from xonsh.aliases import xonsh_exit
-from xonsh.tools import ON_WINDOWS, check_for_partial_string, LINE_CONT_STR
+from xonsh.tools import check_for_partial_string, LINE_CONT_STR
 from xonsh.shell import transform_command
 
 env = builtins.__xonsh_env__

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -8,7 +8,7 @@ from prompt_toolkit.filters import (Condition, IsMultiline, HasSelection,
 from prompt_toolkit.keys import Keys
 
 from xonsh.aliases import xonsh_exit
-from xonsh.tools import check_for_partial_string, LINE_CONT_STR
+from xonsh.tools import check_for_partial_string, LINE_CONTINUATION
 from xonsh.shell import transform_command
 
 env = builtins.__xonsh_env__
@@ -50,7 +50,7 @@ def carriage_return(b, cli, *, autoindent=True):
         b.delete_before_cursor(count=len(indent))
     elif (not doc.on_first_line and not current_line_blank):
         b.newline(copy_margin=autoindent)
-    elif (doc.current_line.endswith(str(LINE_CONT_STR))):
+    elif (doc.current_line.endswith(str(LINE_CONTINUATION))):
         b.newline(copy_margin=autoindent)
     elif (doc.find_next_word_beginning() is not None and
             (any(not _is_blank(i) for i in doc.lines_from_current[1:]))):

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -8,7 +8,7 @@ from prompt_toolkit.filters import (Condition, IsMultiline, HasSelection,
 from prompt_toolkit.keys import Keys
 
 from xonsh.aliases import xonsh_exit
-from xonsh.tools import ON_WINDOWS, check_for_partial_string
+from xonsh.tools import ON_WINDOWS, check_for_partial_string, LINE_CONT_STR
 from xonsh.shell import transform_command
 
 env = builtins.__xonsh_env__
@@ -50,9 +50,7 @@ def carriage_return(b, cli, *, autoindent=True):
         b.delete_before_cursor(count=len(indent))
     elif (not doc.on_first_line and not current_line_blank):
         b.newline(copy_margin=autoindent)
-    elif (doc.char_before_cursor == '\\' and
-            not (not builtins.__xonsh_env__.get('FORCE_POSIX_PATHS') and
-                 ON_WINDOWS)):
+    elif (doc.current_line.endswith(str(LINE_CONT_STR))):
         b.newline(copy_margin=autoindent)
     elif (doc.find_next_word_beginning() is not None and
             (any(not _is_blank(i) for i in doc.lines_from_current[1:]))):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -357,6 +357,7 @@ def LINE_CONT_STR():
     else:
         return '\\'
 
+
 def get_logical_line(lines, idx):
     """Returns a single logical line (i.e. one without line continuations)
     from a list of lines.  This line should begin at index idx. This also

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -345,6 +345,16 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
         rtn = line[:beg] + rtn + line[end:]
     return rtn
 
+@lazyobject
+def LINE_CONT_STR():
+    """ The line contiuation characters used in subproc mode. In interactive
+         mode on Windows the backslash must be preseeded by a space. This is because
+         paths on windows may end in a backspace.
+    """
+    if ON_WINDOWS and builtins.__xonsh_env__.get('XONSH_INTERACTIVE'):
+        return ' \\'
+    else:
+        return '\\'
 
 def get_logical_line(lines, idx):
     """Returns a single logical line (i.e. one without line continuations)
@@ -355,7 +365,7 @@ def get_logical_line(lines, idx):
     n = 1
     nlines = len(lines)
     line = lines[idx]
-    while line.endswith('\\') and idx < nlines:
+    while line.endswith(str(LINE_CONT_STR)) and idx < nlines:
         n += 1
         idx += 1
         line = line[:-1] + lines[idx]
@@ -379,7 +389,7 @@ def replace_logical_line(lines, logical, idx, n):
             logical = ''
         else:
             # found space to split on
-            lines[i] = logical[:b] + '\\'
+            lines[i] = logical[:b] + LINE_CONT_STR
             logical = logical[b:]
     lines[idx+n-1] = logical
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -345,6 +345,7 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
         rtn = line[:beg] + rtn + line[end:]
     return rtn
 
+
 @lazyobject
 def LINE_CONT_STR():
     """ The line contiuation characters used in subproc mode. In interactive

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -389,7 +389,7 @@ def replace_logical_line(lines, logical, idx, n):
             logical = ''
         else:
             # found space to split on
-            lines[i] = logical[:b] + LINE_CONT_STR
+            lines[i] = logical[:b] + str(LINE_CONT_STR)
             logical = logical[b:]
     lines[idx+n-1] = logical
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -347,7 +347,7 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
 
 
 @lazyobject
-def LINE_CONT_STR():
+def LINE_CONTINUATION():
     """ The line contiuation characters used in subproc mode. In interactive
          mode on Windows the backslash must be preseeded by a space. This is because
          paths on windows may end in a backspace.
@@ -367,7 +367,7 @@ def get_logical_line(lines, idx):
     n = 1
     nlines = len(lines)
     line = lines[idx]
-    while line.endswith(str(LINE_CONT_STR)) and idx < nlines:
+    while line.endswith(str(LINE_CONTINUATION)) and idx < nlines:
         n += 1
         idx += 1
         line = line[:-1] + lines[idx]
@@ -391,7 +391,7 @@ def replace_logical_line(lines, logical, idx, n):
             logical = ''
         else:
             # found space to split on
-            lines[i] = logical[:b] + str(LINE_CONT_STR)
+            lines[i] = logical[:b] + str(LINE_CONTINUATION)
             logical = logical[b:]
     lines[idx+n-1] = logical
 


### PR DESCRIPTION
Ensure that line continuations are preceded by a space in interactive mode on windows. This ensures that we can handle subproc commands like: `cd Users\Documents\` or other commands that ends with windows paths.

This only applies to interactive mode to ensure that xonsh scripts are still somewhat portable. 

Fixes #2213 and #2243