### PR TITLE
Windows redirection bug fix

### DIFF
--- a/news/windows_redirection.rst
+++ b/news/windows_redirection.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+Fixed error when using redirection (e.g., >) on Windows. #2470
+
+**Security:** None

--- a/news/windows_redirection.rst
+++ b/news/windows_redirection.rst
@@ -8,6 +8,6 @@
 
 **Fixed:**
 
-Fixed error when using redirection (e.g., >) on Windows. #2470
+* Fixed error when using redirection (e.g., >) on Windows.
 
 **Security:** None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -233,6 +233,13 @@ aliases['ls'] = 'spam spam sausage spam'
 
 echo @$(which ls)
 """, 'spam spam sausage spam\n', 0),
+#
+# test redirection
+#
+("""
+echo Just the place for a snark. >tttt
+cat tttt
+""", 'Just the place for a snark.\n', 0),
 ]
 
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -549,7 +549,7 @@ class PopenThread(threading.Thread):
                                                        self._signal_winch)
         # start up process
         if ON_WINDOWS and stdout is not None:
-            os.set_handle_inheritable(stdout.fileno(), False)
+            os.set_inheritable(stdout.fileno(), False)
 
         try:
             self.proc = proc = subprocess.Popen(*args,


### PR DESCRIPTION
The call to os.set_handle_inheritable expects a Windows handle, but it is being passed a posix file descriptor.
fileno() returns a posix file descriptor which is a small integer. The method os.set_inheritable() does accept a posix file descriptor. The fix is to simply replace set_handle_inheritable to set_inheritable.

This PR includes an regression test that will fail without the fix described.