### PR TITLE
fix EOFError when press c-d

### DIFF
--- a/news/eoferror.rst
+++ b/news/eoferror.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix EOFError when press `control+d`
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk2/key_bindings.py
+++ b/xonsh/ptk2/key_bindings.py
@@ -148,7 +148,7 @@ def ctrl_d_condition():
     empty.
     """
     if builtins.__xonsh__.env.get("IGNOREEOF"):
-        raise EOFError
+        return False
     else:
         app = get_app()
         buffer_name = app.current_buffer.name


### PR DESCRIPTION
https://github.com/xonsh/xonsh/issues/2951

before:
```
$ $IGNOREEOF
True
$ [ctrl + d]
Unhandled exception in event loop:
  File "~~/prompt_toolkit/eventloop/posix.py", line 154, in _run_task
    t()
  File "~~/prompt_toolkit/eventloop/context.py", line 115, in new_func
    return func(*a, **kw)
  File "~~/prompt_toolkit/application/application.py", line 555, in read_from_input
    self.key_processor.process_keys()
  File "~~/prompt_toolkit/key_binding/key_processor.py", line 273, in process_keys
    self._process_coroutine.send(key_press)
  File "~~/prompt_toolkit/key_binding/key_processor.py", line 163, in _process
    matches = self._get_matches(buffer)
  File "~~/prompt_toolkit/key_binding/key_processor.py", line 123, in _get_matches
    return [b for b in self._bindings.get_bindings_for_keys(keys) if b.filter()]
  File "~~/prompt_toolkit/key_binding/key_processor.py", line 123, in <listcomp>
    return [b for b in self._bindings.get_bindings_for_keys(keys) if b.filter()]
  File "~~/prompt_toolkit/filters/base.py", line 214, in __call__
    return self.func()
  File "~~/xonsh/ptk2/key_bindings.py", line 151, in ctrl_d_condition
    raise EOFError
```

after:
```
$ $IGNOREEOF
True
$ [ctrl + d]
Use "exit" to leave the shell.
$ $IGNOREEOF=False
$ [ctrl + d]
(exit xonsh)
```