### PR TITLE
Fix `$CDPATH` completion misfire

### DIFF
--- a/news/cdpath_completion_fix.rst
+++ b/news/cdpath_completion_fix.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* completions relative to ``CDPATH`` only trigger when used with ``cd``
+
+**Security:** None

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -1,7 +1,15 @@
+import builtins
+
 import pytest
+from unittest.mock import patch
 
 from xonsh.environ import Env
 import xonsh.completers.path as xcp
+
+
+@pytest.fixture(autouse=True)
+def xonsh_execer_autouse(xonsh_builtins, xonsh_execer):
+    return xonsh_execer
 
 
 def test_pattern_need_quotes():
@@ -18,3 +26,16 @@ def test_complete_path(xonsh_builtins):
                                     'CDPATH': set(),
     }
     xcp.complete_path('[1-0.1]', '[1-0.1]', 0, 7, dict())
+
+
+@patch('xonsh.completers.path._add_cdpaths')
+def test_cd_path_no_cd(mock_add_cdpaths, xonsh_builtins):
+    xonsh_builtins.__xonsh_env__ = {'CASE_SENSITIVE_COMPLETIONS': False,
+                                    'GLOB_SORTED': True,
+                                    'SUBSEQUENCE_PATH_COMPLETION': False,
+                                    'FUZZY_PATH_COMPLETION': False,
+                                    'SUGGEST_THRESHOLD': 3,
+                                    'CDPATH': ['/'],
+    }
+    xcp.complete_path('a', 'cat a', 4, 5, dict())
+    mock_add_cdpaths.assert_not_called()

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -20,6 +20,18 @@ def PATTERN_NEED_QUOTES():
     return re.compile(pattern)
 
 
+def cd_in_command(line):
+    lexer = builtins.__xonsh_execer__.parser.lexer
+    lexer.reset()
+    lexer.input(line)
+    have_cd = False
+    for tok in lexer:
+        if tok.type == 'NAME' and tok.value == 'cd':
+            have_cd = True
+            break
+    return have_cd
+
+
 def _path_from_partial_string(inp, pos=None):
     if pos is None:
         pos = len(inp)
@@ -295,7 +307,7 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
     if tilde in prefix:
         home = os.path.expanduser(tilde)
         paths = {s.replace(home, tilde) for s in paths}
-    if cdpath:
+    if cdpath and cd_in_command(line):
         _add_cdpaths(paths, prefix)
     paths = set(filter(filtfunc, paths))
     paths, _ = _quote_paths({_normpath(s) for s in paths},


### PR DESCRIPTION
The `path` completer runs for many commands (which is the correct
behavior) but we are adding in possible `CDPATH` completions for commands
other than `cd` which doesn't make any sense since only `cd` supports
path resolution via `CDPATH`.

This adds a naive check to only add in the `CDPATH` completions if the
current command is `cd`.

This resolves #2677 

There's a trade-off here.  It will prevent invalid path completion for non `cd` commands but will also disable path competion relative to `CDPATH` if `cd` is part of a chained command with an `and` or `or`