### PR TITLE
ipython not threadable: predict_shell should be used

### DIFF
--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -346,7 +346,7 @@ def default_threadable_predictors():
         'fish': predict_shell,
         'gvim': predict_help_ver,
         'htop': predict_help_ver,
-        'ipython': predict_help_ver,
+        'ipython': predict_shell,
         'ksh': predict_shell,
         'less': predict_help_ver,
         'man': predict_help_ver,


### PR DESCRIPTION
See #2438. Use `predict_shell` instead of `predict_help_ver`. Sorry for this mistake on my last commit.

I didn't add new item in changes, I think it is not necessary.