### PR TITLE
Pin black version in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           name: configure conda
           command: |
               export PATH="$HOME/miniconda/bin:$PATH"
-              pip install black
+              pip install black==18.9b0
       - save_cache:
           key: miniconda-v1-black
           paths:

--- a/news/pin-black-in-ci.rst
+++ b/news/pin-black-in-ci.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Circle CI config updated to use a pinned version of ``black`` (18.9b0)
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Resolves xonsh#2846 by updating CircleCI config to explicitly use version 18.9b0 (latest at the time of this writing).

When staging this PR in my local fork, the Circle CI builds for `master` had the same output as this branch: 

* `build_black` and `build_34` pass
* `build_35` fails 1 test
```
tests/test_ast.py:54: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

input = 'l = 1\nls -l\n'

    def check_parse(input):
>       tree = builtins.__xonsh__.execer.parse(input, ctx=None)
E       AttributeError: module 'builtins' has no attribute '__xonsh__'
```

* `build_36` fails the lint check

```
/home/circleci/project/xontrib/bashisms.py:35:14: W504 line break after binary operator
```