### PR TITLE
Add flush method to tests/tools::DummyHistory

### DIFF
--- a/tests/tools.py
+++ b/tests/tools.py
@@ -87,6 +87,9 @@ class DummyHistory:
     def append(self, x):
         pass
 
+    def flush(self, *args, **kwargs):
+        pass
+
 
 class DummyEnv(MutableMapping):
 


### PR DESCRIPTION
tests Heizenbug

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/Users/travis/build/xonsh/xonsh/xonsh/built_ins.py", line 1201, in _lastflush
    builtins.__xonsh_history__.flush(at_exit=True)
AttributeError: 'DummyHistory' object has no attribute 'flush'
```

no news