### PR TITLE
Make ptk xontribs compatible with ptk1 and ptk2

### DIFF
--- a/news/fix_xontrib_ptk_ptk2.rst
+++ b/news/fix_xontrib_ptk_ptk2.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+- ptk dependent xontribs (that use custom keybindings) now work with both ptk1
+  and ptk2
+
+**Security:** None

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -5,6 +5,8 @@ import sys
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.filters import Condition, EmacsInsertMode, ViInsertMode
 
+from xonsh.platform import ptk_shell_type
+
 __all__ = ()
 
 
@@ -19,7 +21,11 @@ def bash_preproc(cmd, **kw):
 
 @events.on_ptk_create
 def custom_keybindings(bindings, **kw):
-    handler = bindings.add
+    if ptk_shell_type() == 'prompt_toolkit2':
+        handler = bindings.add
+    else:
+        handler = bindings.registry.add_binding
+
     insert_mode = ViInsertMode() | EmacsInsertMode()
 
     @Condition

--- a/xontrib/whole_word_jumping.py
+++ b/xontrib/whole_word_jumping.py
@@ -4,6 +4,8 @@ Alt+Left/Right remains unmodified to jump over smaller word segments.
 """
 from prompt_toolkit.keys import Keys
 
+from xonsh.platform import ptk_shell_type
+
 __all__ = ()
 
 
@@ -15,7 +17,10 @@ def custom_keybindings(bindings, **kw):
     # Alt+Left and Alt+Right still jump over smaller word segments.
     # See https://github.com/xonsh/xonsh/issues/2403
 
-    handler = bindings.add
+    if ptk_shell_type() == 'prompt_toolkit2':
+        handler = bindings.add
+    else:
+        handler = bindings.registry.add_binding
 
     @handler(Keys.ControlLeft)
     def ctrl_left(event):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
This should take care of the remaining issues raised in #2734 -- all of the xontribs (that we bundle) that make use of custom keybindings should now work in both ptk1 and ptk2