### PR TITLE
Aliases predictor threadable

### DIFF
--- a/news/aliases_predictor_threadable.rst
+++ b/news/aliases_predictor_threadable.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* For aliases, predictor is build with the predictor of original command, in
+  place of default predictor.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -213,7 +213,14 @@ class CommandsCache(cabc.Mapping):
             val == (name, True) and self.locate_binary(name, ignore_alias=True) is None
         )
 
-    def predictor_threadable(self, cmd0):
+    def predict_threadable(self, cmd):
+        """Predicts whether a command list is able to be run on a background
+        thread, rather than the main thread.
+        """
+        predictor = self.get_predictor_threadable(cmd[0])
+        return predictor(cmd[1:])
+
+    def get_predictor_threadable(self, cmd0):
         """Return the predictor whether a command list is able to be run on a
         background thread, rather than the main thread.
         """
@@ -235,13 +242,6 @@ class CommandsCache(cabc.Mapping):
             predictors[name] = self.default_predictor(name, cmd0)
         predictor = predictors[name]
         return predictor
-
-    def predict_threadable(self, cmd):
-        """Predicts whether a command list is able to be run on a background
-        thread, rather than the main thread.
-        """
-        predictor = self.predictor_threadable(cmd[0])
-        return predictor(cmd[1:])
 
     #
     # Background Predictors (as methods)

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -213,11 +213,11 @@ class CommandsCache(cabc.Mapping):
             val == (name, True) and self.locate_binary(name, ignore_alias=True) is None
         )
 
-    def predict_threadable(self, cmd):
-        """Predicts whether a command list is able to be run on a background
-        thread, rather than the main thread.
+    def predictor_threadable(self, cmd0):
+        """Return the predictor whether a command list is able to be run on a
+        background thread, rather than the main thread.
         """
-        name = self.cached_name(cmd[0])
+        name = self.cached_name(cmd0)
         predictors = self.threadable_predictors
         if ON_WINDOWS:
             # On all names (keys) are stored in upper case so instead
@@ -232,8 +232,15 @@ class CommandsCache(cabc.Mapping):
                 if pre in predictors:
                     predictors[name] = predictors[pre]
         if name not in predictors:
-            predictors[name] = self.default_predictor(name, cmd[0])
+            predictors[name] = self.default_predictor(name, cmd0)
         predictor = predictors[name]
+        return predictor
+
+    def predict_threadable(self, cmd):
+        """Predicts whether a command list is able to be run on a background
+        thread, rather than the main thread.
+        """
+        predictor = self.predictor_threadable(cmd[0])
         return predictor(cmd[1:])
 
     #


### PR DESCRIPTION
I had problems with aliases and predictors in command cache.

For example:
```
jben@garance ~ $ ipython                                                                                         
Python 3.7.3rc1 (default, Mar 13 2019, 11:01:15) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import os 
   ...: [os.readlink(f'/proc/self/fd/{i}') for i in range(3)]                                                    
Out[1]: ['/dev/pts/5', '/dev/pts/5', '/dev/pts/5']
```

Ok, we are not threaded (because ipython have a predictor). Let's do a alias:

```
jben@garance ~ $ aliases['ipy']='ipython'                                                                        
jben@garance ~ $ ipy                                                                                             
Python 3.7.3rc1 (default, Mar 13 2019, 11:01:15) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import os 
   ...: [os.readlink(f'/proc/self/fd/{i}') for i in range(3)]                                                    
Out[1]: ['/dev/pts/5', '/dev/pts/6', '/dev/pts/7']
```

Ok, we are threaded. Some strange behavior can occurs.

There is no reason for making a different decision for a alias.

This branch build a predictor by analyzing the alias, and the returned predictor is build based on the predictor of original command (special entry, binary analysis or other).