### PR TITLE
SciPy sprint new aliases.

### DIFF
--- a/news/aaron-sprint-2018.rst
+++ b/news/aaron-sprint-2018.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+- Added feature to aliases.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -152,6 +152,9 @@ def xonsh_exit(args, stdin=None):
     print()  # gimme a newline
     return None, None
 
+def xonsh_reset(args, stdin=None):
+    """ Clears __xonsh_ctx__"""
+    builtins.__xonsh_ctx__.clear()
 
 @lazyobject
 def _SOURCE_FOREIGN_PARSER():
@@ -470,6 +473,7 @@ def make_default_aliases():
         'xontrib': xontribs_main,
         'completer': xca.completer_alias,
         'xpip': detect_xpip_alias(),
+        'xonsh-reset': xonsh_reset,
     }
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.


### PR DESCRIPTION
Added an aliases to clear the pythonic variables within the xonsh shell.