### PR TITLE
properly return terminal in interactive mode

### DIFF
--- a/news/raisesub.rst
+++ b/news/raisesub.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed issue where xonsh would fail to properly return the terminal prompt
+  (and eat up 100% CPU) after a failed subprocess command in interactive mode
+  if ``$RAISE_SUBPROC_ERROR = True``.
+
+**Security:** None

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -2149,8 +2149,12 @@ class CommandPipeline:
                 rtn is not None and
                 rtn > 0 and
                 builtins.__xonsh_env__.get('RAISE_SUBPROC_ERROR')):
-            raise subprocess.CalledProcessError(rtn, spec.cmd,
-                                                output=self.output)
+            try:
+                raise subprocess.CalledProcessError(rtn, spec.cmd,
+                                                    output=self.output)
+            finally:
+                # this is need to get a working terminal in interactive mode
+                self._return_terminal()
 
     #
     # Properties


### PR DESCRIPTION
even in the event of `$RAISE_SUBPROC_ERROR = True`. Should fix #2654