### PR TITLE
Escaped deprecation

### DIFF
--- a/news/fix_escape_deprecation_warning.rst
+++ b/news/fix_escape_deprecation_warning.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed deprecation warnings from unallowed escape sequences as well as importing abstract base classes directly from `collections` 
+
+**Security:** None

--- a/news/fix_escape_deprecation_warning.rst
+++ b/news/fix_escape_deprecation_warning.rst
@@ -8,6 +8,6 @@
 
 **Fixed:**
 
-* Fixed deprecation warnings from unallowed escape sequences as well as importing abstract base classes directly from `collections` 
+* Fixed deprecation warnings from unallowed escape sequences as well as importing abstract base classes directly from ``collections`` 
 
 **Security:** None

--- a/release.xsh
+++ b/release.xsh
@@ -45,9 +45,9 @@ def ver_news(ver):
     news += merge_news()
     return news
 VERSION_UPDATE_PATTERNS = [
-    ('__version__\s*=.*', (lambda ver: "__version__ = '{0}'".format(ver)),
+    (r'__version__\s*=.*', (lambda ver: "__version__ = '{0}'".format(ver)),
         [PROJECT, '__init__.py']),
-    ('version:\s*', (lambda ver: 'version: {0}.{{build}}'.format(ver)),
+    (r'version:\s*', (lambda ver: 'version: {0}.{{build}}'.format(ver)),
         ['.appveyor.yml']),
     ('.. current developments', ver_news, ['CHANGELOG.rst']),
 ]

--- a/rever.xsh
+++ b/rever.xsh
@@ -7,7 +7,7 @@ $ACTIVITIES = ['version_bump', 'changelog', 'pytest',
 
 $VERSION_BUMP_PATTERNS = [
     ('.appveyor.yml', 'version:.*', 'version: $VERSION.{build}'),
-    ('xonsh/__init__.py', '__version__\s*=.*', '__version__ = "$VERSION"'),
+    ('xonsh/__init__.py', r'__version__\s*=.*', '__version__ = "$VERSION"'),
     ]
 $CHANGELOG_FILENAME = 'CHANGELOG.rst'
 $CHANGELOG_TEMPLATE = 'TEMPLATE.rst'

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals, print_function
 import os
 import sys
-from collections import Sequence
+from collections.abc import Sequence
 
 sys.path.insert(0, os.path.abspath(".."))  # FIXME
 from pprint import pformat

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -293,7 +293,7 @@ END_TOK_TYPES = LazyObject(
     lambda: frozenset(["SEMI", "AND", "OR", "RPAREN"]), globals(), "END_TOK_TYPES"
 )
 RE_END_TOKS = LazyObject(
-    lambda: re.compile("(;|and|\&\&|or|\|\||\))"), globals(), "RE_END_TOKS"
+    lambda: re.compile(r"(;|and|\&\&|or|\|\||\))"), globals(), "RE_END_TOKS"
 )
 LPARENS = LazyObject(
     lambda: frozenset(
@@ -1613,7 +1613,7 @@ def dynamic_cwd_tuple_to_str(x):
 
 
 RE_HISTORY_TUPLE = LazyObject(
-    lambda: re.compile("([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*([A-Za-z]*)"),
+    lambda: re.compile(r"([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*([A-Za-z]*)"),
     globals(),
     "RE_HISTORY_TUPLE",
 )


### PR DESCRIPTION
This fixes some deprecation warnings from unallowed escape sequences as well as importing abstract base classes directly from `collections` . 

It may solve some of the problems reported in #2863. But probably not all, since some of the deprecation warnings may come from xonsh dependencies. 