### PR TITLE
Create a pre-commit hook for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -125,6 +125,11 @@ If you want to lint the entire code base run::
 
     $ pylint $(find tests xonsh -name \*.py | sort)
 
+We also use ``black`` for formatting the code base (which includes running in
+our tests)::
+
+    $ black --check --exclude=xonsh/ply/ xonsh/ xontrib/
+
 **********
 Imports
 **********

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -130,6 +130,10 @@ our tests)::
 
     $ black --check --exclude=xonsh/ply/ xonsh/ xontrib/
 
+To add this as a git pre-commit hook::
+
+    $ pre-commit install
+
 **********
 Imports
 **********

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -9,3 +9,4 @@ matplotlib
 doctr
 tornado
 black
+pre-commit

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,3 +8,4 @@ pyzmq
 matplotlib
 doctr
 tornado
+black

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,3 +9,4 @@ pygments>=2.2
 codecov
 coverage
 black
+pre-commit

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,3 +8,4 @@ prompt-toolkit
 pygments>=2.2
 codecov
 coverage
+black


### PR DESCRIPTION
After sitting next to @gforsyth and seeing him have broken tests due to not running `black`, he mentioned [pre-commit](https://pre-commit.com) and I was _hooked_[1]. So, I put it into a PR and sent it up.

[1] @scopatz and @gforsyth have been making terrible puns all week.