### PR TITLE
Publish results from tests on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,5 +27,11 @@ jobs:
       installOptions: '-c conda-forge'
       updateConda: false
   - script: |
-      pytest --timeout=10
+      pytest --timeout=10 --junitxml=junit/test-results.xml
     displayName: 'pytest'
+
+# Publish build results
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/test-*.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
     displayName: 'pytest'
 
 # Publish build results
-- task: PublishTestResults@2
-  inputs:
-    testResultsFiles: '**/test-*.xml'
-    testRunTitle: 'Publish test results for Python $(python.version)'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'


### PR DESCRIPTION
This adds a publishing step to the azure pipeline. That may make it a little easier to see what tests fail, maybe there is a chance it can be reported right back to GitHub.

No news item for this is necessary. 
