### PR TITLE
Fix typo in changelog.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -107,7 +107,7 @@ v0.8.4
 
 **Fixed:**
 
-* Fixed issue with ``and`` & ``or`` being incoreectly tokenized in implicit
+* Fixed issue with ``and`` & ``or`` being incorrectly tokenized in implicit
   subprocesses. Auto-wrapping of certain subprocesses will now correctly work.
   For example::
 


### PR DESCRIPTION
I noticed a minor typo while perusing the changelog.


<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->