### PR TITLE
Fix for raising error in get_predictor_threadable on win

### DIFF
--- a/news/fix-pred-thrdable-on-win.rst
+++ b/news/fix-pred-thrdable-on-win.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix causing error in ``get_predictor_threadable`` on windows when try to run not exist command
+
+
+**Security:**
+
+* <news item>

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -23,7 +23,7 @@ def test_commands_cache_lazy(xonsh_builtins):
 def test_predict_threadable_unknown_command(xonsh_builtins):
     cc = CommandsCache()
     result = cc.predict_threadable(["command_should_not_found"])
-    assert type(result) == bool
+    assert isinstance(result, bool)
 
 
 TRUE_SHELL_ARGS = [

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -20,6 +20,12 @@ def test_commands_cache_lazy(xonsh_builtins):
     assert 0 == cc.lazylen()
 
 
+def test_predict_threadable_unknown_command(xonsh_builtins):
+    cc = CommandsCache()
+    result = cc.predict_threadable(["command_should_not_found"])
+    assert type(result) == bool
+
+
 TRUE_SHELL_ARGS = [
     ["-c", "yo"],
     ["-c=yo"],

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -232,7 +232,7 @@ class CommandsCache(cabc.Mapping):
             # we get the original cmd or alias name
             path, _ = self.lazyget(name, (None, None))
             if path is None:
-                return True
+                return predict_true
             else:
                 name = pathbasename(path)
             if name not in predictors:

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -11,7 +11,6 @@ import time
 import builtins
 import argparse
 import collections.abc as cabc
-from typing import Callable, List
 
 from xonsh.platform import ON_WINDOWS, ON_POSIX, pathbasename
 from xonsh.tools import executables_in
@@ -221,7 +220,7 @@ class CommandsCache(cabc.Mapping):
         predictor = self.get_predictor_threadable(cmd[0])
         return predictor(cmd[1:])
 
-    def get_predictor_threadable(self, cmd0: str) -> Callable[[List[str]], bool]:
+    def get_predictor_threadable(self, cmd0):
         """Return the predictor whether a command list is able to be run on a
         background thread, rather than the main thread.
         """

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -11,6 +11,7 @@ import time
 import builtins
 import argparse
 import collections.abc as cabc
+from typing import Callable, List
 
 from xonsh.platform import ON_WINDOWS, ON_POSIX, pathbasename
 from xonsh.tools import executables_in
@@ -220,7 +221,7 @@ class CommandsCache(cabc.Mapping):
         predictor = self.get_predictor_threadable(cmd[0])
         return predictor(cmd[1:])
 
-    def get_predictor_threadable(self, cmd0):
+    def get_predictor_threadable(self, cmd0: str) -> Callable[[List[str]], bool]:
         """Return the predictor whether a command list is able to be run on a
         background thread, rather than the main thread.
         """


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
## xonfig

```
+------------------+-------------------------------------------------------+
| xonsh            | 0.9.3                                                 |
| Git SHA          | 3b011dcf                                              |
| Commit Date      | May 16 04:11:49 2019                                  |
| Python           | 3.7.3                                                 |
| PLY              | 3.11                                                  |
| have readline    | False                                                 |
| prompt toolkit   | 2.0.9                                                 |
| shell type       | prompt_toolkit2                                       |
| pygments         | 2.3.1                                                 |
| on posix         | False                                                 |
| on linux         | False                                                 |
| on darwin        | False                                                 |
| on windows       | True                                                  |
| on cygwin        | <xonsh.lazyasd.LazyBool object at 0x00000180EBDCCD68> |
| on msys2         | <xonsh.lazyasd.LazyBool object at 0x00000180EBDCCC50> |
| is superuser     | False                                                 |
| default encoding | utf-8                                                 |
| xonsh encoding   | utf-8                                                 |
| encoding errors  | surrogateescape                                       |
+------------------+-------------------------------------------------------+
```

## Expected Behavior

Process `predict_threadable` without errors.

## Current Behavior

Raise `TypeError: 'bool' object is not callable` in `predict_threadable`

## Steps to Reproduce

1. Prepare Windows 10
1. Install xonsh 0.9.3
1. run `xonsh --no-rc`
1. Try to execute a command that not contained in `__xonsh__.commands_cache` such like `command_should_not_found`

## Solution

Return callable object in `get_predictor_threadable`

