### PR TITLE
Fix problem with partial aliases not having __name__ attribute

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -208,6 +208,7 @@ class PartialEvalAliasBase:
         """
         self.f = f
         self.acc_args = acc_args
+        self.__name__ = self.__class__.__name__
 
     def __call__(
         self, args, stdin=None, stdout=None, stderr=None, spec=None, stack=None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -208,7 +208,7 @@ class PartialEvalAliasBase:
         """
         self.f = f
         self.acc_args = acc_args
-        self.__name__ = self.__class__.__name__
+        self.__name__ = getattr(f, "__name__", self.__class__.__name__)
 
     def __call__(
         self, args, stdin=None, stdout=None, stderr=None, spec=None, stack=None


### PR DESCRIPTION
No news items needed for this. 

This fixes a problem with Partial aliases not having a `__name__` attribute in the same location as the previous aliases. @scopatz I don't know if this is the correct fix. 

Without this I get the following error when running a simple aliases: 
```
snail@sea ~\Documents\xonsh
$ cdx
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "C:\Users\mel\anaconda3\lib\site-packages\xonsh\proc.py", line 1856, in __init__
    proc = spec.run(pipeline_group=pipeline_group)
  File "C:\Users\mel\anaconda3\lib\site-packages\xonsh\built_ins.py", line 538, in run
    event_name = self._cmd_event_name()
  File "C:\Users\mel\anaconda3\lib\site-packages\xonsh\built_ins.py", line 612, in _cmd_event_name
    return self.alias.__name__
AttributeError: 'PartialEvalAlias2' object has no attribute '__name__'
```