### PR TITLE
Pygments codes

### DIFF
--- a/news/ptk2_pygments_formatter.rst
+++ b/news/ptk2_pygments_formatter.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed a crash when using the ``$XONSH_STDERR_PREFIX/POSTFIX`` with
+  prompt_toolkit and Pygments 2.2.
+
+**Security:** None

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ flake8-max-line-length = 180
 flake8-ignore =
     *.py E122
     *.py E402
+    *.py W503  # line break before binary operators is a good thing
     tests/tools.py E128
     xonsh/pygments_cache.py ALL
     # flake8 gives incorrect unused import errors, F401

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -115,6 +115,15 @@ def pygments_version():
 
 
 @functools.lru_cache(1)
+def pygments_version_info():
+    """ Returns `pygments`'s version as tuple of integers. """
+    if HAS_PYGMENTS:
+        return tuple(int(x) for x in pygments_version().strip('<>+-=.').split('.'))
+    else:
+        return None
+
+
+@functools.lru_cache(1)
 def has_prompt_toolkit():
     """Tests if the `prompt_toolkit` is available."""
     spec = importlib.util.find_spec('prompt_toolkit')

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -23,14 +23,21 @@ from xonsh.tools import (
     intensify_colors_for_cmd_exe,
     ansicolors_to_ptk1_names,
     ANSICOLOR_NAMES_MAP,
-    hardcode_colors_for_win10
+    PTK_NEW_OLD_COLOR_MAP,
+    hardcode_colors_for_win10,
 )
 
 from xonsh.color_tools import (RE_BACKGROUND, BASE_XONSH_COLORS, make_palette,
                                find_closest_color)
 from xonsh.style_tools import norm_name
 from xonsh.lazyimps import terminal256
-from xonsh.platform import os_environ, win_ansi_support
+from xonsh.platform import (
+    os_environ,
+    win_ansi_support,
+    ptk_version_info,
+    pygments_version_info,
+)
+
 from xonsh.pygments_cache import get_style_by_name
 
 
@@ -1335,12 +1342,45 @@ def pygments_style_by_name(name):
     return astyle
 
 
+
+def _monkey_patch_pygments_codes():
+    """ Monky patch pygments' dict of console codes, 
+        with new color names
+    """
+    import pygments.console
+    if 'brightblack' in pygments.console.codes:
+        # Assume that colors are already fixed in pygments
+        # for example when using pygments from source
+        return
+
+    if not getattr(pygments.console, "_xonsh_patched", False):
+        patched_codes = {}
+        for new, old in PTK_NEW_OLD_COLOR_MAP.items():
+            if old in pygments.console.codes:
+                patched_codes[new[1:]] = pygments.console.codes[old]
+        pygments.console.codes.update(patched_codes)
+        pygments.console._xonsh_patched = True
+
+
 #
 # Formatter
 #
 
 @lazyobject
 def XonshTerminal256Formatter():
+
+    if (
+        ptk_version_info()
+        and ptk_version_info() > (2, 0)
+        and pygments_version_info()
+        and (2, 2) <= pygments_version_info() < (2, 3)
+    ):
+        # Monky patch pygments' dict of console codes
+        # with the new color names used by PTK2
+        # Can be removed once pygment names get fixed.
+        _monkey_patch_pygments_codes()
+
+
     class XonshTerminal256FormatterProxy(terminal256.Terminal256Formatter):
         """Proxy class for xonsh terminal256 formatting that understands.
         xonsh color tokens.

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1342,9 +1342,8 @@ def pygments_style_by_name(name):
     return astyle
 
 
-
 def _monkey_patch_pygments_codes():
-    """ Monky patch pygments' dict of console codes, 
+    """ Monky patch pygments' dict of console codes,
         with new color names
     """
     import pygments.console
@@ -1379,7 +1378,6 @@ def XonshTerminal256Formatter():
         # with the new color names used by PTK2
         # Can be removed once pygment names get fixed.
         _monkey_patch_pygments_codes()
-
 
     class XonshTerminal256FormatterProxy(terminal256.Terminal256Formatter):
         """Proxy class for xonsh terminal256 formatting that understands.

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1638,24 +1638,30 @@ def _get_color_indexes(style_map):
                 rgb = None
             yield token, index, rgb
 
+
+# Map of new PTK2 color names to PTK1 variants
+PTK_NEW_OLD_COLOR_MAP = LazyObject(lambda: {
+    "black": "black",
+    "red": "darkred",
+    "green": "darkgreen",
+    "yellow": "brown",
+    "blue": "darkblue",
+    "magenta": "purple",
+    "cyan": "teal",
+    "gray": "lightgray",
+    "brightblack": "darkgray",
+    "brightred": "red",
+    "brightgreen": "green",
+    "brightyellow": "yellow",
+    "brightblue": "blue",
+    "brightmagenta": "fuchsia",
+    "brightcyan": "turquoise",
+    "white": "white",
+}, globals(), "PTK_NEW_OLD_COLOR_MAP")
+
 # Map of new ansicolor names to old PTK1 names
 ANSICOLOR_NAMES_MAP = LazyObject(lambda: {
-    'ansiblack': '#ansiblack',
-    'ansired': '#ansidarkred',
-    'ansigreen': '#ansidarkgreen',
-    'ansiyellow': '#ansibrown',
-    'ansiblue': '#ansidarkblue',
-    'ansimagenta': '#ansipurple',
-    'ansicyan': '#ansiteal',
-    'ansigray': '#ansilightgray',
-    'ansibrightblack': '#ansidarkgray',
-    'ansibrightred': '#ansired',
-    'ansibrightgreen': '#ansigreen',
-    'ansibrightyellow': '#ansiyellow',
-    'ansibrightblue': '#ansiblue',
-    'ansibrightmagenta': '#ansifuchsia',
-    'ansibrightcyan': '#ansiturquoise',
-    'ansiwhite': '#ansiwhite',
+    "ansi" + k: "#ansi" + v for k, v in PTK_NEW_OLD_COLOR_MAP
 }, globals(), 'ANSICOLOR_NAMES_MAP')
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1661,8 +1661,8 @@ PTK_NEW_OLD_COLOR_MAP = LazyObject(lambda: {
 
 # Map of new ansicolor names to old PTK1 names
 ANSICOLOR_NAMES_MAP = LazyObject(lambda: {
-    "ansi" + k: "#ansi" + v for k, v in PTK_NEW_OLD_COLOR_MAP
-}, globals(), 'ANSICOLOR_NAMES_MAP')
+    "ansi" + k: "#ansi" + v for k, v in PTK_NEW_OLD_COLOR_MAP.items()
+}, globals(), "ANSICOLOR_NAMES_MAP")
 
 
 def _win10_color_map():


### PR DESCRIPTION
Fixes #2778 (hopefully)

The fix ads a patch to pygments's terminal formatter. To make it work with PTK2 color names, which we now use in xonsh. 

I know this is a hack. But I couldn't come up with something better. And this should temporary until the next release of pygments which will hopefully include our color name fix: 

https://bitbucket.org/birkenfeld/pygments-main/pull-requests/777/change-ansi-color-names-to-more-saying/diff 

