### PR TITLE
Allow disabling individual items in gitstatus prompt

### DIFF
--- a/news/gitstatus.rst
+++ b/news/gitstatus.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Allow disabling individual items in gitstatus prompt
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/gitstatus.py
+++ b/xonsh/prompt/gitstatus.py
@@ -187,20 +187,23 @@ def gitstatus_prompt():
     if s.operations:
         ret += _get_def("OPERATION") + "|" + "|".join(s.operations)
     ret += "|"
-    if s.staged > 0:
-        ret += _get_def("STAGED") + str(s.staged) + "{NO_COLOR}"
-    if s.conflicts > 0:
-        ret += _get_def("CONFLICTS") + str(s.conflicts) + "{NO_COLOR}"
-    if s.changed > 0:
-        ret += _get_def("CHANGED") + str(s.changed) + "{NO_COLOR}"
-    if s.deleted > 0:
-        ret += _get_def("DELETED") + str(s.deleted) + "{NO_COLOR}"
-    if s.untracked > 0:
-        ret += _get_def("UNTRACKED") + str(s.untracked) + "{NO_COLOR}"
-    if s.stashed > 0:
-        ret += _get_def("STASHED") + str(s.stashed) + "{NO_COLOR}"
+    for category in (
+        "staged",
+        "conflicts",
+        "changed",
+        "deleted",
+        "untracked",
+        "stashed",
+    ):
+        symbol = _get_def(category.upper())
+        value = getattr(s, category)
+        if symbol and value > 0:
+            ret += symbol + str(value) + "{NO_COLOR}"
     if s.staged + s.conflicts + s.changed + s.deleted + s.untracked + s.stashed == 0:
-        ret += _get_def("CLEAN") + "{NO_COLOR}"
+        symbol = _get_def("CLEAN")
+        if symbol:
+            ret += symbol + "{NO_COLOR}"
+    ret = ret.rstrip("|")
     ret += "{NO_COLOR}"
 
     return ret


### PR DESCRIPTION
Setting $XONSH_GITSTATUS_* to an empty string lead to the number of files
still being displayed, without any way to see to which category those
belonged. It might even display "11", which could be "1 changed file" and
"1 staged file" or "11 staged files".

Changing the logic to hide the entire entry if the corresponding
$XONSH_GITSTATUS_* setting is empty allows for an easy way to disable some
of the categories.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
