### PR TITLE
Implement more bang commands: !$ !* !^ !<cmd>

### DIFF
--- a/news/bang-commands.rst
+++ b/news/bang-commands.rst
@@ -1,0 +1,5 @@
+**Added:**
+
+* Implemented the following "bang command" bashisms: ``!$``, ``$*``, ``!^``, 
+  and ``!<str>``.  These are in addition to ``!!``, which was already 
+  implemented.

--- a/news/bang-commands.rst
+++ b/news/bang-commands.rst
@@ -3,3 +3,4 @@
 * Implemented the following "bang command" bashisms: ``!$``, ``$*``, ``!^``, 
   and ``!<str>``.  These are in addition to ``!!``, which was already 
   implemented.
+

--- a/tests/test_bashisms.py
+++ b/tests/test_bashisms.py
@@ -2,11 +2,43 @@
 import pytest
 
 
-@pytest.mark.parametrize("inp, exp", [("x = 42", "x = 42"), ("!!", "ls")])
-def test_preproc(inp, exp, xonsh_builtins):
+@pytest.mark.parametrize(
+        "history, inp, exp", [
+            # No history:
+            ([], '!!', ''),
+            ([], '!$', ''),
+            ([], '!^', ''),
+            ([], '!*', ''),
+            ([], '!echo', ''),
+
+            # No substitution:
+            (['aa 1 2', 'ab 3 4'], "ls", "ls"),
+            (['aa 1 2', 'ab 3 4'], "x = 42", "x = 42"),
+            (['aa 1 2', 'ab 3 4'], '!', '!'),
+
+            # Bang command only:
+            (['aa 1 2', 'ab 3 4'], "!!", "ab 3 4"),
+            (['aa 1 2', 'ab 3 4'], "!$", "4"),
+            (['aa 1 2', 'ab 3 4'], "!^", "ab"),
+            (['aa 1 2', 'ab 3 4'], "!*", "3 4"),
+            (['aa 1 2', 'ab 3 4'], "!a", "ab 3 4"),
+            (['aa 1 2', 'ab 3 4'], "!aa", "aa 1 2"),
+            (['aa 1 2', 'ab 3 4'], "!ab", "ab 3 4"),
+
+            # Bang command with others:
+            (['aa 1 2', 'ab 3 4'], "echo !! >log", "echo ab 3 4 >log"),
+            (['aa 1 2', 'ab 3 4'], "echo !$ >log", "echo 4 >log"),
+            (['aa 1 2', 'ab 3 4'], "echo !^ >log", "echo ab >log"),
+            (['aa 1 2', 'ab 3 4'], "echo !* >log", "echo 3 4 >log"),
+            (['aa 1 2', 'ab 3 4'], "echo !a >log", "echo ab 3 4 >log"),
+            (['aa 1 2', 'ab 3 4'], "echo !aa >log", "echo aa 1 2 >log"),
+            (['aa 1 2', 'ab 3 4'], "echo !ab >log", "echo ab 3 4 >log"),
+        ]
+)
+def test_preproc(history, inp, exp, xonsh_builtins):
     """Test the bash preprocessor."""
     from xontrib.bashisms import bash_preproc
 
-    xonsh_builtins.__xonsh__.history.inps = ["ls\n"]
+    xonsh_builtins.__xonsh__.history.inps = history
     obs = bash_preproc(inp)
     assert exp == obs

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -29,7 +29,7 @@ def bash_preproc(cmd, **kw):
             try:
                 return bang_previous[arg](inputs[-1])
             except IndexError:
-                print(f"xonsh: no history for '!{arg}'")
+                print("xonsh: no history for '!{}'".format(arg))
                 return ''
 
         # Look back in history for a matching command.
@@ -37,7 +37,7 @@ def bash_preproc(cmd, **kw):
             try:
                 return next((x for x in reversed(inputs) if x.startswith(arg)))
             except StopIteration:
-                print(f"xonsh: no previous commands match '!{arg}'")
+                print("xonsh: no previous commands match '!{}'".format(arg))
                 return ''
 
     return re.sub(r'!([!$^*]|[\w]+)', replace_bang, cmd.strip())

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -1,6 +1,7 @@
 """Bash-like interface extensions for xonsh."""
 import shlex
 import sys
+import re
 
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.filters import Condition, EmacsInsertMode, ViInsertMode
@@ -12,11 +13,34 @@ __all__ = ()
 
 @events.on_transform_command
 def bash_preproc(cmd, **kw):
-    if not __xonsh__.history.inps:
-        if cmd.strip() == '!!':
-            return ''
-        return cmd
-    return cmd.replace('!!', __xonsh__.history.inps[-1].strip())
+    bang_previous = {
+            '!': lambda x: x,
+            '$': lambda x: shlex.split(x)[-1],
+            '^': lambda x: shlex.split(x)[0],
+            '*': lambda x: ' '.join(shlex.split(x)[1:]),
+    }
+
+    def replace_bang(m):
+        arg = m.group(1)
+        inputs = __xonsh__.history.inps
+
+        # Dissect the previous command.
+        if arg in bang_previous:
+            try:
+                return bang_previous[arg](inputs[-1])
+            except IndexError:
+                print(f"xonsh: no history for '!{arg}'")
+                return ''
+
+        # Look back in history for a matching command.
+        else:
+            try:
+                return next((x for x in reversed(inputs) if x.startswith(arg)))
+            except StopIteration:
+                print(f"xonsh: no previous commands match '!{arg}'")
+                return ''
+
+    return re.sub(r'!([!$^*]|[\w]+)', replace_bang, cmd.strip())
 
 
 @events.on_ptk_create


### PR DESCRIPTION
While the 'bashisms' xontrib provides the `!!` command, several related commands are notably missing:
```
!$        # The last argument of the previous command.
!*        # All arguments but the first of the previous command.
!^        # The first argument of the previous command.
!<cmd>    # The last command beginning with the string "cmd".
```
This commit implements these commands in the same fashion as `!!`.  Note that this remains far from a complete implementation of the bash bang command syntax, but it covers the comands that I use on a daily basis and is hopefully a step in the right direction.

If there's interest, I could also implement more of the bash syntax, e.g.:
```
!!:2      # The second argument of the previous command.
!!:2-3    # The second and third arguments of the previous command.
!!:2-$    # The second through final arguments of the previous command.
!!:-2     # The first two arguments of the previous command.
!-2       # The command before last.
!-2:2     # The second argument of the command before last.
```

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
