### PR TITLE
Tweak `command_skipper` to avoid overwriting tokens with completer output

### DIFF
--- a/news/spaceitallout.rst
+++ b/news/spaceitallout.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Tweaked ``xonsh.completers.commands.complete_skipper()`` to insert a space following
+  certain tokens (``&&``, ``||``, ``|``, ``and``, ``or``) to avoid overwriting existing tokens
+  with completer output.
+
+**Security:**
+
+* <news item>,

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -48,6 +48,10 @@ def complete_skipper(cmd, line, start, end, ctx):
     if skip_part_num == 0:
         return set()
 
+    # If there's no space following an END_PROC_TOKEN, insert one
+    if parts[-1] in END_PROC_TOKENS:
+        return(set(" "), 0)
+
     if len(parts) == skip_part_num + 1:
         comp_func = complete_command
     else:


### PR DESCRIPTION
Followup to #3002 -- in the event that the last token on a line (without a trailing space) is one of `&&`, `|`, `||`, `and` or `or`, completer will now insert a single space, allowing the next completer call to complete without issue.
