### PR TITLE
Fix @$ subprocess operator

### DIFF
--- a/news/fix-captured-inject.rst
+++ b/news/fix-captured-inject.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``@$()`` subprocess operator now properly strips newline characters off
+  the lines of multiline output.
+
+* ``@$()`` subprocess operator does not require leading and trailing whitespace
+  anymore, so expansions like ``cd /lib/modules/@$(uname -r)/kernel`` or
+  ``gdb --pid=@$(pidof crashme)`` are now possible.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -312,6 +312,34 @@ echo @$(which ls)
         0,
     ),
     #
+    # test @$() without leading/trailig WS
+    #
+    (
+        """
+def _echo(args):
+    print(' '.join(args))
+aliases['echo'] = _echo
+
+echo foo_@$(echo spam)_bar
+""",
+        "foo_spam_bar\n",
+        0,
+    ),
+    #
+    # test @$() outer product
+    #
+    (
+        """
+def _echo(args):
+    print(' '.join(args))
+aliases['echo'] = _echo
+
+echo foo_@$(echo spam sausage)_bar
+""",
+        "foo_spam_bar foo_sausage_bar\n",
+        0,
+    ),
+    #
     # test redirection
     #
     (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2250,6 +2250,13 @@ def test_rhs_nested_injection():
     check_xonsh_ast({}, "$[ls @$(dirname @$(which python))]", False)
 
 
+def test_merged_injection():
+    tree = check_xonsh_ast({}, "![a@$(echo 1 2)b]", False, return_obs=True)
+    assert isinstance(tree, AST)
+    func = tree.body.args[0].right.func
+    assert func.attr == "list_of_list_of_strs_outer_product"
+
+
 def test_backtick_octothorpe():
     check_xonsh_ast({}, "print(`#.*`)", False)
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -992,8 +992,12 @@ def subproc_captured_inject(*cmds):
     The string is split using xonsh's lexer, rather than Python's str.split()
     or shlex.split().
     """
-    s = run_subproc(cmds, captured="stdout")
-    toks = builtins.__xonsh__.execer.parser.lexer.split(s.strip())
+    o = run_subproc(cmds, captured="object")
+    o.end()
+    toks = []
+    for line in o:
+        line = line.rstrip(os.linesep)
+        toks.extend(builtins.__xonsh__.execer.parser.lexer.split(line))
     return toks
 
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -3140,7 +3140,9 @@ class BaseParser(object):
         p[0] = p0
 
     def p_subproc_atom_subproc_inject(self, p):
-        """subproc_atom : atdollar_lparen_tok subproc RPAREN"""
+        """subproc_atom : atdollar_lparen_tok subproc RPAREN
+           subproc_arg_part : atdollar_lparen_tok subproc RPAREN
+        """
         p1 = p[1]
         p0 = xonsh_call(
             "__xonsh__.subproc_captured_inject", p[2], lineno=p1.lineno, col=p1.lexpos
@@ -3149,12 +3151,16 @@ class BaseParser(object):
         p[0] = p0
 
     def p_subproc_atom_subproc_inject_bang_empty(self, p):
-        """subproc_atom : atdollar_lparen_tok subproc bang_tok RPAREN"""
+        """subproc_atom : atdollar_lparen_tok subproc bang_tok RPAREN
+           subproc_arg_part : atdollar_lparen_tok subproc bang_tok RPAREN
+        """
         self._append_subproc_bang_empty(p)
         self.p_subproc_atom_subproc_inject(p)
 
     def p_subproc_atom_subproc_inject_bang(self, p):
-        """subproc_atom : atdollar_lparen_tok subproc bang_tok nocloser rparen_tok"""
+        """subproc_atom : atdollar_lparen_tok subproc bang_tok nocloser rparen_tok
+           subproc_arg_part : atdollar_lparen_tok subproc bang_tok nocloser rparen_tok
+        """
         self._append_subproc_bang(p)
         self.p_subproc_atom_subproc_inject(p)
 


### PR DESCRIPTION
`@$(cmd)` operator now returns a list of tokens created by splitting the command's output at the newline character.

Closes #2328