### PR TITLE
fix E126 error in xontrib/bashisms.py

### DIFF
--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -14,10 +14,10 @@ __all__ = ()
 @events.on_transform_command
 def bash_preproc(cmd, **kw):
     bang_previous = {
-            '!': lambda x: x,
-            '$': lambda x: shlex.split(x)[-1],
-            '^': lambda x: shlex.split(x)[0],
-            '*': lambda x: ' '.join(shlex.split(x)[1:]),
+        '!': lambda x: x,
+        '$': lambda x: shlex.split(x)[-1],
+        '^': lambda x: shlex.split(x)[0],
+        '*': lambda x: ' '.join(shlex.split(x)[1:]),
     }
 
     def replace_bang(m):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

I don't know why Flake 8 check failure caused in CI although nobody touched xontrib/bashisms.py...

I hope this patch passes flake8 check again.
