### PR TITLE
First crack at issue and pr template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,19 @@
+<!--- Provide a general summary of the issue in the Title above -->
+<!--- If you have a question along the lines of "How do I do this Bash command in xonsh"
+please first look over the Bash to Xonsh translation guide: http://xon.sh/bash_to_xsh.html
+If you don't find an answer there, please do open an issue! -->
+
+## xonfig
+<!--- Please post the output of the `xonfig` command (run from inside xonsh) so we know more about your current setup -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+<!--- If part of your bug report is a traceback, please first enter debug mode before triggering the error
+To enter debug mode, set the environment variable `XONSH_DEBUG=1` _before_ starting `xonsh`.  
+On Linux and OSX, an easy way to to do this is to run `env XONSH_DEBUG=1 xonsh` -->
+
+## Steps to Reproduce
+<!--- Please try to write out a minimal reproducible snippet to trigger the bug, it will help us fix it! -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
+to help keep our changelog up to date! There are instructions available here:
+http://xon.sh/devguide.html#changelog -->
+
+<!--- If there is specific issue / feature request that this PR is addressing,
+please link to the corresponding issue by using the `#issuenumber` syntax.
+Thanks again! -->


### PR DESCRIPTION
Github apparently now supports multiple issue templates, which may be something we want to look at to distinguish between bug reports, feature requests and general questions.  That said, this should get us underway.

Also added a PR template requesting that contributors add a news entry.

Having said that, I don't think this particular PR requires a news entry.  

Resolves #2727 