### PR TITLE
Tests git commit no gpg sign

### DIFF
--- a/news/tests_git_commit_no-gpg-sign.rst
+++ b/news/tests_git_commit_no-gpg-sign.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lib/test_os.xsh
+++ b/tests/test_lib/test_os.xsh
@@ -33,7 +33,7 @@ def test_rmtree():
             git config user.name "Code Monkey"
             touch thing.txt
             git add thing.txt
-            git commit -am "add thing"
+            git commit -a --no-gpg-sign -m "add thing"
             popd
             assert os.path.exists('rmtree_test')
             assert os.path.exists('rmtree_test/thing.txt')

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -209,7 +209,7 @@ def test_repo(request):
         with open("test-file", "w"):
             pass
         sp.call(["git", "add", "test-file"])
-        sp.call(["git", "commit", "-m", "test commit"])
+        sp.call(["git", "commit", "--no-gpg-sign", "-m", "test commit"])
     return {"name": vc, "dir": temp_dir}
 
 


### PR DESCRIPTION
The command `gpg commit` is used in some tests. I have a `gitconfig` with `gpgsign = true`, therefore, `git` interact to `gpg` during tests, tests fails or skipped if I do not sign.

For testing, there is no reason to sign commits, so this PR add `--no-gpg-sign` to `git commit` commands.

Since the change is only on `tests/`, I think no news item is necessary. I have commited a empty news item to satisfy the tests on CI.