### PR TITLE
aliases can be any sequence, not only list

### DIFF
--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -274,7 +274,9 @@ class CommandsCache(cabc.Mapping):
         alss = getattr(builtins, "aliases", dict())
         while cmd0 in alss:
             alias_name = alss[cmd0]
-            if not isinstance(alias_name, list):
+            if isinstance(alias_name, (str, bytes)) or not isinstance(
+                alias_name, cabc.Sequence
+            ):
                 return predict_true
             for arg in alias_name[:0:-1]:
                 first_args.insert(0, arg)


### PR DESCRIPTION
When I wrote threadabilty predictor for aliases in #3086, I was considering "normal" aliases as a `list`. Today I add a aliases with a tuple, I works perfectly with xonsh, but the predictor was returning the default prediction.

This is a very minor change, I think this does not desserve a news item.