### PR TITLE
Fix multi-item path completion

### DIFF
--- a/news/tab_deep.rst
+++ b/news/tab_deep.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* PTK tab-completion now auto-accepts completion if only one option is present
+  (note that fix is only for PTK2)
+
+**Security:** None

--- a/xonsh/ptk2/key_bindings.py
+++ b/xonsh/ptk2/key_bindings.py
@@ -344,34 +344,3 @@ def load_xonsh_bindings(key_bindings):
     @handle(Keys.ControlJ, filter=IsSearching())
     def accept_search(event):
         search.accept_search()
-
-    @handle(Keys.ControlI, filter=insert_mode)
-    def generate_completions(event):
-        """
-        Tab-completion: where the first tab completes the common suffix and the
-        second tab lists all the completions.
-
-        Notes
-        -----
-        This method was forked from the mainline prompt-toolkit repo.
-        Copyright (c) 2014, Jonathan Slenders, All rights reserved.
-        """
-        b = event.current_buffer
-
-        try:
-            start_completion = event.cli.start_completion
-        except AttributeError:  # PTK 2.0
-            start_completion = event.current_buffer.start_completion
-
-        def second_tab():
-            if b.complete_state:
-                b.complete_next()
-            else:
-                start_completion(select_first=False)
-
-        # On the second tab-press, or when already navigating through
-        # completions.
-        if event.is_repeat or b.complete_state:
-            second_tab()
-        else:
-            start_completion(insert_common_part=True, select_first=False)


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->
The keybinding logic for multiple `TAB`s brought up the selection menu if the event was repeated, hence why tabbing into a deep folder tree would bring up the selection menu every other time.

We had originally forked the code there from prompt_toolkit -- simply removing the keybinding seems to have fixed it (change only implemented for ptk2).

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
Fixes #2791 
