### PR TITLE
Remove duplicate `pip` completer

### DIFF
--- a/news/remove_dup_completer.rst
+++ b/news/remove_dup_completer.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Removed duplicate ``pip`` completer
+
+**Security:** None

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -22,7 +22,6 @@ def default_completers():
         ('completer', complete_completer),
         ('skip', complete_skipper),
         ('pip', complete_pip),
-        ('xpip', complete_pip),
         ('cd', complete_cd),
         ('rmdir', complete_rmdir),
         ('xonfig', complete_xonfig),


### PR DESCRIPTION
`xpip` just uses the regular `pip` completer and it doesn't need its own entry
in the `__xonsh_completers__` dict.  That will just run the same checks twice
and slow down completions overall.