### PR TITLE
Catch PermissionError which occur when a user doesn't have access to …

### DIFF
--- a/news/hg_permission_error.rst
+++ b/news/hg_permission_error.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed issue which occurs when user doesn't have access to parent directory and
+  xonsh scan all parents directory to find if we are in a Hg repository.
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -60,14 +60,17 @@ def _get_hg_root(q):
     while True:
         if not os.path.isdir(_curpwd):
             return False
-        if any([b.name == ".hg" for b in xt.scandir(_curpwd)]):
-            q.put(_curpwd)
-            break
-        else:
-            _oldpwd = _curpwd
-            _curpwd = os.path.split(_curpwd)[0]
-            if _oldpwd == _curpwd:
-                return False
+        try:
+            if any([b.name == ".hg" for b in xt.scandir(_curpwd)]):
+                q.put(_curpwd)
+                break
+            else:
+                _oldpwd = _curpwd
+                _curpwd = os.path.split(_curpwd)[0]
+                if _oldpwd == _curpwd:
+                    return False
+        except OSError:
+            return False
 
 
 def get_hg_branch(root=None):


### PR DESCRIPTION
Catch PermissionError which occur when a user doesn't have access to directory.

For example, this behavior occurs:
```
leger@somewhere ~ $                                                                                                                      
Exception in thread Thread-16:
Traceback (most recent call last):
  File "/home/lab/leger/.local/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/home/lab/leger/.local/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/lab/leger/.local/lib/python3.7/site-packages/xonsh/prompt/vc.py", line 63, in _get_hg_root
    if any([b.name == ".hg" for b in xt.scandir(_curpwd)]):
PermissionError: [Errno 13] Permission denied: '/home/lab'

leger@somewhere ~ $ 
```

Because on this server, my home is `/home/lab/leger`, but I cannot stat `/home/lab`. In this case, when a user doesn't have access to parent directory, I assume we can stop scanning and if a `.hg` is not found yet, we can consider we are not in a Hg repo.