### PR TITLE
[WIP] Fix foreign xonfig wizard empty shell name entry

### DIFF
--- a/news/xonfig-wizard.rst
+++ b/news/xonfig-wizard.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Foreign shell xonfig wizard empty shell name entry
+
+**Security:** None

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -114,7 +114,8 @@ def make_fs_wiz():
     """Makes the foreign shell part of the wizard."""
     cond = wiz.create_truefalse_cond(prompt='Add a new foreign shell, ' + wiz.YN)
     fs = wiz.While(cond=cond, body=[
-        wiz.Input('shell name (e.g. bash): ',
+        wiz.Input("shell name [str, default='bash']: ",
+                  converter=lambda val: val or 'bash',
                   path='/foreign_shells/{idx}/shell'),
         wiz.StoreNonEmpty('interactive shell [bool, default=True]: ',
                           converter=to_bool,


### PR DESCRIPTION
#2371
a little hacky  but it does the job.

I think the wizard visitor needs some more functionality, we need some way 
to break traversing the tree and return to the parent.

With the current wizard implementation i can't think of a way to 'cancel' setting 
the foreign shell in case of an empty value from the user (which can be an often
case if you just spam return while in wizard.) and return to the main wizard.

(tests :cry:)