### PR TITLE
Fix win paths

### DIFF
--- a/news/win_path.rst
+++ b/news/win_path.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a bug on Windows which meant xonsh wasn't using PATH enrivonment variable but instead relying on a default
+  value from the widnows registry. 
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -794,8 +794,10 @@ class Env(cabc.MutableMapping):
             args = (os_environ,)
         for key, val in dict(*args, **kwargs).items():
             self[key] = val
-        if ON_WINDOWS and 'Path' in self._d:
-            self._d['PATH'] = self._d.pop('Path')
+        if ON_WINDOWS:
+            path_key = next((k for k in self._d if k.upper() == 'PATH'), None)
+            if path_key:
+                self['PATH'] = self._d.pop(path_key)
         if 'PATH' not in self._d:
             # this is here so the PATH is accessible to subprocs and so that
             # it can be modified in-place in the xonshrc file

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -794,6 +794,8 @@ class Env(cabc.MutableMapping):
             args = (os_environ,)
         for key, val in dict(*args, **kwargs).items():
             self[key] = val
+        if ON_WINDOWS and 'Path' in self._d:
+            self._d['PATH'] = self._d.pop('Path')
         if 'PATH' not in self._d:
             # this is here so the PATH is accessible to subprocs and so that
             # it can be modified in-place in the xonshrc file


### PR DESCRIPTION
Fixes #2320 (Hopefully)

It ensures that if the `Path` variable from windows is renamed to `PATH`. 