### PR TITLE
only remove attribute if it exists

### DIFF
--- a/news/fix_history_replay.rst
+++ b/news/fix_history_replay.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``history replay`` no longer barfs on ``style_name`` when setting up the
+  environment
+
+**Security:** None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1576,7 +1576,8 @@ def intensify_colors_on_win_setter(enable):
     """
     enable = to_bool(enable)
     if hasattr(builtins, '__xonsh_shell__'):
-        delattr(builtins.__xonsh_shell__.shell.styler, 'style_name')
+        if hasattr(builtins.__xonsh_shell__.shell.styler, 'style_name'):
+            delattr(builtins.__xonsh_shell__.shell.styler, 'style_name')
     return enable
 
 


### PR DESCRIPTION
Attempt to fix #2264 which only rears its head during history replay (on
linux).