### PR TITLE
Fix interpretation of color names with PTK2 and Pygments 2.3

### DIFF
--- a/news/fix-ptk2-pygments-colors.rst
+++ b/news/fix-ptk2-pygments-colors.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed interpretation of color names with PTK2 and Pygments 2.3.
+
+**Security:**
+
+* <news item>

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1431,7 +1431,7 @@ def XonshTerminal256Formatter():
         ptk_version_info()
         and ptk_version_info() > (2, 0)
         and pygments_version_info()
-        and (2, 2) <= pygments_version_info() < (2, 3)
+        and (2, 2, 0) <= pygments_version_info() <= (2, 3, 0)
     ):
         # Monky patch pygments' dict of console codes
         # with the new color names used by PTK2


### PR DESCRIPTION
Fixes #2948.
@melund It turned out to be fairly simple. Let's hope your upstream PR gets merged before 2.3.1 ;)

Edit: Maybe it requires clarification that I intentionally set the upper bound to 2.3.0. The upstream PR has already been approved, so I expect the color monkey patching to not be needed for 2.3.1 any more.