### PR TITLE
Fix ctrlr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ matrix:
           language: generic
           env: PYTHON="3.7" MINICONDA_OS="MacOSX"
     allow_failures:
-        - python: ["nightly", "pypy3"]
+        - python: "nightly"
+        - python: "pypy3"
 
 before_install:
   - if [[ ! ("$TRAVIS_PYTHON_VERSION" == "nightly" || "$TRAVIS_PYTHON_VERSION" == "3.6-dev") && ! $BUILD_DOCS ]]; then

--- a/news/fix_ctrlr.rst
+++ b/news/fix_ctrlr.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix for ``Enter`` not returning from Control-R search buffer
+
+**Security:** None

--- a/xonsh/ptk2/key_bindings.py
+++ b/xonsh/ptk2/key_bindings.py
@@ -2,9 +2,10 @@
 """Key bindings for prompt_toolkit xonsh shell."""
 import builtins
 
+from prompt_toolkit import search
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import (Condition, IsMultiline, HasSelection,
-                                    EmacsInsertMode, ViInsertMode)
+                                    EmacsInsertMode, ViInsertMode, IsSearching)
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.application.current import get_app
 
@@ -338,6 +339,11 @@ def load_xonsh_bindings(key_bindings):
         relative_begin_index = b.document.get_start_of_line_position()
         b.cursor_left(count=abs(relative_begin_index))
         b.cursor_down(count=1)
+
+    @handle(Keys.ControlM, filter=IsSearching())
+    @handle(Keys.ControlJ, filter=IsSearching())
+    def accept_search(event):
+        search.accept_search()
 
     @handle(Keys.ControlI, filter=insert_mode)
     def generate_completions(event):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->
This may be an issue upstream in PTK or it might be because we override
all sorts of keybindings to allow for a friendlier multiline experience.

In any case, registering an explicit keybinding to break out of the
search mode restores the functionality.
<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
Fix for #2793 