### PR TITLE
Run os.environ.clear() for test_environ.py

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -15,6 +15,8 @@ from xonsh.environ import Env, locate_binary, DEFAULT_ENSURERS, DEFAULT_VALUES, 
 
 from tools import skip_if_on_unix
 
+os.environ.clear()
+
 def test_env_normal():
     env = Env(VAR='wakka')
     assert 'wakka' == env['VAR']


### PR DESCRIPTION
Before I added this I was seeing this in the test failure:
```
E           assert 'LINES' not in {'ANDROID_SDK_ROOT': '/Users/bencreasy/.config/android', 'ANKI_BASE': '/Users/bencreasy/dotfiles/local/anki', 'ANSIBLE_CONFIG': '/Users/bencreasy/.config/ansible', 'ATOM_HOME': '/Users/bencreasy/.config/atom/', ...}

tests/test_environ.py:228: AssertionError
````

I'm not sure if this was actually causing the test to fail, however - it seems that Python is loading some other `default_env()` function?

My original motivation is to fix the package for nixpkgs where I see this:
```
11 failed, 2985 passed, 23 skipped, 4 deselected, 1 warnings in 72.71 seconds =
builder for '/nix/store/1vbsjwvlmclqm1nvrr00nf7wfc3di5z1-xonsh-0.6.4.drv' failed with exit code 1
```

Is there an open issue tracking setting up darwin CI? I might be willing to help out with that. Willing to help a bit in fixing tests if I can figure out how to debug the code...