### PR TITLE
Don't load xonshrc is xonsh is running a script

### DIFF
--- a/news/no_rc_for_scripts.rst
+++ b/news/no_rc_for_scripts.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* When xonsh is used to run an ``xsh`` script, the ``xonshrc`` is not loaded
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,7 +59,11 @@ def test_premain_custom_rc(shell, tmpdir):
 
 
 def test_no_rc_with_script(shell, tmpdir):
-    builtins.__xonsh_env__ = Env(XONSH_CACHE_SCRIPTS=False)
+    xonsh.main.premain(['tests/sample.xsh'])
+    assert not (builtins.__xonsh_env__.get('XONSH_INTERACTIVE'))
+
+
+def test_custom_rc_with_script(shell, tmpdir):
     f = tmpdir.join('wakkawakka')
     f.write("print('hi')")
     xonsh.main.premain(['--rc', f.strpath, 'tests/sample.xsh'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,6 +58,14 @@ def test_premain_custom_rc(shell, tmpdir):
     assert f.strpath in builtins.__xonsh_env__.get('XONSHRC')
 
 
+def test_no_rc_with_script(shell, tmpdir):
+    builtins.__xonsh_env__ = Env(XONSH_CACHE_SCRIPTS=False)
+    f = tmpdir.join('wakkawakka')
+    f.write("print('hi')")
+    xonsh.main.premain(['--rc', f.strpath, 'tests/sample.xsh'])
+    assert not (builtins.__xonsh_env__.get('XONSH_INTERACTIVE'))
+
+
 def test_premain_no_rc(shell, tmpdir):
     xonsh.main.premain(['--no-rc'])
     assert not builtins.__xonsh_env__.get('XONSHRC')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 
 import xonsh.main
+from xonsh.main import XonshMode
 from xonsh.environ import Env
 import pytest
 from tools import TEST_DIR
@@ -50,24 +51,46 @@ def test_premain_D(shell):
     assert (builtins.__xonsh_env__.get('TEST2') == 'LOL')
 
 
-def test_premain_custom_rc(shell, tmpdir):
+def test_premain_custom_rc(shell, tmpdir, monkeypatch):
+    monkeypatch.setattr(sys.stdin, 'isatty', lambda: True)
     builtins.__xonsh_env__ = Env(XONSH_CACHE_SCRIPTS=False)
     f = tmpdir.join('wakkawakka')
     f.write("print('hi')")
-    xonsh.main.premain(['--rc', f.strpath])
+    args = xonsh.main.premain(['--rc', f.strpath])
+    assert args.mode == XonshMode.interactive
     assert f.strpath in builtins.__xonsh_env__.get('XONSHRC')
 
 
 def test_no_rc_with_script(shell, tmpdir):
-    xonsh.main.premain(['tests/sample.xsh'])
-    assert not (builtins.__xonsh_env__.get('XONSH_INTERACTIVE'))
+    args = xonsh.main.premain(['tests/sample.xsh'])
+    assert not (args.mode == XonshMode.interactive)
+
+
+def test_force_interactive_rc_with_script(shell, tmpdir):
+    args = xonsh.main.premain(['-i', 'tests/sample.xsh'])
+    assert builtins.__xonsh_env__.get('XONSH_INTERACTIVE')
+
+
+def test_force_interactive_custom_rc_with_script(shell, tmpdir):
+    """Calling a custom RC file on a script-call with the interactive flag
+    should run interactively
+    """
+    builtins.__xonsh_env__ = Env(XONSH_CACHE_SCRIPTS=False)
+    f = tmpdir.join('wakkawakka')
+    f.write("print('hi')")
+    args = xonsh.main.premain(['-i', '--rc', f.strpath, 'tests/sample.xsh'])
+    assert args.mode == XonshMode.interactive
+    assert f.strpath in builtins.__xonsh_env__.get('XONSHRC')
 
 
 def test_custom_rc_with_script(shell, tmpdir):
+    """Calling a custom RC file on a script-call without the interactive flag
+    should not run interactively
+    """
     f = tmpdir.join('wakkawakka')
     f.write("print('hi')")
-    xonsh.main.premain(['--rc', f.strpath, 'tests/sample.xsh'])
-    assert not (builtins.__xonsh_env__.get('XONSH_INTERACTIVE'))
+    args = xonsh.main.premain(['--rc', f.strpath, 'tests/sample.xsh'])
+    assert not (args.mode == XonshMode.interactive)
 
 
 def test_premain_no_rc(shell, tmpdir):

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -236,6 +236,9 @@ def start_services(shell_kwargs):
     env = builtins.__xonsh_env__
     rc = shell_kwargs.get('rc', None)
     rc = env.get('XONSHRC') if rc is None else rc
+    if shell_kwargs['shell_type'] != 'none':
+        #  Don't load xonshrc if not interactive shell
+        rc = None
     events.on_pre_rc.fire()
     xonshrc_context(rcfiles=rc, execer=execer, ctx=ctx, env=env, login=login)
     events.on_post_rc.fire()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -218,7 +218,7 @@ class XonshMode(enum.Enum):
     interactive = 3
 
 
-def start_services(shell_kwargs):
+def start_services(shell_kwargs, args):
     """Starts up the essential services in the proper order.
     This returns the environment instance as a convenience.
     """
@@ -236,7 +236,7 @@ def start_services(shell_kwargs):
     env = builtins.__xonsh_env__
     rc = shell_kwargs.get('rc', None)
     rc = env.get('XONSHRC') if rc is None else rc
-    if shell_kwargs['shell_type'] != 'none':
+    if args.mode != XonshMode.interactive:
         #  Don't load xonshrc if not interactive shell
         rc = None
     events.on_pre_rc.fire()
@@ -291,7 +291,7 @@ def premain(argv=None):
         args.mode = XonshMode.interactive
         shell_kwargs['completer'] = True
         shell_kwargs['login'] = True
-    env = start_services(shell_kwargs)
+    env = start_services(shell_kwargs, args)
     env['XONSH_LOGIN'] = shell_kwargs['login']
     if args.defines is not None:
         env.update([x.split('=', 1) for x in args.defines])

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -236,7 +236,7 @@ def start_services(shell_kwargs, args):
     env = builtins.__xonsh_env__
     rc = shell_kwargs.get('rc', None)
     rc = env.get('XONSHRC') if rc is None else rc
-    if args.mode != XonshMode.interactive:
+    if args.mode != XonshMode.interactive and not args.force_interactive:
         #  Don't load xonshrc if not interactive shell
         rc = None
     events.on_pre_rc.fire()
@@ -295,7 +295,7 @@ def premain(argv=None):
     env['XONSH_LOGIN'] = shell_kwargs['login']
     if args.defines is not None:
         env.update([x.split('=', 1) for x in args.defines])
-    env['XONSH_INTERACTIVE'] = args.force_interactive
+    env['XONSH_INTERACTIVE'] = args.force_interactive or (args.mode == XonshMode.interactive)
     if ON_WINDOWS:
         setup_win_unicode_console(env.get('WIN_UNICODE_CONSOLE', True))
     return args


### PR DESCRIPTION
As per discussions with @asmeurer -- if xonsh is being used to launch a script,
e.g.

```
xonsh run_my_cool_deploy.xsh
```

then it should not load the `xonshrc` file since this should be reserved for
interactive functionality and we don't want side effects in the script.

Basically, if you need a xontrib to be loaded for your script, load it in your
script