### PR TITLE
xontrib-ssh-agent added

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -190,6 +190,11 @@
   "package": "xontrib-schedule",
   "url": "https://github.com/astronouth7303/xontrib-schedule",
   "description": ["Xonsh Task Scheduling"]
+ },
+ {"name": "ssh_agent",
+  "package": "xontrib-ssh-agent",
+  "url": "https://bitbucket.org/dyuri/xontrib-ssh-agent",
+  "description": ["ssh-agent integration"]
  }
  ],
  "packages": {
@@ -333,6 +338,13 @@
    "url": "https://github.com/6syun9/xontrib-readable-traceback",
    "install": {
     "pip": "xpip install xontrib-readable-traceback"
+   }
+  },
+  "xontrib-ssh-agent": {
+   "license": "MIT",
+   "url": "https://bitbucket.org/dyuri/xontrib-ssh-agent",
+   "install": {
+    "pip": "xpip install xontrib-ssh-agent"
    }
   }
  }


### PR DESCRIPTION
Thanks for this awesome shell, I just discovered it last week and I'm already in love with it.

Since I use `ssh` a lot, I've created a xontrib to start `ssh-agent` and add ssh identities "automatically".