### PR TITLE
Interactive mode with command or script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ include/
 feedstock/
 *.cred
 tttt
+tags

--- a/news/interactive.rst
+++ b/news/interactive.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* interactive mode to work with command and script options
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ def xonsh_events():
 @pytest.yield_fixture
 def xonsh_builtins(xonsh_events):
     """Mock out most of the builtins xonsh attributes."""
+    old_builtins = set(dir(builtins))
     builtins.__xonsh_env__ = DummyEnv()
     if ON_WINDOWS:
         builtins.__xonsh_env__['PATHEXT'] = ['.EXE', '.BAT', '.CMD']
@@ -72,41 +73,8 @@ def xonsh_builtins(xonsh_events):
     # be firing events on the global instance.
     builtins.events = xonsh_events
     yield builtins
-    if hasattr(builtins, '__xonsh_env__'):
-        del builtins.__xonsh_env__
-    if hasattr(builtins, '__xonsh_ctx__'):
-        del builtins.__xonsh_ctx__
-    if hasattr(builtins, '__xonsh_shell__'):
-        del builtins.__xonsh_shell__
-    if hasattr(builtins, '__xonsh_help__'):
-        del builtins.__xonsh_help__
-    if hasattr(builtins, '__xonsh_glob__'):
-        del builtins.__xonsh_glob__
-    if hasattr(builtins, '__xonsh_exit__'):
-        del builtins.__xonsh_exit__
-    if hasattr(builtins, '__xonsh_superhelp__'):
-        del builtins.__xonsh_superhelp__
-    del builtins.__xonsh_regexpath__
-    if hasattr(builtins, '__xonsh_expand_path__'):
-        del builtins.__xonsh_expand_path__
-    if hasattr(builtins, '__xonsh_stdout_uncaptured__'):
-        del builtins.__xonsh_stdout_uncaptured__
-    if hasattr(builtins, '__xonsh_stderr_uncaptured__'):
-        del builtins.__xonsh_stderr_uncaptured__
-    del builtins.__xonsh_subproc_captured__
-    if hasattr(builtins, '__xonsh_subproc_uncaptured__'):
-        del builtins.__xonsh_subproc_uncaptured__
-    del builtins.__xonsh_ensure_list_of_strs__
-    del builtins.__xonsh_commands_cache__
-    del builtins.__xonsh_all_jobs__
-    if hasattr(builtins, '__xonsh_history__'):
-        del builtins.__xonsh_history__
-    del builtins.__xonsh_enter_macro__
-    del builtins.evalx
-    del builtins.execx
-    del builtins.compilex
-    del builtins.aliases
-    del builtins.events
+    for attr in set(dir(builtins)) - old_builtins:
+        delattr(builtins, attr)
     tasks.clear()  # must to this to enable resetting all_jobs
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,8 @@ def xonsh_builtins(xonsh_events):
         del builtins.__xonsh_env__
     if hasattr(builtins, '__xonsh_ctx__'):
         del builtins.__xonsh_ctx__
-    del builtins.__xonsh_shell__
+    if hasattr(builtins, '__xonsh_shell__'):
+        del builtins.__xonsh_shell__
     if hasattr(builtins, '__xonsh_help__'):
         del builtins.__xonsh_help__
     if hasattr(builtins, '__xonsh_glob__'):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -144,7 +144,7 @@ def test_main_xonsh_interactive_command(xonsh_builtins):
     assert shell.shell.cmdloop.called
 
 
-def test_main_xonsh_interactive_command(xonsh_builtins, monkeypatch):
+def test_main_xonsh_interactive_script(xonsh_builtins, monkeypatch):
     shell_mock = Mock()
     run_script_with_cache_mock = Mock()
     isfile_mock = Mock(return_value=True)
@@ -166,3 +166,14 @@ def test_main_xonsh_interactive_command(xonsh_builtins, monkeypatch):
 
     assert run_script_with_cache_mock.called
     assert shell.shell.cmdloop.called
+
+
+@pytest.mark.parametrize('args', [
+    ['-ic', '"a=10"'],
+    ['-i', 'script.xsh']
+    ])
+def test_premain_force_interactive_with_command_or_sript(args):
+    args = xonsh.main.premain(args)
+
+    assert args.mode == xonsh.main.XonshMode.interactive
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -175,5 +175,5 @@ def test_main_xonsh_interactive_script(xonsh_builtins, monkeypatch):
 def test_premain_force_interactive_with_command_or_sript(args):
     args = xonsh.main.premain(args)
 
-    assert args.mode == xonsh.main.XonshMode.interactive
+    assert args.force_interactive
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,20 +6,24 @@ from contextlib import contextmanager
 import builtins
 import os.path
 import sys
+from unittest.mock import Mock
+from argparse import Namespace
 
 import xonsh.main
 import pytest
 from tools import TEST_DIR
 
 
-def Shell(*args, **kwargs):
-    pass
+class Shell:
+    def __init__(self, *args, **kwargs):
+        pass
 
 
 @pytest.fixture
 def shell(xonsh_builtins, xonsh_execer, monkeypatch):
     """Xonsh Shell Mock"""
     monkeypatch.setattr(xonsh.main, 'Shell', Shell)
+    return Shell
 
 
 def test_premain_no_arg(shell, monkeypatch):
@@ -118,3 +122,47 @@ def test_xonsh_failback_script_from_file(shell, monkeypatch):
     with pytest.raises(Exception):
         xonsh.main.main()
     assert len(checker) == 0
+
+
+def test_main_xonsh_interactive_command(xonsh_builtins):
+    shell_mock = Mock()
+    run_code_with_cache_mock = Mock()
+    cmdloop_mock = Mock()
+    xonsh.main.run_code_with_cache = run_code_with_cache_mock
+    shell = xonsh_builtins.__xonsh_shell__ = shell_mock()
+    shell.shell.cmdloop = cmdloop_mock
+    env = xonsh_builtins.__xonsh_env__
+    env['LOADED_CONFIG'] = True
+    args = Namespace(mode=xonsh.main.XonshMode.single_command,
+                     force_interactive=True,
+                     command='a=10')
+
+    xonsh.main.main_xonsh(args)
+
+
+    assert run_code_with_cache_mock.called
+    assert shell.shell.cmdloop.called
+
+
+def test_main_xonsh_interactive_command(xonsh_builtins, monkeypatch):
+    shell_mock = Mock()
+    run_script_with_cache_mock = Mock()
+    isfile_mock = Mock(return_value=True)
+    cmdloop_mock = Mock()
+    xonsh.main.run_script_with_cache = run_script_with_cache_mock
+    shell = xonsh_builtins.__xonsh_shell__ = shell_mock()
+    shell.shell.cmdloop = cmdloop_mock
+    env = xonsh_builtins.__xonsh_env__
+    env['LOADED_CONFIG'] = True
+    monkeypatch.setattr(os.path, 'isfile', isfile_mock)
+    args = Namespace(mode=xonsh.main.XonshMode.script_from_file,
+                     force_interactive=True,
+                     file='',
+                     args=[]
+                     )
+
+    xonsh.main.main_xonsh(args)
+
+
+    assert run_script_with_cache_mock.called
+    assert shell.shell.cmdloop.called

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,7 +172,7 @@ def test_main_xonsh_interactive_script(xonsh_builtins, monkeypatch):
     ['-ic', '"a=10"'],
     ['-i', 'script.xsh']
     ])
-def test_premain_force_interactive_with_command_or_sript(args):
+def test_premain_force_interactive_with_command_or_script(args):
     args = xonsh.main.premain(args)
 
     assert args.force_interactive

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -351,22 +351,7 @@ def main_xonsh(args):
     env = builtins.__xonsh_env__
     shell = builtins.__xonsh_shell__
     try:
-        if args.mode == XonshMode.interactive:
-            # enter the shell
-            env['XONSH_INTERACTIVE'] = True
-            ignore_sigtstp()
-            if (env['XONSH_INTERACTIVE'] and
-                    not env['LOADED_CONFIG'] and
-                    not any(os.path.isfile(i) for i in env['XONSHRC'])):
-                print('Could not find xonsh configuration or run control files.',
-                      file=sys.stderr)
-                xonfig_main(['wizard', '--confirm'])
-            events.on_pre_cmdloop.fire()
-            try:
-                shell.shell.cmdloop()
-            finally:
-                events.on_post_cmdloop.fire()
-        elif args.mode == XonshMode.single_command:
+        if args.mode == XonshMode.single_command:
             # run a single command and exit
             run_code_with_cache(args.command.lstrip(), shell.execer, mode='single')
         elif args.mode == XonshMode.script_from_file:
@@ -386,6 +371,21 @@ def main_xonsh(args):
             code = sys.stdin.read()
             run_code_with_cache(code, shell.execer, glb=shell.ctx, loc=None,
                                 mode='exec')
+        if args.mode == XonshMode.interactive or args.force_interactive:
+            # enter the shell
+            env['XONSH_INTERACTIVE'] = True
+            ignore_sigtstp()
+            if (env['XONSH_INTERACTIVE'] and
+                    not env['LOADED_CONFIG'] and
+                    not any(os.path.isfile(i) for i in env['XONSHRC'])):
+                print('Could not find xonsh configuration or run control files.',
+                      file=sys.stderr)
+                xonfig_main(['wizard', '--confirm'])
+            events.on_pre_cmdloop.fire()
+            try:
+                shell.shell.cmdloop()
+            finally:
+                events.on_post_cmdloop.fire()
     finally:
         events.on_exit.fire()
     postmain(args)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -353,7 +353,8 @@ def main_xonsh(args):
     try:
         if args.mode == XonshMode.single_command:
             # run a single command and exit
-            run_code_with_cache(args.command.lstrip(), shell.execer, mode='single')
+            run_code_with_cache(args.command.lstrip(), shell.execer,
+                                glb=shell.ctx, loc=None, mode='single')
         elif args.mode == XonshMode.script_from_file:
             # run a script contained in a file
             path = os.path.abspath(os.path.expanduser(args.file))
@@ -375,9 +376,8 @@ def main_xonsh(args):
             # enter the shell
             env['XONSH_INTERACTIVE'] = True
             ignore_sigtstp()
-            if (env['XONSH_INTERACTIVE'] and
-                    not env['LOADED_CONFIG'] and
-                    not any(os.path.isfile(i) for i in env['XONSHRC'])):
+            if (not env['LOADED_CONFIG'] and
+                not any(os.path.isfile(i) for i in env['XONSHRC'])):
                 print('Could not find xonsh configuration or run control files.',
                       file=sys.stderr)
                 xonfig_main(['wizard', '--confirm'])

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -377,7 +377,7 @@ def main_xonsh(args):
             env['XONSH_INTERACTIVE'] = True
             ignore_sigtstp()
             if (not env['LOADED_CONFIG'] and
-                not any(os.path.isfile(i) for i in env['XONSHRC'])):
+               not any(os.path.isfile(i) for i in env['XONSHRC'])):
                 print('Could not find xonsh configuration or run control files.',
                       file=sys.stderr)
                 xonfig_main(['wizard', '--confirm'])

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -280,11 +280,10 @@ def premain(argv=None):
     elif not sys.stdin.isatty() and not args.force_interactive:
         args.mode = XonshMode.script_from_stdin
     else:
-        args.mode = XonshMode.interactive
-    if not args.force_interactive and not args.mode == XonshMode.interactive:
+        args.force_interactive = True
+    if not args.force_interactive:
         shell_kwargs['shell_type'] = 'none'
     else:
-        args.mode = XonshMode.interactive
         shell_kwargs['completer'] = True
         shell_kwargs['login'] = True
     env = start_services(shell_kwargs)
@@ -372,7 +371,7 @@ def main_xonsh(args):
             code = sys.stdin.read()
             run_code_with_cache(code, shell.execer, glb=shell.ctx, loc=None,
                                 mode='exec')
-        if args.mode == XonshMode.interactive or args.force_interactive:
+        if args.force_interactive:
             # enter the shell
             env['XONSH_INTERACTIVE'] = True
             ignore_sigtstp()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -275,12 +275,13 @@ def premain(argv=None):
     setattr(sys, 'displayhook', _pprint_displayhook)
     if args.command is not None:
         args.mode = XonshMode.single_command
-        shell_kwargs['shell_type'] = 'none'
     elif args.file is not None:
         args.mode = XonshMode.script_from_file
-        shell_kwargs['shell_type'] = 'none'
     elif not sys.stdin.isatty() and not args.force_interactive:
         args.mode = XonshMode.script_from_stdin
+    else:
+        args.mode = XonshMode.interactive
+    if not args.force_interactive and not args.mode == XonshMode.interactive:
         shell_kwargs['shell_type'] = 'none'
     else:
         args.mode = XonshMode.interactive
@@ -288,9 +289,9 @@ def premain(argv=None):
         shell_kwargs['login'] = True
     env = start_services(shell_kwargs)
     env['XONSH_LOGIN'] = shell_kwargs['login']
+    env['XONSH_INTERACTIVE'] = args.force_interactive
     if args.defines is not None:
         env.update([x.split('=', 1) for x in args.defines])
-    env['XONSH_INTERACTIVE'] = args.force_interactive
     if ON_WINDOWS:
         setup_win_unicode_console(env.get('WIN_UNICODE_CONSOLE', True))
     return args


### PR DESCRIPTION
this patch adds functionality similar to the python repl
when forcing interactive mode with command or script :
`xonsh -ic '...'`
`xonsh -i script.xsh`