### PR TITLE
Fix crash when setting $INTENSIFY_COLORS_ON_WIN

### DIFF
--- a/news/fix_crash_intensify_color.rst
+++ b/news/fix_crash_intensify_color.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix a crash when setting `$INTENSIFY_COLORS_ON_WIN` in certain situations. 
+
+**Security:**
+
+* <news item>

--- a/news/fix_crash_intensify_color.rst
+++ b/news/fix_crash_intensify_color.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fix a crash when setting `$INTENSIFY_COLORS_ON_WIN` in certain situations. 
+* Fix a crash when setting ``$INTENSIFY_COLORS_ON_WIN`` in certain situations. 
 
 **Security:**
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1932,7 +1932,8 @@ def intensify_colors_on_win_setter(enable):
     environment variable.
     """
     enable = to_bool(enable)
-    if builtins.__xonsh__.shell is not None:
+    shell = builtins.__xonsh__.get('shell', None)
+    if shell is not None:
         if hasattr(builtins.__xonsh__.shell.shell.styler, "style_name"):
             delattr(builtins.__xonsh__.shell.shell.styler, "style_name")
     return enable

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1932,10 +1932,12 @@ def intensify_colors_on_win_setter(enable):
     environment variable.
     """
     enable = to_bool(enable)
-    shell = builtins.__xonsh__.get('shell', None)
-    if shell is not None:
-        if hasattr(builtins.__xonsh__.shell.shell.styler, "style_name"):
-            delattr(builtins.__xonsh__.shell.shell.styler, "style_name")
+    if (
+        hasattr(builtins.__xonsh__, "shell")
+        and builtins.__xonsh__.shell is not None
+        and hasattr(builtins.__xonsh__.shell.shell.styler, "style_name")
+    ):
+        delattr(builtins.__xonsh__.shell.shell.styler, "style_name")
     return enable
 
 


### PR DESCRIPTION
This fixes a crash when `$INTENSIFY_COLORS_ON_WIN` is set in xonshrc, and xonsh is somehow invoked without a shell, because `__xonsh__.shell.shell` did not exist. 

It happend to me when running Pytest for different project in xonsh. 

```
INTERNALERROR>   File "C:\Users\mel\Anaconda3\lib\site-packages\xonsh\environ.py", line 1504, in __setitem__
INTERNALERROR>     val = ensurer.convert(val)
INTERNALERROR>   File "C:\Users\mel\Anaconda3\lib\site-packages\xonsh\tools.py", line 1935, in intensify_colors_on_win_setter
INTERNALERROR>     if builtins.__xonsh__.shell is not None:
INTERNALERROR> AttributeError: 'XonshSession' object has no attribute 'shell'
```

This PR fixes the problem