### PR TITLE
Fix a regression with subproc @() evaluation

### DIFF
--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -3140,7 +3140,7 @@ class BaseParser(object):
         if isinstance(p1, list):
             # has an expanding function call, such as @(x)
             p0 = xonsh_call(
-                "__xonsh__.xonsh_list_of_list_of_strs_outer_product",
+                "__xonsh__.list_of_list_of_strs_outer_product",
                 args=[ensure_has_elts(p1)],
                 lineno=p1[0].lineno,
                 col=p1[0].col_offset,


### PR DESCRIPTION
(No news item needed for this since #2713 was not release yet) 

I was getting the following:
```
AttributeError: 'XonshSession' object has no attribute 'xonsh_list_of_list_of_strs_outer_product'
```
The xonsh session restructure broke the @() expansion in subproc mode.

This PR restores it. 
```
snail@sea ~\Documents\xonsh 
$ echo 18.10.@(f"{x:02d}" for x in range(1,10))
18.10.01 18.10.02 18.10.03 18.10.04 18.10.05 18.10.06 18.10.07 18.10.08 18.10.09
```
