### PR TITLE
Update py-bash-completion with prefix length fix

### DIFF
--- a/news/update_bash_completion.rst
+++ b/news/update_bash_completion.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``bash_completion`` no longer returns invalid prefix lengths for directories
+  containing escape file names
+
+**Security:** None

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -14,7 +14,7 @@ import platform
 import functools
 import subprocess
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 @functools.lru_cache(1)
@@ -284,7 +284,8 @@ def bash_completions(prefix, line, begidx, endidx, env=None, paths=None,
     quote_paths : callable, optional
         A functions that quotes file system paths. You shouldn't normally need
         this as the default is acceptable 99+% of the time. This function should
-        a set of the new paths and a boolean for whether the paths were quoted.
+        return a set of the new paths and a boolean for whether the paths were
+        quoted.
 
     Returns
     -------
@@ -354,7 +355,7 @@ def bash_completions(prefix, line, begidx, endidx, env=None, paths=None,
     if '-o nospace' in complete_stmt:
         out = set([x.rstrip() for x in out])
 
-    return out, len(prefix) - strip_len
+    return out, max(len(prefix) - strip_len, 0)
 
 
 def bash_complete_line(line, return_line=True, **kwargs):


### PR DESCRIPTION
Porting over from `xonsh/py-bash-completion`

Should fix the assertion errors popping up in the prompt toolkit shell