### PR TITLE
Potential fix for ast test failures from attribute error

### DIFF
--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -49,7 +49,7 @@ def test_gather_load_store_names_tuple():
         "l = 1",
     ],
 )
-def test_multilline_num(xonsh_builtins, line1):
+def test_multilline_num(line1):
     code = line1 + "\nls -l\n"
     tree = check_parse(code)
     lsnode = tree.body[1]


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Potential fix for the test failures on master and several open PRs (the `AttributeError` when trying to access `builtins.__xonsh__`)

No news entry for this one (if it works).  Deeply confused by this but the test with a call to `check_parse` that didn't have a `xonsh_builtins` argument wasn't failing, so thought this was worth a shot.
