### PR TITLE
Pin `prompt_toolkit` in travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - if [[ $BUILD_DOCS = true ]]; then
       python setup.py install;
       pip install -r requirements-docs.txt;
-      pip install pygments prompt_toolkit ply psutil ipykernel matplotlib;
+      pip install pygments prompt_toolkit<2 ply psutil ipykernel matplotlib;
       pip install doctr;
     else
       pip install -r requirements-tests.txt;

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
 cloud_sptheme
 numpydoc==0.5
 Sphinx==1.5.6
-prompt_toolkit
+prompt_toolkit<2

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,7 +5,7 @@ pytest==2.9.2
 pytest-flake8==0.5
 pytest-cov==2.3.0
 pytest-timeout==1.0.0
-prompt-toolkit==1.0.3
+prompt-toolkit<2
 pygments==2.1.3
 codecov==2.0.5
 flake8==2.6.2


### PR DESCRIPTION
Temporary fix (that we implemented everywhere else) to prevent failures
due to the prompt_toolkit release

No news item required for this one