### PR TITLE
Fix at dollar

### DIFF
--- a/news/fix_at_dollar.rst
+++ b/news/fix_at_dollar.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* ``@$`` operator now functions properly when returned command is an alias
+
+**Security:** None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -217,6 +217,14 @@ aliases['echo'] = _echo
 echo --option1 \
 --option2
 """, '--option1 --option2\n', 0),
+#
+# test @$() with aliases
+#
+("""
+aliases['ls'] = 'spam spam sausage spam'
+
+echo @$(which ls)
+""", 'spam spam sausage spam\n', 0),
 ]
 
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -858,7 +858,7 @@ def subproc_captured_inject(*cmds):
     or shlex.split().
     """
     s = run_subproc(cmds, captured='stdout')
-    toks = builtins.__xonsh_execer__.parser.lexer.split(s)
+    toks = builtins.__xonsh_execer__.parser.lexer.split(s.strip())
     return toks
 
 


### PR DESCRIPTION
This was borking out when using `@$` with aliased commands (due, I think, to a
trailing newline character that wasn't being stripped out).

Should resolve #2340

Testing this is tricky since it touches a lot of the xonsh internals...