### PR TITLE
Allow f-strings in check_quotes

### DIFF
--- a/news/add_fstrings_to_check_quotes.rst
+++ b/news/add_fstrings_to_check_quotes.rst
@@ -6,7 +6,7 @@
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
 
 * Now f-strings can be used inside @() without explicit enclosing command in ![]
 

--- a/news/add_fstrings_to_check_quotes.rst
+++ b/news/add_fstrings_to_check_quotes.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+* Now f-strings can be used inside @() without explicit enclosing command in ![]
+
+**Security:** None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -432,6 +432,7 @@ def test_replace_logical_line(src, idx, exp_line, exp_n):
     ("'y'", True),
     ('b"x"', True),
     ("r'y'", True),
+    ("f'z'", True),
     ('"""hello\nmom"""', True),
 ])
 def test_check_quotes(inp, exp):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1631,7 +1631,7 @@ def format_std_prepost(template, env=None):
     return s
 
 
-_RE_STRING_START = "[bBprRuU]*"
+_RE_STRING_START = "[bBprRuUf]*"
 _RE_STRING_TRIPLE_DOUBLE = '"""'
 _RE_STRING_TRIPLE_SINGLE = "'''"
 _RE_STRING_DOUBLE = '"'


### PR DESCRIPTION
This allows using f-strings inside @() when command not explicitly enclosed inside ![]