### PR TITLE
Add all test files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,11 @@
 include logo.txt
 include scripts/*
-include tests/*
 include license
 include CHANGELOG.rst
 include README.rst
+include run-tests.xsh
+recursive-include tests *
+exclude tests/test_news.py
 recursive-include xonsh/ply/example *
 recursive-include xonsh/ply/doc *
 recursive-include xonsh/ply/test *

--- a/news/test-manifest.rst
+++ b/news/test-manifest.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* The release tarball now includes all test files.

--- a/news/test-manifest.rst
+++ b/news/test-manifest.rst
@@ -1,3 +1,4 @@
 **Fixed:**
 
 * The release tarball now includes all test files.
+


### PR DESCRIPTION
While packaging xonsh for Fedora, I lacked all of the files necessary for running the tests. This patch should fix that.

https://bugzilla.redhat.com/show_bug.cgi?id=1695139