### PR TITLE
Escape regex in path completion

### DIFF
--- a/news/escape_regex.rst
+++ b/news/escape_regex.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Escape regex characters in ``path_complete`` to avoid regex parsing errors for
+  certain combinations of characters in path completer
+
+**Security:** None

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -1,5 +1,20 @@
+import pytest
+
+from xonsh.environ import Env
 import xonsh.completers.path as xcp
+
 
 def test_pattern_need_quotes():
     # just make sure the regex compiles
     xcp.PATTERN_NEED_QUOTES.match('')
+
+
+def test_complete_path(xonsh_builtins):
+    xonsh_builtins.__xonsh_env__ = {'CASE_SENSITIVE_COMPLETIONS': False,
+                                    'GLOB_SORTED': True,
+                                    'SUBSEQUENCE_PATH_COMPLETION': False,
+                                    'FUZZY_PATH_COMPLETION': False,
+                                    'SUGGEST_THRESHOLD': 3,
+                                    'CDPATH': set(),
+    }
+    xcp.complete_path('[1-0.1]', '[1-0.1]', 0, 7, dict())

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -1,6 +1,7 @@
 import os
 import re
 import ast
+import glob
 import builtins
 
 import xonsh.tools as xt
@@ -264,6 +265,7 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
     env = builtins.__xonsh_env__
     csc = env.get('CASE_SENSITIVE_COMPLETIONS')
     glob_sorted = env.get('GLOB_SORTED')
+    prefix = glob.escape(prefix)
     for s in xt.iglobpath(prefix + '*', ignore_case=(not csc),
                           sort_result=glob_sorted):
         paths.add(s)


### PR DESCRIPTION
Fix for #2534 

We append a `*` to the prefix before trying path globbing and for prefixes with `[]` that was throwing errors. There's a `glob.escape` to fix that.