### PR TITLE
Allow 'off' as falsy value

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1185,7 +1185,7 @@ def logfile_opt_to_str(x):
 
 
 _FALSES = LazyObject(
-    lambda: frozenset(["", "0", "n", "f", "no", "none", "false"]), globals(), "_FALSES"
+    lambda: frozenset(["", "0", "n", "f", "no", "none", "false", "off"]), globals(), "_FALSES"
 )
 
 


### PR DESCRIPTION
Just a simple one.
I think some users might want to use 'off' as a falsy value (e.g. me).