### PR TITLE
Fix cat empty file

### DIFF
--- a/news/fix-cat-empty-file.rst
+++ b/news/fix-cat-empty-file.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* fix causing infinite loop when doing ``cat`` empty file
+
+**Security:**
+
+* <news item>

--- a/tests/test_xoreutils.py
+++ b/tests/test_xoreutils.py
@@ -122,6 +122,7 @@ class TestCat:
         content = "this is a content\nfor testing xoreutil's cat"
         with open(self.tempfile, "w") as f:
             f.write(content)
+        expected_content = content.replace("\n", os.linesep)
 
         stdin = io.StringIO()
         stdout_buf = io.BytesIO()
@@ -132,7 +133,7 @@ class TestCat:
         cat._cat_single_file(opts, self.tempfile, stdin, stdout, stderr)
         stdout.flush()
         stderr.flush()
-        assert stdout_buf.getvalue() == bytes(content, "utf-8")
+        assert stdout_buf.getvalue() == bytes(expected_content, "utf-8")
         assert stderr_buf.getvalue() == b''
 
     def test_cat_empty_file(self):

--- a/tests/test_xoreutils.py
+++ b/tests/test_xoreutils.py
@@ -6,6 +6,7 @@ from xonsh.xoreutils import _which
 from xonsh.xoreutils import uptime
 from xonsh.xoreutils import cat
 from xonsh.tools import ON_WINDOWS
+from xonsh.platform import DEFAULT_ENCODING
 
 
 class TestWhich:
@@ -104,6 +105,14 @@ def test_boottime():
     assert uptime._BOOTTIME > 0.0
 
 
+@pytest.fixture
+def cat_env_fixture(xonsh_builtins):
+    with xonsh_builtins.__xonsh__.env.swap(
+            XONSH_ENCODING=DEFAULT_ENCODING,
+            XONSH_ENCODING_ERRORS="surrogateescape"):
+        yield xonsh_builtins
+
+
 class TestCat:
     tempfile = None
 
@@ -116,7 +125,7 @@ class TestCat:
     def teardown_method(self, _method):
         os.remove(self.tempfile)
 
-    def test_cat_single_file_work_exist_content(self):
+    def test_cat_single_file_work_exist_content(self, cat_env_fixture):
         import io
 
         content = "this is a content\nfor testing xoreutil's cat"
@@ -136,9 +145,8 @@ class TestCat:
         assert stdout_buf.getvalue() == bytes(expected_content, "utf-8")
         assert stderr_buf.getvalue() == b''
 
-    def test_cat_empty_file(self):
+    def test_cat_empty_file(self, cat_env_fixture):
         import io
-
         with open(self.tempfile, "w") as f:
             f.write("")
 

--- a/tests/test_xoreutils.py
+++ b/tests/test_xoreutils.py
@@ -111,6 +111,7 @@ class TestCat:
         import tempfile
         tmpfile = tempfile.mkstemp()
         self.tempfile = tmpfile[1]
+        os.close(tmpfile[0])
 
     def teardown_method(self, _method):
         os.remove(self.tempfile)

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -55,7 +55,7 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
         f = xproc.NonBlockingFDReader(fobj.fileno(), timeout=0.1)
     sep = os.linesep.encode(enc, enc_errors)
     last_was_blank = False
-    while file_size is None or read_size < file_size:
+    while file_size is not None and read_size < file_size:
         try:
             last_was_blank, line_count, read_size, endnow = _cat_line(
                 f,

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -1,5 +1,6 @@
 """Implements a cat command for xonsh."""
 import os
+import stat
 import time
 import builtins
 
@@ -48,14 +49,15 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
         print("cat: No such file or directory: {}".format(fname), file=err)
         return True, line_count
     else:
-        file_size = os.stat(fname).st_size
-        if file_size == 0:
+        fstat = os.stat(fname)
+        file_size = fstat.st_size
+        if file_size == 0 and not stat.S_ISREG(fstat.st_mode):
             file_size = None
         fobj = open(fname, "rb")
         f = xproc.NonBlockingFDReader(fobj.fileno(), timeout=0.1)
     sep = os.linesep.encode(enc, enc_errors)
     last_was_blank = False
-    while file_size is not None and read_size < file_size:
+    while file_size is None or read_size < file_size:
         try:
             last_was_blank, line_count, read_size, endnow = _cat_line(
                 f,


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Fixed causing infinite loop when doing `cat` empty file 
and add test about `cat`.

Reproduce problem:

```sh
xonsh --no-rc
xontrib load coreutils
touch empty_file
cat empty_file
# Hang up. Maybe it needs to kill this process from other terminal.
```

Reproduce `xonfig`:
```
+------------------+----------------------+
| xonsh            | 0.8.12.dev19         |
| Git SHA          | 5d87fc76             |
| Commit Date      | Mar 23 23:55:33 2019 |
| Python           | 3.7.3                |
| PLY              | 3.11                 |
| have readline    | True                 |
| prompt toolkit   | 2.0.9                |
| shell type       | prompt_toolkit2      |
| pygments         | 2.3.1                |
| on posix         | True                 |
| on linux         | True                 |
| distro           | arch                 |
| on darwin        | False                |
| on windows       | False                |
| on cygwin        | False                |
| on msys2         | False                |
| is superuser     | False                |
| default encoding | utf-8                |
| xonsh encoding   | utf-8                |
| encoding errors  | surrogateescape      |
+------------------+----------------------+
```
