### PR TITLE
allow user to invoke specific interpreter for vox virtualenv creation

### DIFF
--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -23,7 +23,16 @@ To create a new environment with vox, run ``vox new <envname>``::
     Creating environment...
     Environment "myenv" created. Activate it with "vox activate myenv".
 
-Vox uses under the hood Python 3's ``venv`` module. By default, environments are stored in ``~/.virtualenvs``, but you can override it by setting the ``$VIRTUALENV_HOME`` environment variable.
+The interpreter ``vox`` uses to create a virtualenv is configured via the ``$VOX_DEFAULT_INTERPRETER`` environment variable.
+
+You may also set the interpreter used to creat the virtual environment by passing it explicitly to ``vox new`` i.e.::
+
+    $ vox new python2-env -p /usr/local/bin/python2
+
+Under the hood, vox uses Python 3's ``venv`` module to create Python 3 virtualenvs. [this is the default]
+If a Python 2 intrepreter is passed to ``vox new`` it will use the Python 2 interpreter's ``virtualenv`` module. 
+
+By default, environments are stored in ``~/.virtualenvs``, but you can override it by setting the ``$VIRTUALENV_HOME`` environment variable.
 
 To see all existing environments, run ``vox list``::
 

--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -25,12 +25,13 @@ To create a new environment with vox, run ``vox new <envname>``::
 
 The interpreter ``vox`` uses to create a virtualenv is configured via the ``$VOX_DEFAULT_INTERPRETER`` environment variable.
 
-You may also set the interpreter used to creat the virtual environment by passing it explicitly to ``vox new`` i.e.::
+You may also set the interpreter used to create the virtual environment by passing it explicitly to ``vox new`` i.e.::
 
     $ vox new python2-env -p /usr/local/bin/python2
 
 Under the hood, vox uses Python 3's ``venv`` module to create Python 3 virtualenvs. [this is the default]
-If a Python 2 intrepreter is passed to ``vox new`` it will use the Python 2 interpreter's ``virtualenv`` module. 
+
+If a Python 2 intrepreter is chosen, it will use the Python 2 interpreter's ``virtualenv`` module. 
 
 By default, environments are stored in ``~/.virtualenvs``, but you can override it by setting the ``$VIRTUALENV_HOME`` environment variable.
 

--- a/news/vox-virtualenvs.rst
+++ b/news/vox-virtualenvs.rst
@@ -2,3 +2,23 @@
 
 * ``vox new`` has an added ``-p --interpreter`` flag for choosing the python interpreter to use for virtualenv creation
 * The default Python intrepreter vox uses to create virtual environments can be set using the ``$VOX_DEFAULT_INTERPRETER`` environment variable.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/vox-virtualenvs.rst
+++ b/news/vox-virtualenvs.rst
@@ -1,0 +1,4 @@
+**Added:**
+
+* ``vox new`` has an added ``-p --interpreter`` flag for choosing the python interpreter to use for virtualenv creation
+* The default Python intrepreter vox uses to create virtual environments can be set using the ``$VOX_DEFAULT_INTERPRETER`` environment variable.

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -29,7 +29,7 @@ def check_news_file(fname):
                 pytest.fail(
                     "{}:{}: single grave accents"
                     " are not valid rst".format(name, i + 1),
-                    pytrace=False,
+                    pytrace=True,
                 )
 
         # determine the form of line
@@ -40,7 +40,7 @@ def check_news_file(fname):
                     "{}:{}: {!r} not a proper category "
                     "must be one of {}"
                     "".format(name, i + 1, cat, list(CATEGORIES)),
-                    pytrace=False,
+                    pytrace=True,
                 )
             if l.endswith("None"):
                 form += "3"
@@ -53,14 +53,14 @@ def check_news_file(fname):
         elif l.strip() == "":
             form += "0"
         else:
-            pytest.fail("{}:{}: invalid rst".format(name, i + 1), pytrace=False)
+            pytest.fail("{}:{}: invalid rst".format(name, i + 1), pytrace=True)
     # The file should have:
     #   empty lines around categories
     #   at least one content line in a non null category
     reg = re.compile(r"^(3(0|$)|20(1|4)(1|0|4)*0|204$)+$")
     if not reg.match(form):
         print(form)
-        pytest.fail("{}: invalid rst".format(name), pytrace=False)
+        pytest.fail("{}: invalid rst".format(name), pytrace=True)
 
 
 @pytest.mark.parametrize("fname", list(scandir(NEWSDIR)))

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -1,6 +1,7 @@
 """Python virtual environment manager for xonsh."""
 
 import sys
+import textwrap
 import xontrib.voxapi as voxapi
 import xonsh.lazyasd as lazyasd
 
@@ -30,8 +31,13 @@ class VoxHandler:
         create.add_argument(
             "-p",
             "--interpreter",
-            default=voxapi.VOX_DEFAULT_INTERPRETER,
-            help=f"The Python interpreter used to create the virtual environment default: {voxapi.VOX_DEFAULT_INTERPRETER}",
+            default=None,
+            help=textwrap.dedent(
+                """
+                The Python interpreter used to create the virtual environment. 
+                Can be configured via the $VOX_DEFAULT_INTERPRETER environment variable.
+                """
+            ).strip(),
         )
 
         from xonsh.platform import ON_WINDOWS

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -49,6 +49,7 @@ class VoxHandler:
                                  'by default)')
 
         create.add_argument(
+            "-p",
             "--interpreter",
             default=voxapi.DEFAULT_VOX_INTERPRETER,
             help=f"The Python interpreter used to create the virtual environment default: {voxapi.DEFAULT_VOX_INTERPRETER}",

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -27,8 +27,12 @@ class VoxHandler:
                             help='Give the virtual environment access to the '
                                  'system site-packages dir.')
 
-        create.add_argument('--interpreter', default=sys.executable,
-                            help='The Python interpreter used to create the virtual env.')
+        create.add_argument(
+            "-p",
+            "--interpreter",
+            default=voxapi.VOX_DEFAULT_INTERPRETER,
+            help=f"The Python interpreter used to create the virtual environment default: {voxapi.VOX_DEFAULT_INTERPRETER}",
+        )
 
         from xonsh.platform import ON_WINDOWS
         group = create.add_mutually_exclusive_group()
@@ -47,13 +51,6 @@ class VoxHandler:
                             help='Skips installing or upgrading pip in the '
                                  'virtual environment (pip is bootstrapped '
                                  'by default)')
-
-        create.add_argument(
-            "-p",
-            "--interpreter",
-            default=voxapi.DEFAULT_VOX_INTERPRETER,
-            help=f"The Python interpreter used to create the virtual environment default: {voxapi.DEFAULT_VOX_INTERPRETER}",
-        )
 
         activate = subparsers.add_parser(
             'activate', aliases=['workon', 'enter'],

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -34,7 +34,7 @@ class VoxHandler:
             default=None,
             help=textwrap.dedent(
                 """
-                The Python interpreter used to create the virtual environment. 
+                The Python interpreter used to create the virtual environment.
                 Can be configured via the $VOX_DEFAULT_INTERPRETER environment variable.
                 """
             ).strip(),

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -27,6 +27,9 @@ class VoxHandler:
                             help='Give the virtual environment access to the '
                                  'system site-packages dir.')
 
+        create.add_argument('--interpreter', default=sys.executable,
+                            help='The Python interpreter used to create the virtual env.')
+
         from xonsh.platform import ON_WINDOWS
         group = create.add_mutually_exclusive_group()
         group.add_argument('--symlinks', default=not ON_WINDOWS,
@@ -44,6 +47,12 @@ class VoxHandler:
                             help='Skips installing or upgrading pip in the '
                                  'virtual environment (pip is bootstrapped '
                                  'by default)')
+
+        create.add_argument(
+            "--interpreter",
+            default=voxapi.DEFAULT_VOX_INTERPRETER,
+            help=f"The Python interpreter used to create the virtual environment default: {voxapi.DEFAULT_VOX_INTERPRETER}",
+        )
 
         activate = subparsers.add_parser(
             'activate', aliases=['workon', 'enter'],
@@ -94,11 +103,14 @@ class VoxHandler:
     def cmd_new(self, args, stdin=None):
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
         """
-        print('Creating environment...')
-        self.vox.create(args.name,
-                        system_site_packages=args.system_site_packages,
-                        symlinks=args.symlinks,
-                        with_pip=args.with_pip)
+        print("Creating environment...")
+        self.vox.create(
+            args.name,
+            system_site_packages=args.system_site_packages,
+            symlinks=args.symlinks,
+            with_pip=args.with_pip,
+            interpreter=args.interpreter,
+        )
         msg = 'Environment {0!r} created. Activate it with "vox activate {0}".\n'
         print(msg.format(args.name))
 

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -233,6 +233,7 @@ class Vox(collections.abc.Mapping):
             with_pip,
             upgrade,
         ]
+        cmd = [arg for arg in cmd if arg]  # remove empty args
 
         logging.debug(cmd)
 

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -10,10 +10,11 @@ Vox defines several events related to the life cycle of virtual environments:
 """
 import os
 import sys
-import venv
 import shutil
 import builtins
 import collections.abc
+import subprocess as sp
+
 
 from xonsh.platform import ON_POSIX, ON_WINDOWS
 from xonsh.fs import PathLike, fspath
@@ -21,6 +22,10 @@ from xonsh.fs import PathLike, fspath
 # This is because builtins aren't globally created during testing.
 # FIXME: Is there a better way?
 from xonsh.events import events
+
+DEFAULT_VOX_INTERPRETER = builtins.__xonsh__.env.get(
+    "DEFAULT_VOX_INTERPRETER", sys.executable
+)
 
 
 events.doc('vox_on_create', """
@@ -114,14 +119,23 @@ class Vox(collections.abc.Mapping):
         else:
             self.venvdir = builtins.__xonsh__.env['VIRTUALENV_HOME']
 
-    def create(self, name, *, system_site_packages=False, symlinks=False,
-               with_pip=True):
+    def create(
+        self,
+        name,
+        *,
+        interpreter=DEFAULT_VOX_INTERPRETER,
+        system_site_packages=False,
+        symlinks=False,
+        with_pip=True,
+    ):
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
 
         Parameters
         ----------
         name : str
             Virtual environment name
+        interpreter: str
+            Python interpreter used to create the virtual environment.
         system_site_packages : bool
             If True, the system (global) site-packages dir is available to
             created environments.
@@ -138,14 +152,23 @@ class Vox(collections.abc.Mapping):
         else:
             env_path = os.path.join(self.venvdir, name)
         if not self._check_reserved(env_path):
-            raise ValueError("venv can't contain reserved names ({})".format(', '.join(_subdir_names())))
-        venv.create(
-            env_path,
-            system_site_packages=system_site_packages, symlinks=symlinks,
-            with_pip=with_pip)
+            raise ValueError(
+                "venv can't contain reserved names ({})".format(
+                    ", ".join(_subdir_names())
+                )
+            )
+
+        self._create(env_path, interpreter, symlinks=symlinks, with_pip=with_pip)
         events.vox_on_create.fire(name=name)
 
-    def upgrade(self, name, *, symlinks=False, with_pip=True):
+    def upgrade(
+        self,
+        name,
+        *,
+        symlinks=False,
+        with_pip=True,
+        interpreter=DEFAULT_VOX_INTERPRETER,
+    ):
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
 
         WARNING: If a virtual environment was created with symlinks or without PIP, you must
@@ -155,6 +178,8 @@ class Vox(collections.abc.Mapping):
         ----------
         name : str
             Virtual environment name
+        interpreter: str
+            The Python interpreter used to create the virtualenv
         symlinks : bool
             If True, attempt to symlink rather than copy files into virtual
             environment.
@@ -164,24 +189,57 @@ class Vox(collections.abc.Mapping):
         # venv doesn't reload this, so we have to do it ourselves.
         # Is there a bug for this in Python? There should be.
         env_path, bin_path = self[name]
-        cfgfile = os.path.join(env_path, 'pyvenv.cfg')
+        cfgfile = os.path.join(env_path, "pyvenv.cfg")
         cfgops = {}
         with open(cfgfile) as cfgfile:
             for l in cfgfile:
                 l = l.strip()
-                if '=' not in l:
+                if "=" not in l:
                     continue
-                k, v = l.split('=', 1)
+                k, v = l.split("=", 1)
                 cfgops[k.strip()] = v.strip()
         flags = {
-            'system_site_packages': cfgops['include-system-site-packages'] == 'true',
-            'symlinks': symlinks,
-            'with_pip': with_pip,
+            "system_site_packages": cfgops["include-system-site-packages"] == "true",
+            "symlinks": symlinks,
+            "with_pip": with_pip,
         }
         # END things we shouldn't be doing.
 
         # Ok, do what we came here to do.
-        venv.create(env_path, upgrade=True, **flags)
+        self_.create(env_path, interpreter, upgrade=True, **flags)
+
+    @staticmethod
+    def _create(
+        env_path,
+        interpreter,
+        *,
+        system_site_packages=False,
+        symlinks=False,
+        with_pip=True,
+        upgrade=False,
+    ):
+        interpreter_major_version = int(
+            sp.run([interpreter, "--version"], stderr=sp.PIPE)
+            .stderr.decode()
+            .split()[-1]
+            .split(".")[0]
+        )
+        module = "venv" if interpreter_major_version >= 3 else "virtualenv"
+        system_site_packages = "--system-site-packages" if system_site_packages else ""
+        symlinks = "--symlinks" if symlinks and interpreter_major_version >= 3 else ""
+        with_pip = "" if with_pip else "--without-pip"
+        upgrade = "--upgrade" if upgrade else ""
+
+        cmd = shlex.split(
+            f"{interpreter} -m {module} {env_path} {system_site_packages} {symlinks} {with_pip} {upgrade}"
+        )
+
+        logging.debug(cmd)
+
+        process = sp.run(cmd)
+
+        if process.returncode != 0:
+            raise SystemExit(process.returncode)
 
     @staticmethod
     def _check_reserved(name):

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -120,7 +120,6 @@ class Vox(collections.abc.Mapping):
     def create(
         self,
         name,
-        *,
         interpreter=None,
         system_site_packages=False,
         symlinks=False,
@@ -162,7 +161,7 @@ class Vox(collections.abc.Mapping):
         self._create(env_path, interpreter, symlinks=symlinks, with_pip=with_pip)
         events.vox_on_create.fire(name=name)
 
-    def upgrade(self, name, *, symlinks=False, with_pip=True, interpreter=None):
+    def upgrade(self, name, symlinks=False, with_pip=True, interpreter=None):
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
 
         WARNING: If a virtual environment was created with symlinks or without PIP, you must
@@ -209,7 +208,6 @@ class Vox(collections.abc.Mapping):
     def _create(
         env_path,
         interpreter,
-        *,
         system_site_packages=False,
         symlinks=False,
         with_pip=True,

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -23,8 +23,8 @@ from xonsh.fs import PathLike, fspath
 # FIXME: Is there a better way?
 from xonsh.events import events
 
-DEFAULT_VOX_INTERPRETER = builtins.__xonsh__.env.get(
-    "DEFAULT_VOX_INTERPRETER", sys.executable
+VOX_DEFAULT_INTERPRETER = builtins.__xonsh__.env.get(
+    "VOX_DEFAULT_INTERPRETER", sys.executable
 )
 
 
@@ -123,7 +123,7 @@ class Vox(collections.abc.Mapping):
         self,
         name,
         *,
-        interpreter=DEFAULT_VOX_INTERPRETER,
+        interpreter=VOX_DEFAULT_INTERPRETER,
         system_site_packages=False,
         symlinks=False,
         with_pip=True,
@@ -167,7 +167,7 @@ class Vox(collections.abc.Mapping):
         *,
         symlinks=False,
         with_pip=True,
-        interpreter=DEFAULT_VOX_INTERPRETER,
+        interpreter=VOX_DEFAULT_INTERPRETER,
     ):
         """Create a virtual environment in $VIRTUALENV_HOME with python3's ``venv``.
 

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -10,7 +10,6 @@ Vox defines several events related to the life cycle of virtual environments:
 """
 import os
 import sys
-import shlex
 import shutil
 import logging
 import builtins
@@ -224,11 +223,16 @@ class Vox(collections.abc.Mapping):
         with_pip = "" if with_pip else "--without-pip"
         upgrade = "--upgrade" if upgrade else ""
 
-        cmd = shlex.split(
-            "{interpreter} -m {module} {env_path} {system_site_packages} {symlinks} {with_pip} {upgrade}".format(
-                **locals()
-            )
-        )
+        cmd = [
+            interpreter,
+            "-m",
+            module,
+            env_path,
+            system_site_packages,
+            symlinks,
+            with_pip,
+            upgrade,
+        ]
 
         logging.debug(cmd)
 


### PR DESCRIPTION
This PR allows one to pass a `-p` or `--interpreter` argument to `vox new` in order to specify a specific interpreter to virtual environment creation.

If not passed, the interpreter will be determined by the value of the `$VOX_DEFAULT_INTREPRETER` environment variable. If not set, vox will default to using `xonsh`'s `sys.executable`.

This PR addresses the following issues:

#2347
#692
