### PR TITLE
Ipython threadable

### DIFF
--- a/news/ipython_not_threadable.rst
+++ b/news/ipython_not_threadable.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Added ``ipython`` as unthreadable in command cache threadabilty predictors.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -346,6 +346,7 @@ def default_threadable_predictors():
         'fish': predict_shell,
         'gvim': predict_help_ver,
         'htop': predict_help_ver,
+        'ipython': predict_help_ver,
         'ksh': predict_shell,
         'less': predict_help_ver,
         'man': predict_help_ver,


### PR DESCRIPTION
`IPython` is considered as threadable by the default predictor, and strange behavior occur when the terminal is resized, in particular when `IPython` is using `ptk`.