### PR TITLE
Fix color names for PTK2 and Pygments 2.3.1

### DIFF
--- a/news/ptk2-pygments-2_3_1-colors.rst
+++ b/news/ptk2-pygments-2_3_1-colors.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed interpretation of color names with PTK2 and Pygments 2.3.1.
+
+**Security:**
+
+* <news item>

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1431,7 +1431,7 @@ def XonshTerminal256Formatter():
         ptk_version_info()
         and ptk_version_info() > (2, 0)
         and pygments_version_info()
-        and (2, 2, 0) <= pygments_version_info() <= (2, 3, 0)
+        and (2, 2, 0) <= pygments_version_info() < (2, 4, 0)
     ):
         # Monky patch pygments' dict of console codes
         # with the new color names used by PTK2


### PR DESCRIPTION
This is a follow-up to #2954. The [upstream PR](https://bitbucket.org/birkenfeld/pygments-main/pull-requests/777/change-ansi-color-names-to-more-saying/diff) was already merged for Pygments 2.4, so this should be the last time we need to take care about it.