### PR TITLE
Fix "'NoneType' object is not iterable" on stty lookup

### DIFF
--- a/news/stty_lookup_bug.rst
+++ b/news/stty_lookup_bug.rst
@@ -1,0 +1,5 @@
+**Fixed:**
+
+* Fixed a "'NoneType' object is not iterable" bug when looking up ``stty``
+  in command cache.
+

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -641,7 +641,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         """
         if not ON_POSIX:
             return
-        stty, _ = builtins.__xonsh__.commands_cache.lazyget("stty", None)
+        stty, _ = builtins.__xonsh__.commands_cache.lazyget("stty", (None, None))
         if stty is None:
             return
         # If available, we should just call the stty utility. This call should


### PR DESCRIPTION
Was getting this error after running any shell command in xonsh 0.8.12, Win 10, cygwin, Python 3.6.4:

```
$ git diff . | vim -
Vim: Reading from stdin...

xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "_env/lib/python3.6/site-packages/xonsh/base_shell.py", line 360, in default
    run_compiled_code(code, self.ctx, None, "single")
  File "_env/lib/python3.6/site-packages/xonsh/codecache.py", line 67, in run_compiled_code
    func(code, glb, loc)
  File "<xonsh-code>", line 1, in <module>
  File "_env/lib/python3.6/site-packages/xonsh/built_ins.py", line 987, in subproc_captured_hiddenobject
    return run_subproc(cmds, captured="hiddenobject")
  File "_env/lib/python3.6/site-packages/xonsh/built_ins.py", line 950, in run_subproc
    command.end()
  File "_env/lib/python3.6/site-packages/xonsh/proc.py", line 2118, in end
    self._return_terminal()
  File "_env/lib/python3.6/site-packages/xonsh/proc.py", line 2151, in _return_terminal
    builtins.__xonsh__.shell.shell.restore_tty_sanity()
  File "_env/lib/python3.6/site-packages/xonsh/readline_shell.py", line 644, in restore_tty_sanity
    stty, _ = builtins.__xonsh__.commands_cache.lazyget("stty", None)
TypeError: 'NoneType' object is not iterable
```

Seems like a simple mistake in the default value for lazyget.