### PR TITLE
Don't show the repr of the LazyBool for whether or not xonsh is running on Linux.

### DIFF
--- a/news/xonfig-output.rst
+++ b/news/xonfig-output.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``xonfig`` now displays the proper value for "on linux"
+
+**Security:** None

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -374,7 +374,7 @@ def _info(ns):
         ('shell type', env.get('SHELL_TYPE')),
         ('pygments', pygments_version()),
         ('on posix', bool(ON_POSIX)),
-        ('on linux', ON_LINUX),
+        ('on linux', bool(ON_LINUX)),
     ])
     if ON_LINUX:
         data.append(('distro', linux_distro()))


### PR DESCRIPTION
Before this change:

```
nhoad@nhoad-laptop ~ $ xonfig | grep linux
| on linux         | <xonsh.lazyasd.LazyBool object at 0x7f869e059e10> |
```

After this change:

```
nhoad@nhoad-laptop ~ $ xonfig | grep linux
| on linux         | True                 |
```