### PR TITLE
Ensure shell names are lower case

### DIFF
--- a/news/foreign_shells_names.rst
+++ b/news/foreign_shells_names.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a bug if foreign_shell name was not written in lower case in 
+  the static configuration file ``config.json``
+
+**Security:** None

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -490,7 +490,7 @@ def ensure_shell(shell):
     if not (shell_keys <= VALID_SHELL_PARAMS):
         msg = 'unknown shell keys: {0}'
         raise KeyError(msg.format(shell_keys - VALID_SHELL_PARAMS))
-    shell['shell'] = ensure_string(shell['shell'])
+    shell['shell'] = ensure_string(shell['shell']).lower()
     if 'interactive' in shell_keys:
         shell['interactive'] = to_bool(shell['interactive'])
     if 'login' in shell_keys:


### PR DESCRIPTION
Closes #2282. This should handle the case where foreign shell names are not written i lower case in config.json

