### PR TITLE
Document missing output history with sqlite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,5 @@ workflows:
     jobs:
       - build_35
       - build_36
+      - build_37
       - build_black
-      # conda-foge does not yet have all Python 3.7 packages available
-      # uncomment when it does
-      #- build_37

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ env:
        - secure: "pvQHCsdcIRjwNvsBrZxP8cZWEwug0+PLg1T8841ZLkMdCaO3YheqmxF1xGjAqty6hLppz6vX1LFEKmPjKurLL0/i+be6MhT8/ZikFpSan7TdNUqISxeFx31ls+QpuFKzCV7ZEx7C1ms8LPWEGmzMMN6bCtOBVtGznD9KKWZmLlA="
 matrix:
     include:
-        # Travis does not yet support Python 3.7 on Linux
-        # uncomment the following when it does
-        #- os: linux
-        #  python: 3.7
-        #  env:
-        #    - MINICONDA_OS="Linux"
-        #    - CI=true
-        #    - TRAVIS=true
+        - os: linux
+          dist: xenial  # required for Python >= 3.7
+          python: 3.7
+          env:
+            - MINICONDA_OS="Linux"
+            - BUILD_DOCS=false
         - os: linux
           python: 3.6
           env:
@@ -19,6 +17,7 @@ matrix:
             - BUILD_DOCS=true
         - os: linux
           python: "nightly"
+          dist: xenial  # required for Python >= 3.7
         - os: linux
           python: "pypy3"
           env:
@@ -74,4 +73,3 @@ script:
     else
       xonsh run-tests.xsh --timeout=10;
     fi
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
   - script: |
       call activate conda-test-$(python.version)
       pip install .
-      xonsh run-tests.xsh --timeout=10 --junitxml=junit/test-results.xml
+      xonsh run-tests.xsh --timeout=10 --junitxml=junit/test-results.%%d.xml
     displayName: 'Tests'
 
   # Publish build results

--- a/docs/tutorial_hist.rst
+++ b/docs/tutorial_hist.rst
@@ -465,7 +465,9 @@ Sqlite History Backend
 Xonsh has a second built-in history backend powered by sqlite (other than
 the JSON version mentioned all above in this tutorial). It shares the same
 functionality as the JSON version in most ways, except it currently doesn't
-support ``history diff`` and ``history replay`` actions.
+support ``history diff`` and ``history replay`` actions and does not store
+the output of commands, as the json-backend does. E.g. 
+`__xonsh__.history[-1].out` will always be `None`.
 
 The Sqlite history backend can provide a speed advantage in loading history
 into a just-started xonsh session. The JSON history backend may need to read

--- a/news/allow-avoid-overwrite-in-run-tests.rst
+++ b/news/allow-avoid-overwrite-in-run-tests.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add processing ``%d`` for avoid overwriting in ``run-tests.xsh``
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/command_cache_env_pred.rst
+++ b/news/command_cache_env_pred.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* threadable predictor for 'env' command based on predictor from the executed
+  command. Fixes #2759 and #3103.
+
+**Security:**
+
+* <news item>

--- a/news/env-dash-S.rst
+++ b/news/env-dash-S.rst
@@ -1,0 +1,6 @@
+**Fixed:**
+
+* An error in the 'xon.sh' executable that only popped up during testing has
+  been fixed.  Specifically: It now directly calls 'python3' without invoking
+  'env'.
+

--- a/news/fix-ptk1-bashisms.rst
+++ b/news/fix-ptk1-bashisms.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* bashisms extension can be used again with prompt_toolkit v1
+
+**Security:**
+
+* <news item>

--- a/news/fix_crash_intensify_color.rst
+++ b/news/fix_crash_intensify_color.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix a crash when setting ``$INTENSIFY_COLORS_ON_WIN`` in certain situations. 
+
+**Security:**
+
+* <news item>

--- a/news/noexpand-raw-string.rst
+++ b/news/noexpand-raw-string.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Xonsh now does not attempt to expand raw strings, so now::
+
+    $ echo "$HOME"
+    /home/user
+    $ echo r"$HOME"
+    $HOME
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/revert_portable_env_args_trick.rst
+++ b/news/revert_portable_env_args_trick.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* portable trick to pass args which replace '/usr/bin/env' is removed and
+  '/usr/bin/env' is used. Fixes bug when a python3 used is outside the default
+  'PATH'.
+
+**Security:**
+
+* <news item>

--- a/news/unthread-sudoedit.rst
+++ b/news/unthread-sudoedit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* sudoedit now runs unthreaded
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/run-tests.xsh
+++ b/run-tests.xsh
@@ -1,10 +1,24 @@
 #!/usr/bin/env xonsh
+import sys
+args = sys.argv[1:]
+
+
+def replace_args(num):
+    """
+    Replace %d to num for avoid overwrite files
+
+    Example of args: --junitxml=junit/test-results.%d.xml
+    """
+    return [
+        (arg % num) if "%d" in arg else arg
+        for arg in args]
+
 $RAISE_SUBPROC_ERROR = True
 
 run_separately = [
     'tests/test_ptk_highlight.py',
     ]
 
-![pytest  @($ARGS[1:]) --ignore @(run_separately)]
-for fname in run_separately:
-    ![pytest  @($ARGS[1:]) @(fname)]
+![pytest @(replace_args(0)) --ignore @(run_separately)]
+for index, fname in enumerate(run_separately):
+    ![pytest @(replace_args(index+1)) @(fname)]

--- a/scripts/xon.sh
+++ b/scripts/xon.sh
@@ -7,4 +7,4 @@ if [ -z "${LC_ALL+x}" ] && [ -z "${LC_CTYPE+x}" ] && \
 fi
 
 # run python
-exec /usr/bin/env PYTHONUNBUFFERED=1 python3 -u -m xonsh "$@"
+exec python3 -u -m xonsh "$@"

--- a/scripts/xonsh
+++ b/scripts/xonsh
@@ -1,7 +1,4 @@
-#!/bin/sh
-''''exec python3 -u "$0" "$@"
-'''#'
-# Portable trick to pass option [-u] to python3, more portable than /usr/bin/env.
+#!/usr/bin/env python3 -u
 
 from xonsh.main import main
 main()

--- a/scripts/xonsh-cat
+++ b/scripts/xonsh-cat
@@ -1,7 +1,4 @@
-#!/bin/sh
-''''exec python3 -u "$0" "$@"
-'''#'
-# Portable trick to pass option [-u] to python3, more portable than /usr/bin/env.
+#!/usr/bin/env python3 -u
 
 from xonsh.xoreutils.cat import cat_main as main
 main()

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -274,18 +274,21 @@ def test_make_args_env():
     }
     assert exp == obs
 
+
 def test_delitem():
     env = Env(VAR="a value")
-    assert env['VAR'] == 'a value'
-    del env['VAR']
+    assert env["VAR"] == "a value"
+    del env["VAR"]
     with pytest.raises(Exception):
-        a = env['VAR']
+        a = env["VAR"]
+
 
 def test_delitem_default():
     env = Env()
-    a_key,a_value = next(env._defaults.items().__iter__())
+    a_key, a_value = next(
+        (k, v) for (k, v) in env._defaults.items() if isinstance(v, str)
+    )
     del env[a_key]
     assert env[a_key] == a_value
     del env[a_key]
     assert env[a_key] == a_value
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@ import itertools
 
 import pytest
 
-from xonsh.ast import AST, With, Pass, pdump
+from xonsh.ast import AST, With, Pass, pdump, Str, Call
 from xonsh.parser import Parser
 from xonsh.parsers.base import eval_fstr_fields
 
@@ -2866,6 +2866,20 @@ def test_withbang_as_many_suite(body):
         assert item.optional_vars.id == targ
         s = item.context_expr.args[1].s
         assert s == body
+
+
+def test_subproc_raw_str_literal():
+    tree = check_xonsh_ast({}, "!(echo '$foo')", run=False, return_obs=True)
+    assert isinstance(tree, AST)
+    subproc = tree.body
+    assert isinstance(subproc.args[0].elts[1], Call)
+    assert subproc.args[0].elts[1].func.attr == "expand_path"
+
+    tree = check_xonsh_ast({}, "!(echo r'$foo')", run=False, return_obs=True)
+    assert isinstance(tree, AST)
+    subproc = tree.body
+    assert isinstance(subproc.args[0].elts[1], Str)
+    assert subproc.args[0].elts[1].s == "$foo"
 
 
 # test invalid expressions

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -479,6 +479,7 @@ def default_threadable_predictors():
         "ssh": predict_false,
         "startx": predict_false,
         "sudo": predict_help_ver,
+        "sudoedit": predict_help_ver,
         "tcsh": predict_shell,
         "telnet": predict_false,
         "tput": predict_false,

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -420,6 +420,19 @@ def predict_hg(args):
         return not ns.interactive
 
 
+def predict_env(args):
+    """Predict if env is launching a threadable command or not.
+    The launched command is extracted from env args, and the predictor of
+    lauched command is used."""
+
+    for i in range(len(args)):
+        if args[i] and args[i][0] != "-" and "=" not in args[i]:
+            # args[i] is the command and the following is its arguments
+            # so args[i:] is used to predict if the command is threadable
+            return builtins.__xonsh__.commands_cache.predict_threadable(args[i:])
+    return True
+
+
 def default_threadable_predictors():
     """Generates a new defaultdict for known threadable predictors.
     The default is to predict true.
@@ -435,6 +448,7 @@ def default_threadable_predictors():
         "cmd": predict_shell,
         "cryptop": predict_false,
         "curl": predict_true,
+        "env": predict_env,
         "ex": predict_false,
         "emacsclient": predict_false,
         "fish": predict_shell,

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2451,8 +2451,9 @@ class BaseParser(object):
         else:
             s = ast.literal_eval(p1.value)
             is_bytes = "b" in prefix
+            is_raw = "r" in prefix
             cls = ast.Bytes if is_bytes else ast.Str
-            p[0] = cls(s=s, lineno=p1.lineno, col_offset=p1.lexpos)
+            p[0] = cls(s=s, lineno=p1.lineno, col_offset=p1.lexpos, is_raw=is_raw)
 
     def p_string_literal_list(self, p):
         """string_literal_list : string_literal
@@ -3167,9 +3168,12 @@ class BaseParser(object):
 
     def p_subproc_atom_str(self, p):
         """subproc_atom : string_literal"""
-        p0 = xonsh_call(
-            "__xonsh__.expand_path", args=[p[1]], lineno=self.lineno, col=self.col
-        )
+        if hasattr(p[1], "is_raw") and p[1].is_raw:
+            p0 = p[1]
+        else:
+            p0 = xonsh_call(
+                "__xonsh__.expand_path", args=[p[1]], lineno=self.lineno, col=self.col
+            )
         p0._cliarg_action = "append"
         p[0] = p0
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1932,9 +1932,12 @@ def intensify_colors_on_win_setter(enable):
     environment variable.
     """
     enable = to_bool(enable)
-    if builtins.__xonsh__.shell is not None:
-        if hasattr(builtins.__xonsh__.shell.shell.styler, "style_name"):
-            delattr(builtins.__xonsh__.shell.shell.styler, "style_name")
+    if (
+        hasattr(builtins.__xonsh__, "shell")
+        and builtins.__xonsh__.shell is not None
+        and hasattr(builtins.__xonsh__.shell.shell.styler, "style_name")
+    ):
+        delattr(builtins.__xonsh__.shell.shell.styler, "style_name")
     return enable
 
 

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -47,14 +47,19 @@ def bash_preproc(cmd, **kw):
 def custom_keybindings(bindings, **kw):
     if ptk_shell_type() == "prompt_toolkit2":
         handler = bindings.add
+
+        @Condition
+        def last_command_exists():
+            return len(__xonsh__.history) > 0
+
     else:
         handler = bindings.registry.add_binding
 
-    insert_mode = ViInsertMode() | EmacsInsertMode()
+        @Condition
+        def last_command_exists(cli):
+            return len(__xonsh__.history) > 0
 
-    @Condition
-    def last_command_exists():
-        return len(__xonsh__.history) > 0
+    insert_mode = ViInsertMode() | EmacsInsertMode()
 
     @handler(Keys.Escape, ".", filter=last_command_exists & insert_mode)
     def recall_last_arg(event):


### PR DESCRIPTION
Not sure if this a known bug with the sqlite history backend or just not implemented (yet) and somebody forgot to mention it in the documentation.

Whichever, this does not work:
```
15-11:57[confus@jcgbx ~]
$ history info
backend: sqlite
sessionid: 2965636d-6679-4f21-848d-5a9ca0bf17bd
filename: /home/confus/.local/share/xonsh/xonsh-history.sqlite
session items: 0
all items: 23
gc options: (16256, 'commands')
15-11:57[confus@jcgbx ~]
$ history info
backend: sqlite
sessionid: 2965636d-6679-4f21-848d-5a9ca0bf17bd
filename: /home/confus/.local/share/xonsh/xonsh-history.sqlite
session items: 0
all items: 23
gc options: (16256, 'commands')
```
but with the json-backend it does:
```
15-11:55[confus@jcgbx ~/devel/unix/xonsh/docs]  master|✓
$ history info
backend: json
sessionid: 9187eb95-a14f-46f7-957c-3bab4aedf0eb
filename: /home/confus/.local/share/xonsh/xonsh-9187eb95-a14f-46f7-957c-3bab4aedf0eb.json
length: 18
buffersize: 100
bufferlength: 18
gc options: (16256, 'commands')
15-11:56[confus@jcgbx ~/devel/unix/xonsh/docs]  master|✓
$ print(1+1)
2
15-11:56[confus@jcgbx ~/devel/unix/xonsh/docs]  master|✓
$ __xonsh__.history[-1].out
'2\n'
```