### PR TITLE
Recommend `xip` to install my xontribs

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -211,14 +211,14 @@
    "license": "GPLv3",
    "url": "https://github.com/astronouth7303/xontrib-avox",
    "install": {
-    "pip": "pip install xontrib-avox"
+    "pip": "xip install xontrib-avox"
    }
   },
   "xontrib-z": {
    "license": "GPLv3",
    "url": "https://github.com/astronouth7303/xontrib-z",
    "install": {
-    "pip": "pip install xontrib-z"
+    "pip": "xip install xontrib-z"
    }
   },
   "xontrib-powerline": {


### PR DESCRIPTION
xontribs should be installed with xip now, so recommend that for the xontribs I'm responsible for.

This is mostly to try to improve on #2318.

(No news required.)