### PR TITLE
Line continuations not always working on Win

### DIFF
--- a/news/linecont.rst
+++ b/news/linecont.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Correct line continuation would not work on Windows if the line continuations were used
+  in the ``xonshrc`` file.
+
+**Security:** None

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -8,7 +8,7 @@ import builtins
 
 from xonsh.tools import (XonshError, print_exception, DefaultNotGiven,
                          check_for_partial_string, format_std_prepost,
-                         LINE_CONTINUATION)
+                         get_line_continuation)
 from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.codecache import (should_use_cache, code_cache_name,
                              code_cache_check, get_cache_filename,
@@ -429,7 +429,8 @@ class BaseShell(object):
             if usecache:
                 self.reset_buffer()
                 return src, code
-        if src.endswith(str(LINE_CONTINUATION)+'\n'):
+        lincont = get_line_continuation()
+        if src.endswith(lincont+'\n'):
             self.need_more_lines = True
             return src, None
         try:

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -8,7 +8,7 @@ from prompt_toolkit.filters import (Condition, IsMultiline, HasSelection,
 from prompt_toolkit.keys import Keys
 
 from xonsh.aliases import xonsh_exit
-from xonsh.tools import check_for_partial_string, LINE_CONTINUATION
+from xonsh.tools import check_for_partial_string, get_line_continuation
 from xonsh.shell import transform_command
 
 env = builtins.__xonsh_env__
@@ -50,7 +50,7 @@ def carriage_return(b, cli, *, autoindent=True):
         b.delete_before_cursor(count=len(indent))
     elif (not doc.on_first_line and not current_line_blank):
         b.newline(copy_margin=autoindent)
-    elif (doc.current_line.endswith(str(LINE_CONTINUATION))):
+    elif (doc.current_line.endswith(get_line_continuation())):
         b.newline(copy_margin=autoindent)
     elif (doc.find_next_word_beginning() is not None and
             (any(not _is_blank(i) for i in doc.lines_from_current[1:]))):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -410,7 +410,8 @@ def get_line_continuation():
          mode on Windows the backslash must be preseeded by a space. This is because
          paths on windows may end in a backspace.
     """
-    if ON_WINDOWS and builtins.__xonsh_env__.get('XONSH_INTERACTIVE', False):
+    if (ON_WINDOWS and hasattr(builtins, '__xonsh_env__') and
+            builtins.__xonsh_env__.get('XONSH_INTERACTIVE', False)):
         return ' \\'
     else:
         return '\\'

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -445,7 +445,7 @@ def replace_logical_line(lines, logical, idx, n):
     """Replaces lines at idx that may end in line continuation with a logical
     line that spans n lines.
     """
-    lincont = get_line_continuation()
+    linecont = get_line_continuation()
     if n == 1:
         lines[idx] = logical
         return

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -405,13 +405,12 @@ def _have_open_triple_quotes(s):
     return open_triple
 
 
-@lazyobject
-def LINE_CONTINUATION():
+def get_line_continuation():
     """ The line contiuation characters used in subproc mode. In interactive
          mode on Windows the backslash must be preseeded by a space. This is because
          paths on windows may end in a backspace.
     """
-    if ON_WINDOWS and builtins.__xonsh_env__.get('XONSH_INTERACTIVE'):
+    if ON_WINDOWS and builtins.__xonsh_env__.get('XONSH_INTERACTIVE', False):
         return ' \\'
     else:
         return '\\'
@@ -425,7 +424,7 @@ def get_logical_line(lines, idx):
     """
     n = 1
     nlines = len(lines)
-    linecont = str(LINE_CONTINUATION)
+    linecont = get_line_continuation()
     while idx > 0 and lines[idx-1].endswith(linecont):
         idx -= 1
     start = idx
@@ -446,6 +445,7 @@ def replace_logical_line(lines, logical, idx, n):
     """Replaces lines at idx that may end in line continuation with a logical
     line that spans n lines.
     """
+    lincont = get_line_continuation()
     if n == 1:
         lines[idx] = logical
         return
@@ -459,7 +459,7 @@ def replace_logical_line(lines, logical, idx, n):
             logical = ''
         else:
             # found space to split on
-            lines[i] = logical[:b] + str(LINE_CONTINUATION)
+            lines[i] = logical[:b] + linecont
             logical = logical[b:]
     lines[idx+n-1] = logical
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -407,8 +407,8 @@ def _have_open_triple_quotes(s):
 
 def get_line_continuation():
     """ The line contiuation characters used in subproc mode. In interactive
-         mode on Windows the backslash must be preseeded by a space. This is because
-         paths on windows may end in a backspace.
+         mode on Windows the backslash must be preceded by a space. This is because
+         paths on Windows may end in a backslash.
     """
     if (ON_WINDOWS and hasattr(builtins, '__xonsh_env__') and
             builtins.__xonsh_env__.get('XONSH_INTERACTIVE', False)):


### PR DESCRIPTION
I encountered a problem with line continuations not working as expected on Windows. 

Since `$XONSH_INTERACTIVE` changes state during startup, the [`LINE_CONTINUATION`](https://github.com/xonsh/xonsh/blob/c9f1ea7a4f8f8f5b01e25bb017fe73cac28f7aa4/xonsh/tools.py#L408) string can't be a Lazy object. If `LINE_CONTINUATION` was instantiated during startup it becomes the non-interactive version, and stay that way.

This PR makes line continuation a normal function again. 
