### PR TITLE
Fixed def spam(*): pass issue

### DIFF
--- a/news/synstar.rst
+++ b/news/synstar.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Properly throw ``SyntaxError`` when no kwargs are defined
+  in a kwarg-only function. This used to throw a
+  ``TypeError: 'NoneType' object is not iterable``.
+
+**Security:** None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2310,3 +2310,8 @@ def test_syntax_error_augassign_ops(exp):
 def test_syntax_error_augassign_cmp(exp):
     with pytest.raises(SyntaxError):
         PARSER.parse('{} += a'.format(exp))
+
+
+def test_syntax_error_bar_kwonlyargs():
+    with pytest.raises(SyntaxError):
+        PARSER.parse('def spam(*):\n   pass\n', mode='exec')


### PR DESCRIPTION
Should close #2547.  The parser was being too loose. This was trickier to fix than expected because of how PLY special cases SyntaxError: http://www.dabeaz.com/ply/ply.html#ply_nn35