### PR TITLE
Make os_environ case-preserving and case-insensitive on Windows

### DIFF
--- a/news/os_env.rst
+++ b/news/os_env.rst
@@ -1,0 +1,17 @@
+**Added:** None
+
+**Changed:**
+
+* The ``xonsh.platform.os_environ`` wrapper is  now case-insesitive and
+  case-preserving on Windows.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a regression on Windows where caused ``which`` reported that the
+  ``PATH`` envrionment variable could not be found. 
+
+**Security:** None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -364,7 +364,7 @@ if ON_WINDOWS:
         """ Case-preseving wrapper for os.environ on Windows.
             It uses nt.environ to get the correct cased keys on
             initialization. It also preseves the case of any variables
-            add after initialization. 
+            add after initialization.
         """
         def __init__(self):
             import nt

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -363,7 +363,7 @@ if ON_WINDOWS:
     class OSEnvironCasePreserving(collections.MutableMapping):
         """ Case-preseving wrapper for os.environ on Windows.
             It uses nt.environ to get the correct cased keys on
-            initialization. It also preseves the case of any variables
+            initialization. It also preserves the case of any variables
             add after initialization.
         """
         def __init__(self):
@@ -371,7 +371,7 @@ if ON_WINDOWS:
             self._upperkeys = dict((k.upper(), k) for k in nt.environ)
 
         def _sync(self):
-            """ Ensure that the case sentive map of the keys are
+            """ Ensure that the case sensitive map of the keys are
                 in sync with os.environ
             """
             envkeys = set(os.environ.keys())


### PR DESCRIPTION
fixes #2297 

This PR wraps `os.environ` with a case-preserving case-insensitive class on Windows. 

