### PR TITLE
Command cache env pred

### DIFF
--- a/news/command_cache_env_pred.rst
+++ b/news/command_cache_env_pred.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* threadable predictor for 'env' command based on predictor from the executed
+  command. Fixes #2759 and #3103.
+
+**Security:**
+
+* <news item>

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -380,6 +380,15 @@ def predict_hg(args):
         return not ns.interactive
 
 
+def predict_env(args):
+    """Predict if env is launching a threadable command or not"""
+
+    for i in range(len(args)):
+        if args[i] and args[i][0] != "-" and "=" not in args[i]:
+            return builtins.__xonsh__.commands_cache.predict_threadable(args[i:])
+    return True
+
+
 def default_threadable_predictors():
     """Generates a new defaultdict for known threadable predictors.
     The default is to predict true.
@@ -395,6 +404,7 @@ def default_threadable_predictors():
         "cmd": predict_shell,
         "cryptop": predict_false,
         "curl": predict_true,
+        "env": predict_env,
         "ex": predict_false,
         "emacsclient": predict_false,
         "fish": predict_shell,

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -381,10 +381,14 @@ def predict_hg(args):
 
 
 def predict_env(args):
-    """Predict if env is launching a threadable command or not"""
+    """Predict if env is launching a threadable command or not.
+    The launched command is extracted from env args, and the predictor of
+    lauched command is used."""
 
     for i in range(len(args)):
         if args[i] and args[i][0] != "-" and "=" not in args[i]:
+            # args[i] is the command and the following is its arguments
+            # so args[i:] is used to predict if the command is threadable
             return builtins.__xonsh__.commands_cache.predict_threadable(args[i:])
     return True
 


### PR DESCRIPTION
For `env`, a special predictor based on the predictor for the executed command.

Fixes #2759 and #3103.