### PR TITLE
Bash completion spacetime continuum

### DIFF
--- a/news/bash_completion_spacetime_continuum.rst
+++ b/news/bash_completion_spacetime_continuum.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed issue with incorrect strip lengths for prefixes with quotes in them
+* Fixed bash script to also consider leading double quotes and not just single
+  quotes
+
+**Security:** None

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -344,14 +344,14 @@ def bash_completions(prefix, line, begidx, endidx, env=None, paths=None,
     # Ensure input to `commonprefix` is a list (now required by Python 3.6)
     commprefix = os.path.commonprefix(list(out))
     strip_len = 0
+    strip_prefix = prefix.strip("\"'")
     while strip_len < len(prefix):
-        if commprefix.startswith(prefix[strip_len:]):
+        if commprefix.startswith(strip_prefix[strip_len:]):
             break
         strip_len += 1
 
     if '-o noquote' not in complete_stmt:
         out, need_quotes = quote_paths(out, '', '')
-        strip_len += int(need_quotes)
     if '-o nospace' in complete_stmt:
         out = set([x.rstrip() for x in out])
 

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -206,7 +206,7 @@ quote_readline()
 
 _quote_readline_by_ref()
 {{
-    if [[ $1 == \'* ]]; then
+    if [[ $1 == \'* || $1 == \"* ]]; then
         # Leave out first character
         printf -v $2 %s "${{1:1}}"
     else


### PR DESCRIPTION
*Note*: This PR is tracking xonsh/py-bash-completion#8 

The current behavior of this code in xonsh right now is as follows:
```
mkdir -p "this is a test"  # in otherwise empty dir to avoid multiple
matches
ls th[tab] -> ls t'this is a test/'
ls 'th[tab] -> ls 't'this is a test/'
ls "th[tab] -> no results
```

Initially the leading double-quote seemed to work in xonsh but that is
actually the bash completer failing completely and then xonsh falling
back on to the path completer which works correctly for this completion.
Wild.

If I directly import the `bash_completions` function in the same test
directory with that folder name and call it directly:

```
gil@bad_cat ~/tmp shell  bash_completions('"th', 'ls "th', 5, 6)
(set(), 0)
gil@bad_cat ~/tmp shell  bash_completions("'th", "ls 'th", 5, 6)
({"'this is a test/'"}, 1
```

Note that the double-quoted lead returns nothing.  Also, the
single-quoted lead says that the number of characters to strip off of
the prefix is 1, which will leave a leading `'t` as evidenced above.

So, two main fixes in here:

* Make the underlying bash completion script also look for leading
double-quotes
* Correctly count the strip-length depending on if there are or aren't
leading quotes (irrespective of quote type)