### PR TITLE
Set PTY size to same size as main terminal for threadable commands

### DIFF
--- a/news/pty_size.rst
+++ b/news/pty_size.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* PTYs created for running threadable command have now size set to same size
+  than main terminal.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -45,7 +45,7 @@ from xonsh.tools import (
     XonshError,
     XonshCalledProcessError,
 )
-from xonsh.lazyimps import pty, termios
+from xonsh.lazyimps import pty, termios, fcntl
 from xonsh.commands_cache import CommandsCache
 from xonsh.events import events
 
@@ -771,6 +771,17 @@ def _safe_pipe_properties(fd, use_tty=False):
     props = termios.tcgetattr(fd)
     props[1] = props[1] & (~termios.ONLCR) | termios.ONLRET
     termios.tcsetattr(fd, termios.TCSANOW, props)
+    # newly created PTYs have a stardard size (24x80), set size to the same size
+    # than the current terminal
+    winsize = None
+    if sys.stdin.isatty():
+        winsize = fcntl.ioctl(sys.stdin.fileno(), termios.TIOCGWINSZ, b"0000")
+    elif sys.stdout.isatty():
+        winsize = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, b"0000")
+    elif sys.stderr.isatty():
+        winsize = fcntl.ioctl(sys.stderr.fileno(), termios.TIOCGWINSZ, b"0000")
+    if winsize is not None:
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)
 
 
 def _update_last_spec(last):


### PR DESCRIPTION
Commands which are threadable are run with separated PTY. For some usage, PTY should have the same size as the command is not threadable. For example, before this branch:

```
jben@garance ~ $ __xonsh__.commands_cache.threadable_predictors['tput']=xonsh.commands_cache.predict_false # we want tput as NOT threadable                    
jben@garance ~ $ tput cols                                                                                                                                     
159
jben@garance ~ $ __xonsh__.commands_cache.threadable_predictors['tput']=xonsh.commands_cache.predict_true # we want tput threadable                            
jben@garance ~ $ tput cols                                                                                                                                     
80
```

With this branch:

```
jben@garance ~ $ __xonsh__.commands_cache.threadable_predictors['tput']=xonsh.commands_cache.predict_false # we want tput as NOT threadable                    
jben@garance ~ $ tput cols                                                                                                                                     
159
jben@garance ~ $ __xonsh__.commands_cache.threadable_predictors['tput']=xonsh.commands_cache.predict_true # we want tput threadable                            
jben@garance ~ $ tput cols                                                                                                                                     
159
```

Many command which have artifacts with threading are more tolerant with this behavior. But those commands still need to be added to exception in command_cache. For some case, the size is the only reason why the command is not threadable.