### PR TITLE
Avoid stale data when determining active tasks

### DIFF
--- a/news/get_next_task.rst
+++ b/news/get_next_task.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Avoid displaying finished tasks in title.
+
+**Security:**
+
+* <news item>

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -84,7 +84,6 @@ if ON_WINDOWS:
         Wait for the active job to finish, to be killed by SIGINT, or to be
         suspended by ctrl-z.
         """
-        _clear_dead_jobs()
         active_task = get_next_task()
         # Return when there are no foreground active task
         if active_task is None:
@@ -187,7 +186,6 @@ else:
         Wait for the active job to finish, to be killed by SIGINT, or to be
         suspended by ctrl-z.
         """
-        _clear_dead_jobs()
         active_task = get_next_task()
         # Return when there are no foreground active task
         if active_task is None:
@@ -233,6 +231,7 @@ def _safe_wait_for_active_job(last_task=None, backgrounded=False):
 
 def get_next_task():
     """ Get the next active task and put it on top of the queue"""
+    _clear_dead_jobs()
     selected_task = None
     for tid in tasks:
         task = get_task(tid)


### PR DESCRIPTION
Two of the three callers of get_next_task already called _clear_dead_jobs
to update the task state before searching for active tasks.

xonsh.prompt.job._current_job did not call _clear_dead_jobs, which lead to
tasks still being displayed in the title, even though they had already
finished.

Moving the call to _clear_dead_jobs into get_next_task ensures that it
always returns correct data.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
