### PR TITLE
Fire on_pre_prompt before any prompt calculations are done.

### DIFF
--- a/news/compute-prompt-after-event.rst
+++ b/news/compute-prompt-after-event.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* ``on_pre_prompt`` is now fired before prompt calculations are made, allowing modifications to the prompt.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -63,6 +63,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
+        events.on_pre_prompt.fire()
         env = builtins.__xonsh_env__
         mouse_support = env.get('MOUSE_SUPPORT')
         if store_in_history:
@@ -115,7 +116,6 @@ class PromptToolkitShell(BaseShell):
                     prompt_args['style'] = PygmentsStyle(pyghooks.xonsh_style_proxy(self.styler))
                 else:
                     prompt_args['style'] = style_from_dict(DEFAULT_STYLE_DICT)
-            events.on_pre_prompt.fire()
             line = self.prompter.prompt(**prompt_args)
             events.on_post_prompt.fire()
         return line


### PR DESCRIPTION
Under PTK, any changes made to `$PROMPT` in an `on_pre_prompt` handler take effect with a one-prompt delay.

This moves when `on_pre_prompt` is fired to before any prompt calculations are made.

The readline shell already behaved this way (all of its logic being in `.prompt`). The base shell doesn't raise the event at all.