### PR TITLE
Change url of xontrib-autojump

### DIFF
--- a/news/3036-change-xontrib-autojump.rst
+++ b/news/3036-change-xontrib-autojump.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* change url of xontrib-autojump
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -6,7 +6,7 @@
  },
  {"name": "autojump",
   "package": "xontrib-autojump",
-  "url": "https://github.com/gsaga/autojump-xonsh",
+  "url": "https://github.com/sagartewari01/autojump-xonsh",
   "description": ["autojump support for xonsh"]
  },
  {"name": "autoxsh",


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Changed to the [repository link](https://github.com/sagartewari01/autojump-xonsh) that linked from [PyPI](https://pypi.org/project/xontrib-autojump/).

Maybe this PR fixes #3036.

