### PR TITLE
Fix for `DEFAULT_STYLE_DICT` error on ptk2

### DIFF
--- a/news/fix-default-style-dict.rst
+++ b/news/fix-default-style-dict.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+- ``prompt_toolkit >= 2`` will start up even if Pygments isn't present
+
+**Security:** None

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -24,7 +24,7 @@ from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.formatted_text import PygmentsTokens
 from prompt_toolkit.styles.pygments import (style_from_pygments_cls,
-                                            style_from_pygments_dict, pygments_token_to_classname)
+                                            style_from_pygments_dict)
 
 
 Token = _TokenType()
@@ -115,11 +115,7 @@ class PromptToolkit2Shell(BaseShell):
                 style = style_from_pygments_cls(
                     pyghooks.xonsh_style_proxy(self.styler))
             else:
-                style_dict = {
-                    pygments_token_to_classname(key.__name__): value
-                    for key, value in DEFAULT_STYLE_DICT
-                }
-                style = style_from_pygments_dict(style_dict)
+                style = style_from_pygments_dict(DEFAULT_STYLE_DICT)
 
             prompt_args['style'] = style
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

This fixes one of the failure modes raised in #2734 (starting up without Pygments present on ptk2)

The other issue is due to backwards incompatibilities in the xontribs due to the ptk shift.