### PR TITLE
Update _collapsed_pwd to return two chars if a dir begins with "."

### DIFF
--- a/news/update-collapsed-pwd.rst
+++ b/news/update-collapsed-pwd.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Update xonsh/prompt/cwd.py _collapsed_pwd to print 2 chars if a directory begins with "."
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/cwd.py
+++ b/xonsh/prompt/cwd.py
@@ -37,7 +37,9 @@ def _collapsed_pwd():
     pwd = _replace_home_cwd().split(sep)
     l = len(pwd)
     leader = sep if l > 0 and len(pwd[0]) == 0 else ""
-    base = [i[0] if ix != l - 1 else i for ix, i in enumerate(pwd) if len(i) > 0]
+    base = [i[0]
+            if ix != l - 1 and i[0] != '.' else i[0:2]
+            if ix != l - 1 else i for ix, i in enumerate(pwd) if len(i) > 0]
     return leader + sep.join(base)
 
 


### PR DESCRIPTION
Hi, I'm excited about what xonsh will enable us to do.

I found the current _collapsed_pwd only show "." for collapsed hidden directory.
I feel this makes it ambiguous, so I made this PR.

#### current way
```
$ pwd
/Users/qqhann/.tmp/foo/.bar/hoge
$ def _collapsed_pwd():
.     sep = xt.get_sep()
.     pwd = _replace_home_cwd().split(sep)
.     l = len(pwd)
.     leader = sep if l > 0 and len(pwd[0]) == 0 else ""
.     base = [i[0] if ix != l - 1 else i for ix, i in enumerate(pwd) if len(i) > 0]
.     return leader + sep.join(base)
.
$ _collapsed_pwd()
'~/./f/./hoge'
```

#### changed to
```
$ pwd
/Users/qqhann/.tmp/foo/.bar/hoge
$ def _collapsed_pwd():
.     sep = xt.get_sep()
.     pwd = _replace_home_cwd().split(sep)
.     l = len(pwd)
.     leader = sep if l > 0 and len(pwd[0]) == 0 else ""
.     base = [i[0]
.             if ix != l - 1 and i[0] != '.' else i[0:2]
.             if ix != l - 1 else i for ix, i in enumerate(pwd) if len(i) > 0]
.     return leader + sep.join(base)
.
$ _collapsed_pwd()
'~/.t/f/.b/hoge'
