### PR TITLE
Free cwd on win

### DIFF
--- a/news/free_cwd_only_on_win.rst
+++ b/news/free_cwd_only_on_win.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Ensure that the ``free_cwd`` contrib can only be active on pure Windows. 
+
+**Security:** None

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -81,18 +81,18 @@
   "description": ["Adds return code info to the prompt"]
   },
   {"name": "free_cwd",
-  "package": "xonsh",
-  "url": "http://xon.sh",
-  "description": [
-    "Release the lock on the current directory whenever the",
-    "prompt is shown. Enabling this will allow the other programs or",
-    "Windows Explorer to delete or rename the current or parent",
-    "directories. Internally, it is accomplished by temporarily resetting",
-    "CWD to the root drive folder while waiting at the prompt. This only",
-    "works with the prompt_toolkit backend and can cause cause issues",
-    "if any extensions are enabled that hook the prompt and relies on",
-    "``os.getcwd()``"]
- },
+    "package": "xonsh",
+    "url": "http://xon.sh",
+    "description": [
+      "Windows only xontrib, to release the lock on the current directory",
+      "whenever the prompt is shown. Enabling this will allow the other",
+      "programs or Windows Explorer to delete or rename the current or parent",
+      "directories. Internally, it is accomplished by temporarily resetting",
+      "CWD to the root drive folder while waiting at the prompt. This only",
+      "works with the prompt_toolkit backend and can cause cause issues",
+      "if any extensions are enabled that hook the prompt and relies on",
+      "``os.getcwd()``"]
+  },
   {"name": "whole_word_jumping",
   "package": "xonsh",
   "url": "http://xon.sh",

--- a/xontrib/free_cwd.py
+++ b/xontrib/free_cwd.py
@@ -11,6 +11,7 @@ import os
 import builtins
 import functools
 from xonsh.tools import print_exception
+from xonsh.platform import ON_WINDOWS, ON_CYGWIN
 
 
 def _chdir_up(path):
@@ -88,7 +89,8 @@ def _cwd_restore_wrapper(func):
 
 @events.on_ptk_create
 def setup_release_cwd_hook(prompter, history, completer, bindings, **kw):
-    prompter.prompt = _cwd_release_wrapper(prompter.prompt)
-    if completer.completer:
-        # Temporarily restore cwd for callbacks to the completer
-        completer.completer.complete = _cwd_restore_wrapper(completer.completer.complete)
+    if ON_WINDOWS and not ON_CYGWIN:
+        prompter.prompt = _cwd_release_wrapper(prompter.prompt)
+        if completer.completer:
+            # Temporarily restore cwd for callbacks to the completer
+            completer.completer.complete = _cwd_restore_wrapper(completer.completer.complete)

--- a/xontrib/free_cwd.py
+++ b/xontrib/free_cwd.py
@@ -1,5 +1,5 @@
 """ This will release the lock on the current directory whenever the
-    prompt is shown. Enabling this will allow the other programs or
+    prompt is shown. Enabling this will allow other programs or
     Windows Explorer to delete or rename the current or parent
     directories. Internally, it is accomplished by temporarily resetting
     CWD to the root drive folder while waiting at the prompt. This only
@@ -30,7 +30,7 @@ def _chdir_up(path):
 
 
 def _cwd_release_wrapper(func):
-    """ Decorator for Windows to the wrap the prompt function and release
+    """ Decorator for Windows to wrap the prompt function and release
         the process lock on the current directory while the prompt is
         displayed. This works by temporarily setting
         the workdir to the users home directory.


### PR DESCRIPTION
This fixes the problem reported by @paulschellin in #2548 

It ensures that ``free_cwd`` xontrib can only be active on windows.