### PR TITLE
Fixed a regression with xonfig styles

### DIFF
--- a/news/fix-xonfig-styles.rst
+++ b/news/fix-xonfig-styles.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a regression with ``xonfig styles`` reporting ``AttributeError: module 'pygments' has no attribute 'styles'``
+
+**Security:** None

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -279,7 +279,7 @@ class PromptToolkitShell(BaseShell):
         """Returns an iterable of all available style names."""
         if not HAS_PYGMENTS:
             return ['For other xonsh styles, please install pygments']
-        from pygments.styles import get_all_styles 
+        from pygments.styles import get_all_styles
         return get_all_styles()
 
     def color_style(self):

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -279,7 +279,8 @@ class PromptToolkitShell(BaseShell):
         """Returns an iterable of all available style names."""
         if not HAS_PYGMENTS:
             return ['For other xonsh styles, please install pygments']
-        return pygments.styles.get_all_styles()
+        from pygments.styles import get_all_styles 
+        return get_all_styles()
 
     def color_style(self):
         """Returns the current color map."""

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -286,7 +286,7 @@ class PromptToolkit2Shell(BaseShell):
         """Returns an iterable of all available style names."""
         if not HAS_PYGMENTS:
             return ['For other xonsh styles, please install pygments']
-        from pygments.styles import get_all_styles 
+        from pygments.styles import get_all_styles
         return get_all_styles()
 
     def color_style(self):

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -286,7 +286,8 @@ class PromptToolkit2Shell(BaseShell):
         """Returns an iterable of all available style names."""
         if not HAS_PYGMENTS:
             return ['For other xonsh styles, please install pygments']
-        return pygments.styles.get_all_styles()
+        from pygments.styles import get_all_styles 
+        return get_all_styles()
 
     def color_style(self):
         """Returns the current color map."""


### PR DESCRIPTION
The "xonfig styles" command was reporting
AttributeError: module 'pygments' has no attribute 'styles'

Now we import the styles package from pygments explicitly