### PR TITLE
Rewrite xontrib json stuff to be zipapp friendly

### DIFF
--- a/news/zipapp.rst
+++ b/news/zipapp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* The zipapp extra was added to install the importlib.resources backport on <3.7
+
+**Changed:**
+
+* xontrib metadata loading is now zipapp safe when possible
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -402,6 +402,7 @@ def main():
             "mac": ["gnureadline"],
             "linux": ["distro"],
             "proctitle": ["setproctitle"],
+            "zipapp": ['importlib_resources; python_version < "3.7"'],
         }
         skw["python_requires"] = ">=3.5"
     setup(**skw)


### PR DESCRIPTION
Make the xontrib machinery zipapp friendly.

The resulting checking is more complicated than I'd like, but there's a lot of edge cases. Good news: All of it can be removed when 3.5, 3.6 are no longer supported.

Full disclosure: This is part of my own use of building xonsh zipapps and using them in my homelab. They should make xonsh more robust against being installed with other applications and being started inside of active venvs.