### PR TITLE
Fix `cat` can't read pseudo files with zero size

### DIFF
--- a/news/3182-fix-cat-proc-file.rst
+++ b/news/3182-fix-cat-proc-file.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix ``cat`` can't read pseudo files with zero size such as /proc/\* or /sys/\* (#3182, #3199)
+
+**Security:**
+
+* <news item>

--- a/tests/test_xoreutils.py
+++ b/tests/test_xoreutils.py
@@ -191,6 +191,24 @@ class TestCat:
         assert stdout_buf.getvalue() == bytes(expected_content, "utf-8")
         assert stderr_buf.getvalue() == b''
 
+    def test_cat_single_file_with_end_newline(self, cat_env_fixture):
+        content = "this is a content withe \\n\nfor testing xoreutil's cat\n"
+        with open(self.tempfile, "w") as f:
+            f.write(content)
+        expected_content = content.replace("\n", os.linesep)
+
+        stdin = io.StringIO()
+        stdout_buf = io.BytesIO()
+        stderr_buf = io.BytesIO()
+        stdout = io.TextIOWrapper(stdout_buf)
+        stderr = io.TextIOWrapper(stderr_buf)
+        opts = cat._cat_parse_args([])
+        cat._cat_single_file(opts, self.tempfile, stdin, stdout, stderr)
+        stdout.flush()
+        stderr.flush()
+        assert stdout_buf.getvalue() == bytes(expected_content, "utf-8")
+        assert stderr_buf.getvalue() == b''
+
     def test_cat_empty_file(self, cat_env_fixture):
         with open(self.tempfile, "w") as f:
             f.write("")

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -1,6 +1,5 @@
 """Implements a cat command for xonsh."""
 import os
-import stat
 import time
 import builtins
 
@@ -39,7 +38,7 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
     enc = env.get("XONSH_ENCODING")
     enc_errors = env.get("XONSH_ENCODING_ERRORS")
     read_size = 0
-    file_size = fobj = None
+    fobj = None
     if fname == "-":
         f = stdin
     elif os.path.isdir(fname):
@@ -49,15 +48,11 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
         print("cat: No such file or directory: {}".format(fname), file=err)
         return True, line_count
     else:
-        fstat = os.stat(fname)
-        file_size = fstat.st_size
-        if file_size == 0 and not stat.S_ISREG(fstat.st_mode):
-            file_size = None
         fobj = open(fname, "rb")
         f = xproc.NonBlockingFDReader(fobj.fileno(), timeout=0.1)
     sep = os.linesep.encode(enc, enc_errors)
     last_was_blank = False
-    while file_size is None or read_size < file_size:
+    while True:
         try:
             last_was_blank, line_count, read_size, endnow = _cat_line(
                 f,

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -42,7 +42,7 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
     enc = env.get("XONSH_ENCODING")
     enc_errors = env.get("XONSH_ENCODING_ERRORS")
     read_size = 0
-    fobj = None
+    file_size = fobj = None
     if fname == "-":
         f = stdin
     elif os.path.isdir(fname):
@@ -52,11 +52,14 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
         print("cat: No such file or directory: {}".format(fname), file=err)
         return True, line_count
     else:
+        file_size = os.stat(fname).st_size
+        if file_size == 0:
+            file_size = None
         fobj = open(fname, "rb")
         f = xproc.NonBlockingFDReader(fobj.fileno(), timeout=0.1)
     sep = os.linesep.encode(enc, enc_errors)
     last_was_blank = False
-    while True:
+    while file_size is None or read_size < file_size:
         try:
             last_was_blank, line_count, read_size, endnow = _cat_line(
                 f,

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -11,12 +11,14 @@ def _cat_line(
     f, sep, last_was_blank, line_count, opts, out, enc, enc_errors, read_size
 ):
     _r = r = f.readline(size=80)
+    restore_newline = False
     if isinstance(_r, str):
         _r = r = _r.encode(enc, enc_errors)
     if r == b"":
         return last_was_blank, line_count, read_size, True
     if r.endswith(sep):
         _r = _r[: -len(sep)]
+        restore_newline = True
     this_one_blank = _r == b""
     if last_was_blank and this_one_blank and opts["squeeze_blank"]:
         return last_was_blank, line_count, read_size, False
@@ -27,6 +29,8 @@ def _cat_line(
         line_count += 1
     if opts["show_ends"]:
         _r = _r + b"$"
+    if restore_newline:
+        _r = _r + sep
     out.buffer.write(_r)
     out.flush()
     read_size += len(r)

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -15,12 +15,12 @@ def _cat_line(
     if isinstance(_r, str):
         _r = r = _r.encode(enc, enc_errors)
     if r == b"":
-        last_was_blank, line_count, read_size, True
+        return last_was_blank, line_count, read_size, True
     if r.endswith(sep):
         _r = _r[: -len(sep)]
     this_one_blank = _r == b""
     if last_was_blank and this_one_blank and opts["squeeze_blank"]:
-        last_was_blank, line_count, read_size, False
+        return last_was_blank, line_count, read_size, False
     last_was_blank = this_one_blank
     if opts["number_all"] or (opts["number_nonblank"] and not this_one_blank):
         start = ("%6d " % line_count).encode(enc, enc_errors)


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

I hope this patch will fix #3182 and #3199.
I tried `cat /proc/cpuinfo` in my machine.
