### PR TITLE
minial Python 3.8 fix

### DIFF
--- a/news/py38.rst
+++ b/news/py38.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Minor update for Python v3.8.
+
+**Security:**
+
+* <news item>

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -711,7 +711,10 @@ class BaseParser(object):
 
     def p_file_input(self, p):
         """file_input : file_stmts"""
-        p[0] = ast.Module(body=p[1])
+        if PYTHON_VERSION_INFO < (3, 8, 0):
+            p[0] = ast.Module(body=p[1])
+        else:
+            p[0] = ast.Module(body=p[1], type_ignores=[])
 
     def p_file_stmts_nl(self, p):
         """file_stmts : newline_or_stmt"""


### PR DESCRIPTION
This is a minimal fix to stop xonsh from throwing errors on Python 3.8.  It doesn't implement all of 3.8 yet.  This is done to allow the virtualenv test suite to pass. CC @gaborbernat @gforsyth 