### PR TITLE
PEP-515 Support (Underscores in Numeric Literals)

### DIFF
--- a/news/numeric_underscores.rst
+++ b/news/numeric_underscores.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Support for PEP 515: Underscores in Numeric Literals
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -91,18 +91,22 @@ def check_tokens_subproc(inp, exp, stop=-1):
 
 def test_int_literal():
     assert check_token('42', ['NUMBER', '42', 0])
+    assert check_token('4_2', ['NUMBER', '4_2', 0])
 
 
 def test_hex_literal():
     assert check_token('0x42', ['NUMBER', '0x42', 0])
+    assert check_token('0x4_2', ['NUMBER', '0x4_2', 0])
 
 
 def test_oct_o_literal():
     assert check_token('0o42', ['NUMBER', '0o42', 0])
+    assert check_token('0o4_2', ['NUMBER', '0o4_2', 0])
 
 
 def test_bin_literal():
     assert check_token('0b101010', ['NUMBER', '0b101010', 0])
+    assert check_token('0b10_10_10', ['NUMBER', '0b10_10_10', 0])
 
 
 def test_indent():
@@ -382,7 +386,7 @@ def test_regex_globs():
 
 
 @pytest.mark.parametrize('case', [
-    '0.0', '.0', '0.', '1e10', '1.e42', '0.1e42', '0.5e-42', '5E10', '5e+42'])
+    '0.0', '.0', '0.', '1e10', '1.e42', '0.1e42', '0.5e-42', '5E10', '5e+42', '1_0e1_0'])
 def test_float_literals(case):
     assert check_token(case, ['NUMBER', case, 0])
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -68,9 +68,11 @@ def check_xonsh(xenv, inp, run=True, mode='exec'):
 
 def test_int_literal():
     check_ast('42')
+    check_ast('4_2')
 
 def test_float_literal():
     check_ast('42.0')
+    check_ast('4_2.4_2')
 
 def test_imag_literal():
     check_ast('42j')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -68,10 +68,16 @@ def check_xonsh(xenv, inp, run=True, mode='exec'):
 
 def test_int_literal():
     check_ast('42')
+
+@skip_if_lt_py36
+def test_int_literal_underscore():
     check_ast('4_2')
 
 def test_float_literal():
     check_ast('42.0')
+
+@skip_if_lt_py36
+def test_float_literal_underscore():
     check_ast('4_2.4_2')
 
 def test_imag_literal():

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2024,7 +2024,7 @@ class BaseParser(object):
     def p_number(self, p):
         """number : number_tok"""
         p1 = p[1]
-        p[0] = ast.Num(n=ast.literal_eval(p1.value), lineno=p1.lineno,
+        p[0] = ast.Num(n=ast.literal_eval(p1.value.replace('_', '')), lineno=p1.lineno,
                        col_offset=p1.lexpos)
 
     def p_testlist_comp_comp(self, p):

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -200,7 +200,7 @@ Decnumber = r'(?:0(?:_?0)*|[1-9](?:_?[0-9])*)'
 Intnumber = group(Hexnumber, Binnumber, Octnumber, Decnumber)
 Exponent = r'[eE][-+]?[0-9](?:_?[0-9])*'
 Pointfloat = group(r'[0-9](?:_?[0-9])*\.(?:[0-9](?:_?[0-9])*)?',
-                           r'\.[0-9](?:_?[0-9])*') + maybe(Exponent)
+                   r'\.[0-9](?:_?[0-9])*') + maybe(Exponent)
 Expfloat = r'[0-9](?:_?[0-9])*' + Exponent
 Floatnumber = group(Pointfloat, Expfloat)
 Imagnumber = group(r'[0-9](?:_?[0-9])*[jJ]', Floatnumber + r'[jJ]')

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -193,16 +193,17 @@ Comment = r'#[^\r\n]*'
 Ignore = Whitespace + tokany(r'\\\r?\n' + Whitespace) + maybe(Comment)
 Name_RE = r'\$?\w+'
 
-Hexnumber = r'0[xX][0-9a-fA-F]+'
-Binnumber = r'0[bB][01]+'
-Octnumber = r'0[oO][0-7]+'
-Decnumber = r'(?:0+|[1-9][0-9]*)'
+Hexnumber = r'0[xX](?:_?[0-9a-fA-F])+'
+Binnumber = r'0[bB](?:_?[01])+'
+Octnumber = r'0[oO](?:_?[0-7])+'
+Decnumber = r'(?:0(?:_?0)*|[1-9](?:_?[0-9])*)'
 Intnumber = group(Hexnumber, Binnumber, Octnumber, Decnumber)
-Exponent = r'[eE][-+]?[0-9]+'
-Pointfloat = group(r'[0-9]+\.[0-9]*', r'\.[0-9]+') + maybe(Exponent)
-Expfloat = r'[0-9]+' + Exponent
+Exponent = r'[eE][-+]?[0-9](?:_?[0-9])*'
+Pointfloat = group(r'[0-9](?:_?[0-9])*\.(?:[0-9](?:_?[0-9])*)?',
+                           r'\.[0-9](?:_?[0-9])*') + maybe(Exponent)
+Expfloat = r'[0-9](?:_?[0-9])*' + Exponent
 Floatnumber = group(Pointfloat, Expfloat)
-Imagnumber = group(r'[0-9]+[jJ]', Floatnumber + r'[jJ]')
+Imagnumber = group(r'[0-9](?:_?[0-9])*[jJ]', Floatnumber + r'[jJ]')
 Number = group(Imagnumber, Floatnumber, Intnumber)
 
 StringPrefix = r'(?:[bBp][rR]?|[rR][bBpfF]?|[uU]|[fF][rR]?)?'


### PR DESCRIPTION
This adds support for PEP-515 (underscores in numeric literals). Support
is added unconditionally on underlying python version by patching the
tokenizer with the regexes used in cpython 3.6, then modifying the
parser to unconditionally remove underscores before evaluating numeric
literals, which avoids needing to check for the underlying version.