### PR TITLE
The black check no longer skips files buried deeper in the directory tree

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,10 +213,7 @@ jobs:
       - run:
           command: |
             export PATH="$HOME/miniconda/bin:$PATH"
-            cd xonsh/
-            black --exclude ply *.py --check
-            cd ../xontrib/
-            black *.py --check
+            black --check --exclude=xonsh/ply/ xonsh/ xontrib/
 
 
 workflows:

--- a/news/black_xontribs.rst
+++ b/news/black_xontribs.rst
@@ -6,6 +6,9 @@
 
 * Circle now runs ``black`` checks on contents of bundled xontribs
 
+* The ``black`` checks no longer skip some files buried deeper in the directory
+  tree.
+
 **Deprecated:**
 
 * <news item>

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -50,7 +50,7 @@ def complete_skipper(cmd, line, start, end, ctx):
 
     # If there's no space following an END_PROC_TOKEN, insert one
     if parts[-1] in END_PROC_TOKENS:
-        return(set(" "), 0)
+        return (set(" "), 0)
 
     if len(parts) == skip_part_num + 1:
         comp_func = complete_command

--- a/xonsh/lib/collections.py
+++ b/xonsh/lib/collections.py
@@ -37,8 +37,9 @@ class ChainDB(ChainMap):
                     res = ChainDB(result)
                 else:
                     res.maps.append(result)
-        elif all([isinstance(result, (MutableSequence,
-                                      MutableSet)) for result in results]):
+        elif all(
+            [isinstance(result, (MutableSequence, MutableSet)) for result in results]
+        ):
             results_chain = itertools.chain(*results)
             # if all reults have the same type, cast into that type
             if all([isinstance(result, type(results[0])) for result in results]):

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2422,7 +2422,7 @@ class BaseParser(object):
         prefix = RE_STRINGPREFIX.match(p1.value).group().lower()
         if "p" in prefix and "f" in prefix:
             new_pref = prefix.replace("p", "")
-            value_without_p = new_pref + p1.value[len(prefix):]
+            value_without_p = new_pref + p1.value[len(prefix) :]
             s = eval_fstr_fields(value_without_p, new_pref, filename=self.lexer.fname)
             s = pyparse(s).body[0].value
             s = ast.increment_lineno(s, p1.lineno - 1)

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -23,10 +23,7 @@ def env_name():
     ``{env_prefix}`` and ``{env_postfix}`` fields.
     """
     env_name = find_env_name()
-    if (
-        builtins.__xonsh__.env.get("VIRTUAL_ENV_DISABLE_PROMPT")
-        or not env_name
-    ):
+    if builtins.__xonsh__.env.get("VIRTUAL_ENV_DISABLE_PROMPT") or not env_name:
         # env name prompt printing disabled, or no environment; just return
         return
 

--- a/xonsh/xoreutils/uptime.py
+++ b/xonsh/xoreutils/uptime.py
@@ -89,7 +89,7 @@ def _uptime_beos():
     if not hasattr(xp.LIBC, "system_time"):
         return None
     xp.LIBC.system_time.restype = ctypes.c_int64
-    return xp.LIBC.system_time() / 1000000.
+    return xp.LIBC.system_time() / 1000000.0
 
 
 def _uptime_bsd():
@@ -110,8 +110,8 @@ def _uptime_bsd():
     sec, usec = struct.unpack_from("@LL", buf.raw)
     # OS X disagrees what that second value is.
     if usec > 1000000:
-        usec = 0.
-    _BOOTTIME = sec + usec / 1000000.
+        usec = 0.0
+    _BOOTTIME = sec + usec / 1000000.0
     up = time.time() - _BOOTTIME
     if up < 0:
         up = None
@@ -225,11 +225,11 @@ def _uptime_windows():
     if hasattr(xp.LIBC, "GetTickCount64"):
         # Vista/Server 2008 or later.
         xp.LIBC.GetTickCount64.restype = ctypes.c_uint64
-        return xp.LIBC.GetTickCount64() / 1000.
+        return xp.LIBC.GetTickCount64() / 1000.0
     if hasattr(xp.LIBC, "GetTickCount"):
         # WinCE and Win2k or later; gives wrong answers after 49.7 days.
         xp.LIBC.GetTickCount.restype = ctypes.c_uint32
-        return xp.LIBC.GetTickCount() / 1000.
+        return xp.LIBC.GetTickCount() / 1000.0
     return None
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

This is a really trivial fix. I changed black to run on directories instead of `*.py`.

I also ran black once on all the files that had previously been skipped over. For security, please verify that I did not inject any malicious code.