### PR TITLE
Set prompt_toolkit version to <2.0.0 in requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,7 @@ def main():
         }
         skw['cmdclass']['develop'] = xdevelop
         skw['extras_require'] = {
-            'ptk':  ['prompt-toolkit'],
+            'ptk':  ['prompt-toolkit<2.0.0'],
             'pygments': ['pygments'],
             'win': ['win_unicode_console'],
             'mac': ['gnureadline'],


### PR DESCRIPTION
The current xonsh version will break when prompt_toolkit 2.0 is released.
Set version to <2.0.0 until 2.0 compatibility has been merged.