### PR TITLE
gistatus: Don't SIGKILL git to avoid leftover .git/index.lock.

### DIFF
--- a/news/gitstatus-fix-leftover-index-lock.rst
+++ b/news/gitstatus-fix-leftover-index-lock.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed leftover ``.git/index.lock`` in ``gitstatus``
+
+**Security:** None

--- a/xonsh/prompt/gitstatus.py
+++ b/xonsh/prompt/gitstatus.py
@@ -17,11 +17,33 @@ GitStatus = collections.namedtuple('GitStatus',
 
 def _check_output(*args, **kwargs):
     kwargs.update(dict(env=builtins.__xonsh_env__.detype(),
+                       stdout=subprocess.PIPE,
                        stderr=subprocess.DEVNULL,
-                       timeout=builtins.__xonsh_env__['VC_BRANCH_TIMEOUT'],
                        universal_newlines=True
                        ))
-    return subprocess.check_output(*args, **kwargs)
+    timeout = builtins.__xonsh_env__['VC_BRANCH_TIMEOUT']
+    # See https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate
+    with subprocess.Popen(*args, **kwargs) as proc:
+        try:
+            out, err = proc.communicate(timeout=timeout)
+            if proc.returncode != 0:
+                raise subprocess.CalledProcessError(proc.returncode, proc.args, output=out, stderr=err)  # note err will always be empty as we redirect stderr to DEVNULL abvoe
+            return out
+        except subprocess.TimeoutExpired:
+            # We use `.terminate()` (SIGTERM) instead of `.kill()` (SIGKILL) here
+            # because otherwise we guarantee that a `.git/index.lock` file will be
+            # left over, and subsequent git operations will fail.
+            # We don't want that.
+            # As a result, we must rely on git to exit properly on SIGTERM.
+            proc.terminate()
+            # We wait() to ensure that git has finished before the next
+            # `gitstatus` prompt is rendered (otherwise `index.lock` still exists,
+            # and it will fail).
+            # We don't technically have to call `wait()` here as the
+            # `with subprocess.Popen()` context manager above would do that
+            # for us, but we do it to be explicit that waiting is being done.
+            proc.wait()  # we ignore what git says after we sent it SIGTERM
+            raise
 
 
 @xl.lazyobject


### PR DESCRIPTION
Instead, ask it nicely to terminate using SIGTERM.