### PR TITLE
Fix env swap

### DIFF
--- a/news/fix_Env_swap.rst
+++ b/news/fix_Env_swap.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:**
+
+* xonsh/environ.py
+  Exceptions are caught in the code executed under Env.swap()
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -109,6 +109,17 @@ def test_swap():
     assert 'VAR3' not in env
 
 
+def test_swap_exception_replacement():
+    env = Env(VAR='original value')
+    try:
+        with env.swap(VAR='inner value'):
+            assert env['VAR'] == 'inner value'
+            raise Exception()
+    except Exception:
+        assert env['VAR'] == 'original value'
+    assert env['VAR'] == 'original value'
+
+
 @skip_if_on_unix
 def test_locate_binary_on_windows(xonsh_builtins):
     files = ('file1.exe', 'FILE2.BAT', 'file3.txt')

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -921,8 +921,8 @@ class Env(cabc.MutableMapping):
         exception = None
         try:
             yield self
-        except Exception as e:
-            exception = e
+        except Exception as exception:
+            pass
         finally:
             # restore the values
             for k, v in old.items():
@@ -931,7 +931,7 @@ class Env(cabc.MutableMapping):
                 else:
                     self[k] = v
             if exception is not None:
-                raise exception
+                raise exception from None
 
     #
     # Mutable mapping interface

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -918,13 +918,20 @@ class Env(cabc.MutableMapping):
             old[k] = self.get(k, NotImplemented)
             self[k] = v
 
-        yield self
-        # restore the values
-        for k, v in old.items():
-            if v is NotImplemented:
-                del self[k]
-            else:
-                self[k] = v
+        exception = None
+        try:
+            yield self
+        except Exception as e:
+            exception = e
+        finally:
+            # restore the values
+            for k, v in old.items():
+                if v is NotImplemented:
+                    del self[k]
+                else:
+                    self[k] = v
+            if exception != None:
+                raise exception
 
     #
     # Mutable mapping interface

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -930,7 +930,7 @@ class Env(cabc.MutableMapping):
                     del self[k]
                 else:
                     self[k] = v
-            if exception != None:
+            if exception is not None:
                 raise exception
 
     #


### PR DESCRIPTION
Code executed under `with ${...}.swap()` might throw an exception in which case the swapped values will not be restored. This pull request fixes this bug. Here is a minimal test case which demonstrates the bug:

    $VAR='original value'
    try:
    	with ${...}.swap(VAR='inner value'):
    		echo $VAR
    		raise Exception() 
    except:
    	print('hi')
    	echo $VAR
    
    echo $VAR
    

This produces the following output:

    inner value
    hi
    inner value
    inner value
    

Note: test_integration.py fails on both this branch and master with the exact same error message.