### PR TITLE
Fix regression for INTENSIFY_COLORS_ON_WIN due to PTK2

### DIFF
--- a/news/color_win.rst
+++ b/news/color_win.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix regression in ``INTENSIFY_COLORS_ON_WIN`` functionality due to prompt_toolkit 2 update.
+
+**Security:** None

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -298,7 +298,7 @@ def clean_jobs():
                 else:
                     msg = 'there is an unfinished job'
 
-                if builtins.__xonsh_env__['SHELL_TYPE'] != 'prompt_toolkit':
+                if 'prompt_toolkit' not in builtins.__xonsh_env__['SHELL_TYPE']:
                     # The Ctrl+D binding for prompt_toolkit already inserts a
                     # newline
                     print()

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -41,7 +41,7 @@ import operator
 # dependencies
 from xonsh import __version__
 from xonsh.lazyasd import LazyObject, LazyDict, lazyobject
-from xonsh.platform import (has_prompt_toolkit, scandir, DEFAULT_ENCODING,
+from xonsh.platform import (scandir, DEFAULT_ENCODING,
                             ON_LINUX, ON_WINDOWS, PYTHON_VERSION_INFO,
                             expanduser, os_environ)
 
@@ -1572,12 +1572,10 @@ def _token_attr_from_stylemap(stylemap):
     """yields tokens attr, and index from a stylemap """
     import prompt_toolkit as ptk
     if builtins.__xonsh_shell__.shell_type == 'prompt_toolkit1':
-        colorlookup = ptk.terminal.win32_output.ColorLookupTable
         style = ptk.styles.style_from_dict(stylemap)
         for token in stylemap:
             yield token, style.token_to_attrs[token]
     else:
-        from prompt_toolkit.styles.pygments import pygments_token_to_classname
         style = ptk.styles.style_from_pygments_dict(stylemap)
         for token in stylemap:
             style_str = 'class:{}'.format(


### PR DESCRIPTION
This fixes a problem with the [`INTENSIFY_COLORS_ON_WIN` hack](http://xon.sh/envvars.html#intensify-colors-on-win), which stopped working when we add PTK2 support. 

The hack is still useful for older versions of Windows. 
But there is a nicer workaround on Win10 where PTK2 now uses ANSI escapes to give full color support. The default colour scheme in the terminal still have unreadable blue and red colors. Instead, we could create a win10 style with hard-coded colour values, and use that as the default style on Win10. I will try to look into that.

 


