### PR TITLE
CI: use `conda` directly instead of CondaEnvironment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,27 +21,20 @@ jobs:
 
   # Conda Environment
   # Create and activate a Conda environment.
-  - task: CondaEnvironment@1
-    inputs:
-      packageSpecs: 'python=$(python.version) conda=4.5.11 pygments prompt_toolkit pytest pytest-timeout numpy psutil matplotlib flake8 coverage pyflakes pytest-cov pytest-flake8 codecov'
-      installOptions: '-c conda-forge/label/cf201901'
-      updateConda: false
-    condition: eq(variables['python.version'], '3.5')
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
+  - script: 'conda create --yes --quiet --name conda-test-$(python.version) -c conda-forge/label/cf201901 python=$(python.version) conda=4.5.11 pygments prompt_toolkit pytest pytest-timeout numpy psutil matplotlib flake8 coverage pyflakes pytest-cov pytest-flake8 codecov'
     displayName: 'Conda Environment (conda-forge/label/cf201901)'
-  - task: CondaEnvironment@1
-    inputs:
-      packageSpecs: 'python=$(python.version) pygments prompt_toolkit pytest pytest-timeout numpy psutil matplotlib flake8 coverage pyflakes pytest-cov pytest-flake8 codecov'
-      installOptions: '-c conda-forge/label/cf201901'
-      updateConda: false
     condition: eq(variables['python.version'], '3.5')
-  - task: CondaEnvironment@1
-    inputs:
-      packageSpecs: 'python=$(python.version) pygments prompt_toolkit pytest pytest-timeout numpy psutil matplotlib flake8 coverage pyflakes pytest-cov pytest-flake8 codecov'
-      installOptions: '-c conda-forge'
-      updateConda: false
+  - script: |
+      call activate conda-test-$(python.version)
+      conda install --yes --quiet -c conda-forge/label/cf201901 python=$(python.version) pygments prompt_toolkit pytest pytest-timeout numpy psutil matplotlib flake8 coverage pyflakes pytest-cov pytest-flake8 codecov
+    condition: eq(variables['python.version'], '3.5')
+  - script: 'conda create --yes --quiet --name conda-test-$(python.version) -c conda-forge python=$(python.version) pygments prompt_toolkit pytest pytest-timeout numpy psutil matplotlib flake8 coverage pyflakes pytest-cov pytest-flake8 codecov'
     condition: ne(variables['python.version'], '3.5')
     displayName: 'Conda Environment (conda-forge)'
   - script: |
+      call activate conda-test-$(python.version)
       pip install .
       xonsh run-tests.xsh --timeout=10 --junitxml=junit/test-results.xml
     displayName: 'Tests'


### PR DESCRIPTION
CondaEnvironment is deprecated.
Rewrite to follow this instruction:
https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda?view=azure-devops&tabs=vs2017

This PR fixes causing ImportError in Azure Pipelines Python 3.7 Conda Environment ([like this](https://dev.azure.com/xonsh/xonsh/_build/results?buildId=565)) , but the results of some tests become unstable. (I checked some testcase causes `AttributeError: module 'builtins' has no attribute '__xonsh__'
`)

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
