### PR TITLE
Not threadable asciinema

### DIFF
--- a/news/not_threadable_asciinema.rst
+++ b/news/not_threadable_asciinema.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* asciinema (terminal recorder) added in not threadable commands.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -387,6 +387,7 @@ def default_threadable_predictors():
     # alphabetical, for what it is worth.
     predictors = {
         "aurman": predict_false,
+        "asciinema": predict_help_ver,
         "bash": predict_shell,
         "csh": predict_shell,
         "clear": predict_false,


### PR DESCRIPTION
`asciinema` (terminal recorder tool) can have very strange behavior when threaded. Seems to be resolved when pty size is correctly specified (see #3079) but, I think it is safer to add this command in not threadable commands.