### PR TITLE
Fix behavior of enter key in VI_MODE

### DIFF
--- a/news/vi_mode_enter.rst
+++ b/news/vi_mode_enter.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Hitting ``Enter`` while ``$VI_MODE=True`` now executes the current code block
+  irrespective of cursor position
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk2/key_bindings.py
+++ b/xonsh/ptk2/key_bindings.py
@@ -304,8 +304,8 @@ def load_xonsh_bindings(key_bindings):
         b.validate_and_handle()
         xonsh_exit([])
 
-    @handle(Keys.ControlJ, filter=IsMultiline())
-    @handle(Keys.ControlM, filter=IsMultiline())
+    @handle(Keys.ControlJ, filter=IsMultiline() & insert_mode)
+    @handle(Keys.ControlM, filter=IsMultiline() & insert_mode)
     def multiline_carriage_return(event):
         """ Wrapper around carriage_return multiline parser """
         b = event.cli.current_buffer


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Closes #3218 

h/t to @ivanov for noticing the inconsistent behavior

When not in `insertmode`, whether this is in VI mode or Emacs mode, a carriage return should execute the current block, regardless of cursor position.  This makes that happen.