### PR TITLE
Spelling Fixes

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -31,5 +31,5 @@ pylint:
 
 mccabe:
   disable:
-    - MC0000  # not Py3k compatabile
+    - MC0000  # not Py3k compatible
     - MC0001  # silly cyclomatic complexity

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,9 +19,9 @@ v0.5.10
 * Pretty printing of the $PATH variable
 * Add "fzf-widgets" xontrib which provides fuzzy search productivity widgets
   with on custom keybindings to xontrib list.
-* New ``free_cwd`` xontrib for Windows, which prevent the current directory from beeing locked when the prompt is shown. 
+* New ``free_cwd`` xontrib for Windows, which prevent the current directory from being locked when the prompt is shown.
   This allows the other programs or Windows explorer to delete the current or parent directory. This is accomplished by 
-  reseting the CWD to the users home directory temporarily while the prompt is displayed. The directory is still locked 
+  resetting the CWD to the users home directory temporarily while the prompt is displayed. The directory is still locked
   while any commands are processed so xonsh still can't remove it own working directory.
 
 
@@ -43,8 +43,8 @@ v0.5.10
   in the ``xonshrc`` file.
 * Fixed a regression in the Windows ``sudo`` command, that allows users to run elevated commands in xonsh.
 * Fix echo command from xoreutils.
-* Fixed a bug on Windows which meant xonsh wasn't using PATH enrivonment variable but instead relying on a default
-  value from the widnows registry.
+* Fixed a bug on Windows which meant xonsh wasn't using PATH environment variable but instead relying on a default
+  value from the windows registry.
 
 
 
@@ -80,7 +80,7 @@ v0.5.8
 
 **Changed:**
 
-* The ``xonsh.platform.os_environ`` wrapper is  now case-insesitive and
+* The ``xonsh.platform.os_environ`` wrapper is  now case-insensitive and
   case-preserving on Windows.
 * The private ``_TeeStd`` class will no longer attempt to write to a
   standard buffer after the tee has been 'closed' and the standard
@@ -95,7 +95,7 @@ v0.5.8
 * Fixed a bug if foreign_shell name was not written in lower case in 
   the static configuration file ``config.json``
 * Fixed a regression on Windows where caused ``which`` reported that the
-  ``PATH`` envrionment variable could not be found.
+  ``PATH`` environment variable could not be found.
 * Fixed issue with foregrounding jobs that were started in the background.
 * Fixed that ``Ctrl-C`` crashes xonsh after running an invalid command.
 * Fixed an potential ``ProcessLookupError`` issue, see #2288.
@@ -109,7 +109,7 @@ v0.5.7
 **Added:**
 
 * New ``color_tools`` module provides basic color tools for converting
-  to and from various formats as well as creating pallettes from color
+  to and from various formats as well as creating palettes from color
   strings.
 * Redirections may now be used in string and list-of-strings
   aliases.
@@ -135,7 +135,7 @@ v0.5.7
   prior to running the next command.
 * Line continuation backslashes are respected on Windows in the PTK shell if
   the backspace is is preceded by a space.
-* Added ``ponysay`` as a command which will ususally not run in a
+* Added ``ponysay`` as a command which will usually not run in a
   threaded mode in the commands cache.
 * New ``jsonutils`` module available for serializing special
   xonsh objects to JSON.
@@ -145,7 +145,7 @@ v0.5.7
 
 * The literal tokens ``and`` and ``or`` must be surrounded by
   whitespace to delimit subprocess mode. If they do not have
-  whitespace on both sides in subproc mode, they are condisered
+  whitespace on both sides in subproc mode, they are considered
   to be part of a command argument.
 * The ``xontrib`` command is now flagged as unthreadable and will be
   run on the main Python thread. This allows xontribs to set signal
@@ -186,8 +186,8 @@ v0.5.7
   able to be used in xonsh. These styles are dynamically created upon
   first use, rather than being lazily loaded by xonsh.
 * On Windows, ``os.environ`` is case insensitive. This would potentially
-  change the case of envrionment variables set into the environment.
-  Xonsh now uses ``nt.envrion``, the case sensitive counterpart, to avoid
+  change the case of environment variables set into the environment.
+  Xonsh now uses ``nt.environ``, the case sensitive counterpart, to avoid
   these issues on Windows.
 * Fix how ``$PWD`` is managed in order to work with symlinks gracefully
 * ``history replay`` no longer barfs on ``style_name`` when setting up the
@@ -198,7 +198,7 @@ v0.5.7
 * Certain vim commands issue commands involving subshells,
   and this is now supported.
 * Null bytes handed to Popen are now automatically escaped prior
-  to running a subprocess. This preevents Popen from issuing
+  to running a subprocess. This prevents Popen from issuing
   embedded null byte exceptions.
 * Xonsh will no longer crash is the current working directory is
   removed out from under it.
@@ -210,9 +210,9 @@ v0.5.7
   preceded by a space on Windows. This only applies to xonsh in interactive
   mode to ensure  scripts are portable.
 * Importing ``*.xsh`` files will now respect the encoding listed in
-  that file and properly fallback to UTF-8. This beahviour follows
+  that file and properly fallback to UTF-8. This behaviour follows
   the rules described in PEP 263.
-* Wizard is now able to properly serialize envrionment paths.
+* Wizard is now able to properly serialize environment paths.
 
 
 v0.5.6
@@ -228,7 +228,7 @@ v0.5.6
 * The ``trace`` will automatically disable color printing when
   stdout is not a TTY or stdout is captured.
 * New ``jedi`` xontrib enables jedi-based tab completions when it is loaded.
-  This supercedes xonsh's default Python-mode completer.
+  This supersedes xonsh's default Python-mode completer.
 * The lexer has a new ``split()`` method which splits strings
   according to xonsh's rules for whitespace and quotes.
 * New events for hooking into the Python import process are now available.
@@ -245,31 +245,31 @@ v0.5.6
 **Changed:**
 
 * The prompt toolkit shell's first completion will now be the
-  current token from the auto-suggetion, if available.
+  current token from the auto-suggestion, if available.
 * Sourcing foreign shells will now safely skip applying aliases
   with the same name as existing xonsh aliases by default.
-  This prevents accitidentally overwriting important xonsh standard
+  This prevents accidentally overwriting important xonsh standard
   aliases, such as ``cd``.
 
 
 **Fixed:**
 
-* Threadable predicition for subprocesses will now consult both the command
+* Threadable prediction for subprocesses will now consult both the command
   as it was typed in and any resolved aliases.
 * The first prompt will no longer print in the middle of the line if the user has
   already started typing.
 * Windows consoles will now automatically enable virtual terminal processing
   with the readline shell, if available. This allows the full use of ANSI
   escape sequences.
-* On the Windows readline shell, the teb-completion supression prompt will no
+* On the Windows readline shell, the tab-completion suppression prompt will no
   longer error out depending on what you press.
-* Fixed issue with subprocess mode wrapping not repecting line continuation
+* Fixed issue with subprocess mode wrapping not respecting line continuation
   backslashes.
 * Handle a bug where Bash On Windows causes platform.windows_bash_command()
   to raise CalledProcessError.
 * Fixed issues pertaining to completing from raw string paths.
   This is particularly relevant to Windows, where raw strings
-  are instered in path completion.
+  are inserted in path completion.
 * Replace deprecated calls to ``time.clock()`` by calls to
   ``time.perf_counter()``.
 * Use ``clock()`` to set the start time of ``_timings`` in non-windows instead
@@ -280,10 +280,10 @@ v0.5.6
   xonsh semantics, rather than just on whitespace using ``str.split()``.
 * The ``mpl`` xontrib has been updated to improve matplotlib
   handling. If ``xontrib load mpl`` is run before matplotlib
-  is imported and xonsh is in ineteractive mode, matplotlib
+  is imported and xonsh is in interactive mode, matplotlib
   will automatically enter interactive mode as well. Additionally,
   ``pyplot.show()`` is patched in interactive mode to be non-blocking.
-  If a non-blocking show fails to draw the figre for some reason,
+  If a non-blocking show fails to draw the figure for some reason,
   a regular blocking version is called.
 * Fixed issues like ``timeit ls`` causing OSError - "Inappropriate ioctl
   for device".
@@ -316,7 +316,7 @@ v0.5.5
   of run control to a single entry point and loading system.
 * The ``xonsh.shell.Shell()`` class now requires that an Execer instance
   be explicitly provided to its init method. This class is no longer
-  responsible for creating an execer an its deprendencies.
+  responsible for creating an execer an its dependencies.
 * Moved decorators ``unthreadable``, ``uncapturable`` from
   ``xonsh.proc`` to ``xonsh.tools``.
 * Some refactorings on jobs control.
@@ -338,15 +338,15 @@ v0.5.5
 **Fixed:**
 
 * Command pipelines that end in a callable alias are now interruptable with
-  ``^C`` and the processes that are piped into the alais have their file handles
+  ``^C`` and the processes that are piped into the alias have their file handles
   closed. This should ensure that the entire pipeline is closed.
 * Fixed issue where unthreadable subprocs were not allowed to be
   captured with the ``$(cmd)`` operator.
 * The ``ProcProxy`` class (unthreadable aliases) was not being executed and would
-  hange if the alias was capturable. This has been fixed.
+  hang if the alias was capturable. This has been fixed.
 * Fixed a ``tcsetattr: Interrupted system call`` issue when run xonsh scripts.
 * Fixed issue with ``ValueError`` being thrown from ``inspect.signature()``
-  when called on C-extention callables in tab completer.
+  when called on C-extension callables in tab completer.
 * Fixed issue that ``ls | less`` crashes on Mac.
 * Threadable prediction was incorrectly based on the user input command, rather than
   the version where aliases have been resolved. This has been corrected.
@@ -442,7 +442,7 @@ v0.5.3
 **Fixed:**
 
 * ``PopenThread`` will now re-issue SIGINT to the main thread when it is
-  recieved.
+  received.
 * Fixed an issue that using sqlite history backend does not kill unfinished
   jobs when quitting xonsh with a second "exit".
 * Fixed an issue that xonsh would fail over to external shells when
@@ -452,7 +452,7 @@ v0.5.3
   server. See https://mail.python.org/pipermail/python-list/2013-June/650460.html for
   more details.
 * Restored the ability to ^Z and ``fg`` processes on posix platforms.
-* CommandPipelines were not gauranteeded to have been ended when the return code
+* CommandPipelines were not guaranteed to have been ended when the return code
   was requested. This has been fixed.
 * Introduce path expansion in ``is_writable_file`` to fix
   ``$XONSH_TRACEBACK_LOGFILE=~/xonsh.log``.
@@ -521,11 +521,11 @@ v0.5.0
 * Added entry to customization faq re: tab completion selection (#1725)
 * Added entry to customization faq re: libgcc core dump (#1160)
 * Section about quoting in the tutorial.
-* The ``$VC_HG_SHOW_BRANCH`` environement variable to control whether to hide the hg branch in the prompt.
+* The ``$VC_HG_SHOW_BRANCH`` environment variable to control whether to hide the hg branch in the prompt.
 * xonfig now contains the latest git commit date if xonsh installed
   from source.
 * Alt+Enter will execute a multiline code block irrespective of cursor position
-* Windows now has the ability to read output asyncronously from
+* Windows now has the ability to read output asynchronously from
   the console.
 * Use `doctr <https://drdoctr.github.io/doctr/>`_ to deploy dev docs to github pages
 * New ``xonsh.proc.uncapturable()`` decorator for declaring that function
@@ -533,12 +533,12 @@ v0.5.0
 * New history backend sqlite.
 * Prompt user to install xontrib package if they try to load an uninstalled
   xontrib
-* Callable aliases may now take a final ``spec`` arguemnt, which is the
-  cooresponding ``SubprocSpec`` instance.
+* Callable aliases may now take a final ``spec`` argument, which is the
+  corresponding ``SubprocSpec`` instance.
 * New ``bashisms`` xontrib provides additional Bash-like syntax, such as ``!!``.
   This xontrib only affects the command line, and not xonsh scripts.
 * Tests that create testing repos (git, hg)
-* New subprocess specification class ``SubprocSpec`` is used for specifiying
+* New subprocess specification class ``SubprocSpec`` is used for specifying
   and manipulating subprocess classes prior to execution.
 * New ``PopenThread`` class runs subprocesses on a a separate thread.
 * New ``CommandPipeline`` and ``HiddenCommandPipeline`` classes manage the
@@ -554,11 +554,11 @@ v0.5.0
   ``f()``, ``f(args)``,  ``f(args, stdin=None)``,
   ``f(args, stdin=None, stdout=None)``, and `
   ``f(args, stdin=None, stdout=None, stderr=None)``.
-* Uncaptured subprocesses now recieve a PTY file handle for stdout and
+* Uncaptured subprocesses now receive a PTY file handle for stdout and
   stderr.
 * New ``$XONSH_PROC_FREQUENCY`` environment variable that specifies how long
-  loops in the subprocess framwork should sleep. This may be adjusted from
-  its default value to improved perfromance and mitigate "leaky" pipes on
+  loops in the subprocess framework should sleep. This may be adjusted from
+  its default value to improved performance and mitigate "leaky" pipes on
   slower machines.
 * ``Shift+Tab`` moves backwards in completion dropdown in prompt_toolkit
 * PromptFormatter class that holds all the related prompt methods
@@ -654,7 +654,7 @@ v0.5.0
 * readline/ptk shells use PromptFormatter
 * Updated the bundled version of ``ply`` to current master available
 * vended ``ply`` is now a git subtree to help with any future updates
-* ``WHITE``  color keyword now means lightgray and ``INTENSE_WHITE`` commpletely white
+* ``WHITE``  color keyword now means lightgray and ``INTENSE_WHITE`` completely white
 * Removed ``add_to_shell`` doc section from ``*nix`` install pages and instead
   relocated it to the general customization page
 * Moved a few ``*nix`` customization tips from the linux install page to the general
@@ -686,7 +686,7 @@ v0.5.0
 * Jupyter kernel installation now respects the setuptools ``root`` parameter.
 * Fix ``__repr__`` and ``__str__`` methods of ``SubprocSpec`` so they report
   correctly
-* Fixed the meassage printed when which is unable to find the command.
+* Fixed the message printed when which is unable to find the command.
 * Fixed a handful of sphinx errors and warnings in the docs
 * Fixed many PEP8 violations that had gone unnoticed
 * Fix failure to detect an Anaconda python distribution if the python was install from the conda-forge channel.
@@ -700,7 +700,7 @@ v0.5.0
 * Added a minimum time buffer time for command pipelines to check for
   if previous commands have executed successfully.  This is helpful
   for pipelines where the last command takes a long time to start up,
-  such as GNU Parallel. This also checks to make sure that output has occured.
+  such as GNU Parallel. This also checks to make sure that output has occurred.
   This includes piping 2+ commands together and pipelines that end in
   unthreadable commands.
 * ``curr_branch`` reports correctly when ``git config status.short true`` is used
@@ -710,23 +710,23 @@ v0.5.0
 * Aliases that begin with a comma now complete correctly (no spurious comma)
 * Use ``python3`` in shebang lines for compatibility with distros that still use Python 2 as the default Python
 * STDOUT is only stored when ``$XONSH_STORE_STDOUT=True``
-* Fixed issue with alais redirections to files throwing an OSError because
+* Fixed issue with alias redirections to files throwing an OSError because
   the function ProcProxies were not being waited upon.
-* Fixed issue with callablable aliases that happen to call sys.exit() or
+* Fixed issue with callable aliases that happen to call sys.exit() or
   raise SystemExit taking out the whole xonsh process.
 * Safely flushes file handles on threaded buffers.
 * Proper default value and documentation for ``$BASH_COMPLETIONS``
 * Fixed readline completer issues on paths with spaces
 * Fix bug in ``argvquote()`` functions used when sourcing batch files on Windows. The bug meant an extra backslash was added to UNC paths.
   Thanks to @bytesemantics for spotting it, and @janschulz for fixing the issue.
-* pep8, lint and refator in pytest style of ``test_ptk_multiline.py``, ``test_replay.py``
+* pep8, lint and refactor in pytest style of ``test_ptk_multiline.py``, ``test_replay.py``
 * Tab completion of aliases returned a upper cased alias on Windows.
 * History show all action now also include current session items.
 * ``proc.stream_stderr`` now handles stderr that doesn't have buffer attribute
 * Made ``history show`` result sorted.
 * Fixed issue that ``history gc`` does not delete empty history files.
 * Standard stream tees have been fixed to accept the possibility that
-  they may not be backed by a binary buffer. This inludes the pipeline
+  they may not be backed by a binary buffer. This includes the pipeline
   stdout tee as well as the shell tees.
 * Fixed a bug when the pygments plugin was used by third party editors etc.
 * CPU usage of ``PopenThread`` and ``CommandPipeline`` has been brought
@@ -774,12 +774,12 @@ v0.4.7
 * moved prompt formatting specific functions from ``xonsh.environ``
   to ``xonsh.prompt.base``
 * All prompt formatter functions moved to ``xonsh.prompt`` subpackage
-* Printing the message about foreign aliases being ingored happens only
+* Printing the message about foreign aliases being ignored happens only
   if XONSH_DEBUG is set.
 * Use ``SetConsoleTitleW()`` on Windows instead of a process call.
 * Tutorial to reflect the current history command argument functionality
 * Macro function arguments now default to ``str``, rather than ``eval``,
-  for consistentcy with other parts of the macro system.
+  for consistency with other parts of the macro system.
 
 
 **Removed:**
@@ -800,13 +800,13 @@ v0.4.7
 * ``xonsh.prompt.vc_branch.git_dirty_working_directory``
    uses ``porcelain`` option instead of using the bytestring
    ``nothing to commit`` to find out if a git directory is dirty
-* Fix bug where know commands where not highlighed on windows.
+* Fix bug where know commands where not highlighted on windows.
 * Fixed completer showing executable in upper case on windows.
-* Fixed issue where tilde expansion was occuring more than once before an
+* Fixed issue where tilde expansion was occurring more than once before an
   equals sign.
 * test_dirstack test_cdpath_expansion leaving stray testing dirs
 * Better completer display for long completions in prompt-toolkit
-* Automatucally append newine to target of ``source`` alias, so that it may
+* Automatically append newline to target of ``source`` alias, so that it may
   be exec'd.
 * test_news fails when single graves around word
 * Slashes in virtual environment names work in vox
@@ -836,7 +836,7 @@ v0.4.6
 * NetBSD is now supported.
 * Macro function calls are now available. These use a Rust-like
   ``f!(arg)`` syntax.
-* Macro subprocess call now avalaible with the ``echo! x y z``
+* Macro subprocess call now available with the ``echo! x y z``
   syntax.
 * A new `event subsystem <http://xon.sh/tutorial_events.html>`_ has been added.
 * howto install sections for Debian/Ubuntu and Fedora.
@@ -893,12 +893,12 @@ v0.4.6
 **Fixed:**
 
 * xonsh modules imported now have the __file__ attribute
-* Context senstitive AST transformer was not adding argument names to the
+* Context sensitive AST transformer was not adding argument names to the
   local scope. This would then enable extraneous subprocess mode wrapping
   for expressions whose leftmost name was function argument. This has been
   fixed by properly adding the argument names to the scope.
 * Foreign shell functions that are mapped to empty filenames no longer
-  receive alaises since they can't be found to source later.
+  receive aliases since they can't be found to source later.
 * Correctly preserve arguments given to xon.sh, in case there are quoted ones.
 * Environment variables in subprocess mode were not being expanded
   unless they were in a sting. They are now expanded properly.
@@ -1028,7 +1028,7 @@ v0.4.4
 * ``vox remove`` command can remove multiple environments at once.
 * Added FreeBSD support.
 * Tab completion for pip python package manager.
-* Regular expressions for enviroment variable matching
+* Regular expressions for environment variable matching.
 
 * __contains__ method on Env
 * Added news tests to enforce changelog conformity.
@@ -1051,7 +1051,7 @@ v0.4.4
 * xonsh_builtins, xonsh_execer fixtures in conftest.py
 * Docs on how to tweak the Windows ConHost for a better color scheme.
 * Docs: how to fix Thunar's "Open Terminal Here" action.
-* A new API class was added to Vox: ``xontrib.voxapi.Vox``. This allows programtic access to the virtual environment machinery for other xontribs. See the API documentation for details.
+* A new API class was added to Vox: ``xontrib.voxapi.Vox``. This allows programmatic access to the virtual environment machinery for other xontribs. See the API documentation for details.
 * History now accepts multiple slices arguments separated by spaces
 
 
@@ -1059,7 +1059,7 @@ v0.4.4
 
 * amalgamate now works on Python 2 and allows relative imports.
 * Top-level xonsh package now more lazy.
-* Show conda environement name in prompt in parentheses similiar what conda does.
+* Show conda environment name in prompt in parentheses similar what conda does.
 * Implementation of expandvars now uses regex
 * Because of the addition of "optional items" to the prompt format string, the
   functions ``xonsh.environ.current_branch``, ``xonsh.environ.env_name`` and
@@ -1111,7 +1111,7 @@ v0.4.4
 * Fix bug that prevented disabling $INTENSIFY_COLORS_ON_WIN in ``xonshrc``
 * ``LazyJSON`` will now hide failures to close, and instead rely on reference
   counting if something goes wrong.
-* Fixed maximum recurssion error with color styles.
+* Fixed maximum recursion error with color styles.
 * Parser tables will no longer be generated in the current directory
   by accident.
 * Error messages when zsh or bash history file is not found
@@ -1153,7 +1153,7 @@ v0.4.3
 * Minor amalgamate bug with ``import pkg.mod`` amalgamated imports.
 * No longer raises an error if a directory in ``$PATH`` does not exist on
   Python v3.4.
-* Fixed a readline shell completion issue that caused by inconsistence between
+* Fixed a readline shell completion issue that caused by inconsistency between
   ``$CASE_SENSITIVE_COMPLETIONS`` and readline's inputrc setting.
 
 
@@ -1218,7 +1218,7 @@ v0.4.0
     - A ``LazyBool`` will only be created when ``__bool__()`` is called.
 
   Additionally, when fully loaded, the above objects will replace themselves
-  by name in the context that they were handed, thus derefenceing themselves.
+  by name in the context that they were handed, thus dereferencing themselves.
   This is useful for global variables that may be expensive to create,
   should only be created once, and may not be used in any particular session.
 * New ``xon.sh`` script added for launching xonsh from a sh environment.
@@ -1234,7 +1234,7 @@ v0.4.0
 * New ``Block`` and ``Functor`` context managers are now available as
   part of the ``xonsh.contexts`` module.
 * ``Block`` provides support for turning a context body into a non-executing
-  list of string lines. This is implmement via a syntax tree transformation.
+  list of string lines. This is implement via a syntax tree transformation.
   This is useful for creating remote execution tools that seek to prevent
   local execution.
 * ``Functor`` is a subclass of the ``Block`` context manager that turns the
@@ -1283,10 +1283,10 @@ v0.4.0
   can be resolved properly.
 * In ``VI_MODE``, the ``v`` key will enter character selection mode, not open
   the editor.  ``Ctrl-X Ctrl-E`` will still open an editor in any mode
-* ``$XONSH_DEBUG`` will now supress amalgamted imports. This usually needs to be
+* ``$XONSH_DEBUG`` will now suppress amalgamated imports. This usually needs to be
   set in the calling environment or prior to *any* xonsh imports.
-* Restuctured ``xonsh.platform`` to be fully lazy.
-* Restuctured ``xonsh.ansi_colors`` to be fully lazy.
+* Restructured ``xonsh.platform`` to be fully lazy.
+* Restructured ``xonsh.ansi_colors`` to be fully lazy.
 * Ensured the ``pygments`` and ``xonsh.pyghooks`` are not imported until
   actually needed.
 * Yacc parser is now loaded in a background thread.
@@ -1298,7 +1298,7 @@ v0.4.0
 * On Windows the ``PROMPT`` environment variable is reset to `$P$G` before
   sourcing ``*.bat`` files.
 * On Windows the ``PROMPT`` environment variable is reset to `$P$G` before starting
-  subprocesses. This prevents the unformatted xonsh ``PROMPT`` tempalte from showing up
+  subprocesses. This prevents the unformatted xonsh ``PROMPT`` template from showing up
   when running batch files with ``ECHO ON```
 * ``@()`` now passes through functions as well as strings, which allows for the
   use of anonymous aliases and aliases not explicitly added to the ``aliases``
@@ -1336,7 +1336,7 @@ v0.4.0
 
 * Issue where ``xonsh`` did not expand user and environment variables in
   ``$PATH``, forcing the user to add absolute paths.
-* Fixed a problem with aliases not always beeing found.
+* Fixed a problem with aliases not always being found.
 * Fixed issue where input was directed to the last process in a pipeline,
   rather than the first.
 * Bug where xonfig wizard can't find ENV docs
@@ -1371,7 +1371,7 @@ v0.3.4
   attempted to load.
 * Only show the prompt for the wizard if we did not attempt to load any run
   control files (as opposed to if none were successfully loaded).
-* Git and mercurial branch and dirty function refactor to imporve run times.
+* Git and mercurial branch and dirty function refactor to improve run times.
 
 
 **Fixed:**
@@ -1385,7 +1385,7 @@ v0.3.4
 * Fixed crash resulting from malformed ``$PROMPT``.
 * Fixed regression on Windows with the locate_binary() function.
   The bug prevented `source-cmd` from working correctly and broke the
-  ``activate``/``deactivate`` aliases for the conda environements.
+  ``activate``/``deactivate`` aliases for the conda environments.
 * Fixed crash resulting from errors other than syntax errors in run control
   file.
 * On Windows if bash is not on the path look in the registry for the defaults
@@ -1429,7 +1429,7 @@ v0.3.3
 
 **Fixed:**
 
-* Fixed crashed bash-completer when bash is not avaiable on Windows
+* Fixed crashed bash-completer when bash is not available on Windows
 * Fixed bug on Windows where tab-completion for executables would return all files.
 * Fixed bug on Windows which caused the bash $PROMPT variable to be used when no
   no $PROMPT variable was set in .xonshrc
@@ -1438,7 +1438,7 @@ v0.3.3
 * The --shell-type CLI flag now takes precedence over $SHELL_TYPE specified in
   .xonshrc
 * Fixed an issue about ``os.killpg()`` on OS X which caused xonsh crash with
-  occasionality
+  occasionally.
 
 
 
@@ -1465,7 +1465,7 @@ v0.3.1
   commands and arguments.
 * Added ``$DYNAMIC_CWD_WIDTH`` to allow the adjusting of the current working
   directory width in the prompt.
-* Added ``$XONSH_DEBUG`` environment variable to help with debuging.
+* Added ``$XONSH_DEBUG`` environment variable to help with debugging.
 * The ``${...}`` shortcut for ``__xonsh_env__`` now returns appropriate
   completion options
 
@@ -1495,7 +1495,7 @@ v0.3.1
   triggered by libedit.
 * ``$MULTILINE_PROMPT`` now allows colors, as originally intended.
 * Rectified install issue with Jupyter hook when installing with pyenv,
-  Jupyter install hook now repects ``--prefix`` argument.
+  Jupyter install hook now respects ``--prefix`` argument.
 * Fixed issue with the xonsh.ply subpackage not being installed.
 * Fixed a parsing bug whereby a trailing ``&`` on a line was being ignored
   (processes were unable to be started in the background)
@@ -1509,7 +1509,7 @@ v0.3.0
 * ``and``, ``or``, ``&&``, ``||`` have been added as subprocess logical operators,
   by popular demand!
 * Subprocesses may be negated with ``not`` and grouped together with parentheses.
-* New framework for writing xonsh extentions, called ``xontribs``.
+* New framework for writing xonsh extensions, called ``xontribs``.
 * Added a new shell type ``'none'``, used to avoid importing ``readline`` or
   ``prompt_toolkit`` when running scripts or running a single command.
 * New: `sudo` functionality on Windows through an alias
@@ -1572,14 +1572,14 @@ v0.3.0
 * Fixed bug with loading prompt-toolkit shell < v0.57.
 * Fixed bug with prompt-toolkit completion when the cursor is not at the end of
   the line.
-* Aliases will now evaluate enviornment variables and other expansions
+* Aliases will now evaluate environment variables and other expansions
   at execution time rather than passing through a literal string.
-* Fixed environment variables from os.environ not beeing loaded when a running
+* Fixed environment variables from os.environ not being loaded when a running
   a script
 * The readline shell will now load the inputrc files.
 * Fixed bug that prevented `source-alias` from working.
 * Now able to ``^C`` the xonfig wizard on start up.
-* Fixed deadlock on Windows when runing subprocess that generates enough output
+* Fixed deadlock on Windows when running subprocess that generates enough output
   to fill the OS pipe buffer.
 * Sourcing foreign shells will now return a non-zero exit code if the
   source operation failed for some reason.
@@ -1600,7 +1600,7 @@ v0.2.7
   for the concrete shell type based on the availability on the user's machine.
 * New environment variable ``$XONSH_COLOR_STYLE`` will set the color mapping
   for all of xonsh.
-* New ``XonshStyle`` pygments style will determine the approriate color
+* New ``XonshStyle`` pygments style will determine the appropriate color
   mapping based on ``$XONSH_COLOR_STYLE``.  The associated ``xonsh_style_proxy()``
   is intended for wrapping ``XonshStyle`` when actually being used by
   pygments.
@@ -1609,7 +1609,7 @@ v0.2.7
   anywhere.
 * ``xonsh.tools.HAVE_PYGMENTS`` flag now denotes if pygments is installed and
   available on the users system.
-* The ``ansi_colors`` module is now availble for handling ANSI color codes.
+* The ``ansi_colors`` module is now available for handling ANSI color codes.
 * ``?`` and ``??`` operator output now has colored titles, like in IPython.
 * ``??`` will syntax highlight source code if pygments is available.
 * Python mode output is now syntax highlighted if pygments is available.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -143,13 +143,13 @@ the above from from-import syntax.
 Alternatively, for modules outside of the current package (or modules that are
 not amalgamated) the import statement should be either ``import pkg.x`` or
 ``import pkg.x as name``. This is because these are the only cases where the
-amalgamater is able to automatically insert lazy imports in way that is guarantted
+amalgamater is able to automatically insert lazy imports in way that is guaranteed
 to be safe. This is due to the ambiguity that ``from pkg.x import name`` may
 import a variable that cannot be lazily constructed or may import a module.
 So the simple rules to follow are that:
 
 1. Import objects from modules in the same package directly in using from-import,
-2. Import objects from moudules outside of the package via a direct import
+2. Import objects from modules outside of the package via a direct import
    or import-as statement.
 
 How to Test
@@ -167,7 +167,7 @@ you just have to run this::
 
 This will build and run the current state of the repository in an isolated
 container (it may take a while the first time you run it). There are two
-additionals arguments you can pass this script.
+additional arguments you can pass this script.
 
 * The version of python
 * the version of ``prompt_toolkit``
@@ -233,7 +233,7 @@ parts of xonsh for more test isolation. For a list of the various fixtures::
 
     $ py.test --fixtures
 
-when writting tests it's best to use pytest features i.e parametrization::
+when writing tests it's best to use pytest features i.e parametrization::
 
     @pytest.mark.parametrize('env', [test_env1, test_env2])
     def test_one(env, xonsh_builtins):

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -386,9 +386,9 @@ def rewrite_imports(name, pkg, order, imps):
             for n in a.names:
                 p, dot, m = n.name.rpartition('.')
                 if p == pkg and m in order:
-                    msg = ('Cannot amalgamate amalgam import of '
-                           'amalgamated module:\n\n  import {0}.{1}\n'
-                           '\nin {0}/{2}.py').format(pkg, n.name, name)
+                    msg = ('Cannot amalgamate import of amalgamated module:'
+                           '\n\n  import {0}.{1}\n\nin {0}/{2}.py').format(
+                        pkg, n.name, name)
                     raise RuntimeError(msg)
                 imp = (Import, n.name, n.asname)
                 if imp not in imps:

--- a/amalgamate.py
+++ b/amalgamate.py
@@ -386,7 +386,7 @@ def rewrite_imports(name, pkg, order, imps):
             for n in a.names:
                 p, dot, m = n.name.rpartition('.')
                 if p == pkg and m in order:
-                    msg = ('Cannot amalgamate almagate import of '
+                    msg = ('Cannot amalgamate amalgam import of '
                            'amalgamated module:\n\n  import {0}.{1}\n'
                            '\nin {0}/{2}.py').format(pkg, n.name, name)
                     raise RuntimeError(msg)

--- a/docs/_static/console_colors.reg
+++ b/docs/_static/console_colors.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-; Registry file that maps the solarized palette to the 16 avaliable colors
+; Registry file that maps the solarized palette to the 16 available colors
 ; in a Windows command prompt. Note, hex values in the table are RGB but byte
 ; ordering of a DWORD is BGR, e.g. "ColorTable<##>"=dword:00<B><G><R>
 ;

--- a/docs/advanced_events.rst
+++ b/docs/advanced_events.rst
@@ -4,19 +4,19 @@
 Advanced Events
 ********************
 
-If you havent, go read the `events tutorial <tutorial_events.html>`_ first. This documents the messy
+If you haven't, go read the `events tutorial <tutorial_events.html>`_ first. This documents the messy
 details of the event system.
 
 You may also find the `events API reference <api/events.html>`_ useful.
 
 Why Unordered?
 ==============
-Yes, handler call order is not guarenteed. Please don't file bugs about this.
+Yes, handler call order is not guaranteed. Please don't file bugs about this.
 
 This was chosen because the order of handler registration is dependant on load order, which is 
 stable in a release but not something generally reasoned about. In addition, xontribs mean that we
 don't know what handlers could be registered. So even an "ordered" event system would be unable to
-make guarentees about ordering because of the larger system.
+make guarantees about ordering because of the larger system.
 
 Because of this, the event system is not ordered; this is a form of abstraction. Order-dependant 
 semantics are not encouraged by the built-in methods.

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -72,7 +72,7 @@ only works on xonsh and Python files.
 ``source-bash``
 ====================
 Like the ``source`` command but for Bash files. This is a thin wrapper around
-the ``source-foreign`` alias where the ``shell`` argument is autoamtically set
+the ``source-foreign`` alias where the ``shell`` argument is automatically set
 to ``bash``.
 
 
@@ -111,7 +111,7 @@ Simple alias defined as ``['rsync', '--partial', '-h', '--progress', '--rsh=ssh'
 
 ``showcmd``
 ============
-Displays how comands and arguments are evaluated.
+Displays how commands and arguments are evaluated.
 
 
 ``ipynb``

--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -2,7 +2,7 @@ Bash to Xonsh Translation Guide
 ================================
 As you have probably figured out by now, xonsh is not ``sh``-lang compliant.
 If your muscles have memorized all of the Bash prestidigitations, this page
-will help you put a finger on how to do the equivelent task in xonsh.
+will help you put a finger on how to do the equivalent task in xonsh.
 
 .. list-table::
     :widths: 30 30 40

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -150,7 +150,7 @@ session (say, in your awesome new ``xonsh`` script) you can use the membership o
    >>> 'HOME' in ${...}
    True
 
-To get information about a specific enviroment variable you can use the
+To get information about a specific environment variable you can use the
 :func:`~xonsh.environ.Env.help` method.
 
 .. code-block:: xonshcon
@@ -297,7 +297,7 @@ the directories again.
     >>> l = 2
     >>> ls -l
     42
-    >>> # deleting ls will return us to supbroc-mode
+    >>> # deleting ls will return us to subproc-mode
     >>> del ls
     >>> ls -l
     total 0
@@ -913,7 +913,7 @@ Let's see a demonstration with some simple filenames:
     3
 
 This same kind of search is performed if the backticks are prefaced with ``r``.
-So the following expresions are equivalent: ```test``` and ``r`test```.
+So the following expressions are equivalent: ```test``` and ``r`test```.
 
 Other than the regex matching, this functions in the same way as normal
 globbing.  For more information, please see the documentation for the ``re``
@@ -1203,7 +1203,7 @@ may have one of the following signatures:
 
     def mycmd5(args, stdin=None, stdout=None, stderr=None, spec=None):
         """Lastly, the final form of subprocess callables takes all of the
-        arguments shown above as well as a subpcrocess specification
+        arguments shown above as well as a subprocess specification
         SubprocSpec object. This holds many attributes that dictate how
         the command is being run.  For instance this can be useful for
         knowing if the process is captured by $() or !().
@@ -1316,9 +1316,9 @@ best used in conjunction with the ``unthreadable`` decorator.  For example:
 Aliasing is a powerful way that xonsh allows you to seamlessly interact to
 with Python and subprocess.
 
-.. warning:: If ``FOREIGN_ALIASES_OVERRIDE`` enviroment variable is False
+.. warning:: If ``FOREIGN_ALIASES_OVERRIDE`` environment variable is False
              (the default) then foreign shell aliases that try to override
-             xonsh aliases will be ignored. Setting of this enviroment variable
+             xonsh aliases will be ignored. Setting of this environment variable
              must happen in the static configuration file
              ``$XONSH_CONFIG_DIR/config.json`` in the 'env' section.
 
@@ -1408,7 +1408,7 @@ or ``{BOLD_BLUE}``.  Colors have the form shown below:
   hex color, or the nearest approximation that that is supported by
   the shell and terminal.  For example, ``#fff`` and ``#fafad2`` are
   both valid.
-* ``BACKGROUND_`` may be added to the begining of a color name or hex
+* ``BACKGROUND_`` may be added to the beginning of a color name or hex
   color to set a background color.  For example, ``BACKGROUND_INTENSE_RED``
   and ``BACKGROUND_#123456`` can both be used.
 * ``bg#HEX`` or ``BG#HEX`` are shortcuts for setting a background hex color.
@@ -1586,7 +1586,7 @@ file. Errors in Python mode will already raise exceptions and so this
 is roughly equivalent to Bash's ``set -e``.
 
 Furthermore, you can also toggle the ability to print source code lines with the
-``trace on`` and ``trace off`` commands.  This is roughly equivelent to
+``trace on`` and ``trace off`` commands.  This is roughly equivalent to
 Bash's ``set -x`` or Python's ``python -m trace``, but you know, better.
 
 Importing Xonsh (``*.xsh``)

--- a/docs/tutorial_history_backend.rst
+++ b/docs/tutorial_history_backend.rst
@@ -288,7 +288,7 @@ History items outside of the range defined by
             Parameters
             ----------
             size: None or tuple of a int and a string
-                Detemines the size and units of what would be allowed to remain.
+                Determines the size and units of what would be allowed to remain.
             blocking: bool
                 If set blocking, then wait until gc action finished.
             """

--- a/docs/tutorial_ptk.rst
+++ b/docs/tutorial_ptk.rst
@@ -40,7 +40,7 @@ functionality (in less you take the time to rebind them elsewhere).
 
     * - Keystroke
       - ASCII control representation
-      - Default commmand
+      - Default command
     * - ``Control J``
       - ``<Enter>``
       - Run command

--- a/docs/xonshconfig.rst
+++ b/docs/xonshconfig.rst
@@ -112,7 +112,7 @@ Some examples can be seen below:
 
 Putting it all together
 -----------------------
-The following ecample shows a fully fleshed out config file.
+The following example shows a fully fleshed out config file.
 
 :download:`Download config.json <xonshconfig.json>`
 

--- a/news/spelling_fixes.rst
+++ b/news/spelling_fixes.rst
@@ -2,6 +2,17 @@
 
 *  ``xonsh.color_tools.make_palette()``
 
+   Simple rename of the pre-existing
+   ``xonsh.color_tools.make_pallete()`` function.
+
+*  ``xonsh.tools.decorator()`` function/method decorator.
+
+   This allows for an API function to be annotated with a
+   decorator that documents deprecation, while also tying in
+   functionality that will warn a user that the function has
+   been deprecated, and, raise an ``AssertionError`` if the
+   function has passed its expiry date.
+
 **Changed:** None
 
 **Deprecated:**

--- a/news/spelling_fixes.rst
+++ b/news/spelling_fixes.rst
@@ -19,6 +19,8 @@
 
 *  ``xonsh.color_tools.make_pallette()``
 
+   Deprecated in release 0.5.10 and will be removed in release 0.6.0.
+
 **Removed:** None
 
 **Fixed:**
@@ -26,10 +28,10 @@
 *  Numerous spelling errors in documentation, docstrings/comments, text
    strings and local variable names.
 
-*  Spelling error in the ``xonsh.color_tools.make_pallette()`` public
+*  Spelling error in the ``xonsh.color_tools.make_pallete()`` public
    function declaration. This was fixed by renaming the function to
    ``xonsh.color_tools.make_palette()`` while maintaining a binding
-   of ``make_pallette()`` to the new ``make_palette()`` in case users
+   of ``make_pallete()`` to the new ``make_palette()`` in case users
    are already used to this API.
 
 **Security:** None

--- a/news/spelling_fixes.rst
+++ b/news/spelling_fixes.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+*  ``xonsh.color_tools.make_palette()``
+
+**Changed:** None
+
+**Deprecated:**
+
+*  ``xonsh.color_tools.make_pallette()``
+
+**Removed:** None
+
+**Fixed:**
+
+*  Numerous spelling errors in documentation, docstrings/comments, text
+   strings and local variable names.
+
+*  Spelling error in the ``xonsh.color_tools.make_pallette()`` public
+   function declaration. This was fixed by renaming the function to
+   ``xonsh.color_tools.make_palette()`` while maintaining a binding
+   of ``make_pallette()`` to the new ``make_palette()`` in case users
+   are already used to this API.
+
+**Security:** None

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ def main():
         )
     if HAVE_SETUPTOOLS:
         # WARNING!!! Do not use setuptools 'console_scripts'
-        # It validates the depenendcies (of which we have none) everytime the
+        # It validates the dependencies (of which we have none) every time the
         # 'xonsh' command is run. This validation adds ~0.2 sec. to the startup
         # time of xonsh - for every single xonsh run.  This prevents us from
         # reaching the goal of a startup time of < 0.1 sec.  So never ever write

--- a/tests/test_dirstack_unc.py
+++ b/tests/test_dirstack_unc.py
@@ -140,7 +140,7 @@ def test_uncpushd_push_to_same_share(xonsh_builtins, shares_setup):
     assert len(DIRSTACK) == 2
 
     dirstack.popd([])
-    assert os.path.isdir(TEMP_DRIVE[0] + '\\'), "Temp drived not unmapped till last reference removed"
+    assert os.path.isdir(TEMP_DRIVE[0] + '\\'), "Temp drive not unmapped till last reference removed"
     dirstack.popd([])
     assert owd.casefold() == os.getcwd().casefold(), "popd returned cwd to expected dir"
     assert len(_unc_tempDrives) == 0

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -63,12 +63,12 @@ def test_bad_indent():
         check_parse(code)
 
 def test_good_rhs_subproc():
-    # nonsense but parsebale
+    # nonsense but parsable
     code = 'str().split() | ![grep exit]\n'
     assert(code)
 
 def test_bad_rhs_subproc():
-    # nonsense but unparsebale
+    # nonsense but unparsable
     code = 'str().split() | grep exit\n'
     with pytest.raises(SyntaxError):
         check_parse(code)

--- a/tests/test_ptk_history.py
+++ b/tests/test_ptk_history.py
@@ -10,7 +10,7 @@ from xonsh.ptk.history import PromptToolkitHistory
 
 @pytest.fixture
 def history_obj():
-    """Instatiate `PromptToolkitHistory` and append a line string"""
+    """Instantiate `PromptToolkitHistory` and append a line string"""
     hist = PromptToolkitHistory(load_prev=False)
     hist.append('line10')
     return hist

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,6 +9,7 @@ import warnings
 
 import pytest
 
+from xonsh import __version__
 from xonsh.platform import ON_WINDOWS
 from xonsh.lexer import Lexer
 
@@ -1313,3 +1314,12 @@ def test_deprecated_warning_contains_message():
         my_function()
 
         assert str(warning.pop().message) == 'my_function has been deprecated'
+
+
+@pytest.mark.parametrize('expired_version', ['0.1.0', __version__])
+def test_deprecated_past_expiry_raises_assertion_error(expired_version):
+    @deprecated(removed_in=expired_version)
+    def my_function(): pass
+
+    with pytest.raises(AssertionError):
+        my_function()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import stat
 from tempfile import TemporaryDirectory
+import warnings
 
 import pytest
 
@@ -24,7 +25,7 @@ from xonsh.tools import (
     is_string_seq, pathsep_to_seq, seq_to_pathsep, is_nonstring_seq_of_strings,
     pathsep_to_upper_seq, seq_to_upper_pathsep, expandvars, is_int_as_str, is_slice_as_str,
     ensure_timestamp, get_portions, is_balanced, subexpr_before_unbalanced,
-    swap_values, get_logical_line, replace_logical_line, check_quotes,
+    swap_values, get_logical_line, replace_logical_line, check_quotes, deprecated,
     )
 from xonsh.environ import Env
 
@@ -1247,3 +1248,68 @@ def test_swap_values():
         assert orig['y'] == 43
     assert orig['x'] == 1
     assert 'y' not in orig
+
+
+@pytest.mark.parametrize('arguments, expected_docstring', [
+    ({'deprecated_in': '0.5.10', 'removed_in': '0.6.0'},
+     'my_function has been deprecated in version 0.5.10 and will be removed '
+     'in version 0.6.0'),
+    ({'deprecated_in': '0.5.10'},
+     'my_function has been deprecated in version 0.5.10'),
+    ({'removed_in': '0.6.0'},
+     'my_function has been deprecated and will be removed in version 0.6.0'),
+    ({},
+     'my_function has been deprecated')
+])
+def test_deprecated_docstrings_with_empty_docstring(
+        arguments, expected_docstring):
+    @deprecated(**arguments)
+    def my_function(): pass
+
+    assert my_function.__doc__ == expected_docstring
+
+
+@pytest.mark.parametrize('arguments, expected_docstring', [
+    ({'deprecated_in': '0.5.10', 'removed_in': '0.6.0'},
+     'Does nothing.\n\nmy_function has been deprecated in version 0.5.10 and '
+     'will be removed in version 0.6.0'),
+    ({'deprecated_in': '0.5.10'},
+     'Does nothing.\n\nmy_function has been deprecated in version 0.5.10'),
+    ({'removed_in': '0.6.0'},
+     'Does nothing.\n\nmy_function has been deprecated and will be removed '
+     'in version 0.6.0'),
+    ({},
+     'Does nothing.\n\nmy_function has been deprecated')
+])
+def test_deprecated_docstrings_with_nonempty_docstring(
+        arguments, expected_docstring):
+    @deprecated(**arguments)
+    def my_function():
+        """Does nothing."""
+        pass
+
+    assert my_function.__doc__ == expected_docstring
+
+
+def test_deprecated_warning_raised():
+    @deprecated()
+    def my_function(): pass
+
+    with warnings.catch_warnings(record=True) as warning:
+        warnings.simplefilter('always')
+
+        my_function()
+
+        assert issubclass(warning.pop().category, DeprecationWarning)
+
+
+def test_deprecated_warning_contains_message():
+    @deprecated()
+    def my_function(): pass
+
+    with warnings.catch_warnings(record=True) as warning:
+        warnings.simplefilter('always')
+
+        my_function()
+
+        assert str(warning.pop().message) == 'my_function has been deprecated'

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -404,7 +404,7 @@ def showcmd(args, stdin=None):
 
 def detect_xip_alias():
     """
-    Determines the correct invokation to get xonsh's pip
+    Determines the correct invocation to get xonsh's pip
     """
     if not getattr(sys, 'executable', None):
         return lambda args, stdin=None: ("", "Sorry, unable to run pip on your system (missing sys.executable)", 1)

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -866,11 +866,11 @@ del (_algol_style, _algol_nu_style, _autumn_style, _borland_style, _bw_style,
 #
 # Dynamically generated styles
 #
-def make_ansi_style(pallette):
-    """Makes an ANSI color style from a color pallette"""
+def make_ansi_style(palette):
+    """Makes an ANSI color style from a color palette"""
     style = {'NO_COLOR': '0'}
     for name, t in BASE_XONSH_COLORS.items():
-        closest = find_closest_color(t, pallette)
+        closest = find_closest_color(t, palette)
         if len(closest) == 3:
             closest = ''.join([a*2 for a in closest])
         short = rgb2short(closest)[0]
@@ -892,7 +892,7 @@ def ansi_style_by_name(name):
         raise KeyError('could not find style {0!r}'.format(name))
     from pygments.styles import get_style_by_name
     pstyle = get_style_by_name(name)
-    pallette = make_pallete(pstyle.styles.values())
-    astyle = make_ansi_style(pallette)
+    palette = make_pallete(pstyle.styles.values())
+    astyle = make_ansi_style(palette)
     ANSI_STYLES[name] = astyle
     return astyle

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -6,7 +6,7 @@ import builtins
 
 from xonsh.platform import HAS_PYGMENTS
 from xonsh.lazyasd import LazyDict
-from xonsh.color_tools import (RE_BACKGROUND, BASE_XONSH_COLORS, make_pallete,
+from xonsh.color_tools import (RE_BACKGROUND, BASE_XONSH_COLORS, make_palette,
                                find_closest_color, rgb2short, rgb_to_256)
 
 
@@ -892,7 +892,7 @@ def ansi_style_by_name(name):
         raise KeyError('could not find style {0!r}'.format(name))
     from pygments.styles import get_style_by_name
     pstyle = get_style_by_name(name)
-    palette = make_pallete(pstyle.styles.values())
+    palette = make_palette(pstyle.styles.values())
     astyle = make_ansi_style(palette)
     ANSI_STYLES[name] = astyle
     return astyle

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -19,7 +19,7 @@ def ansi_partial_color_format(template, style='default', cmap=None, hide=False):
     template : str
         The template string, potentially with color names.
     style : str, optional
-        Sytle name to look up color map from.
+        Style name to look up color map from.
     cmap : dict, optional
         A color map to use, this will prevent the color map from being
         looked up via the style name.

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -160,7 +160,7 @@ def xonsh_call(name, args, lineno=None, col=None):
 
 
 def isdescendable(node):
-    """Deteremines whether or not a node is worth visiting. Currently only
+    """Determines whether or not a node is worth visiting. Currently only
     UnaryOp and BoolOp nodes are visited.
     """
     return isinstance(node, (UnaryOp, BoolOp))
@@ -177,7 +177,7 @@ class CtxAwareTransformer(NodeTransformer):
         """Parameters
         ----------
         parser : xonsh.Parser
-            A parse instance to try to parse suprocess statements with.
+            A parse instance to try to parse subprocess statements with.
         """
         super(CtxAwareTransformer, self).__init__()
         self.parser = parser

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -506,8 +506,8 @@ class BaseShell(object):
         return p
 
     def format_color(self, string, hide=False, force_string=False, **kwargs):
-        """Formats the colors in a string. This base implementation's colors are
-        based on ANSI color codes.
+        """Formats the colors in a string. ``BaseShell``'s default implementation
+        of this method uses colors based on ANSI color codes.
         """
         style = builtins.__xonsh_env__.get('XONSH_COLOR_STYLE')
         return ansi_partial_color_format(string, hide=hide, style=style)

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -213,10 +213,10 @@ class _TeeStd(io.TextIOBase):
 
 
 class Tee:
-    """Class that merges tee'd stdout and stderr into a single strea,.
+    """Class that merges tee'd stdout and stderr into a single stream.
 
     This represents what a user would actually see on the command line.
-    This class as the same interface as io.TextIOWrapper, except that
+    This class has the same interface as io.TextIOWrapper, except that
     the buffer is optional.
     """
     # pylint is a stupid about counting public methods when using inheritance.
@@ -480,7 +480,7 @@ class BaseShell(object):
             kernel32.SetConsoleTitleW(t)
         else:
             with open(1, 'wb', closefd=False) as f:
-                # prevent xonsh from answering interative questions
+                # prevent xonsh from answering interactive questions
                 # on the next command by writing the title
                 f.write("\x1b]0;{0}\x07".format(t).encode())
                 f.flush()
@@ -506,15 +506,15 @@ class BaseShell(object):
         return p
 
     def format_color(self, string, hide=False, force_string=False, **kwargs):
-        """Formats the colors in a string. This base implmentation colors based
-        on ANSI color codes
+        """Formats the colors in a string. This base implementation's colors are
+        based on ANSI color codes.
         """
         style = builtins.__xonsh_env__.get('XONSH_COLOR_STYLE')
         return ansi_partial_color_format(string, hide=hide, style=style)
 
     def print_color(self, string, hide=False, **kwargs):
-        """Prints a string in color. This base implmentation will color based
-        ANSI color codes if a string was given as input. If a list of token
+        """Prints a string in color. This base implementation's colors are based
+        on ANSI color codes if a string was given as input. If a list of token
         pairs is given, it will color based on pygments, if available. If
         pygments is not available, it will print a colorless string.
         """

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -191,8 +191,8 @@ def get_script_subproc_command(fname, args):
     if not os.access(fname, os.X_OK):
         raise PermissionError
     if ON_POSIX and not os.access(fname, os.R_OK):
-        # on some systems, some importnat programs (e.g. sudo) will have
-        # execute permissions but not read/write permisions. This enables
+        # on some systems, some important programs (e.g. sudo) will have
+        # execute permissions but not read/write permissions. This enables
         # things with the SUID set to be run. Needs to come before _is_binary()
         # is called, because that function tries to read the file.
         return [fname] + args
@@ -348,7 +348,7 @@ def no_pg_xonsh_preexec_fn():
 
 
 class SubprocSpec:
-    """A container for specifiying how a subprocess command should be
+    """A container for specifying how a subprocess command should be
     executed.
     """
 
@@ -381,7 +381,7 @@ class SubprocSpec:
         args : list of str
             Arguments as originally supplied.
         alias : list of str, callable, or None
-            The alias that was reolved for this command, if any.
+            The alias that was resolved for this command, if any.
         binary_loc : str or None
             Path to binary to execute.
         is_proxy : bool
@@ -549,7 +549,7 @@ class SubprocSpec:
 
     def _fix_null_cmd_bytes(self):
         # Popen does not accept null bytes in its input commands.
-        # that doesn;t stop some subproces from using them. Here we
+        # That doesn't stop some subprocess' from using them. Here we
         # escape them just in case.
         cmd = self.cmd
         for i in range(len(cmd)):
@@ -562,8 +562,8 @@ class SubprocSpec:
     @classmethod
     def build(kls, cmd, *, cls=subprocess.Popen, **kwargs):
         """Creates an instance of the subprocess command, with any
-        modifcations and adjustments based on the actual cmd that
-        was recieved.
+        modifications and adjustments based on the actual cmd that
+        was received.
         """
         # modifications that do not alter cmds may come before creating instance
         spec = kls(cmd, cls=cls, **kwargs)
@@ -662,7 +662,7 @@ class SubprocSpec:
         cls = ProcProxyThread if thable else ProcProxy
         self.cls = cls
         self.threadable = thable
-        # also check capturablity, while we are here
+        # also check capturability, while we are here
         cpable = getattr(alias, '__xonsh_capturable__', self.captured)
         self.captured = cpable
 
@@ -781,7 +781,7 @@ def cmds_to_specs(cmds, captured=False):
             specs[-1].background = True
         else:
             raise XonshError('unrecognized redirect {0!r}'.format(redirect))
-    # Apply boundry conditions
+    # Apply boundary conditions
     _update_last_spec(specs[-1])
     return specs
 
@@ -942,7 +942,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name='<arg>',
     Parameters
     ----------
     raw_arg : str
-        The str reprensetaion of the macro argument.
+        The str representation of the macro argument.
     kind : object
         A flag or type representing how to convert the argument.
     glbs : Mapping
@@ -966,7 +966,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name='<arg>',
     if isinstance(kind, str):
         kind = _convert_kind_flag(kind)
     if kind is str or kind is None:
-        return raw_arg  # short circut since there is nothing else to do
+        return raw_arg  # short circuit since there is nothing else to do
     # select from kind and convert
     execer = builtins.__xonsh_execer__
     filename = macroname + '(' + name + ')'
@@ -1035,9 +1035,9 @@ def call_macro(f, raw_args, glbs, locs):
     f : callable object
         The function that is called as ``f(*args)``.
     raw_args : tuple of str
-        The str reprensetaion of arguments of that were passed into the
+        The str representation of arguments of that were passed into the
         macro. These strings will be parsed, compiled, evaled, or left as
-        a string dependending on the annotations of f.
+        a string depending on the annotations of f.
     glbs : Mapping
         The globals from the call site.
     locs : Mapping or None
@@ -1110,7 +1110,7 @@ def enter_macro(obj, raw_block, glbs, locs):
     raw_block : str
         The str of the block that is the context body.
         This string will be parsed, compiled, evaled, or left as
-        a string dependending on the return annotation of obj.__enter__.
+        a string depending on the return annotation of obj.__enter__.
     glbs : Mapping
         The globals from the context site.
     locs : Mapping or None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -549,7 +549,7 @@ class SubprocSpec:
 
     def _fix_null_cmd_bytes(self):
         # Popen does not accept null bytes in its input commands.
-        # That doesn't stop some subprocess' from using them. Here we
+        # That doesn't stop some subprocesses from using them. Here we
         # escape them just in case.
         cmd = self.cmd
         for i in range(len(cmd)):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -992,7 +992,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name='<arg>',
         arg = type(execer.eval(raw_arg, glbs=glbs, locs=locs,
                                filename=filename))
     else:
-        msg = ('kind={0!r} and mode={1!r} was not recongnized for macro '
+        msg = ('kind={0!r} and mode={1!r} was not recognized for macro '
                'argument {2!r}')
         raise TypeError(msg.format(kind, mode, name))
     return arg

--- a/xonsh/color_tools.py
+++ b/xonsh/color_tools.py
@@ -397,17 +397,17 @@ def color_dist(x, y):
     return math.sqrt((x[0]-y[0])**2 + (x[1]-y[1])**2 + (x[2]-y[2])**2)
 
 
-def find_closest_color(x, pallette):
-    return min(sorted(pallette.keys())[::-1],
-               key=lambda k: color_dist(x, pallette[k]))
+def find_closest_color(x, palette):
+    return min(sorted(palette.keys())[::-1],
+               key=lambda k: color_dist(x, palette[k]))
 
 
 def make_pallete(strings):
-    """Makes a color pallete from a colection of strings."""
-    pallette = {}
+    """Makes a color palete from a collection of strings."""
+    palette = {}
     for s in strings:
         while '#' in s:
             _, t = s.split('#', 1)
             t, _, s = t.partition(' ')
-            pallette[t] = rgb_to_ints(t)
-    return pallette
+            palette[t] = rgb_to_ints(t)
+    return palette

--- a/xonsh/color_tools.py
+++ b/xonsh/color_tools.py
@@ -9,6 +9,7 @@ import re
 import math
 
 from xonsh.lazyasd import lazyobject, LazyObject
+from xonsh.tools import deprecated
 
 
 RE_BACKGROUND = LazyObject(lambda: re.compile('(BG#|BGHEX|BACKGROUND)'),
@@ -412,4 +413,7 @@ def make_palette(strings):
             palette[t] = rgb_to_ints(t)
     return palette
 
-make_pallette = make_palette
+
+@deprecated(deprecated_in='0.5.10', removed_in='0.6.0')
+def make_pallete(*args, **kwargs):
+    make_palette(*args, **kwargs)

--- a/xonsh/color_tools.py
+++ b/xonsh/color_tools.py
@@ -402,8 +402,8 @@ def find_closest_color(x, palette):
                key=lambda k: color_dist(x, palette[k]))
 
 
-def make_pallete(strings):
-    """Makes a color palete from a collection of strings."""
+def make_palette(strings):
+    """Makes a color palette from a collection of strings."""
     palette = {}
     for s in strings:
         while '#' in s:
@@ -411,3 +411,5 @@ def make_pallete(strings):
             t, _, s = t.partition(' ')
             palette[t] = rgb_to_ints(t)
     return palette
+
+make_pallette = make_palette

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -3,7 +3,7 @@
 a command will be able to be run in the background.
 
 A background predictor is a function that accepts a single argument list
-and returns whethere or not the process can be run in the background (returns
+and returns whether or not the process can be run in the background (returns
 True) or must be run the foreground (returns False).
 """
 import os
@@ -39,7 +39,7 @@ class CommandsCache(cabc.Mapping):
     def __iter__(self):
         for cmd, (path, is_alias) in self.all_commands.items():
             if ON_WINDOWS and path is not None:
-                # All comand keys are stored in uppercase on Windows.
+                # All command keys are stored in uppercase on Windows.
                 # This ensures the original command name is returned.
                 cmd = pathbasename(path)
             yield cmd
@@ -223,7 +223,7 @@ class CommandsCache(cabc.Mapping):
             return predict_true
 
     def default_predictor_readbin(self, name, cmd0, timeout, failure):
-        """Make a defautt predictor by
+        """Make a default predictor by
         analyzing the content of the binary. Should only works on POSIX.
         Return failure if the analysis fails.
         """
@@ -297,7 +297,7 @@ def SHELL_PREDICTOR_PARSER():
 
 
 def predict_shell(args):
-    """Precict the backgroundability of the normal shell interface, which
+    """Predict the backgroundability of the normal shell interface, which
     comes down to whether it is being run in subproc mode.
     """
     ns, _ = SHELL_PREDICTOR_PARSER.parse_known_args(args)
@@ -319,7 +319,7 @@ def HELP_VER_PREDICTOR_PARSER():
 
 
 def predict_help_ver(args):
-    """Precict the backgroundability of commands that have help & version
+    """Predict the backgroundability of commands that have help & version
     switches: -h, --help, -v, -V, --version. If either of these options is
     present, the command is assumed to print to stdout normally and is therefore
     threadable. Otherwise, the command is assumed to not be threadable.

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -256,7 +256,7 @@ def bash_completions(prefix, line, begidx, endidx, env=None, paths=None,
     endidx : int
         The index in line that prefix ends on.
     env : Mapping, optional
-        The environment dict to execute the Bash suprocess in.
+        The environment dict to execute the Bash subprocess in.
     paths : list or tuple of str or None, optional
         This is a list (or tuple) of strings that specifies where the
         ``bash_completion`` script may be found. The first valid path will

--- a/xonsh/diff_history.py
+++ b/xonsh/diff_history.py
@@ -52,7 +52,7 @@ def greenline(line):
 
 
 def highlighted_ndiff(a, b):
-    """Returns a highlited string, with bold charaters where different."""
+    """Returns a highlighted string, with bold characters where different."""
     s = ''
     sm = difflib.SequenceMatcher()
     sm.set_seqs(a, b)

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -107,7 +107,7 @@ def _unc_unmap_temp_drive(left_drive, cwd):
     if left_drive not in _unc_tempDrives:   # if not one we've mapped, don't unmap it
         return
 
-    for p in DIRSTACK + [cwd]:              # if still in use , don't aunmap it.
+    for p in DIRSTACK + [cwd]:              # if still in use , don't unmap it.
         if p.casefold().startswith(left_drive):
             return
 
@@ -161,10 +161,10 @@ def _try_cdpath(apath):
     # In bash if a CDPATH is set, an unqualified local folder
     # is considered after all CDPATHs, example:
     # CDPATH=$HOME/src (with src/xonsh/ inside)
-    # $ cd xonsh -> src/xonsh (whith xonsh/xonsh)
+    # $ cd xonsh -> src/xonsh (with xonsh/xonsh)
     # a second $ cd xonsh has no effects, to move in the nested xonsh
     # in bash a full $ cd ./xonsh is needed.
-    # In xonsh a relative folder is allways preferred.
+    # In xonsh a relative folder is always preferred.
     env = builtins.__xonsh_env__
     cdpaths = env.get('CDPATH')
     for cdp in cdpaths:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -772,7 +772,7 @@ class Env(cabc.MutableMapping):
 
     * PATH: any variable whose name ends in PATH is a list of strings.
     * XONSH_HISTORY_SIZE: this variable is an (int | float, str) tuple.
-    * LC_* (locale categories): locale catergory names get/set the Python
+    * LC_* (locale categories): locale category names get/set the Python
       locale via locale.getlocale() and locale.setlocale() functions.
 
     An Env instance may be converted to an untyped version suitable for
@@ -831,7 +831,7 @@ class Env(cabc.MutableMapping):
 
     def replace_env(self):
         """Replaces the contents of os_environ with a detyped version
-        of the xonsh environement.
+        of the xonsh environment.
         """
         if self._orig_env is None:
             self._orig_env = dict(os_environ)
@@ -840,7 +840,7 @@ class Env(cabc.MutableMapping):
 
     def undo_replace_env(self):
         """Replaces the contents of os_environ with a detyped version
-        of the xonsh environement.
+        of the xonsh environment.
         """
         if self._orig_env is not None:
             os_environ.clear()
@@ -874,7 +874,7 @@ class Env(cabc.MutableMapping):
         return vd
 
     def help(self, key):
-        """Get information about a specific enviroment variable."""
+        """Get information about a specific environment variable."""
         vardocs = self.get_docs(key)
         width = min(79, os.get_terminal_size()[0])
         docstr = '\n'.join(textwrap.wrap(vardocs.docstr, width=width))

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -47,7 +47,7 @@ import xonsh.prompt.base as prompt
 events.doc('on_envvar_new', """
 on_envvar_new(name: str, value: Any) -> None
 
-Fires after a new enviroment variable is created.
+Fires after a new environment variable is created.
 Note: Setting envvars inside the handler might
 cause a recursion until the limit.
 """)
@@ -56,7 +56,7 @@ cause a recursion until the limit.
 events.doc('on_envvar_change', """
 on_envvar_change(name: str, oldvalue: Any, newvalue: Any) -> None
 
-Fires after an enviroment variable is changed.
+Fires after an environment variable is changed.
 Note: Setting envvars inside the handler might
 cause a recursion until the limit.
 """)
@@ -521,7 +521,7 @@ def DEFAULT_DOCS():
                       configurable=False),
     'PATH': VarDocs(
         'List of strings representing where to look for executables.'),
-    'PATHEXT': VarDocs('Sequence of extention strings (eg, ``.EXE``) for '
+    'PATHEXT': VarDocs('Sequence of extension strings (eg, ``.EXE``) for '
                        'filtering valid executables by. Each element must be '
                        'uppercase.'),
     'PRETTY_PRINT_RESULTS': VarDocs(
@@ -545,12 +545,12 @@ def DEFAULT_DOCS():
         'The error that is raised is a ``subprocess.CalledProcessError``.'),
     'RIGHT_PROMPT': VarDocs(
         'Template string for right-aligned text '
-        'at the prompt. This may be parameterized in the same way as '
+        'at the prompt. This may be parametrized in the same way as '
         'the ``$PROMPT`` variable. Currently, this is only available in the '
         'prompt-toolkit shell.'),
     'BOTTOM_TOOLBAR': VarDocs(
         'Template string for the bottom toolbar. '
-        'This may be parameterized in the same way as '
+        'This may be parametrized in the same way as '
         'the ``$PROMPT`` variable. Currently, this is only available in the '
         'prompt-toolkit shell.'),
     'SHELL_TYPE': VarDocs(
@@ -580,7 +580,7 @@ def DEFAULT_DOCS():
         'command will be offered as a suggestion.  Also used for "fuzzy" '
         'tab completion of paths.'),
     'SUPPRESS_BRANCH_TIMEOUT_MESSAGE': VarDocs(
-        'Whether or not to supress branch timeout warning messages.'),
+        'Whether or not to suppress branch timeout warning messages.'),
     'TERM': VarDocs(
         'TERM is sometimes set by the terminal emulator. This is used (when '
         "valid) to determine whether or not to set the title. Users shouldn't "
@@ -664,7 +664,7 @@ def DEFAULT_DOCS():
     'XONSH_DEBUG': VarDocs(
         'Sets the xonsh debugging level. This may be an integer or a boolean. '
         'Setting this variable prior to stating xonsh to ``1`` or ``True`` '
-        'will supress amalgamated imports. Setting it to ``2`` will get some '
+        'will suppress amalgamated imports. Setting it to ``2`` will get some '
         'basic information like input transformation, command replacement. '
         'With ``3`` or a higher number will make more debugging information '
         'presented, like PLY parsing messages.',
@@ -720,7 +720,7 @@ def DEFAULT_DOCS():
         '``True`` if xonsh is running as a login shell, and ``False`` otherwise.',
         configurable=False),
     'XONSH_PROC_FREQUENCY': VarDocs(
-        'The process frquency is the time that '
+        'The process frequency is the time that '
         'xonsh process threads sleep for while running command pipelines. '
         'The value has units of seconds [s].'),
     'XONSH_SHOW_TRACEBACK': VarDocs(

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -24,7 +24,7 @@ def debug_level():
         return builtins.__xonsh_env__.get('XONSH_DEBUG')
     # FIXME: Under py.test, return 1(?)
     else:
-        return 0  # Optimize for speed, not guarenteed correctness
+        return 0  # Optimize for speed, not guaranteed correctness
 
 
 class AbstractEvent(collections.abc.MutableSet, abc.ABC):
@@ -267,7 +267,7 @@ class EventManager:
         ----------
         name : str
             The name of the event, eg "on_precommand"
-        species : sublcass of AbstractEvent
+        species : subclass of AbstractEvent
             The type to turn the event in to.
         """
         if isinstance(species, str):

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -65,7 +65,7 @@ class Execer(object):
         # Parsing actually happens in a couple of phases. The first is a
         # shortcut for a context-free parser. Normally, all subprocess
         # lines should be wrapped in $(), to indicate that they are a
-        # subproc. But that would be super annoying. Unfortnately, Python
+        # subproc. But that would be super annoying. Unfortunately, Python
         # mode - after indentation - is whitespace agnostic while, using
         # the Python token, subproc mode is whitespace aware. That is to say,
         # in Python mode "ls -l", "ls-l", and "ls - l" all parse to the
@@ -187,7 +187,7 @@ class Execer(object):
                 if len(line.strip()) == 0:
                     # whitespace only lines are not valid syntax in Python's
                     # interactive mode='single', who knew?! Just ignore them.
-                    # this might cause actual sytax errors to have bad line
+                    # this might cause actual syntax errors to have bad line
                     # numbers reported, but should only affect interactive mode
                     del lines[idx]
                     last_error_line = last_error_col = -1

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -88,7 +88,7 @@ fi
 echo ${namefile}"""
 
 
-# mapping of shell name alises to keys in other lookup dictionaries.
+# mapping of shell name aliases to keys in other lookup dictionaries.
 @lazyobject
 def CANON_SHELL_NAMES():
     return {
@@ -197,7 +197,7 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
     aliascmd : str or None, optional
         The command to generate alias output with.
     extra_args : tuple of str, optional
-        Addtional command line options to pass into the shell.
+        Additional command line options to pass into the shell.
     currenv : tuple of items or None, optional
         Manual override for the current environment.
     safe : bool, optional
@@ -248,7 +248,7 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
     env : dict
         Dictionary of shell's environment. (None if the subproc command fails)
     aliases : dict
-        Dictionary of shell's alaiases, this includes foreign function
+        Dictionary of shell's aliases, this includes foreign function
         wrappers.(None if the subproc command fails)
     """
     cmd = [shell]
@@ -425,9 +425,9 @@ class ForeignShellFunctionAlias(object):
         filename : str
             Where the function is defined, path to source.
         sourcer : str or None, optional
-            Command to source foreing files with.
+            Command to source foreign files with.
         extra_args : tuple of str, optional
-            Addtional command line options to pass into the shell.
+            Additional command line options to pass into the shell.
         """
         sourcer = DEFAULT_SOURCERS.get(shell, 'source') if sourcer is None \
             else sourcer

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -103,8 +103,8 @@ class History:
         Parameters
         ----------
         cmd: dict
-            A dict contains informations of a command. It should contains
-            the following keys like ``inp``, ``rtn``, ``ts`` etc.
+            A dict contains information on a command. It should contain
+            the following keys, like ``inp``, ``rtn``, ``ts`` &etc.
         """
         pass
 
@@ -136,7 +136,7 @@ class History:
         Parameters
         ----------
         size: None or tuple of a int and a string
-            Detemines the size and units of what would be allowed to remain.
+            Determines the size and units of what would be allowed to remain.
         blocking: bool
             If set blocking, then wait until gc action finished.
         """

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -103,8 +103,10 @@ class History:
         Parameters
         ----------
         cmd: dict
-            A dict contains information on a command. It should contain
-            the following keys, like ``inp``, ``rtn``, ``ts`` &etc.
+            This dict contains information about the command that is to be
+            added to the history list. It should contain the keys ``inp``,
+            ``rtn`` and ``ts``. These key names mirror the same names defined
+            as instance variables in the ``HistoryEntry`` class.
         """
         pass
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -360,7 +360,7 @@ class JsonHistory(History):
         ----------
         at_exit : bool, optional
             Whether the JsonHistoryFlusher should act as a thread in the
-            background, or execute immeadiately and block.
+            background, or execute immediately and block.
 
         Returns
         -------
@@ -383,7 +383,7 @@ class JsonHistory(History):
         """
         Returns all history as found in XONSH_DATA_DIR.
 
-        yeild format: {'inp': cmd, 'rtn': 0, ...}
+        yield format: {'inp': cmd, 'rtn': 0, ...}
         """
         while self.gc and self.gc.is_alive():
             time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -338,7 +338,10 @@ class JsonHistory(History):
         Parameters
         ----------
         cmd : dict
-            Command dictionary that should be added to the ordered history.
+            This dict contains information about the command that is to be
+            added to the history list. It should contain the keys ``inp``,
+            ``rtn`` and ``ts``. These key names mirror the same names defined
+            as instance variables in the ``HistoryEntry`` class.
 
         Returns
         -------

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -32,7 +32,7 @@ def _xh_sqlite_create_history_table(cursor):
     """Create Table for history items.
 
     Columns:
-        info - JSON formated, reserved for future extension.
+        info - JSON formatted, reserved for future extension.
     """
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS xonsh_history

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -236,7 +236,7 @@ class XonshImportEventHook(MetaPathFinder):
 
 
 class XonshImportEventLoader(Loader):
-    """A class that dispatches loader calls to another loader and fires relevent
+    """A class that dispatches loader calls to another loader and fires relevant
     xonsh events.
     """
 
@@ -261,11 +261,11 @@ class XonshImportEventLoader(Loader):
         return rtn
 
     def load_module(self, fullname):
-        """Legacy module loading, provided for backwards compatability."""
+        """Legacy module loading, provided for backwards compatibility."""
         return self.loader.load_module(fullname)
 
     def module_repr(self, module):
-        """Legacy module repr, provided for backwards compatability."""
+        """Legacy module repr, provided for backwards compatibility."""
         return self.loader.module_repr(module)
 
 

--- a/xonsh/inspectors.py
+++ b/xonsh/inspectors.py
@@ -188,7 +188,7 @@ def call_tip(oinfo, format_call=True):
     Returns
     -------
     call_info : None, str or (str, dict) tuple.
-      When format_call is True, the whole call information is formattted as a
+      When format_call is True, the whole call information is formatted as a
       single string.  Otherwise, the object's name and its argspec dict are
       returned.  If no call information is available, None is returned.
 

--- a/xonsh/lazyasd.py
+++ b/xonsh/lazyasd.py
@@ -21,7 +21,7 @@ class LazyObject(object):
         provided context (typically the globals of the call site) with the
         given name.
 
-        For example, you can prevent the compilation of a regular expreession
+        For example, you can prevent the compilation of a regular expression
         until it is actually used::
 
             DOT = LazyObject((lambda: re.compile('.')), globals(), 'DOT')
@@ -150,7 +150,7 @@ class LazyDict(cabc.MutableMapping):
         ----------
         loaders : Mapping of keys to functions with no arguments
             A mapping of loader function that performs the actual value
-            construction upon acces.
+            construction upon access.
         ctx : Mapping
             Context to replace the LazyDict instance in
             with the the fully loaded mapping.
@@ -335,7 +335,7 @@ def load_module_in_background(name, package=None, debug='DEBUG', env=None,
         os.environ otherwise.
     replacements : Mapping or None, optional
         Dictionary mapping fully qualified module names (eg foo.bar.baz) that
-        import the lazily loaded moudle, with the variable name in that
+        import the lazily loaded module, with the variable name in that
         module. For example, suppose that foo.bar imports module a as b,
         this dict is then {'foo.bar': 'b'}.
 

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -379,7 +379,7 @@ class Lexer(object):
             t = self.token()
 
     def split(self, s):
-        """Splits a string into a list of strings which are whitepace-separated
+        """Splits a string into a list of strings which are whitespace-separated
         tokens.
         """
         vals = []

--- a/xonsh/macutils.py
+++ b/xonsh/macutils.py
@@ -5,7 +5,7 @@ from xonsh.platform import LIBC
 
 
 def sysctlbyname(name, return_str=True):
-    """Gets a sysctrl value by name. If return_str is true, this will return
+    """Gets a sysctl value by name. If return_str is true, this will return
     a string representation, else it will return the raw value.
     """
     # forked from https://gist.github.com/pudquick/581a71425439f2cf8f09

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -220,7 +220,7 @@ class XonshMode(enum.Enum):
 
 def start_services(shell_kwargs):
     """Starts up the essential services in the proper order.
-    This returns the envrionment instance as a convenience.
+    This returns the environment instance as a convenience.
     """
     install_import_hooks()
     # create execer, which loads builtins
@@ -246,7 +246,7 @@ def start_services(shell_kwargs):
 
 
 def premain(argv=None):
-    """Setup for main xonsh entry point, returns parsed arguments."""
+    """Setup for main xonsh entry point. Returns parsed arguments."""
     if argv is None:
         argv = sys.argv[1:]
     setup_timings()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -171,8 +171,8 @@ def parser():
                    default=None)
     p.add_argument('--timings',
                    help='Prints timing information before the prompt is shown. '
-                        'This is usefull to track down performance issues '
-                        'and investigate startup times.',
+                        'This is useful while tracking down performance issues '
+                        'and investigating startup times.',
                    dest='timings',
                    action='store_true',
                    default=None)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -170,8 +170,8 @@ def parser():
                    choices=('readline', 'prompt_toolkit', 'best', 'random'),
                    default=None)
     p.add_argument('--timings',
-                   help='Prints timing infomation before the prompt is shown. '
-                        'This is usefull to track down perfomance issues '
+                   help='Prints timing information before the prompt is shown. '
+                        'This is usefull to track down performance issues '
                         'and investigate startup times.',
                    dest='timings',
                    action='store_true',

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -190,7 +190,7 @@ def empty_list_if_newline(x):
 
 def lopen_loc(x):
     """Extracts the line and column number for a node that may have anb opening
-    parenthesis, brace, or braket.
+    parenthesis, brace, or bracket.
     """
     lineno = x._lopen_lineno if hasattr(x, '_lopen_lineno') else x.lineno
     col = x._lopen_col if hasattr(x, '_lopen_col') else x.col_offset
@@ -390,7 +390,7 @@ class BaseParser(object):
         setattr(self.__class__, listfunc.__name__, listfunc)
 
     def _tok_rule(self, rulename):
-        """For a rule name, creates a rule that retuns the corresponding token.
+        """For a rule name, creates a rule that returns the corresponding token.
         '_tok' is appended to the rule name.
         """
 
@@ -1437,7 +1437,7 @@ class BaseParser(object):
         self.p_nodedent_base.__func__.__doc__ = doc
 
     def p_nodedent_base(self, p):
-        # see above attachament function
+        # see above attachment function
         pass
 
     def p_nodedent_any(self, p):
@@ -1471,7 +1471,7 @@ class BaseParser(object):
         self.p_nonewline_base.__func__.__doc__ = doc
 
     def p_nonewline_base(self, p):
-        # see above attachament function
+        # see above attachment function
         pass
 
     def p_nonewline_any(self, p):
@@ -1979,7 +1979,7 @@ class BaseParser(object):
         self.p_nocloser_base.__func__.__doc__ = doc
 
     def p_nocloser_base(self, p):
-        # see above attachament function
+        # see above attachment function
         pass
 
     def p_nocloser_any(self, p):
@@ -2098,13 +2098,13 @@ class BaseParser(object):
     # The following grammar rules are no-ops because we don't need to glue the
     # source code back together piece-by-piece. Instead, we simply look for
     # top-level commas and record their positions. With these positions and
-    # the bounding parantheses !() positions we can use the source_slice()
+    # the bounding parenthesis !() positions we can use the source_slice()
     # method. This does a much better job of capturing exactly the source code
     # that was provided. The tokenizer & lexer can be a little lossy, especially
     # with respect to whitespace.
 
     def p_nocomma_tok(self, p):
-        # see attachement function above for docstring
+        # see attachment function above for docstring
         pass
 
     def p_any_raw_tok(self, p):

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2097,11 +2097,11 @@ class BaseParser(object):
 
     # The following grammar rules are no-ops because we don't need to glue the
     # source code back together piece-by-piece. Instead, we simply look for
-    # top-level commas and record their positions. With these positions and
-    # the bounding parenthesis !() positions we can use the source_slice()
-    # method. This does a much better job of capturing exactly the source code
-    # that was provided. The tokenizer & lexer can be a little lossy, especially
-    # with respect to whitespace.
+    # top-level commas and record their positions. With these positions and the
+    # respective positions of the bounding parentheses, we can use the
+    # source_slice() method. This does a much better job of capturing exactly
+    # the source code that was provided. The tokenizer & lexer can be a little
+    # lossy, especially with respect to whitespace.
 
     def p_nocomma_tok(self, p):
         # see attachment function above for docstring

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -189,7 +189,7 @@ def empty_list_if_newline(x):
 
 
 def lopen_loc(x):
-    """Extracts the line and column number for a node that may have anb opening
+    """Extracts the line and column number for a node that may have an opening
     parenthesis, brace, or bracket.
     """
     lineno = x._lopen_lineno if hasattr(x, '_lopen_lineno') else x.lineno

--- a/xonsh/parsers/v34.py
+++ b/xonsh/parsers/v34.py
@@ -25,7 +25,7 @@ class Parser(BaseParser):
         outputdir : str or None, optional
             The directory to place generated tables within.
         """
-        # Rule creation and modifiation *must* take place before super()
+        # Rule creation and modification *must* take place before super()
         opt_rules = ['argument_comma_list', 'comma_argument_list']
         for rule in opt_rules:
             self._opt_rule(rule)

--- a/xonsh/parsers/v35.py
+++ b/xonsh/parsers/v35.py
@@ -25,7 +25,7 @@ class Parser(BaseParser):
         outputdir : str or None, optional
             The directory to place generated tables within.
         """
-        # Rule creation and modifiation *must* take place before super()
+        # Rule creation and modification *must* take place before super()
         tok_rules = ['await', 'async']
         for rule in tok_rules:
             self._tok_rule(rule)
@@ -113,7 +113,7 @@ class Parser(BaseParser):
     # to our LL(1) parser. Even though 'test' includes '*expr' in star_expr,
     # we explicitly match '*' here, too, to give it proper precedence.
     # Illegal combinations and orderings are blocked in ast.c:
-    # multiple (test comp_for) arguements are blocked; keyword unpackings
+    # multiple (test comp_for) arguments are blocked; keyword unpackings
     # that precede iterable unpackings are blocked; etc.
     def p_argument_test_or_star(self, p):
         """argument : test_or_star_expr"""

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -200,7 +200,7 @@ def expanduser():
 def windows_expanduser(path):
     """A Windows-specific expanduser() function for xonsh. This is needed
     since os.path.expanduser() does not check on Windows if the user actually
-    exists. This restircts expanding the '~' if it is not followed by a
+    exists. This restricts expanding the '~' if it is not followed by a
     separator. That is only '~/' and '~\' are expanded.
     """
     if not path.startswith('~'):
@@ -361,7 +361,7 @@ def windows_bash_command():
 
 if ON_WINDOWS:
     class OSEnvironCasePreserving(collections.MutableMapping):
-        """ Case-preseving wrapper for os.environ on Windows.
+        """ Case-preserving wrapper for os.environ on Windows.
             It uses nt.environ to get the correct cased keys on
             initialization. It also preserves the case of any variables
             add after initialization.
@@ -414,7 +414,7 @@ if ON_WINDOWS:
 
 @lazyobject
 def os_environ():
-    """This dispatches to the correct, case-senstive version of os.envrion.
+    """This dispatches to the correct, case-sensitive version of os.environ.
     This is mainly a problem for Windows. See #2024 for more details.
     This can probably go away once support for Python v3.5 or v3.6 is
     dropped.
@@ -427,7 +427,7 @@ def os_environ():
 
 @functools.lru_cache(1)
 def bash_command():
-    """Determines the command for Bash on the current plaform."""
+    """Determines the command for Bash on the current platform."""
     if ON_WINDOWS:
         bc = windows_bash_command()
     else:

--- a/xonsh/pretty.py
+++ b/xonsh/pretty.py
@@ -310,7 +310,7 @@ class RepresentationPrinter(PrettyPrinter):
     printer for a python object.
 
     This class stores processing data on `self` so you must *never* use
-    this class in a threaded environment.  Always lock it or reinstanciate
+    this class in a threaded environment.  Always lock it or reinstantiate
     it.
 
     Instances also have a verbose flag callbacks can access to control their

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -220,8 +220,8 @@ class NonBlockingFDReader(QueueReader):
 
 def populate_buffer(reader, fd, buffer, chunksize):
     """Reads bytes from the file descriptor and copies them into a buffer.
-    The reads happend in parallel, using pread(), and is thus only
-    availabe on posix. If the read fails for any reason, the reader is
+    The reads happened in parallel, using pread(), and is thus only
+    available on posix. If the read fails for any reason, the reader is
     flagged as closed.
     """
     offset = 0
@@ -280,7 +280,7 @@ def _expand_console_buffer(cols, max_offset, expandsize, orig_posize, fd):
 
 def populate_console(reader, fd, buffer, chunksize, queue, expandsize=None):
     """Reads bytes from the file descriptor and puts lines into the queue.
-    The reads happend in parallel,
+    The reads happened in parallel,
     using xonsh.winutils.read_console_output_character(),
     and is thus only available on windows. If the read fails for any reason,
     the reader is flagged as closed.
@@ -300,23 +300,23 @@ def populate_console(reader, fd, buffer, chunksize, queue, expandsize=None):
     # These chunked reads basically need to happen like this because,
     #   a. The default buffer size is HUGE for the console (90k lines x 120 cols)
     #      as so we can't just read in everything at the end and see what we
-    #      care about without a noticible performance hit.
+    #      care about without a noticeable performance hit.
     #   b. Even with this huge size, it is still possible to write more lines than
     #      this, so we should scroll along with the console.
-    # Unfortnately, because we do not have control over the terminal emulator,
-    # It is not possible to compute how far back we should set the begining
+    # Unfortunately, because we do not have control over the terminal emulator,
+    # It is not possible to compute how far back we should set the beginning
     # read position because we don't know how many characters have been popped
     # off the top of the buffer. If we did somehow know this number we could do
     # something like the following:
     #
     #    new_offset = (y*cols) + x
     #    if new_offset == max_offset:
-    #        new_offset -= scolled_offset
+    #        new_offset -= scrolled_offset
     #        x = new_offset%cols
     #        y = new_offset//cols
     #        continue
     #
-    # So this method is imperfect and only works as long as the sceen has
+    # So this method is imperfect and only works as long as the screen has
     # room to expand to.  Thus the trick here is to expand the screen size
     # when we get close enough to the end of the screen. There remain some
     # async issues related to not being able to set the cursor position.
@@ -488,7 +488,7 @@ def safe_flush(handle):
 
 
 def still_writable(fd):
-    """Determines whether a file descriptior is still writable by trying to
+    """Determines whether a file descriptor is still writable by trying to
     write an empty string and seeing if it fails.
     """
     try:
@@ -664,7 +664,7 @@ class PopenThread(threading.Thread):
 
     def _read_write(self, reader, writer, stdbuf):
         """Reads a chunk of bytes from a buffer and write into memory or back
-        down to the standard buffer, as approriate. Returns the number of
+        down to the standard buffer, as appropriate. Returns the number of
         successful reads.
         """
         if reader is None:
@@ -696,7 +696,7 @@ class PopenThread(threading.Thread):
             self._alt_mode_writer(chunk[:i], membuf, stdbuf)
             # switch modes
             # write the flag itself the current mode where alt mode is on
-            # so that it is streamed to the termial ASAP.
+            # so that it is streamed to the terminal ASAP.
             # this is needed for terminal emulators to find the correct
             # positions before and after alt mode.
             alt_mode = (flag in START_ALTERNATE_MODE)
@@ -950,7 +950,7 @@ class Handle(int):
 
 class FileThreadDispatcher:
     """Dispatches to different file handles depending on the
-    current thread. Useful if you want file operation to go to differnt
+    current thread. Useful if you want file operation to go to different
     places for different threads.
     """
 
@@ -960,7 +960,7 @@ class FileThreadDispatcher:
         ----------
         default : file-like or None, optional
             The file handle to write to if a thread cannot be found in
-            the registery. If None, a new in-memory instance.
+            the registry. If None, a new in-memory instance.
 
         Attributes
         ----------
@@ -1111,13 +1111,13 @@ class FileThreadDispatcher:
 
 
 # These should NOT be lazy since they *need* to get the true stdout from the
-# main thread. Also their creation time should be neglibible.
+# main thread. Also their creation time should be negligible.
 STDOUT_DISPATCHER = FileThreadDispatcher(default=sys.stdout)
 STDERR_DISPATCHER = FileThreadDispatcher(default=sys.stderr)
 
 
 def parse_proxy_return(r, stdout, stderr):
-    """Proxies may return a variety of outputs. This hanles them generally.
+    """Proxies may return a variety of outputs. This handles them generally.
 
     Parameters
     ----------
@@ -1189,7 +1189,7 @@ PROXY_KWARG_NAMES = frozenset(['args', 'stdin', 'stdout', 'stderr', 'spec'])
 
 
 def partial_proxy(f):
-    """Dispatches the approriate proxy function based on the number of args."""
+    """Dispatches the appropriate proxy function based on the number of args."""
     numargs = 0
     for name, param in inspect.signature(f).parameters.items():
         if param.kind == param.POSITIONAL_ONLY or \
@@ -1236,7 +1236,8 @@ class ProcProxyThread(threading.Thread):
             set to `None`, then `sys.stderr` is used.
         universal_newlines : bool, optional
             Whether or not to use universal newlines.
-        env : Mapping, optiona            Environment mapping.
+        env : Mapping, optional
+            Environment mapping.
         """
         self.orig_f = f
         self.f = partial_proxy(f)
@@ -1408,7 +1409,7 @@ class ProcProxyThread(threading.Thread):
 
     def _signal_int(self, signum, frame):
         """Signal handler for SIGINT - Ctrl+C may have been pressed."""
-        # check if we have already be interrupted to prevent infintie recurrsion
+        # check if we have already be interrupted to prevent infinite recursion
         if self._interrupted:
             return
         self._interrupted = True
@@ -1605,7 +1606,7 @@ class ProcProxy(object):
 
     def wait(self, timeout=None):
         """Runs the function and returns the result. Timeout argument only
-        present for API compatability.
+        present for API compatibility.
         """
         if self.f is None:
             return 0
@@ -1722,7 +1723,7 @@ class CommandPipeline:
         Parameters
         ----------
         specs : list of SubprocSpec
-            Process sepcifications
+            Process specifications
 
         Attributes
         ----------
@@ -1798,7 +1799,7 @@ class CommandPipeline:
         """Iterates through the last stdout, and returns the lines
         exactly as found.
         """
-        # get approriate handles
+        # get appropriate handles
         spec = self.spec
         proc = self.proc
         timeout = builtins.__xonsh_env__.get('XONSH_PROC_FREQUENCY')
@@ -2094,7 +2095,7 @@ class CommandPipeline:
         self._safe_close(s.captured_stderr)
 
     def _set_input(self):
-        """Sets the input vaiable."""
+        """Sets the input variable."""
         stdin = self.proc.stdin
         if stdin is None or isinstance(stdin, int) or stdin.closed or \
            not stdin.seekable() or not safe_readable(stdin):
@@ -2105,7 +2106,7 @@ class CommandPipeline:
         self.input = self._decode_uninew(input)
 
     def _check_signal(self):
-        """Checks if a signal was recieved and issues a message."""
+        """Checks if a signal was received and issues a message."""
         proc_signal = getattr(self.proc, 'signal', None)
         if proc_signal is None:
             return
@@ -2125,7 +2126,7 @@ class CommandPipeline:
             hist.last_cmd_rtn = self.proc.returncode
 
     def _raise_subproc_error(self):
-        """Raises a subprocess error, if we are suppossed to."""
+        """Raises a subprocess error, if we are supposed to."""
         spec = self.spec
         rtn = self.returncode
         if (not spec.is_proxy and
@@ -2296,7 +2297,7 @@ def pause_call_resume(p, f, *args, **kwargs):
 class PrevProcCloser(threading.Thread):
     """Previous process closer thread for pipelines whose last command
     is itself unthreadable. This makes sure that the pipeline is
-    driven foreward and does not deadlock.
+    driven forward and does not deadlock.
     """
 
     def __init__(self, pipeline):
@@ -2312,7 +2313,7 @@ class PrevProcCloser(threading.Thread):
         self.start()
 
     def run(self):
-        """Runs the closing algorithim."""
+        """Runs the closing algorithm."""
         pipeline = self.pipeline
         check_prev_done = len(pipeline.procs) == 1
         if check_prev_done:

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1410,7 +1410,8 @@ class ProcProxyThread(threading.Thread):
 
     def _signal_int(self, signum, frame):
         """Signal handler for SIGINT - Ctrl+C may have been pressed."""
-        # check if we have already be interrupted to prevent infinite recursion
+        # Check if we have already been interrupted. This should prevent
+        # the possibility of infinite recursion.
         if self._interrupted:
             return
         self._interrupted = True

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -220,8 +220,9 @@ class NonBlockingFDReader(QueueReader):
 
 def populate_buffer(reader, fd, buffer, chunksize):
     """Reads bytes from the file descriptor and copies them into a buffer.
-    The reads happened in parallel, using pread(), and is thus only
-    available on posix. If the read fails for any reason, the reader is
+
+    The reads happen in parallel using the pread() syscall; which is only
+    available on POSIX systems. If the read fails for any reason, the reader is
     flagged as closed.
     """
     offset = 0

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -71,7 +71,7 @@ class PromptFormatter:
             val = self._get_field_value(field)
             return _format_value(val, spec, conv)
         else:
-            # color or unkown field, return as is
+            # color or unknown field, return as is
             return '{' + field + '}'
 
     def _get_field_value(self, field):
@@ -158,7 +158,7 @@ def multiline_prompt(curr=''):
     headlen = len(head)
     # tail is the trailing whitespace
     tail = line if headlen == 0 else line.rsplit(head[-1], 1)[1]
-    # now to constuct the actual string
+    # now to construct the actual string
     dots = builtins.__xonsh_env__.get('MULTILINE_PROMPT')
     dots = dots() if callable(dots) else dots
     if dots is None or len(dots) == 0:

--- a/xonsh/prompt/cwd.py
+++ b/xonsh/prompt/cwd.py
@@ -45,16 +45,16 @@ def _dynamically_collapsed_pwd():
     """Return the compact current working directory.  It respects the
     environment variable DYNAMIC_CWD_WIDTH.
     """
-    originial_path = _replace_home_cwd()
+    original_path = _replace_home_cwd()
     target_width, units = builtins.__xonsh_env__['DYNAMIC_CWD_WIDTH']
     elision_char = builtins.__xonsh_env__['DYNAMIC_CWD_ELISION_CHAR']
     if target_width == float('inf'):
-        return originial_path
+        return original_path
     if (units == '%'):
         cols, _ = shutil.get_terminal_size()
         target_width = (cols * target_width) // 100
     sep = xt.get_sep()
-    pwd = originial_path.split(sep)
+    pwd = original_path.split(sep)
     last = pwd.pop()
     remaining_space = target_width - len(last)
     # Reserve space for separators

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -20,7 +20,7 @@ def env_name(pre_chars='(', post_chars=')'):
 
 
 def vte_new_tab_cwd():
-    """This prints an escape squence that tells VTE terminals the hostname
+    """This prints an escape sequence that tells VTE terminals the hostname
     and pwd. This should not be needed in most cases, but sometimes is for
     certain Linux terminals that do not read the PWD from the environment
     on startup. Note that this does not return a string, it simply prints

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Prompt formatter for simple version control branchs"""
+"""Prompt formatter for simple version control branches"""
 # pylint:disable=no-member, invalid-name
 
 import os
@@ -234,7 +234,7 @@ def branch_color():
 
 def branch_bg_color():
     """Return red if the current branch is dirty, yellow if the dirtiness can
-    not be determined, and green if it clean. These are bacground colors.
+    not be determined, and green if it clean. These are background colors.
     """
     dwd = dirty_working_directory()
     if dwd is None:

--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -7,7 +7,7 @@ import prompt_toolkit.history
 
 
 class PromptToolkitHistory(prompt_toolkit.history.History):
-    """History class that implements the promt-toolkit history interface
+    """History class that implements the prompt-toolkit history interface
     with the xonsh backend.
     """
 

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -306,8 +306,8 @@ class PromptToolkitShell(BaseShell):
         # needs to be performed by the subprocess itself. This fix is important
         # when subprocesses don't properly restore the terminal attributes,
         # like Python in interactive mode. Also note that the sequences "\033M"
-        # and "\033E" seem to work too, but these are techinally VT100 codes.
-        # I used the more primitive ANSI sequence to maximize compatability.
+        # and "\033E" seem to work too, but these are technically VT100 codes.
+        # I used the more primitive ANSI sequence to maximize compatibility.
         # -scopatz 2017-01-28
         #   if not ON_POSIX:
         #       return

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -242,7 +242,7 @@ def color_by_name(name, fg=None, bg=None):
         fg = norm_name(name)
     else:
         bg = norm_name(name)
-    # assmble token
+    # assemble token
     if fg is None and bg is None:
         tokname = 'NO_COLOR'
     elif fg is None:
@@ -360,7 +360,7 @@ def _partial_color_tokenize_main(template, styles):
 
 
 class CompoundColorMap(MutableMapping):
-    """Looks up color tokes by name, potentailly generating the value
+    """Looks up color tokes by name, potentially generating the value
     from the lookup.
     """
 
@@ -410,7 +410,7 @@ class XonshStyle(Style):
         style_name : str, optional
             The style name to initialize with.
         """
-        self.trap = {}  # for traping custom colors set by user
+        self.trap = {}  # for trapping custom colors set by user
         self._smap = {}
         self._style_name = ''
         self.style_name = style_name
@@ -453,7 +453,7 @@ class XonshStyle(Style):
     def enhance_colors_for_cmd_exe(self):
         """ Enhance colors when using cmd.exe on windows.
             When using the default style all blue and dark red colors
-            are changed to CYAN and intence red.
+            are changed to CYAN and intense red.
         """
         env = builtins.__xonsh_env__
         # Ensure we are not using ConEmu

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1401,7 +1401,7 @@ del (_algol_style, _algol_nu_style, _autumn_style, _borland_style, _bw_style,
 
 # dynamic styles
 def make_pygments_style(palette):
-    """Makes a pygments style based on a color palete."""
+    """Makes a pygments style based on a color palette."""
     global Color
     style = {getattr(Color, 'NO_COLOR'): 'noinherit'}
     for name, t in BASE_XONSH_COLORS.items():

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1399,13 +1399,13 @@ del (_algol_style, _algol_nu_style, _autumn_style, _borland_style, _bw_style,
      _vim_style, _vs_style, _xcode_style)
 
 
-# dynamic syles
-def make_pygments_style(pallette):
-    """Makes a pygments style based on a color pallete."""
+# dynamic styles
+def make_pygments_style(palette):
+    """Makes a pygments style based on a color palete."""
     global Color
     style = {getattr(Color, 'NO_COLOR'): 'noinherit'}
     for name, t in BASE_XONSH_COLORS.items():
-        color = find_closest_color(t, pallette)
+        color = find_closest_color(t, palette)
         style[getattr(Color, name)] = '#' + color
         style[getattr(Color, 'BOLD_'+name)] = 'bold #' + color
         style[getattr(Color, 'UNDERLINE_'+name)] = 'underline #' + color
@@ -1419,8 +1419,8 @@ def pygments_style_by_name(name):
     if name in STYLES:
         return STYLES[name]
     pstyle = get_style_by_name(name)
-    pallette = make_pallete(pstyle.styles.values())
-    astyle = make_pygments_style(pallette)
+    palette = make_pallete(pstyle.styles.values())
+    astyle = make_pygments_style(palette)
     STYLES[name] = astyle
     return astyle
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -360,7 +360,7 @@ def _partial_color_tokenize_main(template, styles):
 
 
 class CompoundColorMap(MutableMapping):
-    """Looks up color tokes by name, potentially generating the value
+    """Looks up color tokens by name, potentially generating the value
     from the lookup.
     """
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -24,7 +24,7 @@ from xonsh.commands_cache import CommandsCache
 from xonsh.lazyasd import LazyObject, LazyDict, lazyobject
 from xonsh.tools import (ON_WINDOWS, intensify_colors_for_cmd_exe,
                          expand_gray_colors_for_cmd_exe)
-from xonsh.color_tools import (RE_BACKGROUND, BASE_XONSH_COLORS, make_pallete,
+from xonsh.color_tools import (RE_BACKGROUND, BASE_XONSH_COLORS, make_palette,
                                find_closest_color)
 from xonsh.style_tools import norm_name
 from xonsh.lazyimps import terminal256
@@ -1419,7 +1419,7 @@ def pygments_style_by_name(name):
     if name in STYLES:
         return STYLES[name]
     pstyle = get_style_by_name(name)
-    palette = make_pallete(pstyle.styles.values())
+    palette = make_palette(pstyle.styles.values())
     astyle = make_pygments_style(palette)
     STYLES[name] = astyle
     return astyle

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -134,7 +134,7 @@ def setup_readline():
         except Exception:
             # this seems to fail with libedit
             print_exception('xonsh: could not load readline default init file.')
-    # properly reset intput typed before the first prompt
+    # properly reset input typed before the first prompt
     readline.set_startup_hook(carriage_return)
 
 
@@ -184,7 +184,7 @@ def fix_readline_state_after_ctrl_c():
 
 
 def rl_completion_suppress_append(val=1):
-    """Sets the rl_completion_suppress_append varaiable, if possible.
+    """Sets the rl_completion_suppress_append variable, if possible.
     A value of 1 (default) means to suppress, a value of 0 means to enable.
     """
     if RL_COMPLETION_SUPPRESS_APPEND is None:
@@ -193,7 +193,7 @@ def rl_completion_suppress_append(val=1):
 
 
 def rl_completion_query_items(val=None):
-    """Sets the rl_completion_query_items varaiable, if possible.
+    """Sets the rl_completion_query_items variable, if possible.
     A None value will set this to $COMPLETION_QUERY_LIMIT, otherwise any integer
     is accepted.
     """
@@ -506,7 +506,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         return p
 
     def format_color(self, string, hide=False, force_string=False, **kwargs):
-        """Readline implementation of color formatting. This usess ANSI color
+        """Readline implementation of color formatting. This uses ANSI color
         codes.
         """
         hide = hide if self._force_hide is None else self._force_hide

--- a/xonsh/replay.py
+++ b/xonsh/replay.py
@@ -39,7 +39,7 @@ class Replayer(object):
         Parameters
         ----------
         merge_env : tuple of str or Mappings, optional
-            Describes how to merge the environments, in order of increasing precednce.
+            Describes how to merge the environments, in order of increasing precedence.
             Available strings are 'replay' and 'native'. The 'replay' env comes from the
             history file that we are replaying. The 'native' env comes from what this
             instance of xonsh was started up with. Instead of a string, a dict or other

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -150,7 +150,7 @@ class Shell(object):
                              shell_type))
         self.shell = shell_class(execer=self.execer,
                                  ctx=self.ctx, **kwargs)
-        # allows history garbage colector to start running
+        # allows history garbage collector to start running
         if hist.gc is not None:
             hist.gc.wait_for_shell = False
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -18,7 +18,7 @@ events.doc('on_transform_command', """
 on_transform_command(cmd: str) -> str
 
 Fired to request xontribs to transform a command line. Return the transformed
-command, or the same command if no transformaiton occurs. Only done for
+command, or the same command if no transformation occurs. Only done for
 interactive sessions.
 
 This may be fired multiple times per command, with other transformers input or
@@ -72,8 +72,8 @@ def transform_command(src, show_diff=True):
                 break
         i += 1
         if i == limit:
-            print_exception('Modifcations to source input took more than '
-                            'the recursion limit number of interations to '
+            print_exception('Modifications to source input took more than '
+                            'the recursion limit number of iterations to '
                             'converge.')
     debug_level = builtins.__xonsh_env__.get('XONSH_DEBUG')
     if show_diff and debug_level > 1 and src != raw:

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -151,7 +151,7 @@ def color_by_name(name, fg=None, bg=None):
         fg = norm_name(name)
     else:
         bg = norm_name(name)
-    # assmble token
+    # assemble token
     if fg is None and bg is None:
         tokname = 'NO_COLOR'
     elif fg is None:

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -211,7 +211,7 @@ def timeit_alias(args, stdin=None):
             worst = max(worst, worst_tuning)
         # Check best timing is greater than zero to avoid a
         # ZeroDivisionError.
-        # In cases where the slowest timing is lesser than 10 microseconds
+        # In cases where the slowest timing is less than 10 microseconds
         # we assume that it does not really matter if the fastest
         # timing is 4 times faster than the slowest timing or not.
         if worst > 4 * best and best > 0 and worst > 1e-5:

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -211,7 +211,7 @@ def timeit_alias(args, stdin=None):
             worst = max(worst, worst_tuning)
         # Check best timing is greater than zero to avoid a
         # ZeroDivisionError.
-        # In cases where the slowest timing is lesser than 10 micoseconds
+        # In cases where the slowest timing is lesser than 10 microseconds
         # we assume that it does not really matter if the fastest
         # timing is 4 times faster than the slowest timing or not.
         if worst > 4 * best and best > 0 and worst > 1e-5:

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -801,7 +801,7 @@ def _tokenize(readline, encoding):
 
 def tokenize(readline):
     """
-    The tokenize() generator requires one argment, readline, which
+    The tokenize() generator requires one argument, readline, which
     must be a callable object which provides the same interface as the
     readline() method of built-in file objects.  Each call to the function
     should return one line of input as bytes.  Alternately, readline

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -284,7 +284,7 @@ def find_next_break(line, mincol=0, lexer=None):
 
 def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False,
                  greedy=False):
-    """Excapsulates tokens in a source code line in a uncaptured
+    """Encapsulates tokens in a source code line in a uncaptured
     subprocess ![] starting at a minimum column. If there are no tokens
     (ie in a comment line) this returns None. If greedy is True, it will encapsulate
     normal parentheses. Greedy is False by default.
@@ -418,7 +418,7 @@ def _have_open_triple_quotes(s):
 
 
 def get_line_continuation():
-    """ The line contiuation characters used in subproc mode. In interactive
+    """ The line continuation characters used in subproc mode. In interactive
          mode on Windows the backslash must be preceded by a space. This is because
          paths on Windows may end in a backslash.
     """
@@ -504,7 +504,7 @@ def subexpr_from_unbalanced(expr, ltok, rtok):
 
 
 def subexpr_before_unbalanced(expr, ltok, rtok):
-    """Obtains the expression prior to last unblanced left token."""
+    """Obtains the expression prior to last unbalanced left token."""
     subexpr, _, post = expr.rpartition(ltok)
     nrtoks_in_post = post.count(rtok)
     while nrtoks_in_post != 0:
@@ -875,7 +875,7 @@ def suggestion_sort_helper(x, y):
 
 def escape_windows_cmd_string(s):
     """Returns a string that is usable by the Windows cmd.exe.
-    The escaping is based on details here and emperical testing:
+    The escaping is based on details here and empirical testing:
     http://www.robvanderwoude.com/escapechars.php
     """
     for c in '()%!^<>&|"':
@@ -1427,7 +1427,7 @@ def is_history_backend(x):
 
 def is_dynamic_cwd_width(x):
     """ Determine if the input is a valid input for the DYNAMIC_CWD_WIDTH
-    environement variable.
+    environment variable.
     """
     return (isinstance(x, tuple) and
             len(x) == 2 and
@@ -1463,7 +1463,7 @@ RE_HISTORY_TUPLE = LazyObject(
 
 
 def to_history_tuple(x):
-    """Converts to a canonincal history tuple."""
+    """Converts to a canonical history tuple."""
     if not isinstance(x, (cabc.Sequence, float, int)):
         raise ValueError('history size must be given as a sequence or number')
     if isinstance(x, str):
@@ -1612,7 +1612,7 @@ def format_std_prepost(template, env=None):
     except Exception:
         print_exception()
     # \001\002 is there to fool pygments into not returning an empty string
-    # for potentially empty input. This happend when the template is just a
+    # for potentially empty input. This happens when the template is just a
     # color code with no visible text.
     invis = '\001\002'
     s = shell.format_color(invis + s + invis, force_string=True)
@@ -1725,7 +1725,7 @@ def check_for_partial_string(x):
         return (string_indices[-2], string_indices[-1], starting_quote[-1])
 
 
-# regular expressions for matching enviroment variables
+# regular expressions for matching environment variables
 # i.e $FOO, ${'FOO'}
 @lazyobject
 def POSIX_ENVVAR_REGEX():
@@ -1771,7 +1771,7 @@ def backup_file(fname):
 
 
 def normabspath(p):
-    """Retuns as normalized absolute path, namely, normcase(abspath(p))"""
+    """Returns as normalized absolute path, namely, normcase(abspath(p))"""
     return os.path.normcase(os.path.abspath(p))
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -23,7 +23,7 @@ import collections.abc as cabc
 import contextlib
 import ctypes
 import datetime
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 import functools
 import glob
 import itertools
@@ -2007,7 +2007,7 @@ def _deprecated_message_suffix(deprecated_in, removed_in):
 def _deprecated_error_on_expiration(name, removed_in):
     if not removed_in:
         return
-    elif StrictVersion(__version__) >= StrictVersion(removed_in):
+    elif LooseVersion(__version__) >= LooseVersion(removed_in):
         raise AssertionError(
             '{} has passed its version {} expiry date!'.format(
                 name, removed_in))

--- a/xonsh/tracer.py
+++ b/xonsh/tracer.py
@@ -50,7 +50,7 @@ class TracerType(object):
         # we have to use a function to set usecolor because of the way that
         # lazyasd works. Namely, it cannot dispatch setattr to the target
         # object without being unable to access its own __dict__. This makes
-        # setting an atter look like getting a function.
+        # setting an attr look like getting a function.
         self.usecolor = usecolor
 
     def start(self, filename):

--- a/xonsh/winutils.py
+++ b/xonsh/winutils.py
@@ -28,7 +28,7 @@ from ctypes.wintypes import (HANDLE, BOOL, DWORD, HWND, HINSTANCE, HKEY,
                              LPDWORD, SHORT, LPCWSTR, WORD, SMALL_RECT, LPCSTR)
 
 from xonsh.lazyasd import lazyobject
-from xonsh import lazyimps  # we aren't amagamated in this module.
+from xonsh import lazyimps  # we aren't amalgamated in this module.
 from xonsh import platform
 
 
@@ -246,7 +246,7 @@ def set_console_mode(mode, fd=1):
 
 def enable_virtual_terminal_processing():
     """Enables virtual terminal processing on Windows.
-    This inlcudes ANSI escape sequence interpretation.
+    This includes ANSI escape sequence interpretation.
     See http://stackoverflow.com/a/36760881/2312428
     """
     SetConsoleMode(GetStdHandle(-11), 7)
@@ -305,7 +305,7 @@ def ReadConsoleOutputCharacterW():
 
 def read_console_output_character(x=0, y=0, fd=1, buf=None, bufsize=1024,
                                   raw=False):
-    """Reads chracters from the console buffer.
+    """Reads characters from the console buffer.
 
     Parameters
     ----------
@@ -320,7 +320,7 @@ def read_console_output_character(x=0, y=0, fd=1, buf=None, bufsize=1024,
         An existing buffer to (re-)use.
     bufsize : int, optional
         The maximum read size.
-    raw : bool, opional
+    raw : bool, optional
         Whether to read in and return as bytes (True) or as a
         unicode string (False, default).
 

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -65,7 +65,7 @@ class Question(Node):
             Mapping from user-input responses to nodes.
         converter : callable, optional
             Converts the string the user typed into another object
-            that serves as a key to the reponses dict.
+            that serves as a key to the responses dict.
         path : str or sequence of str, optional
             A path within the storage object.
         """
@@ -99,7 +99,7 @@ class Input(Node):
             default False.
         retry : bool, optional
             In the event that the conversion operation fails, should
-            users be re-prompted until they provide valid input. Deafult False.
+            users be re-prompted until they provide valid input. Default False.
         path : str or sequence of str, optional
             A path within the storage object.
         """
@@ -114,7 +114,7 @@ class Input(Node):
 class While(Node):
     """Computes a body while a condition function evaluates to true.
     The condition function has the form cond(visitor=None, node=None) and
-    should return an object that is convertable to a bool. The beg attribute
+    should return an object that is convertible to a bool. The beg attribute
     specifies the number to start the loop iteration at.
     """
 
@@ -128,7 +128,7 @@ class While(Node):
             Function that determines if the next loop iteration should
             be executed. The condition function has the form
             cond(visitor=None, node=None) and should return an object that
-            is convertable to a bool.
+            is convertible to a bool.
         body : sequence of nodes
             A list of node to execute on each iteration.
         idxname : str, optional
@@ -212,7 +212,7 @@ class StoreNonEmpty(Input):
 
 
 class StateFile(Input):
-    """Node for repesenting the state as a JSON file under a default or user
+    """Node for representing the state as a JSON file under a default or user
     given file name. This node type is likely not useful on its own.
     """
 

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -113,9 +113,10 @@ class Input(Node):
 
 class While(Node):
     """Computes a body while a condition function evaluates to true.
-    The condition function has the form cond(visitor=None, node=None) and
-    should return an object that is convertible to a bool. The beg attribute
-    specifies the number to start the loop iteration at.
+
+    The condition function has the form ``cond(visitor=None, node=None)`` and
+    must return an object that responds to the Python magic method ``__bool__``.
+    The beg attribute specifies the number to start the loop iteration at.
     """
 
     attrs = ('cond', 'body', 'idxname', 'beg', 'path')
@@ -126,11 +127,11 @@ class While(Node):
         ----------
         cond : callable
             Function that determines if the next loop iteration should
-            be executed. The condition function has the form
-            cond(visitor=None, node=None) and should return an object that
-            is convertible to a bool.
+            be executed.
         body : sequence of nodes
-            A list of node to execute on each iteration.
+            A list of node to execute on each iteration. The condition function
+            has the form ``cond(visitor=None, node=None)`` and must return an
+            object that responds to the Python magic method ``__bool__``.
         idxname : str, optional
             The variable name for the index.
         beg : int, optional

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -530,7 +530,7 @@ def STRIP_COLOR_RE():
 
 
 def _align_string(string, align='<', fill=' ', width=80):
-    """ Align and pad a color formattet string """
+    """ Align and pad a color formatted string """
     linelen = len(STRIP_COLOR_RE.sub('', string))
     padlen = max(width-linelen, 0)
     if align == '^':

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -74,7 +74,7 @@ WIZARD_ENV = """
                   {{YELLOW}}--------------------------{{NO_COLOR}}
 The xonsh shell also allows you to setup environment variables from
 the static configuration file. Any variables set in this way are
-superceded by the definitions in the xonshrc or on the command line.
+superseded by the definitions in the xonshrc or on the command line.
 Still, setting environment variables in this way can help define
 options that are global to the system or user.
 

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -27,7 +27,7 @@
   "package": "xonsh",
   "url": "http://xon.sh",
   "description": [
-    "Additional core utilites that are implemened in xonsh. The current list ",
+    "Additional core utilities that are implemented in xonsh. The current list ",
     "includes:\n",
     "\n",
     "* cat\n",
@@ -47,10 +47,10 @@
   "url": "http://xon.sh",
   "description": [
     "The distributed parallel computing library hooks for xonsh. ",
-    "Importantly this provides a subsitute 'dworker' command which enables ",
+    "Importantly this provides a substitute 'dworker' command which enables ",
     "distributed workers to have access to xonsh builtins.\n\n",
     "Furthermore, this xontrib adds a 'DSubmitter' context manager for ",
-    "executing a block remotely. Moroever, this also adds a convienece ",
+    "executing a block remotely. Moreover, this also adds a convenience ",
     "function 'dsubmit()' for creating DSubmitter and Executor instances ",
     "at the same time. Thus users may submit distributed jobs with::\n\n",
     "    with dsubmit('127.0.0.1:8786', rtn='x') as dsub:\n",

--- a/xontrib/coreutils.py
+++ b/xontrib/coreutils.py
@@ -1,4 +1,4 @@
-"""Additional core utilites that are implemented in xonsh. The current list
+"""Additional core utilities that are implemented in xonsh. The current list
 includes:
 
 * cat

--- a/xontrib/distributed.py
+++ b/xontrib/distributed.py
@@ -5,7 +5,7 @@ __all__ = 'DSubmitter', 'dsubmit'
 
 
 def dworker(args, stdin=None):
-    """Programatic access to the dworker utility, to allow launching
+    """Programmatic access to the dworker utility, to allow launching
     workers that also have access to xonsh builtins.
     """
     from distributed.cli import dworker

--- a/xontrib/free_cwd.py
+++ b/xontrib/free_cwd.py
@@ -32,7 +32,7 @@ def _cwd_release_wrapper(func):
     """ Decorator for Windows to the wrap the prompt function and release
         the process lock on the current directory while the prompt is
         displayed. This works by temporarily setting
-        the workdir to the users home direcotry.
+        the workdir to the users home directory.
     """
     env = builtins.__xonsh_env__
     if env.get('UPDATE_PROMPT_ON_KEYPRESS'):

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -44,7 +44,7 @@ def interactive_pyplot(module=None, **kwargs):
         """This is a monkey patched version of matplotlib.pyplot.show()
         for xonsh's interactive mode. First it tries non-blocking mode
         (block=False). If for some reason this fails, it will run show
-        in normal bloking mode (block=True).
+        in normal blocking mode (block=True).
         """
         kwargs.update(block=False)
         rtn = plt_show(*args, **kwargs)

--- a/xontrib/mplhooks.py
+++ b/xontrib/mplhooks.py
@@ -93,7 +93,7 @@ def figure_to_tight_array(fig, width, height, minimal=True):
         # leave only one line for top and bottom
         fig.subplots_adjust(bottom=1/height, top=1-1/height, left=0, right=1)
 
-        # redeuce font size in order to reduce text impact on the image
+        # reduce font size in order to reduce text impact on the image
         font_size = matplotlib.rcParams['font.size']
         matplotlib.rcParams.update({'font.size': 0})
     else:

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -106,7 +106,7 @@ class VoxHandler:
             print('Activated "%s".\n' % args.name)
 
     def cmd_deactivate(self, args, stdin=None):
-        """Deactive the active virtual environment."""
+        """Deactivate the active virtual environment."""
 
         if self.vox.active() is None:
             print('No environment currently active. Activate one with "vox activate".\n', file=sys.stderr)


### PR DESCRIPTION
Hello,

I've been an avid user of Xonsh for a few weeks now and found myself reviewing the code in order to understand a few things about how the shell works more fully. In the process of doing this, I came across a few spelling typos. As I discovered a number of these, I decided it might be a good idea to more thoroughly discover these errors and provide fixes for them.

None of these errors were especially bad. They were mostly common misspellings that can occur while bashing out amazing code.

This PR includes my fixes for all of the spelling errors that I was able to discover. This includes spelling fixes for documentation (restructuredText files), comments/docstrings, text strings, local variable names, and a single function declaration; each in a separate commit.

I've run the py.test suite on my Macbook and it passes, so I don't believe that I broke anything (hooray!) :smile:

I tried to be careful with what typos I corrected, and how I corrected them. My hope is that this will be a simple PR to merge, but feel free to comment if there is anything in this PR that you would like to have changed.