### PR TITLE
Never use os.scandir

### DIFF
--- a/news/scandir_bug.rst
+++ b/news/scandir_bug.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a bug on py34 where os.scandir was used by accident. 
+
+**Security:** None

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -150,6 +150,17 @@ def test_test_repo(test_repo):
         assert os.path.isfile(os.path.join(test_repo['dir'], 'test-file'))
 
 
+def test_no_repo(xonsh_builtins):
+    import queue
+    temp_dir = tempfile.mkdtemp()
+    xonsh_builtins.__xonsh_env__ = Env(VC_BRANCH_TIMEOUT=2, PWD=temp_dir)
+    q = queue.Queue()
+    try:
+        vc._get_hg_root(q)
+    except AttributeError:
+        assert False
+
+
 def test_vc_get_branch(test_repo, xonsh_builtins):
     xonsh_builtins.__xonsh_env__ = Env(VC_BRANCH_TIMEOUT=2)
     # get corresponding function from vc module

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -58,7 +58,7 @@ def _get_hg_root(q):
     while True:
         if not os.path.isdir(_curpwd):
             return False
-        if any([b.name == '.hg' for b in os.scandir(_curpwd)]):
+        if any([b.name == '.hg' for b in xt.scandir(_curpwd)]):
             q.put(_curpwd)
             break
         else:


### PR DESCRIPTION
Fixes #2294. `os.scandir()` is not supported on py34, so we should use our internal version instead. 