### PR TITLE
Allow prompt_ret_code xontrib to set background color

### DIFF
--- a/news/prompt_ret_code_background.rst
+++ b/news/prompt_ret_code_background.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* added $PROMPT_RET_CODE_BACKGROUND which causes the prompt_ret_code xontrib to
+  change background rather than foreground color when true.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/prompt_ret_code_background.rst
+++ b/news/prompt_ret_code_background.rst
@@ -4,8 +4,7 @@
 
 **Changed:**
 
-* added $PROMPT_RET_CODE_BACKGROUND which causes the prompt_ret_code xontrib to
-  change background rather than foreground color when true.
+* added ``$XONTRIB_PROMPT_RET_CODE_COLOR_ZERO`` and ``$XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO`` which can be used to set the color format for the prompt_ret_code xontrib.
 
 **Deprecated:**
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -553,7 +553,7 @@ def source_alias(args, stdin=None):
                     print("source: {}: No such file".format(fname), file=sys.stderr)
                 if i == 0:
                     raise RuntimeError(
-                        "must source at least one file, " + fname + "does not exist."
+                        "must source at least one file, " + fname + " does not exist."
                     )
                 break
         _, fext = os.path.splitext(fpath)

--- a/xontrib/prompt_ret_code.xsh
+++ b/xontrib/prompt_ret_code.xsh
@@ -1,32 +1,35 @@
 from xonsh.tools import ON_WINDOWS as _ON_WINDOWS
+from xonsh.tools import is_string, ensure_string
+from xonsh.environ import Ensurer
+
+
+${...}.set_ensurer("XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
+    Ensurer(is_string, ensure_string, ensure_string))
+
+${...}.set_ensurer("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
+    Ensurer(is_string, ensure_string, ensure_string))
 
 
 def _ret_code_color():
-    try:
-	color_bg = $PROMPT_RET_CODE_BACKGROUND
-    except:
-	color_bg = False
-
-    if color_bg:
-	prefix = 'BACKGROUND'
-    else:
-	prefix = 'BOLD'
-
     if __xonsh__.history.rtns:
-        color = 'blue' if __xonsh__.history.rtns[-1] == 0 else 'red'
+        ret_code = True if __xonsh__.history.rtns[-1] == 0 else False
     else:
-        color = 'blue'
+        ret_code = True
 
     if _ON_WINDOWS:
-        if color == 'blue':
-            return '{%s_INTENSE_CYAN}' % prefix
-        elif color == 'red':
-            return '{%s_INTENSE_RED}' % prefix
+        if ret_code:
+            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
+                    '{BOLD_INTENSE_CYAN}')
+        else:
+            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
+                    '{BOLD_INTENSE_RED}')
     else:
-        if color == 'blue':
-            return '{%s_BLUE}' % prefix
-        elif color == 'red':
-            return '{%s_RED}' % prefix
+        if ret_code:
+            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
+                    '{BOLD_BLUE}')
+        else:
+            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
+                    '{BOLD_RED}')
 
 
 def _ret_code():
@@ -38,7 +41,7 @@ def _ret_code():
 
 
 $PROMPT = $PROMPT.replace('{prompt_end}{NO_COLOR}',
-                          '{ret_code_color}{ret_code}{prompt_end}{NO_COLOR}')
+        '{ret_code_color}{ret_code}{prompt_end}{NO_COLOR}')
 
 
 $PROMPT_FIELDS['ret_code_color'] = _ret_code_color

--- a/xontrib/prompt_ret_code.xsh
+++ b/xontrib/prompt_ret_code.xsh
@@ -10,26 +10,27 @@ ${...}.set_ensurer("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
     Ensurer(is_string, ensure_string, ensure_string))
 
 
+if _ON_WINDOWS:
+    $XONTRIB_PROMPT_RET_CODE_COLOR_ZERO = ${...}.get(
+            "XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
+            '{BOLD_INTENSE_CYAN}')
+    $XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO = ${...}.get(
+            "XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
+            '{BOLD_INTENSE_RED}')
+
+
 def _ret_code_color():
     if __xonsh__.history.rtns:
         ret_code = True if __xonsh__.history.rtns[-1] == 0 else False
     else:
         ret_code = True
 
-    if _ON_WINDOWS:
-        if ret_code:
-            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
-                    '{BOLD_INTENSE_CYAN}')
-        else:
-            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
-                    '{BOLD_INTENSE_RED}')
+    if ret_code:
+	return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
+		'{BOLD_BLUE}')
     else:
-        if ret_code:
-            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_ZERO",
-                    '{BOLD_BLUE}')
-        else:
-            return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
-                    '{BOLD_RED}')
+	return ${...}.get("XONTRIB_PROMPT_RET_CODE_COLOR_NONZERO",
+		'{BOLD_RED}')
 
 
 def _ret_code():

--- a/xontrib/prompt_ret_code.xsh
+++ b/xontrib/prompt_ret_code.xsh
@@ -2,20 +2,31 @@ from xonsh.tools import ON_WINDOWS as _ON_WINDOWS
 
 
 def _ret_code_color():
+    try:
+	color_bg = $PROMPT_RET_CODE_BACKGROUND
+    except:
+	color_bg = False
+
+    if color_bg:
+	prefix = 'BACKGROUND'
+    else:
+	prefix = 'BOLD'
+
     if __xonsh__.history.rtns:
         color = 'blue' if __xonsh__.history.rtns[-1] == 0 else 'red'
     else:
         color = 'blue'
+
     if _ON_WINDOWS:
         if color == 'blue':
-            return '{BOLD_INTENSE_CYAN}'
+            return '{%s_INTENSE_CYAN}' % prefix
         elif color == 'red':
-            return '{BOLD_INTENSE_RED}'
+            return '{%s_INTENSE_RED}' % prefix
     else:
         if color == 'blue':
-            return '{BOLD_BLUE}'
+            return '{%s_BLUE}' % prefix
         elif color == 'red':
-            return '{BOLD_RED}'
+            return '{%s_RED}' % prefix
 
 
 def _ret_code():


### PR DESCRIPTION
I discovered xonsh last week and I've been loving it.

This change extends the prompt_ret_code xontrib. It looks for `$PROMPT_RET_CODE_BACKGROUND` and if it is `True` then the return code will set the prompt background color, rather than foreground color.

I wasn't sure how to look for the existence of a variable nicely and ending up using a `try` block. Is this the best way?

This PR also fixes a typo in xonsh/aliases.py.