### PR TITLE
Unthreadable xontrib command

### DIFF
--- a/news/unthreadsig.rst
+++ b/news/unthreadsig.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+* The ``xontrib`` command is now flagged as unthreadable and will be
+  run on the main Python thread. This allows xontribs to set signal
+  handlers and other operations that require the main thread.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -8,7 +8,7 @@ import functools
 import importlib
 import importlib.util
 
-from xonsh.tools import print_color
+from xonsh.tools import print_color, unthreadable
 
 
 @functools.lru_cache(1)
@@ -157,6 +157,7 @@ _MAIN_XONTRIB_ACTIONS = {
     }
 
 
+@unthreadable
 def xontribs_main(args=None, stdin=None):
     """Alias that loads xontribs"""
     if not args or (args[0] not in _MAIN_XONTRIB_ACTIONS and


### PR DESCRIPTION
This enables signals to be used inside of xontribs on load. Should address #1481