### PR TITLE
Pretty path

### DIFF
--- a/news/pretty_path.rst
+++ b/news/pretty_path.rst
@@ -1,0 +1,13 @@
+**Added:** 
+
+* Pretty printing of the $PATH variable
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -204,6 +204,18 @@ class EnvPath(collections.MutableSequence):
             return False
         return all(map(operator.eq, self, other))
 
+    def _repr_pretty_(self, p, cycle):
+        """ Pretty print path list """
+        if cycle:
+            p.text('EnvPath(...)')
+        else:
+            with p.group(8, 'EnvPath([', '])'):
+                for idx, item in enumerate(self):
+                    if idx:
+                        p.text(',')
+                        p.breakable()
+                    p.pretty(item)
+
 
 class DefaultNotGivenType(object):
     """Singleton for representing when no default value is given."""

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -209,7 +209,7 @@ class EnvPath(collections.MutableSequence):
         if cycle:
             p.text('EnvPath(...)')
         else:
-            with p.group(8, 'EnvPath([', '])'):
+            with p.group(1, 'EnvPath(\n[', ']\n)'):
                 for idx, item in enumerate(self):
                     if idx:
                         p.text(',')


### PR DESCRIPTION
Fixes #2321 

This will pretty print $PATH

```python
EnvPath(
['C:\\Users\\mel\\Anaconda3\\Library\\bin',
 'C:\\Program Files\\ImageMagick-7.0.4-Q16',
 'C:\\Program Files\\Docker\\Docker\\Resources\\bin',
   <snip>
 'C:\\Users\\mel\\AppData\\Local\\Microsoft\\WindowsApps',
 'C:\\Program Files\\CMake\\bin',
 '']
)
```