### PR TITLE
Fix `pip` completer misfires on `bagpipes` and similar

### DIFF
--- a/news/fix_pip_completer.rst
+++ b/news/fix_pip_completer.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``pip`` completer no longer fires when ``pip`` happens to appear within a word
+  like ``bagpipes``
+
+**Security:**
+
+* <news item>

--- a/tests/completers/test_pip_completer.py
+++ b/tests/completers/test_pip_completer.py
@@ -1,0 +1,39 @@
+import pytest
+from xonsh.completers.pip import PIP_RE, PIP_LIST_RE
+
+
+@pytest.mark.parametrize(
+    "line", ["pip", "xpip search", "$(pip", "![pip", "$[pip", "!(xpip"]
+)
+def test_pip_re(line):
+    assert PIP_RE.search(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "pip show",
+        "xpip uninstall",
+        "$(pip show",
+        "![pip uninstall",
+        "$[pip show",
+        "!(xpip uninstall",
+    ],
+)
+def test_pip_list_re(line):
+    assert PIP_LIST_RE.search(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "bagpipes show",
+        "toxbagpip uninstall",
+        "$(tompippery show",
+        "![thewholepipandpaboodle uninstall",
+        "$[littlebopip show",
+        "!(boxpip uninstall",
+    ],
+)
+def test_pip_list_re(line):
+    assert PIP_RE.search(line) is None

--- a/xonsh/completers/pip.py
+++ b/xonsh/completers/pip.py
@@ -9,12 +9,12 @@ import xonsh.lazyasd as xl
 
 @xl.lazyobject
 def PIP_RE():
-    return re.compile(r"pip(?:\d|\.)*")
+    return re.compile(r"\bx?pip(?:\d|\.)*")
 
 
 @xl.lazyobject
 def PIP_LIST_RE():
-    return re.compile(r"pip(?:\d|\.)* (?:uninstall|show)")
+    return re.compile(r"\bx?pip(?:\d|\.)* (?:uninstall|show)")
 
 
 @xl.lazyobject


### PR DESCRIPTION
Requires a word-ending before `pip`, also adding in support for `xpip`

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
Resolves #3142 
