### PR TITLE
Add black check to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,37 @@ jobs:
       - run:
           command: |
             /home/circleci/miniconda/envs/py37-xonsh-test/bin/pytest --timeout=10 --flake8 --cov=./xonsh
+  build_black:
+    machine: true
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - miniconda-v1-black
+      - run:
+          name: install miniconda
+          command: |
+              if [ ! -d "/home/circleci/miniconda" ]; then
+                wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+                bash miniconda.sh -b -p $HOME/miniconda
+                export PATH="$HOME/miniconda/bin:$PATH"
+                conda config --set always_yes yes --set changeps1 no
+              fi
+              sudo chown -R $USER.$USER $HOME
+      - run:
+          name: configure conda
+          command: |
+              export PATH="$HOME/miniconda/bin:$PATH"
+              pip install black
+      - save_cache:
+          key: miniconda-v1-black
+          paths:
+            - "/home/circleci/miniconda"
+      - run:
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            cd xonsh/
+            black --exclude ply *.py --check
 
 workflows:
   version: 2
@@ -184,6 +215,7 @@ workflows:
       - build_34
       - build_35
       - build_36
+      - build_black
       # conda-foge does not yet have all Python 3.7 packages available
       # uncomment when it does
       #- build_37

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1185,7 +1185,9 @@ def logfile_opt_to_str(x):
 
 
 _FALSES = LazyObject(
-    lambda: frozenset(["", "0", "n", "f", "no", "none", "false", "off"]), globals(), "_FALSES"
+    lambda: frozenset(["", "0", "n", "f", "no", "none", "false", "off"]),
+    globals(),
+    "_FALSES",
 )
 
 


### PR DESCRIPTION
There's one line in `xonsh/tools.py` that snuck through our manual reviews, which is actually great.  This should fail when we run `black` now and it finds changes to make, then I can push up the fix to confirm it's working as expected.