### PR TITLE
add Alt-. cmd to recall last arg to bashisms

### DIFF
--- a/news/recall_last_arg.rst
+++ b/news/recall_last_arg.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+* Add ``Alt .`` keybinding to ``bashisms-xontrib`` to insert last argument of
+  previous command into current buffer
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -1,4 +1,6 @@
 """Bash-like interface extensions for xonsh."""
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.filters import Condition, EmacsInsertMode, ViInsertMode
 
 
 @events.on_transform_command
@@ -8,3 +10,19 @@ def bash_preproc(cmd, **kw):
             return ''
         return cmd
     return cmd.replace('!!', __xonsh_history__.inps[-1].strip())
+
+
+@events.on_ptk_create
+def custom_keybindings(bindings, **kw):
+    handler = bindings.registry.add_binding
+    insert_mode = ViInsertMode() | EmacsInsertMode()
+
+    @Condition
+    def last_command_exists(cli):
+        return len(__xonsh_history__) > 0
+
+    @handler(Keys.Escape, '.', filter=last_command_exists &
+             insert_mode)
+    def recall_last_arg(event):
+        arg = __xonsh_history__[-1].cmd.split()[-1]
+        event.current_buffer.insert_text(arg)


### PR DESCRIPTION
As requested in #1480 this adds the `Alt .` shortcut to insert the last argument from the previous command into the current prompt buffer at cursor position.