### PR TITLE
--timings crash fix

### DIFF
--- a/news/jake.rst
+++ b/news/jake.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* AttributeError crash when using --timings flag
+
+**Security:**
+
+* <news item>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,6 +120,8 @@ def test_premain_invalid_arguments(shell, case, capsys):
         xonsh.main.premain([case])
     assert "unrecognized argument" in capsys.readouterr()[1]
 
+def test_premain_timings_arg(shell):
+    xonsh.main.premain(['--timings'])
 
 def test_xonsh_failback(shell, monkeypatch, monkeypatch_stderr):
     failback_checker = []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, print_function
 from contextlib import contextmanager
 
 import builtins
+import os
 import os.path
 import sys
 
@@ -21,6 +22,7 @@ def Shell(*args, **kwargs):
 @pytest.fixture
 def shell(xonsh_builtins, monkeypatch):
     """Xonsh Shell Mock"""
+    del builtins.__xonsh__
     Shell.shell_type_aliases = {"rl": "readline"}
     monkeypatch.setattr(xonsh.main, "Shell", Shell)
 
@@ -54,7 +56,7 @@ def test_premain_D(shell):
 
 def test_premain_custom_rc(shell, tmpdir, monkeypatch):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-    builtins.__xonsh__.env = Env(XONSH_CACHE_SCRIPTS=False)
+    monkeypatch.setitem(os.environ, "XONSH_CACHE_SCRIPTS", 'False')
     f = tmpdir.join("wakkawakka")
     f.write("print('hi')")
     args = xonsh.main.premain(["--rc", f.strpath])
@@ -72,11 +74,11 @@ def test_force_interactive_rc_with_script(shell, tmpdir):
     assert builtins.__xonsh__.env.get("XONSH_INTERACTIVE")
 
 
-def test_force_interactive_custom_rc_with_script(shell, tmpdir):
+def test_force_interactive_custom_rc_with_script(shell, tmpdir, monkeypatch):
     """Calling a custom RC file on a script-call with the interactive flag
     should run interactively
     """
-    builtins.__xonsh__.env = Env(XONSH_CACHE_SCRIPTS=False)
+    monkeypatch.setitem(os.environ, "XONSH_CACHE_SCRIPTS", 'False')
     f = tmpdir.join("wakkawakka")
     f.write("print('hi')")
     args = xonsh.main.premain(["-i", "--rc", f.strpath, "tests/sample.xsh"])

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -307,7 +307,7 @@ def premain(argv=None):
     """Setup for main xonsh entry point. Returns parsed arguments."""
     if argv is None:
         argv = sys.argv[1:]
-    setup_timings()
+    setup_timings(argv)
     setproctitle = get_setproctitle()
     if setproctitle is not None:
         setproctitle(" ".join(["xonsh"] + argv))

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -307,11 +307,11 @@ def premain(argv=None):
     """Setup for main xonsh entry point. Returns parsed arguments."""
     if argv is None:
         argv = sys.argv[1:]
+    builtins.__xonsh__ = XonshSession()
     setup_timings(argv)
     setproctitle = get_setproctitle()
     if setproctitle is not None:
         setproctitle(" ".join(["xonsh"] + argv))
-    builtins.__xonsh__ = XonshSession()
     args = parser.parse_args(argv)
     if args.help:
         parser.print_help()

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -248,9 +248,9 @@ def timeit_alias(args, stdin=None):
 _timings = {"start": clock()}
 
 
-def setup_timings():
+def setup_timings(argv):
     global _timings
-    if "--timings" in sys.argv:
+    if "--timings" in argv:
         events.doc(
             "on_timingprobe",
             """


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
Running `xonsh --timings` would cause the following error:
```
Traceback (most recent call last):
  File "/home/jake/xonsh/xonsh/main.py", line 400, in main
    args = premain(argv)
  File "/home/jake/xonsh/xonsh/main.py", line 310, in premain
    setup_timings(argv)
  File "/home/jake/xonsh/xonsh/timings.py", line 263, in setup_timings
    @events.on_timingprobe
  File "/home/jake/xonsh/xonsh/events.py", line 72, in __call__
    if debug_level():
  File "/home/jake/xonsh/xonsh/events.py", line 25, in debug_level
    if hasattr(builtins.__xonsh__, "env"):
AttributeError: module 'builtins' has no attribute '__xonsh__'
Xonsh encountered an issue during launch
Failback to /bin/sh
```

Fixed by creating `XonshSession` before calling `setup_timings()` in `premain()`. 

The bug was introduced by 5d9e2146772d589cfb2ddfd60a5592c43c279e10 according to `git bisect`, but I was not able to find any github issue about this.