### PR TITLE
Fix a bug with colors beeing converted to old format multiple times

### DIFF
--- a/news/color_py35.rst
+++ b/news/color_py35.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a potential crash (``AssertionError: wrong color format``) on Python 3.5 and prompt_toolkit 1.
+
+**Security:** None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1734,7 +1734,7 @@ def ansicolors_to_ptk1_names(stylemap):
     modified_stylemap = {}
     for token, style_str in stylemap.items():
         for color, ptk1_color in ANSICOLOR_NAMES_MAP.items():
-            if ptk1_color not in style_str:
+            if '#' + color not in style_str:
                 style_str = style_str.replace(color, ptk1_color)
         modified_stylemap[token] = style_str
     return modified_stylemap


### PR DESCRIPTION
Fixes #2780  The logic was clearly wrong here, and I think the reason it worked on py36 was the guaranteed ordering of dicts in Python 3.6. 


