### PR TITLE
remove matplotlib from 3.5 deps

### DIFF
--- a/ci/environment-3.5.yml
+++ b/ci/environment-3.5.yml
@@ -10,7 +10,6 @@ dependencies:
   - pytest-timeout
   - numpy
   - psutil
-  - matplotlib
   - flake8
   - coverage
   - pyflakes


### PR DESCRIPTION
Just a CI fix, no news needed