### PR TITLE
python_requires

### DIFF
--- a/news/pyreq.rst
+++ b/news/pyreq.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* We no longer manually check the Python version in ``setup.py``,
+  but instead use the setuptools ``python_requires`` feature.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -325,8 +325,6 @@ if HAVE_SETUPTOOLS:
 
 def main():
     """The main entry point."""
-    if sys.version_info[:2] < (3, 5):
-        sys.exit("xonsh currently requires Python 3.5+")
     try:
         if "--name" not in sys.argv:
             logo_fname = os.path.join(os.path.dirname(__file__), "logo.txt")
@@ -405,6 +403,7 @@ def main():
             "linux": ["distro"],
             "proctitle": ["setproctitle"],
         }
+        skw["python_requires"] = ">=3.5"
     setup(**skw)
 
 


### PR DESCRIPTION
@gaborbernat - is this the kind of thing that you are looking for?  Happy to do a release after this gets in.  Also, for the python v3.4 tests, is it possible for us to just pin xonsh to `=0.8.12`?  I don't think it makes sense for the 0.9 series to support Python 3.4 anymore.
