### PR TITLE
 send SIGCONT in run_subproc

### DIFF
--- a/news/duck_tape.rst
+++ b/news/duck_tape.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* undesirable SIGSTOP by putting in a SIGCONT
+
+**Security:**
+
+* <news item>

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -905,7 +905,8 @@ def run_subproc(cmds, captured=False):
     if _should_set_title(captured=captured):
         # set title here to get currently executing command
         pause_call_resume(proc, builtins.__xonsh__.shell.settitle)
-    proc.send_signal(signal.SIGCONT)
+    else:
+        pause_call_resume(proc, lambda : 0)
     # create command or return if backgrounding.
     if background:
         return

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -906,7 +906,11 @@ def run_subproc(cmds, captured=False):
         # set title here to get currently executing command
         pause_call_resume(proc, builtins.__xonsh__.shell.settitle)
     else:
-        pause_call_resume(proc, lambda : 0)
+        # for some reason, some programs are in a stopped state when the flow
+        # reaches this point, hence a SIGCONT should be sent to `proc` to make
+        # sure that the shell doesn't hang. This `pause_call_resume` invocation
+        # does this
+        pause_call_resume(proc, int)
     # create command or return if backgrounding.
     if background:
         return

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -905,7 +905,7 @@ def run_subproc(cmds, captured=False):
     if _should_set_title(captured=captured):
         # set title here to get currently executing command
         pause_call_resume(proc, builtins.__xonsh__.shell.settitle)
-    p.send_signal(signal.SIGCONT)
+    proc.send_signal(signal.SIGCONT)
     # create command or return if backgrounding.
     if background:
         return

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -905,6 +905,7 @@ def run_subproc(cmds, captured=False):
     if _should_set_title(captured=captured):
         # set title here to get currently executing command
         pause_call_resume(proc, builtins.__xonsh__.shell.settitle)
+    p.send_signal(signal.SIGCONT)
     # create command or return if backgrounding.
     if background:
         return


### PR DESCRIPTION
It's a hack to fix #2999 and other freaky issues. This is what's causing #2999:
If XONSH_STORE_STDOUT is True
1. [this](https://github.com/sagartewari01/xonsh/blob/27067b6d4e55cc6503c52e221d7ac6aa84176eaa/xonsh/built_ins.py#L863) function returns False.
2. The call to `pause_call_resume` is skipped (https://github.com/sagartewari01/xonsh/blob/27067b6d4e55cc6503c52e221d7ac6aa84176eaa/xonsh/built_ins.py#L907)
3. `pause_call_resume` sends `SIGCONT` to the process.
So it appears to be a `RAII` problem.
As far as I know, sending multiple `SIGCONT`s shouldn't be a problem, so this PR shoudn't have any side effects.