### PR TITLE
Restore AUGASSIGN_OPS

### DIFF
--- a/news/pr-2706-restore-augassign_ops
+++ b/news/pr-2706-restore-augassign_ops
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+- Restored AUGASSIGN_OPS definition, inadvertently removed in #2639.
+
+**Security:** None

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -61,10 +61,9 @@ else:
     ADDSPACE_TOKS = (NAME, NUMBER)
 del token  # must clean up token
 PY35 = (3, 5, 0) <= PYTHON_VERSION_INFO
-if PY35:
-    AUGASSIGN_OPS = r"[+\-*/%&@|^=<>]=?"
-else:
-    AUGASSIGN_OPS = r"[+\-*/%&|^=<>]=?"
+AUGASSIGN_OPS = r"[+\-*/%&@|^=<>]=?"
+if not PY35:
+    AUGASSIGN_OPS = AUGASSIGN_OPS.replace('@', '')
 
 
 COMMENT = N_TOKENS

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -52,16 +52,20 @@ __all__ = token.__all__ + ["COMMENT", "tokenize", "detect_encoding",
                            "NL", "untokenize", "ENCODING", "TokenInfo",
                            "TokenError", 'SEARCHPATH', 'ATDOLLAR', 'ATEQUAL',
                            'DOLLARNAME', 'IOREDIRECT']
-PY35 = (3, 5, 0) <= PYTHON_VERSION_INFO < (3, 7, 0)
-if PY35:
+HAS_ASYNC = (3, 5, 0) <= PYTHON_VERSION_INFO < (3, 7, 0)
+if HAS_ASYNC:
     ASYNC = token.ASYNC
     AWAIT = token.AWAIT
-    AUGASSIGN_OPS = r"[+\-*/%&@|^=<>]=?"
     ADDSPACE_TOKS = (NAME, NUMBER, ASYNC, AWAIT)
 else:
-    AUGASSIGN_OPS = r"[+\-*/%&|^=<>]=?"
     ADDSPACE_TOKS = (NAME, NUMBER)
 del token  # must clean up token
+PY35 = (3, 5, 0) <= PYTHON_VERSION_INFO
+if PY35:
+    AUGASSIGN_OPS = r"[+\-*/%&@|^=<>]=?"
+else:
+    AUGASSIGN_OPS = r"[+\-*/%&|^=<>]=?"
+
 
 COMMENT = N_TOKENS
 tok_name[COMMENT] = 'COMMENT'


### PR DESCRIPTION
Following up on the comment in #2639, restore the prior expectation of AUGASSIGN_OPS on Python 3.7.

Also, I took the liberty in a separate commit to define the value once and tweak it for older Python versions. Feel free to omit that commit.