### PR TITLE
Preserve newline during bashisms transformation.

### DIFF
--- a/news/preserve_newline_during_bashisms_transform.rst
+++ b/news/preserve_newline_during_bashisms_transform.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix issue with bashsisms xontrib causing syntax errors for some Python statements
+
+**Security:**
+
+* <news item>

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -40,7 +40,7 @@ def bash_preproc(cmd, **kw):
                 print("xonsh: no previous commands match '!{}'".format(arg))
                 return ""
 
-    return re.sub(r"!([!$^*]|[\w]+)", replace_bang, cmd.strip())
+    return re.sub(r"!([!$^*]|[\w]+)", replace_bang, cmd)
 
 
 @events.on_ptk_create


### PR DESCRIPTION
Haven't included a news entry yet since this is my first PR and I wanted to make sure it makes sense first.

No test for regression here - was curious if there's even a places for this? `tests/integration.py` seems the most likely since it tests the interaction between multiple components and the interactive prompt, but I'm not seeing any other tests that similarly test xontribs there.

Fixes #3120 