### PR TITLE
Test for value of __xonsh__.shell instead of its existence

### DIFF
--- a/news/shell-attr.rst
+++ b/news/shell-attr.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fixed occasional "no attribute 'settitle' error"
+
+**Security:** None

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -22,7 +22,7 @@ def ctx():
     execer = Execer(xonsh_ctx=ctx)
     builtins.__xonsh__.shell = Shell(execer=execer, ctx=ctx, shell_type="none")
     yield
-    builtins.__xonsh__ = None
+    builtins.__xonsh__.shell = None
 
 
 @skip_if_on_darwin

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -22,7 +22,7 @@ def ctx():
     execer = Execer(xonsh_ctx=ctx)
     builtins.__xonsh__.shell = Shell(execer=execer, ctx=ctx, shell_type="none")
     yield
-    del builtins.__xonsh__.shell
+    builtins.__xonsh__ = None
 
 
 @skip_if_on_darwin

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -863,7 +863,7 @@ def _should_set_title(captured=False):
         env.get("XONSH_INTERACTIVE")
         and not env.get("XONSH_STORE_STDOUT")
         and captured not in STDOUT_CAPTURE_KINDS
-        and hasattr(builtins.__xonsh__, "shell")
+        and builtins.__xonsh__.shell is not None
     )
 
 

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -442,7 +442,6 @@ class ForeignShellFunctionAlias(object):
     def __eq__(self, other):
         if (
             not hasattr(other, "name")
-            or not hasattr(other, "shell")
             or not hasattr(other, "filename")
             or not hasattr(other, "sourcer")
             or not hasattr(other, "exta_args")

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -461,8 +461,7 @@ def postmain(args=None):
     """Teardown for main xonsh entry point, accepts parsed arguments."""
     if ON_WINDOWS:
         setup_win_unicode_console(enable=False)
-    if hasattr(builtins.__xonsh__, "shell"):
-        del builtins.__xonsh__.shell
+    builtins.__xonsh__.shell = None
 
 
 @contextlib.contextmanager

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -2136,7 +2136,7 @@ class CommandPipeline:
             return
         if give_terminal_to(pgid):  # if gave term succeed
             self.term_pgid = pgid
-            if hasattr(builtins.__xonsh__, "shell"):
+            if builtins.__xonsh__.shell is not None:
                 # restoring sanity could probably be called whenever we return
                 # control to the shell. But it only seems to matter after a
                 # ^Z event. This *has* to be called after we give the terminal

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -329,7 +329,7 @@ def partial_color_tokenize(template):
     of tuples mapping the token to the string which has that color.
     These sub-strings maybe templates themselves.
     """
-    if hasattr(builtins.__xonsh__, "shell"):
+    if builtins.__xonsh__.shell is not None:
         styles = __xonsh__.shell.shell.styler.styles
     else:
         styles = None

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -64,9 +64,9 @@ def partial_color_tokenize(template):
     of tuples mapping the token to the string which has that color.
     These sub-strings maybe templates themselves.
     """
-    if HAS_PYGMENTS and hasattr(builtins.__xonsh__, "shell"):
+    if HAS_PYGMENTS and builtins.__xonsh__.shell is not None:
         styles = __xonsh__.shell.shell.styler.styles
-    elif hasattr(builtins.__xonsh__, "shell"):
+    elif builtins.__xonsh__.shell is not None:
         styles = DEFAULT_STYLE_DICT
     else:
         styles = None

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1888,7 +1888,7 @@ def intensify_colors_on_win_setter(enable):
     environment variable.
     """
     enable = to_bool(enable)
-    if hasattr(builtins.__xonsh__, "shell"):
+    if builtins.__xonsh__.shell is not None:
         if hasattr(builtins.__xonsh__.shell.shell.styler, "style_name"):
             delattr(builtins.__xonsh__.shell.shell.styler, "style_name")
     return enable


### PR DESCRIPTION
Since #2866 the `__xonsh__.shell` attribute most probably always exists (unless it gets intentionally deleted). We should rather check for its nullity instead of its existence.
Fixes #2899.