### PR TITLE
Fallback to readline when launching with prompt toolkit 2.x installed

### DIFF
--- a/news/ptk2fallback.rst
+++ b/news/ptk2fallback.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Launching xonsh with prompt_toolkit version 2.x no longer fails, and instead fallsback to readline shell. This is a patch for until prompt_toolkit 2.x support is fully implemented. See PR #2570
+
+**Security:** None

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -141,10 +141,14 @@ def ptk_version_info():
 
 
 @functools.lru_cache(1)
-def ptk_version_is_supported():
+def ptk_above_min_supported():
     minimum_required_ptk_version = (1, 0)
     return ptk_version_info()[:2] >= minimum_required_ptk_version
 
+@functools.lru_cache(1)
+def ptk_below_max_supported():
+    ptk_max_version_cutoff = (2, 0)
+    return ptk_version_info()[:2] < ptk_max_version_cutoff
 
 @functools.lru_cache(1)
 def best_shell_type():

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -145,10 +145,12 @@ def ptk_above_min_supported():
     minimum_required_ptk_version = (1, 0)
     return ptk_version_info()[:2] >= minimum_required_ptk_version
 
+
 @functools.lru_cache(1)
 def ptk_below_max_supported():
     ptk_max_version_cutoff = (2, 0)
     return ptk_version_info()[:2] < ptk_max_version_cutoff
+
 
 @functools.lru_cache(1)
 def best_shell_type():

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -8,7 +8,7 @@ import builtins
 import warnings
 
 from xonsh.platform import (best_shell_type, has_prompt_toolkit,
-                            ptk_version_is_supported)
+                            ptk_above_min_supported, ptk_below_max_supported)
 from xonsh.tools import XonshError, print_exception
 from xonsh.events import events
 import xonsh.history.main as xhm
@@ -132,10 +132,18 @@ class Shell(object):
                 warnings.warn('prompt_toolkit is not available, using '
                               'readline instead.')
                 shell_type = 'readline'
-            elif not ptk_version_is_supported():
+            elif not ptk_above_min_supported():
                 warnings.warn('prompt-toolkit version < v1.0.0 is not '
                               'supported. Please update prompt-toolkit. Using '
                               'readline instead.')
+                shell_type = 'readline'
+            elif not ptk_below_max_supported():
+                warnings.warn('prompt-toolkit version 2.0 is not yet '
+                              'supported. Please see Github PR #2570 for '
+                              'latest status. To use prompt-toolkit now you '
+                              'can downgrade to version 1.x with\n'
+                              'pip install "prompt_toolkit<2"\n'
+                              'Starting xonsh with readline shell instead.')
                 shell_type = 'readline'
         self.shell_type = env['SHELL_TYPE'] = shell_type
         # actually make the shell

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -142,7 +142,7 @@ class Shell(object):
                               'supported. Please see Github PR #2570 for '
                               'latest status. To use prompt-toolkit now you '
                               'can downgrade to version 1.x with\n'
-                              'pip install "prompt_toolkit<2"\n'
+                              'xpip install "prompt_toolkit<2"\n'
                               'Starting xonsh with readline shell instead.')
                 shell_type = 'readline'
         self.shell_type = env['SHELL_TYPE'] = shell_type


### PR DESCRIPTION
Rather than throwing an error, added functionality for falling back to readline shell when version 2.x of prompt toolkit is installed. Please see see discussion on #2570 