### PR TITLE
Update xontrib description

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -319,7 +319,8 @@ def make_xontribs():
            ':Website: {url}\n'
            ':Package: {pkg}\n\n'
            '{desc}\n\n'
-           '{inst}'
+           '{inst}\n\n'
+           '{usage}'
            '-------\n\n')
     for name in names:
         for d in md['xontribs']:
@@ -334,6 +335,7 @@ def make_xontribs():
         if pkgname is None:
             pkg = 'unknown'
             inst = ''
+            usage = ''
         else:
             pd = md['packages'].get(pkgname, {})
             pkg = pkgname
@@ -343,16 +345,24 @@ def make_xontribs():
                 pkg = pkg + ', ' + pd['license']
             inst = ''
             installd = pd.get('install', {})
-            if len(installd) > 0:
+            if pkgname == 'xonsh':
+                inst = ('This xontrib is preinstalled with xonsh.\n\n')
+            elif len(installd) > 0:
                 inst = ('**Installation:**\n\n'
                         '.. code-block:: xonsh\n\n')
                 for k, v in sorted(pd.get('install', {}).items()):
                     cmd = "\n    ".join(v.split('\n'))
                     inst += ('    # install with {k}\n'
-                             '    {cmd}\n\n').format(k=k, cmd=cmd)
+                             '    {cmd}').format(k=k, cmd=cmd)
+            usage = ('**Usage:**\n\n'
+                     'Run the following command to enable (or add '
+                     'it to your :doc:`.xonshrc </xonshrc>` file to enable '
+                     'on startup.)\n\n'
+                     '.. code-block:: xonsh\n\n')
+            usage += '    xontrib load {}\n\n'.format(name)
         s += sec.format(low=name.lower(), title=title, under=under,
                         url=d.get('url', 'unknown'), desc=desc,
-                        pkg=pkg, inst=inst)
+                        pkg=pkg, inst=inst, usage=usage)
     s = s[:-9]
     fname = os.path.join(os.path.dirname(__file__), 'xontribsbody')
     with open(fname, 'w') as f:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,7 +294,7 @@ def make_envvars():
                         default=vd.default, store_as_str=vd.store_as_str)
     s = s[:-9]
     fname = os.path.join(os.path.dirname(__file__), 'envvarsbody')
-    with open(fname, 'w') as f:
+    with open(fname, 'w', encoding='utf-8') as f:
         f.write(s)
 
 

--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -1,1 +1,1 @@
-../CONTRIBUTING.rst
+.. include:: ../CONTRIBUTING.rst

--- a/news/docs_build_win.rst
+++ b/news/docs_build_win.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix bug on Windows when `PATHEXT` environment variable did not exist.
+  This also fixes building the xonsh documentation on Windows. 
+
+**Security:** None

--- a/news/docs_build_win.rst
+++ b/news/docs_build_win.rst
@@ -8,7 +8,7 @@
 
 **Fixed:**
 
-* Fix bug on Windows when `PATHEXT` environment variable did not exist.
+* Fix bug on Windows when ``PATHEXT`` environment variable did not exist.
   This also fixes building the xonsh documentation on Windows. 
 
 **Security:** None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -61,7 +61,7 @@ class CommandsCache(cabc.Mapping):
          name on Windows as a list, conserving the ordering in `PATHEXT`.
          Returns a list as `name` being the only item in it on other platforms."""
         if ON_WINDOWS:
-            pathext = builtins.__xonsh_env__.get('PATHEXT')
+            pathext = builtins.__xonsh_env__.get('PATHEXT', [])
             name = name.upper()
             return [
                 name + ext


### PR DESCRIPTION
This updates xontrib description to leave out the installation section when the xontrib is bundled with xonsh. 

It also adds a 'Usage' section with the command to enable the xontrib. I always thought this was missing from here. 

Finally, it fixes a few issues with building the docs on Windows. 

## New
![image](https://user-images.githubusercontent.com/1038978/39237208-1ecb3ec0-487b-11e8-92b1-b05dfe3c199d.png)

## Old
![image](https://user-images.githubusercontent.com/1038978/39237238-33bdc262-487b-11e8-98fb-ff61e5ffc714.png)

(Disregard the change in fonts. This is from building locally). 