### PR TITLE
Add history matching toggle to search entire line

### DIFF
--- a/news/history_match_anywhere.rst
+++ b/news/history_match_anywhere.rst
@@ -1,0 +1,16 @@
+**Added:**
+
+* Added new env-var ``XONSH_HISTORY_MATCH_ANYWHERE``. If set to ``True`` then
+  up-arrow history matching will match existing history entries with the search
+  term located anywhere, not just at the beginning of the line. Default value is
+  ``False``
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -187,6 +187,7 @@ def DEFAULT_ENSURERS():
     'XONSH_ENCODING_ERRORS': (is_string, ensure_string, ensure_string),
     'XONSH_HISTORY_BACKEND': (is_history_backend, to_itself, ensure_string),
     'XONSH_HISTORY_FILE': (is_string, ensure_string, ensure_string),
+    'XONSH_HISTORY_MATCH_ANYWHERE': (is_bool, to_bool, bool_to_str),
     'XONSH_HISTORY_SIZE': (is_history_tuple, to_history_tuple, history_tuple_to_str),
     'XONSH_LOGIN': (is_bool, to_bool, bool_to_str),
     'XONSH_PROC_FREQUENCY': (is_float, float, str),
@@ -348,6 +349,7 @@ def DEFAULT_VALUES():
         'XONSH_ENCODING_ERRORS': 'surrogateescape',
         'XONSH_HISTORY_BACKEND': 'json',
         'XONSH_HISTORY_FILE': os.path.expanduser('~/.xonsh_history.json'),
+        'XONSH_HISTORY_MATCH_ANYWHERE': False,
         'XONSH_HISTORY_SIZE': (8128, 'commands'),
         'XONSH_LOGIN': False,
         'XONSH_PROC_FREQUENCY': 1e-4,
@@ -721,6 +723,10 @@ def DEFAULT_DOCS():
     'XONSH_HISTORY_FILE': VarDocs(
         'Location of history file (deprecated).',
         configurable=False, default="``~/.xonsh_history``"),
+    'XONSH_HISTORY_MATCH_ANYWHERE': VarDocs(
+        "When searching history from a partial string (by pressing up arrow), "
+        "match command history anywhere in a given line (not just the start)",
+        default="False"),
     'XONSH_HISTORY_SIZE': VarDocs(
         'Value and units tuple that sets the size of history after garbage '
         'collection. Canonical units are:\n\n'

--- a/xonsh/ptk2/history.py
+++ b/xonsh/ptk2/history.py
@@ -39,3 +39,13 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
 
     def __iter__(self):
         return iter(self.get_strings())
+
+
+def _cust_history_matches(self, i):
+    """Custom history search method for prompt_toolkit that matches previous
+    commands anywhere on a line, not just at the start.
+
+    This gets monkeypatched into the prompt_toolkit prompter if
+    ``XONSH_HISTORY_MATCH_ANYWHERE=True``"""
+    return (self.history_search_text is None or
+            self.history_search_text in self._working_lines[i])


### PR DESCRIPTION
Default behavior of prompt_toolkit on an up-arrow history search is to use a
`startswith` check to match previous entries.
This introduces an environment variable `XONSH_HISTORY_MATCH_ANYWHERE` that, if
`True`, will instead perform a history search with an `is in` to allow matching
anywhere.

This could potentially have performance impacts depending on how many history
items are being searched, so I've defaulted it to `False` but I'm open to input
on that (or any of the rest of it).

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
This addresses #2762 