### PR TITLE
Try to open man page as help for subprocess commands

### DIFF
--- a/news/subprocess-help.rst
+++ b/news/subprocess-help.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Open man page when requesting help for subprocess commands, e.g. using ``sh?``
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -563,6 +563,11 @@ class SubprocSpec:
             raise XonshError(e.format(self.cmd[0]))
         except FileNotFoundError:
             cmd0 = self.cmd[0]
+            if len(self.cmd) == 1 and cmd0.endswith("?"):
+                with contextlib.suppress(OSError):
+                    return self.cls(
+                        ["man", cmd0.rstrip("?")], bufsize=bufsize, **kwargs
+                    )
             e = "xonsh: subprocess mode: command not found: {0}".format(cmd0)
             env = builtins.__xonsh__.env
             sug = suggest_commands(cmd0, env, builtins.aliases)


### PR DESCRIPTION
This makes for example 'sh?' equivalent to 'man sh', unless there actually
exists a 'sh?' executable.

Resolves #3204.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
