### PR TITLE
Environ do not delete default value

### DIFF
--- a/news/environ_do_not_delete_default_value.rst
+++ b/news/environ_do_not_delete_default_value.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* deleting a non existing environement variable with default value do nothing
+  instead of raising a exception trying to deleting it in existing values dict.
+
+**Security:**
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -273,3 +273,19 @@ def test_make_args_env():
         "ARG3": "3",
     }
     assert exp == obs
+
+def test_delitem():
+    env = Env(VAR="a value")
+    assert env['VAR'] == 'a value'
+    del env['VAR']
+    with pytest.raises(Exception):
+        a = env['VAR']
+
+def test_delitem_default():
+    env = Env()
+    a_key,a_value = next(env._defaults.items().__iter__())
+    del env[a_key]
+    assert env[a_key] == a_value
+    del env[a_key]
+    assert env[a_key] == a_value
+

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1521,10 +1521,14 @@ class Env(cabc.MutableMapping):
             events.on_envvar_change.fire(name=key, oldvalue=old_value, newvalue=val)
 
     def __delitem__(self, key):
-        del self._d[key]
-        self._detyped = None
-        if self.get("UPDATE_OS_ENVIRON") and key in os_environ:
-            del os_environ[key]
+        if key in self._d:
+            del self._d[key]
+            self._detyped = None
+            if self.get("UPDATE_OS_ENVIRON") and key in os_environ:
+                del os_environ[key]
+        elif key not in self._defaults:
+            e = "Unknown environment variable: ${}"
+            raise KeyError(e.format(key))
 
     def get(self, key, default=None):
         """The environment will look up default values from its own defaults if a


### PR DESCRIPTION
If `Env.__delitem__` is called to delete a value only in default, do nothing

solves #3077