### PR TITLE
Add histcpy to the xontribs

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -79,6 +79,14 @@
   "url": "https://github.com/xsteadfastx/xonsh-docker-tabcomplete",
   "description": ["Adds tabcomplete functionality to docker inside of xonsh."]
  },
+ {"name": "histcpy",
+  "package": "xontrib-histcpy",
+  "url": "https://github.com/con-f-use/xontrib-histcpy",
+  "description": [
+    "Useful aliases and shortcuts for extracting links and text",
+    "from command output history and putting them into the",
+    " clipboard."]
+  },
  {"name": "jedi",
   "package": "xonsh",
   "url": "http://xon.sh",
@@ -264,6 +272,13 @@
    "url": "https://github.com/astronouth7303/xontrib-avox",
    "install": {
     "pip": "xpip install xontrib-avox"
+   }
+  },
+  "xontrib-histcpy": {
+   "license": "GPLv3",
+   "url": "https://github.com/con-f-use/xontrib-histcpy",
+   "install": {
+    "pip": "xpip install xontrib-histcpy"
    }
   },
   "xontrib-z": {


### PR DESCRIPTION
New xontrib!

Searches the command history output for URLs and copy's the user selection to clipboard or opens them in browser. Complete with key-bindings!

![histcpy in action](https://user-images.githubusercontent.com/11145016/58193017-5ac6fa00-7cc2-11e9-8a0f-6ec3b5120595.png)

See: https://github.com/con-f-use/xontrib-histcpy
