### PR TITLE
Ansi colors style bw

### DIFF
--- a/news/ansi_colors_style_bw.rst
+++ b/news/ansi_colors_style_bw.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* Style 'bw'. Background colors was added in the style description.
+

--- a/tests/test_ansi_colors.py
+++ b/tests/test_ansi_colors.py
@@ -5,6 +5,7 @@ from xonsh.ansi_colors import (
     ansi_color_escape_code_to_name,
     ansi_reverse_style,
     ansi_color_name_to_escape_code,
+    ansi_color_style_names,
 )
 
 
@@ -119,3 +120,16 @@ def test_ansi_reverse_style(key, value):
 def test_ansi_color_escape_code_to_name(inp, exp):
     obs = ansi_color_escape_code_to_name(inp, "default", reversed_style=RS)
     assert obs == exp
+
+
+@pytest.mark.parametrize(
+    "color, style",
+    [
+        (color, style)
+        for color in DEFAULT_CMAP.keys()
+        for style in ansi_color_style_names()
+    ],
+)
+def test_ansi_color_name_to_escape_code_for_all_styles(color, style):
+    escape_code = ansi_color_name_to_escape_code(color, style)
+    assert len(escape_code) > 0

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -343,10 +343,23 @@ def ansi_color_escape_code_to_name(escape_code, style, reversed_style=None):
 
 def _bw_style():
     style = {
+        "NO_COLOR": "0",
         "BLACK": "0;30",
         "BLUE": "0;37",
         "CYAN": "0;37",
         "GREEN": "0;37",
+        "PURPLE": "0;37",
+        "RED": "0;37",
+        "WHITE": "0;37",
+        "YELLOW": "0;37",
+        "BACKGROUND_BLACK": "40",
+        "BACKGROUND_RED": "47",
+        "BACKGROUND_GREEN": "47",
+        "BACKGROUND_YELLOW": "47",
+        "BACKGROUND_BLUE": "47",
+        "BACKGROUND_PURPLE": "47",
+        "BACKGROUND_CYAN": "47",
+        "BACKGROUND_WHITE": "47",
         "INTENSE_BLACK": "0;90",
         "INTENSE_BLUE": "0;97",
         "INTENSE_CYAN": "0;97",
@@ -355,11 +368,6 @@ def _bw_style():
         "INTENSE_RED": "0;97",
         "INTENSE_WHITE": "0;97",
         "INTENSE_YELLOW": "0;97",
-        "NO_COLOR": "0",
-        "PURPLE": "0;37",
-        "RED": "0;37",
-        "WHITE": "0;37",
-        "YELLOW": "0;37",
     }
     return style
 


### PR DESCRIPTION
This PR add backgrounds color for `bw` style. These background color can not be deduced from other color like all other styles (except the default style).

This PR add also tests to ensure that all colors are set or can deduced for all styles.

Should fix #3130.