### PR TITLE
cache scripts by realpath

### DIFF
--- a/news/cache-by-realpath.rst
+++ b/news/cache-by-realpath.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Scripts are now cached by their realpath, not just abspath.
+
+**Security:** None

--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -29,7 +29,7 @@ def _CHARACTER_MAP():
 
 def _cache_renamer(path, code=False):
     if not code:
-        path = os.path.abspath(path)
+        path = os.path.realpath(path)
     o = [''.join(_CHARACTER_MAP.get(i, i) for i in w) for w in _splitpath(path)]
     o[-1] = "{}.{}".format(o[-1], sys.implementation.cache_tag)
     return o


### PR DESCRIPTION
Cache scripts by realpath, resolving symlinks,
as per discussion in #2776.
I chose realpath(...) over abspath(realpath(...)),
as realpath does call abspath internally.
