### PR TITLE
Escape null bytes before Popen

### DIFF
--- a/news/nullsub.rst
+++ b/news/nullsub.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Null bytes handed to Popen are now automatically escaped prior
+  to running a subprocess. This preevents Popen from issuing
+  embedded null byte exceptions.
+
+**Security:** None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -498,6 +498,7 @@ class SubprocSpec:
                 kwargs.pop('preexec_fn')
             p = self.cls(self.alias, self.cmd, **kwargs)
         else:
+            self._fix_null_cmd_bytes()
             p = self._run_binary(kwargs)
         p.spec = self
         p.last_in_pipeline = self.last_in_pipeline
@@ -545,6 +546,14 @@ class SubprocSpec:
                 os.setpgid(0, pipeline_group)
                 signal.signal(signal.SIGTSTP, default_signal_pauser)
         kwargs['preexec_fn'] = xonsh_preexec_fn
+
+    def _fix_null_cmd_bytes(self):
+        # Popen does not accept null bytes in its input commands.
+        # that doesn;t stop some subproces from using them. Here we
+        # escape them just in case.
+        cmd = self.cmd
+        for i in range(len(cmd)):
+            cmd[i] = cmd[i].replace('\0', '\\0')
 
     #
     # Building methods


### PR DESCRIPTION
This prevents the error listed in #1771.