### PR TITLE
Fix bashisms xontrib startup on PTK1

### DIFF
--- a/news/fix-ptk1-bashisms.rst
+++ b/news/fix-ptk1-bashisms.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* bashisms extension can be used again with prompt_toolkit v1
+
+**Security:**
+
+* <news item>

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -47,11 +47,14 @@ def bash_preproc(cmd, **kw):
 def custom_keybindings(bindings, **kw):
     if ptk_shell_type() == "prompt_toolkit2":
         handler = bindings.add
+
         @Condition
         def last_command_exists():
             return len(__xonsh__.history) > 0
+
     else:
         handler = bindings.registry.add_binding
+
         @Condition
         def last_command_exists(cli):
             return len(__xonsh__.history) > 0

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -47,14 +47,16 @@ def bash_preproc(cmd, **kw):
 def custom_keybindings(bindings, **kw):
     if ptk_shell_type() == "prompt_toolkit2":
         handler = bindings.add
+        @Condition
+        def last_command_exists():
+            return len(__xonsh__.history) > 0
     else:
         handler = bindings.registry.add_binding
+        @Condition
+        def last_command_exists(cli):
+            return len(__xonsh__.history) > 0
 
     insert_mode = ViInsertMode() | EmacsInsertMode()
-
-    @Condition
-    def last_command_exists():
-        return len(__xonsh__.history) > 0
 
     @handler(Keys.Escape, ".", filter=last_command_exists & insert_mode)
     def recall_last_arg(event):


### PR DESCRIPTION
PTK1 `Condition` expects one positional argument.

Fixes #2843