### PR TITLE
fix path completer issue with f-strings

### DIFF
--- a/news/path_completer_exception.rst
+++ b/news/path_completer_exception.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed path completer crash on attempted f-string completion
+
+**Security:** None

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -57,7 +57,7 @@ def _path_from_partial_string(inp, pos=None):
         _string = _string + end
     try:
         val = ast.literal_eval(_string)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         return None
     if isinstance(val, bytes):
         env = builtins.__xonsh_env__


### PR DESCRIPTION
Fix path completer crash on attempted f-string completion. Fixes the second part of #2822 .
`ast.literal_eval()` can't handle f-strings and raises `ValueError` for them. The patch just silences the exception and gives up on the completion.