### PR TITLE
Dispredir

### DIFF
--- a/news/dispredir.rst
+++ b/news/dispredir.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed stdout/sdterr writing infinite recurssion error that would occur in
+  long pipelines of callable aliases.
+
+**Security:** None

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1002,12 +1002,18 @@ class FileThreadDispatcher:
         """Registers a file handle for the current thread. Returns self so
         that this method can be used in a with-statement.
         """
+        if handle is self:
+            # prevent weird recurssion errors
+            return self
         self.registry[threading.get_ident()] = handle
         return self
 
     def deregister(self):
         """Removes the current thread from the registry."""
-        del self.registry[threading.get_ident()]
+        ident = threading.get_ident()
+        if ident in self.registry:
+            # don't remove if we have already been deregistered
+            del self.registry[threading.get_ident()]
 
     @property
     def available(self):


### PR DESCRIPTION
This is built off #2873 and addresses some very strange issues that are difficult to isolate a reproduce.  

But basically the issue is that the standard out & error thread dispatcher was registering itself as its own handle.  This would occur in long pipelines of callable aliases, but seemingly only in downstream projects when using `Execer.exec("![cmd0 | cmd1 | cmd2]")` on code that had the callable aliases in it.  

I haven't been able to find a simple script that actually consistently fails though.  It seems the failures tend to happen only the first time a script is compiled... but not always.  Below is a script that sometimes fails on master when run with `xonsh test-parallel.xsh` but no longer fails on this branch.

**test-parallel.xsh**
```python
import time

def _cmd0(args, stdin=None, stdout=None, stderr=None, spec=None, stack=None):
    stderr.write('cmd0: writing\n')
    stdout.write('x=1\n')
    return 0

def _cmd1(args, stdin=None, stdout=None, stderr=None, spec=None, stack=None):
    stderr.write('reading from cmd1\n')
    time.sleep(1.1)
    for line in stdin:
        stderr.write('cmd1: read line: ' + repr(line) + '\ncmd1: writing\n')
        stdout.write('x=2\n')
    return 0

def _cmd2(args, stdin=None, stdout=None, stderr=None, spec=None, stack=None):
    stderr.write('reading from cmd2\n')
    for line in stdin:
        stderr.write('cmd2: read line: ' + repr(line) + '\n')

aliases['cmd0'] = _cmd0
aliases['cmd1'] = _cmd1
aliases['cmd2'] = _cmd2

__xonsh__.execer.exec("![cmd0 | cmd1 | cmd2]\n")
```
