### PR TITLE
Fix ResourceWarning: unclosed scandir iterator in imphooks.py

### DIFF
--- a/news/fix-unclosed-scandir-iterator.rst
+++ b/news/fix-unclosed-scandir-iterator.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ResourceWarning: unclosed scandir iterator in imphooks.py
+
+**Security:**
+
+* <news item>

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -84,7 +84,7 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
                 continue
             if not os.path.isdir(p) or not os.access(p, os.R_OK):
                 continue
-            if fname not in (x.name for x in scandir(p)):
+            if fname not in {x.name for x in scandir(p)}:
                 continue
             spec = ModuleSpec(fullname, self)
             self._filenames[fullname] = os.path.join(p, fname)


### PR DESCRIPTION
Another possible fix would be:
```diff
diff --git a/xonsh/imphooks.py b/xonsh/imphooks.py
index e83f06f8..a0ff63b1 100644
--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -84,7 +84,7 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
                 continue
             if not os.path.isdir(p) or not os.access(p, os.R_OK):
                 continue
-            if fname not in (x.name for x in scandir(p)):
+            if fname not in {x.name for x in scandir(p)}:
                 continue
             spec = ModuleSpec(fullname, self)
             self._filenames[fullname] = os.path.join(p, fname)
```
But this would consume the whole iterator, thus loosing the iterator benefits.

Let me know which patch do you prefer, if any :)