### PR TITLE
Add example of arguments for callable aliases

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1329,8 +1329,8 @@ best used in conjunction with the ``unthreadable`` decorator.  For example:
 
     aliases['bvi'] = _binvi
 
-Note that ``@()`` is required to pass the python list ``args`` to subprocess
-a subprocess command.
+Note that ``@()`` is required to pass the python list ``args`` to a subprocess
+command.
 
 -------------
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1324,10 +1324,13 @@ best used in conjunction with the ``unthreadable`` decorator.  For example:
 
     @uncapturable
     @unthreadable
-    def _myvi():
-        vi my.txt
+    def _binvi(args, stdin=None):
+        vi -b @(args)  # Edit binary files
 
-    aliases['myvi'] = _myvi
+    aliases['bvi'] = _binvi
+
+Note that ``@()`` is required to pass the python list ``args`` to subprocess
+a subprocess command.
 
 -------------
 


### PR DESCRIPTION
More discussion in #2819 . The example shows how to pass arguments to subprocess command.

I'm not sure if `vi -b` is the best example since I've never used it, I can change it if necessary.
