### PR TITLE
Not threadable tput

### DIFF
--- a/news/not_threadable_tput.rst
+++ b/news/not_threadable_tput.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* tput added in not threadable commands.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -426,6 +426,7 @@ def default_threadable_predictors():
         "sudo": predict_help_ver,
         "tcsh": predict_shell,
         "telnet": predict_false,
+        "tput": predict_false,
         "top": predict_help_ver,
         "vi": predict_false,
         "view": predict_false,


### PR DESCRIPTION
Usually when a user play with `tput`, they want to interact with the main terminal, not a PTY created between the command and the terminal.