### PR TITLE
history show - add optional null-delimited output

### DIFF
--- a/news/null-delim-history.rst
+++ b/news/null-delim-history.rst
@@ -1,7 +1,7 @@
 **Added:** None
 
 * ``history show`` builtin now supports optional ``-0`` parameter that switches
-  the output to null-delimited. Useful for pipng history to external filters.
+  the output to null-delimited. Useful for piping history to external filters.
 
 **Changed:** None
 

--- a/news/null-delim-history.rst
+++ b/news/null-delim-history.rst
@@ -1,4 +1,4 @@
-**Added:** None
+**Added:**
 
 * ``history show`` builtin now supports optional ``-0`` parameter that switches
   the output to null-delimited. Useful for piping history to external filters.

--- a/news/null-delim-history.rst
+++ b/news/null-delim-history.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+* ``history show`` builtin now supports optional ``-0`` parameter that switches
+  the output to null-delimited. Useful for pipng history to external filters.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -251,7 +251,8 @@ def test_parser_show(args, exp):
               'start_time': None,
               'end_time': None,
               'datetime_format': None,
-              'timestamp': False}
+              'timestamp': False,
+              'null_byte': False}
     ns = _xh_parse_args(shlex.split(args))
     assert ns.__dict__ == exp_ns
 

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -184,18 +184,19 @@ def _xh_show_history(hist, ns, stdout=None, stderr=None):
         for c in commands:
             dt = datetime.datetime.fromtimestamp(c['ts'])
             print('{}:({}) {}'.format(c['ind'], xt.format_datetime(dt), c['inp']),
-                  file=stdout)
+                  file=stdout, end='\n' if not ns.null_byte else '\0')
     elif ns.numerate:
         for c in commands:
-            print('{}: {}'.format(c['ind'], c['inp']), file=stdout)
+            print('{}: {}'.format(c['ind'], c['inp']), file=stdout,
+                  end='\n' if not ns.null_byte else '\0')
     elif ns.timestamp:
         for c in commands:
             dt = datetime.datetime.fromtimestamp(c['ts'])
             print('({}) {}'.format(xt.format_datetime(dt), c['inp']),
-                  file=stdout)
+                  file=stdout, end='\n' if not ns.null_byte else '\0')
     else:
         for c in commands:
-            print(c['inp'], file=stdout)
+            print(c['inp'], file=stdout, end='\n' if not ns.null_byte else '\0')
 
 
 @xla.lazyobject
@@ -233,6 +234,10 @@ def _xh_create_parser():
     show.add_argument('-f', dest='datetime_format', default=None,
                       help='the datetime format to be used for'
                            'filtering and printing')
+    show.add_argument('-0', dest='null_byte', default=False,
+                      action='store_true',
+                      help='separate commands by the null character for piping '
+                           'history to external filters')
     show.add_argument('session', nargs='?', choices=_XH_HISTORY_SESSIONS.keys(),
                       default='session',
                       metavar='session',


### PR DESCRIPTION
Resolves feature request #2746 - "Add option for history builtin to output null-delimited results"
For example usage see [this commit](https://github.com/laloch/xontrib-fzf-widgets/commit/313e163767dbe80d3ecc5b36fde980113d2032e5) in my fork of xontrib-fzf-widgets.