### PR TITLE
gistatus: Fix hash not being shown when in detaced HEAD and there are…

### DIFF
--- a/news/fix-gistatus-for-detached-head-no-tags.rst
+++ b/news/fix-gistatus-for-detached-head-no-tags.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* gistatus: Fixed hash not being shown when in detaced HEAD and there are no tags
+
+**Security:** None

--- a/xonsh/prompt/gitstatus.py
+++ b/xonsh/prompt/gitstatus.py
@@ -48,11 +48,10 @@ def _get_def(key):
 
 
 def _get_tag_or_hash():
-    tag = _check_output(['git', 'describe', '--exact-match']).strip()
-    if tag:
-        return tag
+    tag_or_hash = _check_output(['git', 'describe', '--always']).strip()
     hash_ = _check_output(['git', 'rev-parse', '--short', 'HEAD']).strip()
-    return _get_def('HASH') + hash_
+    have_tag_name = tag_or_hash != hash_
+    return tag_or_hash if have_tag_name else _get_def('HASH') + hash_
 
 
 def _get_stash(gitdir):


### PR DESCRIPTION
… no tags.

The `git describe --exact-match` used until fails with
  fatal: No names found, cannot describe anything.
if there are no tags at all in the repository.
In that case, it exits with exit code 128, and thus the
control flow was aborted, and the fallback `git rev-parse`
was not executed.

As a workaround, `git describe --always` can be used,
which achieves the intended result without increasing the
number of `git` invocations.
See also:
  https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything