### PR TITLE
Change default for `AUTO_SUGGEST_IN_COMPLETIONS`

### DIFF
--- a/news/change_auto_suggest_default.rst
+++ b/news/change_auto_suggest_default.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* set default value of ``$AUTO_SUGGEST_IN_COMPLETIONS=False``
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -274,7 +274,7 @@ def DEFAULT_VALUES():
         'AUTO_CD': False,
         'AUTO_PUSHD': False,
         'AUTO_SUGGEST': True,
-        'AUTO_SUGGEST_IN_COMPLETIONS': True,
+        'AUTO_SUGGEST_IN_COMPLETIONS': False,
         'BASH_COMPLETIONS': BASH_COMPLETIONS_DEFAULT,
         'CASE_SENSITIVE_COMPLETIONS': ON_LINUX,
         'CDPATH': (),


### PR DESCRIPTION
Up for debate -- I think it causes more confusion since it provides
"wrong" completions.