### PR TITLE
Substitute xip for pip in places it should be used.

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -126,10 +126,13 @@ Provides an interface to printing lines of source code prior to their execution.
 .. command-help:: xonsh.tracer.tracermain
 
 
-``xip``
+``xpip``
 =================
 Runs the ``pip`` package manager for xonsh itself. Useful for installations where xonsh is in an
-isolated environment (eg homebrew). Pronounced "kip".
+isolated environment (eg conda, homebrew).
+
+In general, use ``xpip`` if you're configuring or adding features to xonsh, and use ``pip`` if
+you're doing Python development.
 
 
 ``xonfig``

--- a/docs/tutorial_xontrib.rst
+++ b/docs/tutorial_xontrib.rst
@@ -218,7 +218,7 @@ entries have the following structure:
        "url": "http://example",
        "install": {
         "conda": "conda install package-name",
-        "pip": "pip install package-name"}
+        "pip": "xip install package-name"}
        }
      }
     }

--- a/docs/tutorial_xontrib.rst
+++ b/docs/tutorial_xontrib.rst
@@ -218,7 +218,7 @@ entries have the following structure:
        "url": "http://example",
        "install": {
         "conda": "conda install package-name",
-        "pip": "xip install package-name"}
+        "pip": "xpip install package-name"}
        }
      }
     }

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -1,6 +1,8 @@
 **Added:** None
 
-**Changed:** None
+**Changed:**
+
+* ``xip`` is now ``xpip``, because of a conflict with the Mac OSX archive format
 
 **Deprecated:** None
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -416,7 +416,7 @@ def showcmd(args, stdin=None):
         sys.displayhook(args)
 
 
-def detect_xip_alias():
+def detect_xpip_alias():
     """
     Determines the correct invocation to get xonsh's pip
     """
@@ -468,7 +468,7 @@ def make_default_aliases():
         'which': xxw.which,
         'xontrib': xontribs_main,
         'completer': xca.completer_alias,
-        'xip': detect_xip_alias(),
+        'xpip': detect_xpip_alias(),
     }
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -22,6 +22,7 @@ def default_completers():
         ('completer', complete_completer),
         ('skip', complete_skipper),
         ('pip', complete_pip),
+        ('xip', complete_pip),
         ('cd', complete_cd),
         ('rmdir', complete_rmdir),
         ('xonfig', complete_xonfig),

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -22,7 +22,7 @@ def default_completers():
         ('completer', complete_completer),
         ('skip', complete_skipper),
         ('pip', complete_pip),
-        ('xip', complete_pip),
+        ('xpip', complete_pip),
         ('cd', complete_cd),
         ('rmdir', complete_rmdir),
         ('xonfig', complete_xonfig),

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -112,7 +112,7 @@ def setup_readline():
                          "   * failure to wrap or indent lines properly",
                          "",
                          "It is highly recommended that you install gnureadline, which is installable with:",
-                         "     xip install gnureadline",
+                         "     xpip install gnureadline",
                          "*" * 78]), file=sys.stderr)
     else:
         readline.parse_and_bind("tab: complete")

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -112,7 +112,7 @@ def setup_readline():
                          "   * failure to wrap or indent lines properly",
                          "",
                          "It is highly recommended that you install gnureadline, which is installable with:",
-                         "     pip install gnureadline",
+                         "     xip install gnureadline",
                          "*" * 78]), file=sys.stderr)
     else:
         readline.parse_and_bind("tab: complete")

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -170,14 +170,14 @@
    "url": "http://exofrills.org",
    "install": {
     "conda": "conda install -c conda-forge xo",
-    "pip": "pip install exofrills"}
+    "pip": "xip install exofrills"}
    },
   "xonsh": {
    "license": "BSD 3-clause",
    "url": "http://xon.sh",
    "install": {
     "conda": "conda install -c conda-forge xonsh",
-    "pip": "pip install xonsh",
+    "pip": "xip install xonsh",
     "aura": "sudo aura -A xonsh",
     "yaourt": "yaourt -Sa xonsh"}
    },
@@ -185,56 +185,56 @@
    "license": "MIT",
    "url": "https://github.com/Siecje/xontrib-prompt-ret-code",
    "install": {
-    "pip": "pip install xontrib-prompt-ret-code"
+    "pip": "xip install xontrib-prompt-ret-code"
    }
   },
   "xonsh-apt-tabcomplete": {
    "license": "BSD 2-clause",
    "url": "https://github.com/DangerOnTheRanger/xonsh-apt-tabcomplete",
    "install": {
-    "pip": "pip install xonsh-apt-tabcomplete"
+    "pip": "xip install xonsh-apt-tabcomplete"
    }
   },
   "xonsh-docker-tabcomplete": {
    "license": "MIT",
    "url": "https://github.com/xsteadfastx/xonsh-docker-tabcomplete",
    "install": {
-    "pip": "pip install xonsh-docker-tabcomplete"
+    "pip": "xip install xonsh-docker-tabcomplete"
    }
   },
   "xonsh-scrapy-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-scrapy-tabcomplete",
    "install": {
-    "pip": "pip install xonsh-scrapy-tabcomplete"
+    "pip": "xip install xonsh-scrapy-tabcomplete"
     }
    },
   "xonsh-vox-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitosaurus/xonsh-vox-tabcomplete",
    "install": {
-    "pip": "pip install xonsh-vox-tabcomplete"
+    "pip": "xip install xonsh-vox-tabcomplete"
    }
   },
   "xonsh-click-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
    "install": {
-    "pip": "pip install xonsh-click-tabcomplete"
+    "pip": "xip install xonsh-click-tabcomplete"
    }
   },
   "xonsh-autoxsh": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-autoxsh",
    "install": {
-    "pip": "pip install xonsh-autoxsh"
+    "pip": "xip install xonsh-autoxsh"
    }
   },
   "xonda": {
    "license": "MIT",
    "url": "https://github.com/gforsyth/xonda",
    "install": {
-    "pip": "pip install xonda"
+    "pip": "xip install xonda"
    }
   },
   "xontrib-avox": {
@@ -255,21 +255,21 @@
    "license": "MIT",
    "url": "https://github.com/santagada/xontrib-powerline",
    "install": {
-    "pip": "pip install xontrib-powerline"
+    "pip": "xip install xontrib-powerline"
    }
   },
   "xontrib-thefuck": {
    "license": "MIT",
    "url": "https://github.com/meatballs/xontrib-thefuck",
    "install": {
-    "pip": "pip install xontrib-thefuck"
+    "pip": "xip install xontrib-thefuck"
    }
   },
   "xontrib-prompt-vi-mode": {
    "license": "MIT",
    "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
    "install": {
-    "pip": "pip install xontrib-prompt-vi-mode"
+    "pip": "xip install xontrib-prompt-vi-mode"
    }
   },
   "xontrib-fzf-widgets": {

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -170,14 +170,14 @@
    "url": "http://exofrills.org",
    "install": {
     "conda": "conda install -c conda-forge xo",
-    "pip": "xip install exofrills"}
+    "pip": "xpip install exofrills"}
    },
   "xonsh": {
    "license": "BSD 3-clause",
    "url": "http://xon.sh",
    "install": {
     "conda": "conda install -c conda-forge xonsh",
-    "pip": "xip install xonsh",
+    "pip": "xpip install xonsh",
     "aura": "sudo aura -A xonsh",
     "yaourt": "yaourt -Sa xonsh"}
    },
@@ -185,105 +185,105 @@
    "license": "MIT",
    "url": "https://github.com/Siecje/xontrib-prompt-ret-code",
    "install": {
-    "pip": "xip install xontrib-prompt-ret-code"
+    "pip": "xpip install xontrib-prompt-ret-code"
    }
   },
   "xonsh-apt-tabcomplete": {
    "license": "BSD 2-clause",
    "url": "https://github.com/DangerOnTheRanger/xonsh-apt-tabcomplete",
    "install": {
-    "pip": "xip install xonsh-apt-tabcomplete"
+    "pip": "xpip install xonsh-apt-tabcomplete"
    }
   },
   "xonsh-docker-tabcomplete": {
    "license": "MIT",
    "url": "https://github.com/xsteadfastx/xonsh-docker-tabcomplete",
    "install": {
-    "pip": "xip install xonsh-docker-tabcomplete"
+    "pip": "xpip install xonsh-docker-tabcomplete"
    }
   },
   "xonsh-scrapy-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-scrapy-tabcomplete",
    "install": {
-    "pip": "xip install xonsh-scrapy-tabcomplete"
+    "pip": "xpip install xonsh-scrapy-tabcomplete"
     }
    },
   "xonsh-vox-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitosaurus/xonsh-vox-tabcomplete",
    "install": {
-    "pip": "xip install xonsh-vox-tabcomplete"
+    "pip": "xpip install xonsh-vox-tabcomplete"
    }
   },
   "xonsh-click-tabcomplete": {
    "license": "GPLv3",
    "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
    "install": {
-    "pip": "xip install xonsh-click-tabcomplete"
+    "pip": "xpip install xonsh-click-tabcomplete"
    }
   },
   "xonsh-autoxsh": {
    "license": "GPLv3",
    "url": "https://github.com/Granitas/xonsh-autoxsh",
    "install": {
-    "pip": "xip install xonsh-autoxsh"
+    "pip": "xpip install xonsh-autoxsh"
    }
   },
   "xonda": {
    "license": "MIT",
    "url": "https://github.com/gforsyth/xonda",
    "install": {
-    "pip": "xip install xonda"
+    "pip": "xpip install xonda"
    }
   },
   "xontrib-avox": {
    "license": "GPLv3",
    "url": "https://github.com/astronouth7303/xontrib-avox",
    "install": {
-    "pip": "xip install xontrib-avox"
+    "pip": "xpip install xontrib-avox"
    }
   },
   "xontrib-z": {
    "license": "GPLv3",
    "url": "https://github.com/astronouth7303/xontrib-z",
    "install": {
-    "pip": "xip install xontrib-z"
+    "pip": "xpip install xontrib-z"
    }
   },
   "xontrib-powerline": {
    "license": "MIT",
    "url": "https://github.com/santagada/xontrib-powerline",
    "install": {
-    "pip": "xip install xontrib-powerline"
+    "pip": "xpip install xontrib-powerline"
    }
   },
   "xontrib-thefuck": {
    "license": "MIT",
    "url": "https://github.com/meatballs/xontrib-thefuck",
    "install": {
-    "pip": "xip install xontrib-thefuck"
+    "pip": "xpip install xontrib-thefuck"
    }
   },
   "xontrib-prompt-vi-mode": {
    "license": "MIT",
    "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
    "install": {
-    "pip": "xip install xontrib-prompt-vi-mode"
+    "pip": "xpip install xontrib-prompt-vi-mode"
    }
   },
   "xontrib-fzf-widgets": {
    "license": "GPLv3",
    "url": "https://github.com/shahinism/xontrib-fzf-widgets",
    "install": {
-    "pip": "xip install xontrib-fzf-widgets"
+    "pip": "xpip install xontrib-fzf-widgets"
    }
   },
   "xontrib-schedule": {
    "license": "MIT",
    "url": "https://github.com/astronouth7303/xontrib-schedule",
    "install": {
-    "pip": "xip install xontrib-schedule"
+    "pip": "xpip install xontrib-schedule"
    }
   }
  }

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -51,7 +51,7 @@ def prompt_xontrib_install(names):
     print('The following xontribs are enabled but not installed: \n'
           '   {xontribs}\n'
           'To install them run \n'
-          '    pip install {packages}'.format(xontribs=' '.join(names),
+          '    xip install {packages}'.format(xontribs=' '.join(names),
                                               packages=' '.join(packages)))
 
 

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -52,7 +52,7 @@ def prompt_xontrib_install(names):
           '   {xontribs}\n'
           'To install them run \n'
           '    xpip install {packages}'.format(xontribs=' '.join(names),
-                                              packages=' '.join(packages)))
+                                               packages=' '.join(packages)))
 
 
 def update_context(name, ctx=None):

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -51,7 +51,7 @@ def prompt_xontrib_install(names):
     print('The following xontribs are enabled but not installed: \n'
           '   {xontribs}\n'
           'To install them run \n'
-          '    xip install {packages}'.format(xontribs=' '.join(names),
+          '    xpip install {packages}'.format(xontribs=' '.join(names),
                                               packages=' '.join(packages)))
 
 


### PR DESCRIPTION
Try to use `xip` instead of `pip` in places where it should be used.

There is a known conflict with the name `xip`, though. Mac has an archival program [xip](https://en.wikipedia.org/wiki/.XIP).

Considering renaming `xip` to `xpip`.