### PR TITLE
Fix detection of Anaconda

### DIFF
--- a/news/on_anaconda.rst
+++ b/news/on_anaconda.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed environments not showing in the prompt when using Anaconda Python.
+
+* Fixed regression with anaconda activate/deactivate scripts not wokring on Windows.
+
+**Security:**
+
+* <news item>

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -97,7 +97,7 @@ def PYTHON_VERSION_INFO_BYTES():
 
 
 ON_ANACONDA = LazyBool(
-    lambda: any(s in sys.version for s in {"Anaconda", "Continuum", "conda-forge"}),
+    lambda: pathlib.Path(sys.prefix).joinpath("conda-meta").exists(),
     globals(),
     "ON_ANACONDA",
 )


### PR DESCRIPTION
This fixes a regression with `ON_ANACONDA` in `platform.py`. This can no longer detect if we are using an Anaconda based Python. The new method to detect conda is more robust. 

This fixes the environment not showing up in the prompt, and the `activate`/`deactivate` script which has stopped working on Windows. 
