### PR TITLE
Xontrib zipapp support

### DIFF
--- a/news/zipapp.rst
+++ b/news/zipapp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* The zipapp extra was added to install the importlib.resources backport on <3.7
+
+**Changed:**
+
+* xontrib metadata loading is now zipapp safe when possible
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -402,6 +402,7 @@ def main():
             "mac": ["gnureadline"],
             "linux": ["distro"],
             "proctitle": ["setproctitle"],
+            "zipapp": ['importlib_resources; python_version < "3.7"'],
         }
         skw["python_requires"] = ">=3.5"
     setup(**skw)

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -92,12 +92,12 @@ def xontrib_metadata():
                 pass
 
     if impres:
-        with impres.open_text('xonsh', 'xontribs.json') as f:
+        with impres.open_text("xonsh", "xontribs.json") as f:
             md = json.load(f)
     elif pkg_resources:
         # Despite the name, this is a bytes
-        bytesdata = pkg_resources.resource_string('xonsh', 'xontribs.json')
-        md = json.loads(bytesdata.decode('utf-8'))
+        bytesdata = pkg_resources.resource_string("xonsh", "xontribs.json")
+        md = json.loads(bytesdata.decode("utf-8"))
     else:
         path = os.path.join(os.path.dirname(__file__), "xontribs.json")
         with open(path, "r") as f:


### PR DESCRIPTION
Make the xontrib machinery zipapp friendly.

The resulting checking is more complicated than I'd like, but there's a lot of edge cases. Good news: All of it can be removed when 3.5, 3.6 are no longer supported.

Full disclosure: This is part of my own use of building xonsh zipapps and using them in my homelab. They should make xonsh more robust against being installed with other applications and being started inside of active venvs.