### PR TITLE
Add `pf` strings

### DIFF
--- a/news/pf_strings.rst
+++ b/news/pf_strings.rst
@@ -1,0 +1,34 @@
+**Added:**
+
+* New xonsh syntax ``pf`` strings -- combining path strings with f-strings.
+
+  Usage:
+
+  .. code-block:: bash
+       gil@bad_cat ~ $ repos = 'github.com'
+       gil@bad_cat ~ $ pf"~/{repos}"
+       PosixPath('/home/gil/github.com')
+       gil@bad_cat ~ $ pf"{$HOME}"
+       PosixPath('/home/gil')
+       gil@bad_cat ~ $ pf"/home/${'US' + 'ER'}"
+       PosixPath('/home/gil')
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -384,6 +384,17 @@ def test_path_string_literal():
     assert check_token('rp"/foo"', ["STRING", 'rp"/foo"', 0])
 
 
+def test_path_fstring_literal():
+    assert check_token("pf'/foo'", ["STRING", "pf'/foo'", 0])
+    assert check_token('pf"/foo"', ["STRING", 'pf"/foo"', 0])
+    assert check_token("fp'/foo'", ["STRING", "fp'/foo'", 0])
+    assert check_token('fp"/foo"', ["STRING", 'fp"/foo"', 0])
+    assert check_token("pF'/foo'", ["STRING", "pF'/foo'", 0])
+    assert check_token('pF"/foo"', ["STRING", 'pF"/foo"', 0])
+    assert check_token("Fp'/foo'", ["STRING", "Fp'/foo'", 0])
+    assert check_token('Fp"/foo"', ["STRING", 'Fp"/foo"', 0])
+
+
 def test_regex_globs():
     for i in (".*", r"\d*", ".*#{1,2}"):
         for p in ("", "r", "g", "@somethingelse", "p", "pg"):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2042,6 +2042,17 @@ def test_path_literal():
     check_xonsh_ast({}, 'Rp"/foo"', False)
 
 
+def test_path_fstring_literal():
+    check_xonsh_ast({}, 'pf"/foo"', False)
+    check_xonsh_ast({}, 'fp"/foo"', False)
+    check_xonsh_ast({}, 'pF"/foo"', False)
+    check_xonsh_ast({}, 'Fp"/foo"', False)
+    check_xonsh_ast({}, 'pf"/foo{1+1}"', False)
+    check_xonsh_ast({}, 'fp"/foo{1+1}"', False)
+    check_xonsh_ast({}, 'pF"/foo{1+1}"', False)
+    check_xonsh_ast({}, 'Fp"/foo{1+1}"', False)
+
+
 def test_dollar_name():
     check_xonsh_ast({"WAKKA": 42}, "$WAKKA")
 

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -273,7 +273,7 @@ Floatnumber = group(Pointfloat, Expfloat)
 Imagnumber = group(r"[0-9](?:_?[0-9])*[jJ]", Floatnumber + r"[jJ]")
 Number = group(Imagnumber, Floatnumber, Intnumber)
 
-StringPrefix = r"(?:[bBp][rR]?|[rR][bBpfF]?|[uU]|[fF][rR]?)?"
+StringPrefix = r"(?:[bB][rR]?|[p][fFrR]?|[rR][bBpfF]?|[uU]|[fF][rR]?[p]?)?"
 
 # Tail end of ' string.
 Single = r"[^'\\]*(?:\\.[^'\\]*)*'"
@@ -394,6 +394,8 @@ endpats = {
     'br"""': Double3,
     "fr'''": Single3,
     'fr"""': Double3,
+    "fp'''": Single3,
+    'fp"""': Double3,
     "bR'''": Single3,
     'bR"""': Double3,
     "Br'''": Single3,
@@ -408,6 +410,8 @@ endpats = {
     'Rb"""': Double3,
     "Fr'''": Single3,
     'Fr"""': Double3,
+    "Fp'''": Single3,
+    'Fp"""': Double3,
     "rB'''": Single3,
     'rB"""': Double3,
     "rF'''": Single3,
@@ -424,6 +428,10 @@ endpats = {
     'p"""': Double3,
     "pr'''": Single3,
     'pr"""': Double3,
+    "pf'''": Single3,
+    'pf"""': Double3,
+    "pF'''": Single3,
+    'pF"""': Double3,
     "pR'''": Single3,
     'pR"""': Double3,
     "rp'''": Single3,
@@ -503,6 +511,14 @@ for t in (
     'rp""""',
     "Rp'''",
     'Rp""""',
+    "pf'''",
+    'pf""""',
+    "pF'''",
+    'pF""""',
+    "fp'''",
+    'fp""""',
+    "Fp'''",
+    'Fp""""',
 ):
     triple_quoted[t] = t
 single_quoted = {}
@@ -567,6 +583,14 @@ for t in (
     'rp"',
     "Rp'",
     'Rp"',
+    "pf'",
+    'pf"',
+    "pF'",
+    'pF"',
+    "fp'",
+    'fp"',
+    "Fp'",
+    'Fp"',
 ):
     single_quoted[t] = t
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Ok, this still needs some documentation but I got it working and wanted to put it up for review (plus it's fun!).

This resolves #2524 and adds a new bit of syntax which combines p-strings and f-strings.  
This means you can now do things like:

```
gil@bad_cat ~ $ repos = 'github.com'                                           
gil@bad_cat ~ $ fp"~/{repos}"
PosixPath('/home/gil/github.com')
```

but since @scopatz also enabled xonshy f-strings, you can also do things like

```
gil@bad_cat ~ $ pF"{$HOME}"                                              
PosixPath('/home/gil')
```

or you can keep going deeper and try

```
gil@bad_cat ~ $ pf"/home/${'US' + 'ER'}"                                 
PosixPath('/home/gil')
```

This currently doesn't support combining the `pf` prefix with the raw-string prefix because I couldn't think of a reason for them off the top of my head, but if someone wants it, just holler.

Also, just following along with our existing p-string work we support only lowercase `p` prefixes, but either case of `f` -- do we want to remove that ambiguity?