### PR TITLE
Travis-CI: Test Python 3.7 on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 env:
    global:
-       - secure: "pvQHCsdc IRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
+       - secure: "pvQHCsdcIRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
 matrix:
     include:
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 env:
    global:
-       - secure: "pvQHCsdcIRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
+       - secure: "pvQHCsdc IRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
 matrix:
     include:
         - os: linux
@@ -9,8 +9,8 @@ matrix:
           dist: xenial
           env:
             - MINICONDA_OS="Linux"
-            - CI=true
-            - TRAVIS=true
+#            - CI=true
+#            - TRAVIS=true
         - os: linux
           python: 3.6
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ env:
        - secure: "pvQHCsdcIRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
 matrix:
     include:
-        # Travis does not yet support Python 3.7 on Linux
-        # uncomment the following when it does
-        #- os: linux
-        #  python: 3.7
-        #  env:
-        #    - MINICONDA_OS="Linux"
-        #    - CI=true
-        #    - TRAVIS=true
+        - os: linux
+          python: 3.7
+          dist: xenial
+          env:
+            - MINICONDA_OS="Linux"
+            - CI=true
+            - TRAVIS=true
         - os: linux
           python: 3.6
           env:

--- a/news/travis-ci_test_python37_on_linux.rst
+++ b/news/travis-ci_test_python37_on_linux.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
On Travis-CI uses the distribution xenial instead of trusty.