### PR TITLE
convert a next() statement in _which.py to python 3.x style.

### DIFF
--- a/news/2696-which-next-statement.rst
+++ b/news/2696-which-next-statement.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* update xoreutils._which.which() for python 3.x support.
+
+**Security:** None

--- a/xonsh/xoreutils/_which.py
+++ b/xonsh/xoreutils/_which.py
@@ -261,7 +261,7 @@ def which(command, path=None, verbose=0, exts=None):
     If no match is found for the command, a WhichError is raised.
     """
     try:
-        absName, fromWhere = whichgen(command, path, verbose, exts).next()
+        absName, fromWhere = next(whichgen(command, path, verbose, exts))
     except StopIteration:
         raise WhichError("Could not find '%s' on the path." % command)
     if verbose:


### PR DESCRIPTION
Fixes #2696 . The python 2.x style next statement in _which.py is replaced with a python 3.x style one.