### PR TITLE
Inpsect

### DIFF
--- a/news/inpsect.rst
+++ b/news/inpsect.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``inspect.getsource`` now works correctly and the ``__xonsh__.execer`` resets
+  ``<filename>`` correctly.  This was causing several very strange buggy
+  behaviors.
+
+**Security:**
+
+* <news item>

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -54,6 +54,7 @@ class Execer(object):
         parser_args = parser_args or {}
         self.parser = Parser(**parser_args)
         self.filename = filename
+        self._default_filename = filename
         self.debug_level = debug_level
         self.unload = unload
         self.scriptcache = scriptcache
@@ -127,6 +128,7 @@ class Execer(object):
         """
         if filename is None:
             filename = self.filename
+            self.filename = self._default_filename
         if glbs is None or locs is None:
             frame = inspect.stack()[stacklevel][0]
             glbs = frame.f_globals if glbs is None else glbs

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -108,7 +108,7 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
 
     def get_data(self, path):
         """Gets the bytes for a path."""
-        raise NotImplementedError
+        raise OSError
 
     def get_code(self, fullname):
         """Gets the code object for a xonsh file."""
@@ -116,16 +116,22 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
         if filename is None:
             msg = "xonsh file {0!r} could not be found".format(fullname)
             raise ImportError(msg)
-        with open(filename, "rb") as f:
-            src = f.read()
-        enc = find_source_encoding(src)
-        src = src.decode(encoding=enc)
-        src = src if src.endswith("\n") else src + "\n"
+        src = self.get_source(filename)
         execer = self.execer
         execer.filename = filename
         ctx = {}  # dummy for modules
         code = execer.compile(src, glbs=ctx, locs=ctx)
         return code
+
+    def get_source(self, fullpath):
+        if fullpath is None:
+            raise ImportError("could not find fullpath to module")
+        with open(fullpath, "rb") as f:
+            src = f.read()
+        enc = find_source_encoding(src)
+        src = src.decode(encoding=enc)
+        src = src if src.endswith("\n") else src + "\n"
+        return src
 
 
 #


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Fixes #1939

This was a weird one but we now return the proper `filename` for objects even if there is a `xontrib` loaded.
