### PR TITLE
Allow 'off' as falsy value

### DIFF
--- a/news/allow_off_as_falsy.rst
+++ b/news/allow_off_as_falsy.rst
@@ -1,4 +1,4 @@
-**Added:** None
+**Added:**
 
 * 'off' can be passed as falsy value to all flags accepting boolean argument.
 

--- a/news/allow_off_as_falsy.rst
+++ b/news/allow_off_as_falsy.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+* 'off' can be passed as falsy value to all flags accepting boolean argument.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1185,7 +1185,7 @@ def logfile_opt_to_str(x):
 
 
 _FALSES = LazyObject(
-    lambda: frozenset(["", "0", "n", "f", "no", "none", "false"]), globals(), "_FALSES"
+    lambda: frozenset(["", "0", "n", "f", "no", "none", "false", "off"]), globals(), "_FALSES"
 )
 
 


### PR DESCRIPTION
Just a simple one.
I think some users might want to use 'off' as a falsy value (e.g. me).