### PR TITLE
CommandPipeline.output is now fully non-blocking

### DIFF
--- a/news/blockout.rst
+++ b/news/blockout.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* ``CommandPipeline.output`` now does properly lazy, non-blocking creation of
+  output string. ``CommandPipeline.out`` remains blocking.
+
+**Security:** None

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -2181,9 +2181,13 @@ class CommandPipeline:
 
     @property
     def output(self):
-        if self._output is None:
-            self._output = ''.join(self.lines)
-        return self._output
+        """Non-blocking, lazy access to output"""
+        if self.ended:
+            if self._output is None:
+                self._output = ''.join(self.lines)
+            return self._output
+        else:
+            return ''.join(self.lines)
 
     @property
     def out(self):


### PR DESCRIPTION
Should close #2723