### PR TITLE
Import MutableSet from colections.abc to circumvent DeprecationWarning

### DIFF
--- a/news/abc-warning.rst
+++ b/news/abc-warning.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a DeprecationWarning that would show up during an import of MutableSet.
+
+**Security:**
+
+* <news item>

--- a/xonsh/lib/collections.py
+++ b/xonsh/lib/collections.py
@@ -2,8 +2,8 @@
 
 import itertools
 
-from collections import ChainMap, MutableSet
-from collections.abc import MutableMapping, MutableSequence
+from collections import ChainMap
+from collections.abc import MutableMapping, MutableSequence, MutableSet
 
 
 class ChainDBDefaultType(object):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

A trivial fix to get rid of a warning that I would get while running the tests.