### PR TITLE
Adding `libgpm` in pattern used for bin analysis in default backgroundable predictors

### DIFF
--- a/news/predictor_libgpm.rst
+++ b/news/predictor_libgpm.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Change in the behavior of the default predictor with binary analysis. The pattern ``libgpm`` is use, assuming when ``gpm`` is used the program is not threadable. This change solves issues with programs as ``links``.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -49,10 +49,12 @@ def test_predict_shell_false(args):
 PATTERN_BIN_USING_TTY_OR_NOT = [
     (False, {10: b'isnotatty'}),
     (False, {12: b'isatty'}),
+    (False, {151: b'gpm'}),
     (False, {10: b'isatty', 100: b'tcgetattr', }),
     (False, {10: b'isatty', 100: b'tcsetattr'}),
     (True, {10: b'isatty', 100: b'tcsetattr', 1000: b'tcgetattr'}),
     (True, {1000: b'libncurses'}),
+    (True, {4094: b'libgpm'}),
     (True, {2045: b'tcgetattr', 4095: b'tcgetattr', 6140: b'tcsetattr',
             8190: b'isatty'}),
 ]

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -243,6 +243,7 @@ class CommandsCache(cabc.Mapping):
 
         search_for = {
             (b'ncurses',): [False, ],
+            (b'libgpm',): [False, ],
             (b'isatty', b'tcgetattr', b'tcsetattr'): [False, False, False],
         }
         tstart = time.time()


### PR DESCRIPTION
When ``gpm`` is used, we can assume the command is not backgroundable. I had the problem with ``links``, but I had a look on why the predictor with binary analysis fails. Adding in the exception list is not a general fix, so I prefer fix the predictor.