### PR TITLE
Adds xontrib which supports direnv to xontrib list

### DIFF
--- a/news/xontrib-direnv.rst
+++ b/news/xontrib-direnv.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* A `xontrib <https://github.com/74th/xonsh-direnv>`_ which adds support for `direnv <https://direnv.net/>`_

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -52,6 +52,11 @@
     "tools avoid the need for a full subprocess call. Additionally, these ",
     "tools are cross-platform."]
  },
+ {"name": "direnv",
+  "package": "xonsh-direnv",
+  "url": "https://github.com/74th/xonsh-direnv",
+  "description": ["Supports direnv."]
+ },
  {"name": "distributed",
   "package": "xonsh",
   "url": "http://xon.sh",
@@ -203,6 +208,13 @@
    "url": "https://github.com/DangerOnTheRanger/xonsh-apt-tabcomplete",
    "install": {
     "pip": "xpip install xonsh-apt-tabcomplete"
+   }
+  },
+  "xonsh-direnv": {
+   "license": "MIT",
+   "url": "https://github.com/74th/xonsh-direnv",
+   "install": {
+    "pip": "xpip install xonsh-direnv"
    }
   },
   "xonsh-docker-tabcomplete": {


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
http://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

I wants to use [direnv](https://direnv.net/) with xonsh.
I made a xontrib, and published to [PyPI package xonsh-direnv](https://pypi.org/project/xonsh-direnv/).
I'm grad if you add it to `xontrib list`.
