### PR TITLE
Don't capture so much

### DIFF
--- a/news/dont-capture-so-much.rst
+++ b/news/dont-capture-so-much.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* stderr is now longer captured when using $().
+
+**Security:** None

--- a/news/dont-capture-so-much.rst
+++ b/news/dont-capture-so-much.rst
@@ -9,5 +9,6 @@
 **Fixed:**
 
 * stderr is now longer captured when using $().
+* stdout and stderr are no longer captured when using ![].
 
 **Security:** None

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -6,6 +6,7 @@ import re
 import builtins
 import types
 from ast import AST
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -290,3 +291,17 @@ def test_enter_macro():
     assert obj.macro_globals
     assert obj.macro_locals
 
+
+def test__update_last_spec_uncaptured_stderr():
+    last = Mock(captured=True)
+    last.alias = None
+    last.stderr = None
+    last.captured = 'stdout'
+
+    from xonsh.built_ins import _update_last_spec
+
+    with patch('builtins.__xonsh_commands_cache__', create=True):
+        with patch('builtins.__xonsh_stderr_uncaptured__', None, create=True):
+            _update_last_spec(last)
+
+    assert last.stderr is None

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -292,11 +292,13 @@ def test_enter_macro():
     assert obj.macro_locals
 
 
-def test__update_last_spec_uncaptured_stderr():
+@pytest.mark.parametrize('captured', [None, 'hiddenobject', 'stdout'])
+def test__update_last_spec_uncaptured_objects(captured):
     last = Mock(captured=True)
     last.alias = None
+    last.stdout = None
     last.stderr = None
-    last.captured = 'stdout'
+    last.captured = captured
 
     from xonsh.built_ins import _update_last_spec
 
@@ -304,4 +306,8 @@ def test__update_last_spec_uncaptured_stderr():
         with patch('builtins.__xonsh_stderr_uncaptured__', None, create=True):
             _update_last_spec(last)
 
+    if captured == 'stdout':
+        assert last.stdout is not None
+    else:
+        assert last.stdout is None
     assert last.stderr is None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -693,9 +693,9 @@ def _update_last_spec(last):
         cmds_cache = builtins.__xonsh_commands_cache__
         thable = (cmds_cache.predict_threadable(last.args) and
                   cmds_cache.predict_threadable(last.cmd))
-        if captured and thable:
+        if thable:
             last.cls = PopenThread
-        elif not thable:
+        else:
             # foreground processes should use Popen
             last.threadable = False
             if captured == 'object':

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -684,7 +684,7 @@ def _safe_pipe_properties(fd, use_tty=False):
 def _update_last_spec(last):
     captured = last.captured
     last.last_in_pipeline = True
-    if not captured:
+    if not captured or captured == 'hiddenobject':
         return
     callable_alias = callable(last.alias)
     if callable_alias:
@@ -698,9 +698,10 @@ def _update_last_spec(last):
         elif not thable:
             # foreground processes should use Popen
             last.threadable = False
-            if captured == 'object' or captured == 'hiddenobject':
+            if captured == 'object':
                 # CommandPipeline objects should not pipe stdout, stderr
                 return
+
     # cannot used PTY pipes for aliases, for some dark reason,
     # and must use normal pipes instead.
     use_tty = ON_POSIX and not callable_alias

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -684,7 +684,8 @@ def _safe_pipe_properties(fd, use_tty=False):
 def _update_last_spec(last):
     captured = last.captured
     last.last_in_pipeline = True
-    if not captured or captured == 'hiddenobject':
+    if not captured or \
+            (captured == 'hiddenobject' and not (last.stdout or last.stderr)):
         return
     callable_alias = callable(last.alias)
     if callable_alias:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -741,7 +741,7 @@ def _update_last_spec(last):
     elif ON_WINDOWS and not callable_alias:
         last.universal_newlines = True
         last.stderr = None  # must truly stream on windows
-    else:
+    elif captured != 'stdout':
         r, w = pty.openpty() if use_tty else os.pipe()
         _safe_pipe_properties(w, use_tty=use_tty)
         last.stderr = safe_open(w, 'w')

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1683,6 +1683,8 @@ def SIGNAL_MESSAGES():
 
 def safe_readlines(handle, hint=-1):
     """Attempts to read lines without throwing an error."""
+    if not handle:
+        return []
     try:
         lines = handle.readlines(hint)
     except OSError:


### PR DESCRIPTION
This fixes #2404, covering another situation I also discovered.

My additional discovery was that stdout and stderr of hiddenobjects are also being captured, which the documentation states shouldn't be happening - http://xon.sh/tutorial.html#uncaptured-subprocess-with-and. I'm slightly less sure about this change, because the code quite explicitly refers to them as captured:

```
        elif p1 == '![':
            p0 = xonsh_call('__xonsh_subproc_captured_hiddenobject__', p2,
                            lineno=lineno, col=col)
```
and
```
def subproc_captured_hiddenobject(*cmds):
    """Runs a subprocess, capturing the output. Returns an instance of
    HiddenCommandPipeline representing the completed command.
    """
    return run_subproc(cmds, captured='hiddenobject')
```

But I think it might a copy-paste thing from nearby code. Either way the capture is definitely causing issues, e.g. here's two invocations of `fzf` that select the same file:

```
nathan@susannah ~/projects/xonsh master $ fzf
MANIFEST.in
nathan@susannah ~/projects/xonsh master $ fzf
nathan@susannah ~/projects/xonsh master $
```

Given that the documentation states it shouldn't be captured, and with this PR it really isn't captured anymore, I should probably also update the code to state that it's uncaptured. If you find the change agreeable let me know and I'll make those changes.