### PR TITLE
fix wizard crash when an unknown foreign shell is given

### DIFF
--- a/news/fswiz.rst
+++ b/news/fswiz.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* The xonsh ``xonfig wizard`` would crash if an unknown foreign shell was
+  provided. This has been fixed.
+
+**Security:** None

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -147,7 +147,7 @@ _XONFIG_SOURCE_FOREIGN_SHELL_COMMAND = collections.defaultdict(
 def _dump_xonfig_foreign_shell(path, value):
     shell = value["shell"]
     shell = CANON_SHELL_NAMES.get(shell, shell)
-    cmd = [_XONFIG_SOURCE_FOREIGN_SHELL_COMMAND.get(shell)]
+    cmd = [_XONFIG_SOURCE_FOREIGN_SHELL_COMMAND[shell]]
     interactive = value.get("interactive", None)
     if interactive is not None:
         cmd.extend(["--interactive", str(interactive)])


### PR DESCRIPTION
We weren't using defaultdict correctly. Closes #2823
