### PR TITLE
Hide XonshError types

### DIFF
--- a/news/no_exc_type.rst
+++ b/news/no_exc_type.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* When reporting errors without a traceback (i.e. ``$XONSH_SHOW_TRACEBACK = False``) and the error is a ``XonshError``
+  the exception type is not longer printed. 
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -842,12 +842,14 @@ def print_exception(msg=None):
         sys.stderr.write(msg)
 
 
-def display_error_message():
+def display_error_message(strip_xonsh_error_types=True):
     """
     Prints the error message of the current exception on stderr.
     """
     exc_type, exc_value, exc_traceback = sys.exc_info()
     exception_only = traceback.format_exception_only(exc_type, exc_value)
+    if exc_type is XonshError and strip_xonsh_error_types:
+        exception_only[0] = exception_only[0].partition(': ')[-1]
     sys.stderr.write(''.join(exception_only))
 
 


### PR DESCRIPTION
When reporting errors without a traceback (i.e. ``$XONSH_SHOW_TRACEBACK = False``) and the error is a ``XonshError`` the exception type is no longer printed. 

I.e.:
```
snail@sea ~ $ not_a_command
 xonsh: subprocess mode: command not found: not_a_command
```
Instead of: 
```
snail@sea ~ $ not_a_command
xonsh.__amalgam__.XonshError: xonsh: subprocess mode: command not found: not_a_command
```

I don't really like my implementation here. Seems to much like a hack. @scopatz can you think of nicer way of doing this. 