### PR TITLE
Fix for string index error in bash completion

### DIFF
--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -373,7 +373,7 @@ def bash_completions(
     commprefix = os.path.commonprefix(list(out))
     strip_len = 0
     strip_prefix = prefix.strip("\"'")
-    while strip_len < len(prefix):
+    while strip_len < len(strip_prefix):
         if commprefix[strip_len] == strip_prefix[strip_len]:
             break
         strip_len += 1


### PR DESCRIPTION
This fixes #2856 

No news item required since it's fixing a regression introduced since the last release.
