### PR TITLE
Add `<details>` block to issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -4,7 +4,12 @@ please first look over the Bash to Xonsh translation guide: https://xon.sh/bash_
 If you don't find an answer there, please do open an issue! -->
 
 ## xonfig
-<!--- Please post the output of the `xonfig` command (run from inside xonsh) so we know more about your current setup -->
+
+<details>
+```
+$ xonfig
+```
+</details>
 
 ## Expected Behavior
 <!--- Tell us what should happen -->
@@ -14,6 +19,14 @@ If you don't find an answer there, please do open an issue! -->
 <!--- If part of your bug report is a traceback, please first enter debug mode before triggering the error
 To enter debug mode, set the environment variable `XONSH_DEBUG=1` _before_ starting `xonsh`.  
 On Linux and OSX, an easy way to to do this is to run `env XONSH_DEBUG=1 xonsh` -->
+
+### Traceback (if applicable)
+
+<details>
+```
+traceback
+```
+</details>
 
 ## Steps to Reproduce
 <!--- Please try to write out a minimal reproducible snippet to trigger the bug, it will help us fix it! -->


### PR DESCRIPTION
Just noticed this on a conda-forge feedstock and it's nice to not have the issue
text all cluttered up with tracebacks and config outputs

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
