### PR TITLE
Hotfix for colors in readline shell

### DIFF
--- a/news/fix_readline_colors.rst
+++ b/news/fix_readline_colors.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a regression taat prevented the readline backend from beeing used. This
+  regression was caused by the new ansi-color names, which are incompatible with
+  pygments 2.2. 
+
+**Security:** None

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -445,7 +445,7 @@ class XonshStyle(Style):
         self._style_name = value
         # Convert new ansicolor names to old PTK1 names
         # Can be remvoed when PTK1 support is dropped.
-        if builtins.__xonsh_shell__.shell_type in ('prompt_toolkit1', 'jupyter'):
+        if builtins.__xonsh_shell__.shell_type != 'prompt_toolkit2':
             for smap in [self.trap, cmap, PTK_STYLE, self._smap]:
                 smap.update(ansicolors_to_ptk1_names(smap))
         if ON_WINDOWS and 'prompt_toolkit' in builtins.__xonsh_shell__.shell_type:


### PR DESCRIPTION
Fixes #2773. This solves the problem with colors in the readline shell. 

Sorry, about this @scopatz, I completely missed that the readline backend also uses the ansi-colors. We better get a hotfix released soon. 

Is there any chance that our integration test could catch errors like this in the future?