### PR TITLE
Fixed a bug when converting new ptk2 ansi-color names to old names

### DIFF
--- a/news/convert_color_names.rst
+++ b/news/convert_color_names.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+  - Fixed a bug with converting new PTK2 colors names to old names when using PTK1 or Jupyter 
+    as the shell type.
+
+**Security:** None

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -445,7 +445,7 @@ class XonshStyle(Style):
         self._style_name = value
         # Convert new ansicolor names to old PTK1 names
         # Can be remvoed when PTK1 support is dropped.
-        if builtins.__xonsh_shell__.shell_type == 'prompt_toolkit1':
+        if builtins.__xonsh_shell__.shell_type in ('prompt_toolkit1', 'jupyter'):
             for smap in [self.trap, cmap, PTK_STYLE, self._smap]:
                 smap.update(ansicolors_to_ptk1_names(smap))
         if ON_WINDOWS and 'prompt_toolkit' in builtins.__xonsh_shell__.shell_type:
@@ -462,13 +462,13 @@ class XonshStyle(Style):
         """
         env = builtins.__xonsh_env__
         # Ensure we are not using ConEmu or Visual Stuio Code
-        if 'CONEMUANSI' in env or 'VSCODE' in env:
+        if 'CONEMUANSI' in env or 'VSCODE_PID' in env:
             return
         if env.get('INTENSIFY_COLORS_ON_WIN', False):
             if win_ansi_support():
-                newcolors = hardcode_colors_for_win10(self.styles.parents)
+                newcolors = hardcode_colors_for_win10(self.styles)
             else:
-                newcolors = intensify_colors_for_cmd_exe(self.styles.parents)
+                newcolors = intensify_colors_for_cmd_exe(self.styles)
             self.trap.update(newcolors)
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1734,7 +1734,8 @@ def ansicolors_to_ptk1_names(stylemap):
     modified_stylemap = {}
     for token, style_str in stylemap.items():
         for color, ptk1_color in ANSICOLOR_NAMES_MAP.items():
-            style_str = style_str.replace(color, ptk1_color)
+            if ptk1_color not in style_str:
+                style_str = style_str.replace(color, ptk1_color)
         modified_stylemap[token] = style_str
     return modified_stylemap
 


### PR DESCRIPTION
While reviewing @scopatz's #2761 I stumble on a bug I think I caused. 

First, the new PTK ansi-color names should also be converted back when the shell-type is 'jupyter'. This fixes a bug with the pygments and the `XonshTerminal256FormatterProxy` in the notebook.

Fixing this, it turned out there was another bug in the code causing ansi-color names to be converted multiple times. Resulting in bugs like: `wrong color format '##ansidarkblue'` 

This PR fixes both. @scopatz you should probably merge it into #2761 