### PR TITLE
Add process to avoid overwrite files that specified in options in `run-tests.xsh`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
   - script: |
       call activate conda-test-$(python.version)
       pip install .
-      xonsh run-tests.xsh --timeout=10 --junitxml=junit/test-results.xml
+      xonsh run-tests.xsh --timeout=10 --junitxml=junit/test-results.%%d.xml
     displayName: 'Tests'
 
   # Publish build results

--- a/news/allow-avoid-overwrite-in-run-tests.rst
+++ b/news/allow-avoid-overwrite-in-run-tests.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add processing ``%d`` for avoid overwriting in ``run-tests.xsh``
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/run-tests.xsh
+++ b/run-tests.xsh
@@ -1,10 +1,24 @@
 #!/usr/bin/env xonsh
+import sys
+args = sys.argv[1:]
+
+
+def replace_args(num):
+    """
+    Replace %d to num for avoid overwrite files
+
+    Example of args: --junitxml=junit/test-results.%d.xml
+    """
+    return [
+        (arg % num) if "%d" in arg else arg
+        for arg in args]
+
 $RAISE_SUBPROC_ERROR = True
 
 run_separately = [
     'tests/test_ptk_highlight.py',
     ]
 
-![pytest  @($ARGS[1:]) --ignore @(run_separately)]
-for fname in run_separately:
-    ![pytest  @($ARGS[1:]) @(fname)]
+![pytest @(replace_args(0)) --ignore @(run_separately)]
+for index, fname in enumerate(run_separately):
+    ![pytest @(replace_args(index+1)) @(fname)]


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## Problem

Executing `run-tests.xsh` with setting files in options cause unwanted overwriting such like `junit/test-results.xml`.

## Solutions

Add processing `%d` for avoid overwriting in `run-tests.xsh`.
