### PR TITLE
Fixed `escape_windows_cmd_string` not handling ^ correctly

### DIFF
--- a/news/win_escape.rst
+++ b/news/win_escape.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a problem with escaping charet (^) character for cmd.exe in the source-cmd function.
+
+**Security:** None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1070,7 +1070,7 @@ def test_dynamic_cwd_tuple_to_str(inp, exp):
     ('foo&bar', 'foo^&bar'),
     ('foo$?-/_"\\', 'foo$?-/_^"\\'),
     ('^&<>|', '^^^&^<^>^|'),
-    ('this /?', 'this /.')
+    ('()<>','^(^)^<^>'),
 ])
 def test_escape_windows_cmd_string(st, esc):
     obs = escape_windows_cmd_string(st)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -890,9 +890,8 @@ def escape_windows_cmd_string(s):
     The escaping is based on details here and empirical testing:
     http://www.robvanderwoude.com/escapechars.php
     """
-    for c in '()%!^<>&|"':
+    for c in '^()%!<>&|"':
         s = s.replace(c, '^' + c)
-    s = s.replace('/?', '/.')
     return s
 
 


### PR DESCRIPTION
@santagada Can you try "source-cmd" that failed for you with this fix?