### PR TITLE
Add `__dir__` to `DynamicAccessProxy`

### DIFF
--- a/news/fix_DAP_completion.rst
+++ b/news/fix_DAP_completion.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Added proxied ``__dir__`` method to ``DynamicAccessProxy`` to restore
+  tab-completion for objects that use the proxy (especially ``events``) 
+
+**Security:**
+
+* <news item>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,7 +13,7 @@ import xonsh.main
 from xonsh.main import XonshMode
 from xonsh.environ import Env
 import pytest
-from tools import TEST_DIR
+from tools import TEST_DIR, skip_if_on_windows
 
 
 def Shell(*args, **kwargs):
@@ -132,6 +132,7 @@ def test_premain_timings_arg(shell):
     xonsh.main.premain(["--timings"])
 
 
+@skip_if_on_windows
 def test_xonsh_failback(shell, monkeypatch, monkeypatch_stderr):
     failback_checker = []
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1489,6 +1489,9 @@ class DynamicAccessProxy:
     def __call__(self, *args, **kwargs):
         return self.obj.__call__(*args, **kwargs)
 
+    def __dir__(self):
+        return self.obj.__dir__()
+
 
 class DeprecationWarningProxy:
     """Proxies access, but warns in the process."""


### PR DESCRIPTION
This restores tab-completion to objects proxied through
DynamicAccessProxy

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
