### PR TITLE
Fix recent history item ordering in ptk2 shell

### DIFF
--- a/news/fix_ptk2_reverse_history.rst
+++ b/news/fix_ptk2_reverse_history.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Recent command history in ptk2 prompt now returns most recently executed
+  commands first (as expected)
+
+**Security:** None

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -384,7 +384,7 @@ class JsonHistory(History):
         for item, tss in zip(self.inps, self.tss):
             yield {'inp': item.rstrip(), 'ts': tss[0]}
 
-    def all_items(self, **kwargs):
+    def all_items(self, reverse=False, **kwargs):
         """
         Returns all history as found in XONSH_DATA_DIR.
 
@@ -392,7 +392,7 @@ class JsonHistory(History):
         """
         while self.gc and self.gc.is_alive():
             time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer
-        for f in _xhj_get_history_files():
+        for f in _xhj_get_history_files(reverse=reverse):
             try:
                 json_file = xlj.LazyJSON(f, reopen=False)
             except ValueError:

--- a/xonsh/ptk2/history.py
+++ b/xonsh/ptk2/history.py
@@ -25,7 +25,7 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
         hist = builtins.__xonsh_history__
         if hist is None:
             return
-        for cmd in hist.all_items():
+        for cmd in hist.all_items(reverse=True):
             line = cmd['inp'].rstrip()
             strs = self.get_strings()
             if len(strs) == 0 or line != strs[-1]:


### PR DESCRIPTION
Looking at the existing code, it seems like history entries should always be
loaded oldest first (which hasn't been happening, so whaaa?). This is a fix to
reverse the sort order so that we get the newest entries first when browsing
through command history.

Should fix #2766

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
