### PR TITLE
Remove extraneous `try-except`s from ptk2 keybindings

### DIFF
--- a/xonsh/ptk2/key_bindings.py
+++ b/xonsh/ptk2/key_bindings.py
@@ -71,10 +71,7 @@ def carriage_return(b, cli, *, autoindent=True):
     elif current_line_blank and in_partial_string:
         b.newline(copy_margin=autoindent)
     else:
-        try:
-            b.accept_action.validate_and_handle(cli, b)
-        except AttributeError:  # PTK 2.0
-            b.validate_and_handle()
+        b.validate_and_handle()
 
 
 def _is_blank(l):
@@ -154,10 +151,7 @@ def ctrl_d_condition():
         raise EOFError
     else:
         app = get_app()
-        try:
-            buffer_name = app.current_buffer_name
-        except AttributeError:  # PTK 2.0
-            buffer_name = app.current_buffer.name
+        buffer_name = app.current_buffer.name
 
         return buffer_name == DEFAULT_BUFFER and not app.current_buffer.text
 
@@ -305,10 +299,7 @@ def load_xonsh_bindings(key_bindings):
     def call_exit_alias(event):
         """Use xonsh exit function"""
         b = event.cli.current_buffer
-        try:
-            b.accept_action.validate_and_handle(event.cli, b)
-        except AttributeError:  # PTK 2.0
-            b.validate_and_handle()
+        b.validate_and_handle()
         xonsh_exit([])
 
     @handle(Keys.ControlJ, filter=IsMultiline())
@@ -333,10 +324,7 @@ def load_xonsh_bindings(key_bindings):
     def execute_block_now(event):
         """Execute a block of text irrespective of cursor position"""
         b = event.cli.current_buffer
-        try:
-            b.accept_action.validate_and_handle(event.cli, b)
-        except AttributeError:  # PTK 2.0
-            b.validate_and_handle()
+        b.validate_and_handle()
 
     @handle(Keys.Left, filter=beginning_of_line)
     def wrap_cursor_back(event):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Removing some unnecessary checks again PTK version in keybindings.
Just code cleanup, no news entry required for this