### PR TITLE
PTK2 style overrides

### DIFF
--- a/news/style-overrides.rst
+++ b/news/style-overrides.rst
@@ -2,14 +2,14 @@
 
 * Added new env-var ``XONSH_STYLE_OVERRIDES``. The variable is
   a dictionary containing custom prompt_toolkit style definitions.
-  For instance
-  ```
+  For instance::
+
   $XONSH_STYLE_OVERRIDES['completion-menu'] = 'bg:#333333 #EEEEEE'
-  ```
-  will provide for more visually pleasing completion menu style whereas
-  ```
+
+  will provide for more visually pleasing completion menu style whereas::
+
   $XONSH_STYLE_OVERRIDES['bottom-toolbar'] = 'noreverse'
-  ```
+
   will prevent prompt_toolkit from inverting the bottom toolbar colors
   (useful for powerline extension users)
 

--- a/news/style-overrides.rst
+++ b/news/style-overrides.rst
@@ -1,14 +1,14 @@
 **Added:**
 
-* Added new env-var ``XONSH_STYLE_OVERRIDES``. The variable is
+* Added new env-var ``PTK_STYLE_OVERRIDES``. The variable is
   a dictionary containing custom prompt_toolkit style definitions.
   For instance::
 
-  $XONSH_STYLE_OVERRIDES['completion-menu'] = 'bg:#333333 #EEEEEE'
+    $PTK_STYLE_OVERRIDES['completion-menu'] = 'bg:#333333 #EEEEEE'
 
   will provide for more visually pleasing completion menu style whereas::
 
-  $XONSH_STYLE_OVERRIDES['bottom-toolbar'] = 'noreverse'
+    $PTK_STYLE_OVERRIDES['bottom-toolbar'] = 'noreverse'
 
   will prevent prompt_toolkit from inverting the bottom toolbar colors
   (useful for powerline extension users)

--- a/news/style-overrides.rst
+++ b/news/style-overrides.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* Added new env-var ``XONSH_STYLE_OVERRIDES``. The variable is
+  a dictionary containing custom prompt_toolkit style definitions.
+  For instance
+  ```
+  $XONSH_STYLE_OVERRIDES['completion-menu'] = 'bg:#333333 #EEEEEE'
+  ```
+  will provide for more visually pleasing completion menu style whereas
+  ```
+  $XONSH_STYLE_OVERRIDES['bottom-toolbar'] = 'noreverse'
+  ```
+  will prevent prompt_toolkit from inverting the bottom toolbar colors
+  (useful for powerline extension users)
+
+  Note: This only works with prompt_toolkit 2 prompter.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -74,6 +74,9 @@ from xonsh.tools import (
     to_itself,
     swap_values,
     ptk2_color_depth_setter,
+    is_str_str_dict,
+    to_str_str_dict,
+    dict_to_str,
 )
 import xonsh.prompt.base as prompt
 
@@ -228,6 +231,7 @@ def DEFAULT_ENSURERS():
         ),
         "PUSHD_MINUS": (is_bool, to_bool, bool_to_str),
         "PUSHD_SILENT": (is_bool, to_bool, bool_to_str),
+        "PTK_STYLE_OVERRIDES": (is_str_str_dict, to_str_str_dict, dict_to_str),
         "RAISE_SUBPROC_ERROR": (is_bool, to_bool, bool_to_str),
         "RIGHT_PROMPT": (is_string_or_callable, ensure_string, ensure_string),
         "BOTTOM_TOOLBAR": (is_string_or_callable, ensure_string, ensure_string),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -433,6 +433,7 @@ def DEFAULT_VALUES():
         "XONSH_STDERR_POSTFIX": "",
         "XONSH_STORE_STDIN": False,
         "XONSH_STORE_STDOUT": False,
+        "XONSH_STYLE_OVERRIDES": dict(),
         "XONSH_TRACEBACK_LOGFILE": None,
         "XONSH_DATETIME_FORMAT": "%Y-%m-%d %H:%M",
     }
@@ -947,6 +948,9 @@ def DEFAULT_DOCS():
         "XONSH_STORE_STDOUT": VarDocs(
             "Whether or not to store the ``stdout`` and ``stderr`` streams in the "
             "history files."
+        ),
+        "XONSH_STYLE_OVERRIDES": VarDocs(
+            "A dictionary containing custom prompt_toolkit style definitions."
         ),
         "XONSH_TRACEBACK_LOGFILE": VarDocs(
             "Specifies a file to store the traceback log to, regardless of whether "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -26,6 +26,8 @@ from xonsh.platform import (
     os_environ,
 )
 
+from xonsh.style_tools import PTK2_STYLE
+
 from xonsh.tools import (
     always_true,
     always_false,
@@ -390,7 +392,7 @@ def DEFAULT_VALUES():
         "PRETTY_PRINT_RESULTS": True,
         "PROMPT": prompt.default_prompt(),
         "PROMPT_TOOLKIT_COLOR_DEPTH": "",
-        "PTK_STYLE_OVERRIDES": dict(),
+        "PTK_STYLE_OVERRIDES": dict(PTK2_STYLE),
         "PUSHD_MINUS": False,
         "PUSHD_SILENT": False,
         "RAISE_SUBPROC_ERROR": False,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -390,6 +390,7 @@ def DEFAULT_VALUES():
         "PRETTY_PRINT_RESULTS": True,
         "PROMPT": prompt.default_prompt(),
         "PROMPT_TOOLKIT_COLOR_DEPTH": "",
+        "PTK_STYLE_OVERRIDES": dict(),
         "PUSHD_MINUS": False,
         "PUSHD_SILENT": False,
         "RAISE_SUBPROC_ERROR": False,
@@ -433,7 +434,6 @@ def DEFAULT_VALUES():
         "XONSH_STDERR_POSTFIX": "",
         "XONSH_STORE_STDIN": False,
         "XONSH_STORE_STDOUT": False,
-        "XONSH_STYLE_OVERRIDES": dict(),
         "XONSH_TRACEBACK_LOGFILE": None,
         "XONSH_DATETIME_FORMAT": "%Y-%m-%d %H:%M",
     }
@@ -675,6 +675,9 @@ def DEFAULT_DOCS():
             "The color depth used by prompt toolkit 2. Possible values are: "
             "``DEPTH_1_BIT``, ``DEPTH_4_BIT``, ``DEPTH_8_BIT``, ``DEPTH_24_BIT`` "
             "colors. Default is an empty string which means that prompt toolkit decide."
+        ),
+        "PTK_STYLE_OVERRIDES": VarDocs(
+            "A dictionary containing custom prompt_toolkit style definitions."
         ),
         "PUSHD_MINUS": VarDocs(
             "Flag for directory pushing functionality. False is the normal " "behavior."
@@ -948,9 +951,6 @@ def DEFAULT_DOCS():
         "XONSH_STORE_STDOUT": VarDocs(
             "Whether or not to store the ``stdout`` and ``stderr`` streams in the "
             "history files."
-        ),
-        "XONSH_STYLE_OVERRIDES": VarDocs(
-            "A dictionary containing custom prompt_toolkit style definitions."
         ),
         "XONSH_TRACEBACK_LOGFILE": VarDocs(
             "Specifies a file to store the traceback log to, regardless of whether "

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -152,7 +152,7 @@ class PromptToolkit2Shell(BaseShell):
                 try:
                     style_overrides = Style.from_dict(style_overrides_env)
                     prompt_args["style"] = merge_styles([style, style_overrides])
-                except Exception:  # pylint: disable=broad-except
+                except (AttributeError, TypeError, ValueError):
                     print_exception()
 
         line = self.prompter.prompt(**prompt_args)

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -147,7 +147,7 @@ class PromptToolkit2Shell(BaseShell):
 
             prompt_args["style"] = style
 
-            style_overrides_env = env.get("XONSH_STYLE_OVERRIDES")
+            style_overrides_env = env.get("PTK_STYLE_OVERRIDES")
             if style_overrides_env:
                 try:
                     style_overrides = Style.from_dict(style_overrides_env)

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -25,6 +25,7 @@ from prompt_toolkit.shortcuts import print_formatted_text as ptk_print
 from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.styles import merge_styles, Style
 from prompt_toolkit.styles.pygments import (
     style_from_pygments_cls,
     style_from_pygments_dict,
@@ -145,6 +146,14 @@ class PromptToolkit2Shell(BaseShell):
                 style = style_from_pygments_dict(DEFAULT_STYLE_DICT)
 
             prompt_args["style"] = style
+
+            style_overrides_env = env.get("XONSH_STYLE_OVERRIDES")
+            if style_overrides_env:
+                try:
+                    style_overrides = Style.from_dict(style_overrides_env)
+                    prompt_args["style"] = merge_styles([style, style_overrides])
+                except Exception:  # pylint: disable=broad-except
+                    print_exception()
 
         line = self.prompter.prompt(**prompt_args)
         events.on_post_prompt.fire()

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -440,7 +440,7 @@ PTK2_STYLE = {
     "completion-menu.completion": "",
     "completion-menu.completion.current": "bg:ansibrightblack ansiwhite",
     "scrollbar.background": "bg:ansibrightblack",
-    "scrollbar.arrow": "bg:ansiblack ansiwhite bold" ,
+    "scrollbar.arrow": "bg:ansiblack ansiwhite bold",
     "scrollbar.button": "bg:ansiblack",
     "auto-suggestion": "ansibrightblack",
     "aborting": "ansibrightblack",

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -435,17 +435,13 @@ DEFAULT_STYLE_DICT = LazyObject(
     "DEFAULT_STYLE_DICT",
 )
 
-PTK2_STYLE = LazyObject(
-    lambda: {
-        "completion-menu": "bg:ansigray ansiblack",
-        "completion-menu.completion": "",
-        "completion-menu.completion.current": "bg:ansibrightblack ansiwhite",
-        "scrollbar.background": "bg:ansibrightblack",
-        "scrollbar.arrow": "bg:ansiblack ansiwhite bold" ,
-        "scrollbar.button": "bg:ansiblack",
-        "auto-suggestion": "ansibrightblack",
-        "aborting": "ansibrightblack",
-    },
-    globals(),
-    "PTK2_STYLE",
-)
+PTK2_STYLE = {
+    "completion-menu": "bg:ansigray ansiblack",
+    "completion-menu.completion": "",
+    "completion-menu.completion.current": "bg:ansibrightblack ansiwhite",
+    "scrollbar.background": "bg:ansibrightblack",
+    "scrollbar.arrow": "bg:ansiblack ansiwhite bold" ,
+    "scrollbar.button": "bg:ansiblack",
+    "auto-suggestion": "ansibrightblack",
+    "aborting": "ansibrightblack",
+}

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -434,3 +434,18 @@ DEFAULT_STYLE_DICT = LazyObject(
     globals(),
     "DEFAULT_STYLE_DICT",
 )
+
+PTK2_STYLE = LazyObject(
+    lambda: {
+        "completion-menu": "bg:ansigray ansiblack",
+        "completion-menu.completion": "",
+        "completion-menu.completion.current": "bg:ansibrightblack ansiwhite",
+        "scrollbar.background": "bg:ansibrightblack",
+        "scrollbar.arrow": "bg:ansiblack ansiwhite bold" ,
+        "scrollbar.button": "bg:ansiblack",
+        "auto-suggestion": "ansibrightblack",
+        "aborting": "ansibrightblack",
+    },
+    globals(),
+    "PTK2_STYLE",
+)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -36,7 +36,7 @@ import threading
 import traceback
 import warnings
 import operator
-from ast import literal_eval
+import ast
 
 # adding imports from further xonsh modules is discouraged to avoid circular
 # dependencies
@@ -1485,7 +1485,7 @@ def to_dict(x):
     if isinstance(x, dict):
         return x
     try:
-        x = literal_eval(x)
+        x = ast.literal_eval(x)
     except (ValueError, SyntaxError):
         msg = '"{}" can not be converted to Python dictionary.'.format(x)
         warnings.warn(msg, RuntimeWarning)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1472,9 +1472,13 @@ def to_completions_display_value(x):
         x = "multi"
     return x
 
+
 def is_str_str_dict(x):
     """Tests if something is a str:str dictionary"""
-    return isinstance(x, dict) and all(isinstance(k, str) and isinstance(v, str) for k,v in x.items())
+    return isinstance(x, dict) and all(
+        isinstance(k, str) and isinstance(v, str) for k, v in x.items()
+    )
+
 
 def to_dict(x):
     """Converts a string to a dictionary"""
@@ -1488,6 +1492,7 @@ def to_dict(x):
         x = dict()
     return x
 
+
 def to_str_str_dict(x):
     """Converts a string to str:str dictionary"""
     if is_str_str_dict(x):
@@ -1499,11 +1504,13 @@ def to_str_str_dict(x):
         x = dict()
     return x
 
+
 def dict_to_str(x):
     """Converts a dictionary to a string"""
     if not x or len(x) == 0:
         return ""
     return str(x)
+
 
 def setup_win_unicode_console(enable):
     """"Enables or disables unicode display on windows."""

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -36,6 +36,7 @@ import threading
 import traceback
 import warnings
 import operator
+from ast import literal_eval
 
 # adding imports from further xonsh modules is discouraged to avoid circular
 # dependencies
@@ -1471,6 +1472,38 @@ def to_completions_display_value(x):
         x = "multi"
     return x
 
+def is_str_str_dict(x):
+    """Tests if something is a str:str dictionary"""
+    return isinstance(x, dict) and all(isinstance(k, str) and isinstance(v, str) for k,v in x.items())
+
+def to_dict(x):
+    """Converts a string to a dictionary"""
+    if isinstance(x, dict):
+        return x
+    try:
+        x = literal_eval(x)
+    except (ValueError, SyntaxError):
+        msg = '"{}" can not be converted to Python dictionary.'.format(x)
+        warnings.warn(msg, RuntimeWarning)
+        x = dict()
+    return x
+
+def to_str_str_dict(x):
+    """Converts a string to str:str dictionary"""
+    if is_str_str_dict(x):
+        return x
+    x = to_dict(x)
+    if not is_str_str_dict(x):
+        msg = '"{}" can not be converted to str:str dictionary.'.format(x)
+        warnings.warn(msg, RuntimeWarning)
+        x = dict()
+    return x
+
+def dict_to_str(x):
+    """Converts a dictionary to a string"""
+    if not x or len(x) == 0:
+        return ""
+    return str(x)
 
 def setup_win_unicode_console(enable):
     """"Enables or disables unicode display on windows."""


### PR DESCRIPTION
Introduces `$XONSH_STYLE_OVERRIDES` env-var, which is a Python dictionary of prompt_toolkit style definitions.
Closes #2838 and #2840.