### PR TITLE
Do not attempt to expand raw strings in subprocess mode

### DIFF
--- a/news/noexpand-raw-string.rst
+++ b/news/noexpand-raw-string.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Xonsh now does not attempt to expand raw strings, so now::
+
+    $ echo "$HOME"
+    /home/user
+    $ echo r"$HOME"
+    $HOME
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@ import itertools
 
 import pytest
 
-from xonsh.ast import AST, With, Pass, pdump
+from xonsh.ast import AST, With, Pass, pdump, Str, Call
 from xonsh.parser import Parser
 from xonsh.parsers.base import eval_fstr_fields
 
@@ -2887,6 +2887,20 @@ def test_withbang_as_many_suite(body):
         assert item.optional_vars.id == targ
         s = item.context_expr.args[1].s
         assert s == body
+
+
+def test_subproc_raw_str_literal():
+    tree = check_xonsh_ast({}, "!(echo '$foo')", run=False, return_obs=True)
+    assert isinstance(tree, AST)
+    subproc = tree.body
+    assert isinstance(subproc.args[0].elts[1], Call)
+    assert subproc.args[0].elts[1].func.attr == "expand_path"
+
+    tree = check_xonsh_ast({}, "!(echo r'$foo')", run=False, return_obs=True)
+    assert isinstance(tree, AST)
+    subproc = tree.body
+    assert isinstance(subproc.args[0].elts[1], Str)
+    assert subproc.args[0].elts[1].s == "$foo"
 
 
 # test invalid expressions

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -3165,7 +3165,7 @@ class BaseParser(object):
 
     def p_subproc_atom_str(self, p):
         """subproc_atom : string_literal"""
-        if hasattr(p[1], "is_raw") and p[1].is_raw == True:
+        if hasattr(p[1], "is_raw") and p[1].is_raw:
             p0 = p[1]
         else:
             p0 = xonsh_call(

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2448,8 +2448,9 @@ class BaseParser(object):
         else:
             s = ast.literal_eval(p1.value)
             is_bytes = "b" in prefix
+            is_raw = "r" in prefix
             cls = ast.Bytes if is_bytes else ast.Str
-            p[0] = cls(s=s, lineno=p1.lineno, col_offset=p1.lexpos)
+            p[0] = cls(s=s, lineno=p1.lineno, col_offset=p1.lexpos, is_raw=is_raw)
 
     def p_string_literal_list(self, p):
         """string_literal_list : string_literal
@@ -3164,9 +3165,12 @@ class BaseParser(object):
 
     def p_subproc_atom_str(self, p):
         """subproc_atom : string_literal"""
-        p0 = xonsh_call(
-            "__xonsh__.expand_path", args=[p[1]], lineno=self.lineno, col=self.col
-        )
+        if hasattr(p[1], "is_raw") and p[1].is_raw == True:
+            p0 = p[1]
+        else:
+            p0 = xonsh_call(
+                "__xonsh__.expand_path", args=[p[1]], lineno=self.lineno, col=self.col
+            )
         p0._cliarg_action = "append"
         p[0] = p0
 


### PR DESCRIPTION
Closes #2943 
Previously, there was no way to prevent Xonsh from expanding environment variables in strings:
```
~ 🐚  $BAI="BYE"
~ 🐚  env BAI=HAI bash -c "echo $BAI"
BYE
~ 🐚  env BAI=HAI bash -c r"echo $BAI"
BYE
```
Now:
```
~ 🐚  $BAI="BYE"
~ 🐚  env BAI=HAI bash -c "echo $BAI"
BYE
~ 🐚  env BAI=HAI bash -c r"echo $BAI"
HAI
```
Edit: relates also to #1783 