### PR TITLE
entering quotation

### DIFF
--- a/news/dev_quote.rst
+++ b/news/dev_quote.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* Fixed issue that can't insert quotation marks and double quotes 
+  for completion.
+
+**Security:** None

--- a/xonsh/ptk2/key_bindings.py
+++ b/xonsh/ptk2/key_bindings.py
@@ -251,8 +251,8 @@ def load_xonsh_bindings(key_bindings):
 
         if buffer.document.current_char == '\'':
             buffer.cursor_position += 1
-        elif whitespace_or_bracket_before(event.cli)\
-                and whitespace_or_bracket_after(event.cli):
+        elif whitespace_or_bracket_before()\
+                and whitespace_or_bracket_after():
             buffer.insert_text('\'')
             buffer.insert_text('\'', move_cursor=False)
         else:
@@ -264,8 +264,8 @@ def load_xonsh_bindings(key_bindings):
 
         if buffer.document.current_char == '"':
             buffer.cursor_position += 1
-        elif whitespace_or_bracket_before(event.cli)\
-                and whitespace_or_bracket_after(event.cli):
+        elif whitespace_or_bracket_before()\
+                and whitespace_or_bracket_after():
             buffer.insert_text('"')
             buffer.insert_text('"', move_cursor=False)
         else:


### PR DESCRIPTION
`whitespace_or_bracket_before` and `whitespace_or_bracket_after` is no argument required.
https://github.com/xonsh/xonsh/issues/2719