### PR TITLE
Add xontrib-fzf-widgets

### DIFF
--- a/news/add_fzf_widgets_extension.rst
+++ b/news/add_fzf_widgets_extension.rst
@@ -1,6 +1,6 @@
-**Added:** None
+**Added:**
 
-* Add `fzf-widgets` xontrib which provides fuzzy search productivity widgets
+* Add "fzf-widgets" xontrib which provides fuzzy search productivity widgets
   with on custom keybindings to xontrib list.
 
 **Changed:** None

--- a/news/add_fzf_widgets_extension.rst
+++ b/news/add_fzf_widgets_extension.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+* Add `fzf-widgets` xontrib which provides fuzzy search productivity widgets
+  with on custom keybindings to xontrib list.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -264,7 +264,7 @@
    "license": "GPLv3",
    "url": "https://github.com/shahinism/xontrib-fzf-widgets",
    "install": {
-    "pip": "pip install xontrib-fzf-widgets"
+    "pip": "xip install xontrib-fzf-widgets"
    }
   }
  }

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -145,6 +145,11 @@
   "package": "xonsh-click-tabcomplete",
   "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
   "description": ["Adds tabcomplete functionality to click based python applications inside of xonsh."]
+ },
+ {"name": "fzf-widgets",
+  "package": "xontrib-fzf-widgets",
+  "url": "https://github.com/shahinism/xontrib-fzf-widgets",
+  "description": ["Adds some fzf widgets to your xonsh shell."]
  }
  ],
  "packages": {
@@ -253,6 +258,13 @@
    "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
    "install": {
     "pip": "pip install xontrib-prompt-vi-mode"
+   }
+  },
+  "xontrib-fzf-widgets": {
+   "license": "GPLv3",
+   "url": "https://github.com/shahinism/xontrib-fzf-widgets",
+   "install": {
+    "pip": "pip install xontrib-fzf-widgets"
    }
   }
  }


### PR DESCRIPTION
I'm trying to port some of useful [fzf](https://github.com/junegunn/fzf) widgets developed for Bash/ZSH to Xonsh And thought that it might be a good idea to share it with the Xonsh community as a Xontrib. 