### PR TITLE
remove %foo% auto expansion on Windows

### DIFF
--- a/news/win_no_expand_var.rst
+++ b/news/win_no_expand_var.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:**
+
+* On Windows environments variables in wrapped like``%foo%`` are no longer expanded automatically.
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1188,14 +1188,9 @@ def test_expand_case_matching(inp, exp):
     ("$?bar", "$?bar"),
     ("$foo}bar", "bar}bar"),
     ("${'foo", "${'foo"),
-    skip_if_on_unix(("%foo%bar", "barbar")),
-    skip_if_on_unix(("%foo% %a_bool%", "bar True")),
-    skip_if_on_unix(("%foo%%an_int%", "bar42")),
-    skip_if_on_unix(("%foo% $spam ${'a_bool'}", "bar eggs True")),
     (b"foo", "foo"),
     (b"$foo bar", "bar bar"),
     (b"${'foo'}bar", "barbar"),
-    skip_if_on_unix((b"%foo%bar", "barbar")),
 ])
 def test_expandvars(inp, exp, xonsh_builtins):
     """Tweaked for xonsh cases from CPython `test_genericpath.py`"""

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1719,12 +1719,6 @@ def POSIX_ENVVAR_REGEX():
     pat = r"""\$({(?P<quote>['"])|)(?P<envvar>\w+)((?P=quote)}|(?:\1\b))"""
     return re.compile(pat)
 
-if ON_WINDOWS:
-    # i.e %FOO%
-    @lazyobject
-    def WINDOWS_ENVVAR_REGEX():
-        return re.compile(r"%(?P<envvar>\w+)%")
-
 
 def expandvars(path):
     """Expand shell variables of the forms $var, ${var} and %var%.
@@ -1736,13 +1730,6 @@ def expandvars(path):
     elif isinstance(path, pathlib.Path):
         # get the path's string representation
         path = str(path)
-    if ON_WINDOWS and '%' in path:
-        for match in WINDOWS_ENVVAR_REGEX.finditer(path):
-            name = match.group('envvar')
-            if name in env:
-                ensurer = env.get_ensurer(name)
-                value = ensurer.detype(env[name])
-                path = WINDOWS_ENVVAR_REGEX.sub(value, path, count=1)
     if '$' in path:
         for match in POSIX_ENVVAR_REGEX.finditer(path):
             name = match.group('envvar')


### PR DESCRIPTION
This removes the automatic variable expansion on windows for environment variables wrapped in %. 

It has some bugs and it makes it difficult to execute certain commands without macro escapes.  

See: #2322
