### PR TITLE
Callable alias stack - with completer fix

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1202,7 +1202,7 @@ may have one of the following signatures:
         return 0
 
     def mycmd5(args, stdin=None, stdout=None, stderr=None, spec=None):
-        """Lastly, the final form of subprocess callables takes all of the
+        """This form of subprocess callables takes all of the
         arguments shown above as well as a subprocess specification
         SubprocSpec object. This holds many attributes that dictate how
         the command is being run.  For instance this can be useful for
@@ -1216,6 +1216,24 @@ may have one of the following signatures:
         # Now we'll get a newline if the user is at the terminal, and no
         # newline if we are captured
         print('Hi Mom!', end=end)
+        return 0
+
+    def mycmd6(args, stdin=None, stdout=None, stderr=None, spec=None, stack=None):
+        """Lastly, the final form of subprocess callables takes a stack argument
+        in addition to the arguments shown above. The stack is a list of
+        FrameInfo namedtuple objects, as described in the standard library
+        inspect module. The stack is computed such the the call site is the
+        first and innermost entry, while the outer frame is the last entry.
+
+        The stack is only computed if the alias has a "stack" argument.
+        However, the stack is also accessible as "spec.stack".
+        """
+        for frame_info in stack:
+            frame = frame_info[0]
+            print('In function ' + frame_info[3])
+            print('  locals', frame.f_locals)
+            print('  globals', frame.f_globals)
+            print('\n')
         return 0
 
 

--- a/news/compstack.rst
+++ b/news/compstack.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Callable aliases may now accept a ``stack`` argument. If they do, then the
+  stack, as computed from the aliases call site, is provided as a list of
+  ``FrameInfo`` objects (as detailed in the standard library ``inspect``
+  module). Otherwise, the ``stack`` parameter is ``None``.
+* ``SubprocSpec`` now has a ``stack`` attribute, for passing the call stack
+  to callable aliases. This defaults to ``None`` if the spec does not
+  need the stack. The ``resolve_stack()`` method computes the ``stack``
+  attribute.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* The ``completer`` command now correctly finds completion functions
+  when nested inside of other functions.
+
+**Security:** None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -240,6 +240,28 @@ echo @$(which ls)
 echo Just the place for a snark. >tttt
 cat tttt
 """, 'Just the place for a snark.\n', 0),
+#
+# Test completion registration and subproc stack
+#
+("""
+def _f():
+    def j():
+        pass
+
+    global aliases
+    aliases['j'] = j
+
+    def completions(pref, *args):
+        return set(['hello', 'world'])
+
+    completer add j completions "start"
+
+
+_f()
+del _f
+
+"""
+, '', 0),
 ]
 
 

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -1,4 +1,3 @@
-import inspect
 import builtins
 import collections
 

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -38,7 +38,7 @@ def _add_one_completer(name, func, loc='end'):
     builtins.__xonsh_completers__.update(new)
 
 
-def _list_completers(args, stdin=None):
+def _list_completers(args, stdin=None, stack=None):
     o = "Registered Completer Functions: \n"
     _comp = builtins.__xonsh_completers__
     ml = max((len(i) for i in _comp), default=0)
@@ -53,7 +53,7 @@ def _list_completers(args, stdin=None):
     return o + '\n'.join(_strs) + '\n'
 
 
-def _remove_completer(args, stdin=None):
+def _remove_completer(args, stdin=None, stack=None):
     err = None
     if len(args) != 1:
         err = "completer remove takes exactly 1 argument."
@@ -69,7 +69,7 @@ def _remove_completer(args, stdin=None):
         return None, err + '\n', 1
 
 
-def _register_completer(args, stdin=None):
+def _register_completer(args, stdin=None, stack=None):
     err = None
     if len(args) not in {2, 3}:
         err = ("completer add takes either 2 or 3 arguments.\n"
@@ -86,8 +86,7 @@ def _register_completer(args, stdin=None):
                 if not callable(func):
                     err = "%s is not callable" % func_name
             else:
-                print(inspect.stack(context=0))
-                for frame_info in inspect.stack(context=0):
+                for frame_info in stack:
                     frame = frame_info[0]
                     if func_name in frame.f_locals:
                         func = frame.f_locals[func_name]
@@ -104,7 +103,8 @@ def _register_completer(args, stdin=None):
         return None, err + '\n', 1
 
 
-def completer_alias(args, stdin=None):
+def completer_alias(args, stdin=None, stdout=None, stderr=None, spec=None,
+                    stack=None):
     err = None
     if len(args) == 0 or args[0] not in (VALID_ACTIONS | {'help'}):
         err = ('Please specify an action.  Valid actions are: '
@@ -129,7 +129,7 @@ def completer_alias(args, stdin=None):
         func = _remove_completer
     elif args[0] == 'list':
         func = _list_completers
-    return func(args[1:], stdin=stdin)
+    return func(args[1:], stdin=stdin, stack=stack)
 
 COMPLETER_LIST_HELP_STR = """completer list: ordered list the active completers
 


### PR DESCRIPTION
This is probably one of the more nefarious hacks I have implemented in a while. Basically, it gives callable aliases a way to access the call stack of their call site. I have tried to make it so that the alias has to ask for the stack, so we aren't computing these stacks all over the place. 

Folks can probably do some fun things with this :smiling_imp: 

This fixes #2779 
