### PR TITLE
Pass all params to voxapi.create

### DIFF
--- a/news/fix_voxapi_create_params.rst
+++ b/news/fix_voxapi_create_params.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+Pass all params to voxapi.create
+
+**Security:** None

--- a/news/fix_voxapi_create_params.rst
+++ b/news/fix_voxapi_create_params.rst
@@ -6,8 +6,8 @@
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
 
-Pass all params to voxapi.create
+* Pass all params to voxapi.create
 
 **Security:** None

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -23,7 +23,7 @@ class VoxHandler:
                             help='The environments to create')
 
         create.add_argument('--system-site-packages', default=False,
-                            action='store_true', dest='system_site',
+                            action='store_true', dest='system_site_packages',
                             help='Give the virtual environment access to the '
                                  'system site-packages dir.')
 
@@ -89,7 +89,10 @@ class VoxHandler:
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
         """
         print('Creating environment...')
-        self.vox.create(args.name)
+        self.vox.create(args.name,
+                        system_site_packages=args.system_site_packages,
+                        symlinks=args.symlinks,
+                        with_pip=args.with_pip)
         msg = 'Environment {0!r} created. Activate it with "vox activate {0}".\n'
         print(msg.format(args.name))
 


### PR DESCRIPTION
It is looks like it was a little bug, I hope I did not break anything, but I can not run tests on my computer even for code from master:
```
py.test test_vox.py                                    
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/_pytest/config.py", line 342, in _getconftestmodules
    return self._path2confmods[path]                                                                   
KeyError: local('/home/worldmind/code/xonsh/tests')

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/_pytest/config.py", line 373, in _importconftest
    return self._conftestpath2mod[conftestpath]
KeyError: local('/home/worldmind/code/xonsh/tests/conftest.py')

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/_pytest/config.py", line 379, in _importconftest
    mod = conftestpath.pyimport()
  File "/usr/local/lib/python3.5/dist-packages/py/_path/local.py", line 662, in pyimport
    __import__(modname)
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 634, in _load_backward_compatible
  File "/usr/local/lib/python3.5/dist-packages/_pytest/assertion/rewrite.py", line 212, in load_module
    py.builtin.exec_(co, mod.__dict__)
  File "/home/worldmind/code/xonsh/tests/conftest.py", line 13, in <module>
    from tools import DummyShell, sp, DummyCommandsCache, DummyEnv, DummyHistory
  File "/home/worldmind/code/xonsh/tests/tools.py", line 58, in <module>
    ptk_version_info()[0] < 2, reason="prompt-tollkit <2"
TypeError: 'NoneType' object is not subscriptable
ERROR: could not load /home/worldmind/code/xonsh/tests/conftest.py
```

P.S. I have a small question - why here https://github.com/xonsh/xonsh/blob/master/xontrib/voxapi.py#L169 not used some module for config parsing?
