### PR TITLE
Document path helper on macOS.

### DIFF
--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -20,7 +20,7 @@ You can install xonsh using homebrew, conda, pip, or from source.
 
     $ conda config --add channels conda-forge
     $ conda install xonsh
-    
+
 
 **pip:**
 

--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -38,6 +38,24 @@ the following from the source directory,
     $ python3 setup.py install
 
 
+Path Helper
+===========
+
+macOS provides a `path helper
+<http://www.softec.lu/site/DevelopersCorner/MasteringThePathHelper>`_,
+which by default configures paths in bash and other shells. Without
+including these paths, common tools including those installed by Homebrew
+may be unavailable. See ``/etc/profile`` for details on how it is done.
+To ensure the path helper is invoked on xonsh (for all users), add the
+following to ``/etc/xonshrc``::
+
+    source-bash $(/usr/libexec/path_helper -s)
+
+To incorporate the whole functionality of ``/etc/profile``::
+
+    source-bash --seterrprevcmd "" /etc/profile
+
+
 Extras for OSX
 ==============
 


### PR DESCRIPTION
Inspired by [this discussion](https://gitter.im/xonsh/xonsh?at=5ade2a2b3fe1be3704cafde0), provide users and package managers with guidance on configuring the path helper under xonsh.

I use the preferred "macOS" moniker even though "OSX" is used in other parts of the document. I'd recommend using macOS throughout the document, but avoided making that change as it's incidental to the primary goal of this contrib.