### PR TITLE
Python 37

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,10 +7,12 @@ environment:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
     - XONSH_TEST_ENV: "MSYS2"
       MSYS2_PATH: "C:\\msys64"
     # TODO: Miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,50 @@ jobs:
       - run:
           command: |
             /home/circleci/miniconda/envs/py36-xonsh-test/bin/pytest --timeout=10 --flake8 --cov=./xonsh
+  build_37:
+    machine: true
+    environment:
+      PYTHON: "3.7"
+      ENV_NAME: "py37-xonsh-test"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - miniconda-v1-{{ checksum "ci/environment-3.7.yml" }}
+      - run:
+          name: install miniconda
+          command: |
+              if [ ! -d "/home/circleci/miniconda" ]; then
+                wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+                bash miniconda.sh -b -p $HOME/miniconda
+                export PATH="$HOME/miniconda/bin:$PATH"
+                conda config --set always_yes yes --set changeps1 no
+              fi
+              sudo chown -R $USER.$USER $HOME
+      - run:
+          name: configure conda
+          command: |
+              export PATH="$HOME/miniconda/bin:$PATH"
+              export ENV_NAME="py37-xonsh-test"
+              if [ ! -d "/home/circleci/miniconda/envs/py37-xonsh-test" ]; then
+                conda update -q conda
+                conda env create -f ci/environment-${PYTHON}.yml --name=${ENV_NAME}
+                source activate ${ENV_NAME}
+              fi
+              conda env list
+              conda list ${ENV_NAME}
+      - save_cache:
+          key: miniconda-v1-{{ checksum "ci/environment-3.7.yml" }}
+          paths:
+            - "/home/circleci/miniconda"
+      - run:
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate ${ENV_NAME}
+            python setup.py install
+      - run:
+          command: |
+            /home/circleci/miniconda/envs/py37-xonsh-test/bin/pytest --timeout=10 --flake8 --cov=./xonsh
 
 workflows:
   version: 2
@@ -140,3 +184,4 @@ workflows:
       - build_34
       - build_35
       - build_36
+      - build_37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,4 +184,6 @@ workflows:
       - build_34
       - build_35
       - build_36
-      - build_37
+      # conda-foge does not yet have all Python 3.7 packages available
+      # uncomment when it does
+      #- build_37

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 matrix:
     include:
         - os: linux
-          python: 3.5
+          python: 3.7
           env:
             - MINICONDA_OS="Linux"
             - CI=true
@@ -19,10 +19,10 @@ matrix:
           python: "nightly"
         - os: osx
           language: generic
-          env: PYTHON="3.4" MINICONDA_OS="MacOSX"
+          env: PYTHON="3.6" MINICONDA_OS="MacOSX"
         - os: osx
           language: generic
-          env: PYTHON="3.5" MINICONDA_OS="MacOSX"
+          env: PYTHON="3.7" MINICONDA_OS="MacOSX"
     allow_failures:
         - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ env:
        - secure: "pvQHCsdcIRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
 matrix:
     include:
-        - os: linux
-          python: 3.7
-          env:
-            - MINICONDA_OS="Linux"
-            - CI=true
-            - TRAVIS=true
+        # Travis does not yet support Python 3.7 on Linux
+        # uncomment the following when it does
+        #- os: linux
+        #  python: 3.7
+        #  env:
+        #    - MINICONDA_OS="Linux"
+        #    - CI=true
+        #    - TRAVIS=true
         - os: linux
           python: 3.6
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ before_install:
 
 install:
   - if [[ $BUILD_DOCS = true ]]; then
-      pip install -r requirements-docs.txt;
+      pip install --upgrade -r requirements-docs.txt;
       python setup.py install;
     else
-      pip install -r requirements-tests.txt;
+      pip install --upgrade -r requirements-tests.txt;
     fi
 
 before_script:

--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -1,0 +1,20 @@
+name: py37-xonsh-test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - pygments
+  - prompt_toolkit
+  - ply
+  - pytest
+  - pytest-timeout
+  - numpy
+  - psutil
+  - matplotlib
+  - flake8
+  - coverage
+  - pyflakes
+  - pytest-cov
+  - pytest-flake8
+  - codecov

--- a/news/py37.rst
+++ b/news/py37.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed async tokenizing issue on Python v3.7.
+
+**Security:** None

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -774,9 +774,9 @@ def _tokenize(readline, encoding):
                         stashed = tok
                         continue
 
-                    if token == 'def' and (stashed and
-                                           stashed.type == NAME and
-                                           stashed.string == 'async'):
+                    if HAS_ASYNC and token == 'def' and \
+                            (stashed and stashed.type == NAME and
+                             stashed.string == 'async'):
                         async_def = True
                         async_def_indent = indents[-1]
 


### PR DESCRIPTION
This fixes some Python v3.7 bugs and also enables CI for Python 3.7.  

I guess this is as good of a time to ask as any if we should drop CI for Python 3.4 and/or Python 3.5. 