### PR TITLE
Fix typo in Execer page title

### DIFF
--- a/docs/api/execer.rst
+++ b/docs/api/execer.rst
@@ -1,7 +1,7 @@
 .. _xonsh_execer:
 
 ***********************************************************
-Compiliation, Evaluation, & Execution  (``xonsh.execer``)
+Compilation, Evaluation, & Execution  (``xonsh.execer``)
 ***********************************************************
 
 .. automodule:: xonsh.execer


### PR DESCRIPTION
compiliation -> compilation

(See http://xon.sh/api/execer.html)