### PR TITLE
Make sudo on Windows work again

### DIFF
--- a/news/sudo.rst
+++ b/news/sudo.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a regression in the Windows ``sudo`` command, that allows users to run elevated commands in xonsh.
+
+**Security:** None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -15,7 +15,7 @@ from xonsh.foreign_shells import foreign_shell_data
 from xonsh.jobs import jobs, fg, bg, clean_jobs
 from xonsh.platform import (ON_ANACONDA, ON_DARWIN, ON_WINDOWS, ON_FREEBSD,
                             ON_NETBSD)
-from xonsh.tools import uncapturable, unthreadable
+from xonsh.tools import unthreadable
 from xonsh.replay import replay_main
 from xonsh.timings import timeit_alias
 from xonsh.tools import argvquote, escape_windows_cmd_string, to_bool, swap_values

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -15,7 +15,7 @@ from xonsh.foreign_shells import foreign_shell_data
 from xonsh.jobs import jobs, fg, bg, clean_jobs
 from xonsh.platform import (ON_ANACONDA, ON_DARWIN, ON_WINDOWS, ON_FREEBSD,
                             ON_NETBSD)
-from xonsh.tools import unthreadable
+from xonsh.tools import uncapturable, unthreadable
 from xonsh.replay import replay_main
 from xonsh.timings import timeit_alias
 from xonsh.tools import argvquote, escape_windows_cmd_string, to_bool, swap_values
@@ -489,7 +489,7 @@ def make_default_aliases():
         if not locate_binary('sudo'):
             import xonsh.winutils as winutils
 
-            def sudo(args, sdin=None):
+            def sudo(args):
                 if len(args) < 1:
                     print('You need to provide an executable to run as '
                           'Administrator.')

--- a/xonsh/winutils.py
+++ b/xonsh/winutils.py
@@ -21,7 +21,6 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import os
-import sys
 import ctypes
 import subprocess
 from ctypes import c_ulong, c_char_p, c_int, c_void_p, POINTER, byref

--- a/xonsh/winutils.py
+++ b/xonsh/winutils.py
@@ -142,10 +142,6 @@ def sudo(executable, args=None):
         nShow=SW_SHOW
     )
 
-    if not all(stream.isatty() for stream in (sys.stdin, sys.stdout, sys.stderr)):
-        # TODO: Some streams were redirected, we need to manually work them
-        raise NotImplementedError("Redirection is not supported")
-
     if not ShellExecuteEx(byref(execute_info)):
         raise ctypes.WinError()
 


### PR DESCRIPTION
Ideally, we'd move this to a `xontrib` but at least this patch makes it unbroken.