### PR TITLE
Fix exception when trying to send SIGSTOP to finished sudo child

### DIFF
--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -6,6 +6,10 @@
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
+
+* Fixed a bug which under very rare conditions could cause the shell
+  to die with PermissionError exception while sending SIGSTOP signal
+  to a child process.
 
 **Security:** None

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -2413,7 +2413,10 @@ def pause_call_resume(p, f, *args, **kwargs):
         hasattr(p, "send_signal") and ON_POSIX and not ON_MSYS and not ON_CYGWIN
     )
     if can_send_signal:
-        p.send_signal(signal.SIGSTOP)
+        try:
+            p.send_signal(signal.SIGSTOP)
+        except PermissionError:
+            pass
     try:
         f(*args, **kwargs)
     except Exception:


### PR DESCRIPTION
Fixes #2883.
Although the Python's `subprocess` module does its best to not send signals to child processes that have already died, the protection is not atomic/race-free. We need to protect ourselves.