### PR TITLE
Set stack level to 3 for meaningful warning messages

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1464,7 +1464,7 @@ class DeprecationWarningProxy:
             "{} has been deprecated, please use {} instead.".format(
                 self.oldname, self.newname
             ),
-            DeprecationWarning,
+            DeprecationWarning, stacklevel=3
         )
 
     def __getattr__(self, name):


### PR DESCRIPTION
Otherwise, I think the warning is coming from that line, but in reality, powerline is using a deprecated API.

Feel free to close the PR if you don't want this.