### PR TITLE
Tests usrbinenv args

### DIFF
--- a/news/tests_usrbinenv_args.rst
+++ b/news/tests_usrbinenv_args.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Arguments passed to python in 'scripts/xonsh' and in 'scripts/xonsh-cat' are
+  now passed by a portable hack in sh, not anymore by /usr/bin/env.
+
+**Security:**
+
+* <news item>

--- a/scripts/xonsh
+++ b/scripts/xonsh
@@ -1,3 +1,8 @@
-#!/usr/bin/env python3 -u
+#!/bin/sh
+'''#'
+exec python3 -u "$0" "$@"
+'''#'
+# Portable trick to pass option [-u] to python3, more portable than /usr/bin/env.
+
 from xonsh.main import main
 main()

--- a/scripts/xonsh-cat
+++ b/scripts/xonsh-cat
@@ -1,3 +1,8 @@
-#!/usr/bin/env python3 -u
+#!/bin/sh
+'''#'
+exec python3 -u "$0" "$@"
+'''#'
+# Portable trick to pass option [-u] to python3, more portable than /usr/bin/env.
+
 from xonsh.xoreutils.cat import cat_main as main
 main()


### PR DESCRIPTION
Arguments passed to python in `scripts/xonsh` and in `scripts/xonsh-cat` are now passed by a portable hack in sh, not anymore by `/usr/bin/env`, because `/usr/bin/env` can be not able to handle arguments.

Some tests in `test_integrations.py` was failing on my system, and are now passing.

Similar to #3068, but this PR concerns other scripts.