### PR TITLE
vox activate: use absolute path in $PATH

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = true
 source =
   xonsh/
+  xontrib/
 omit =
   */__amalgam__.py
   xonsh/lazyasd.py

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -202,5 +202,6 @@ Authors are sorted by number of commits.
 * Daniel Smith
 * goodboy
 * Atsushi Morimoto
+* Caleb Hattingh
 
 

--- a/news/vox-activate-absolute-path.rst
+++ b/news/vox-activate-absolute-path.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* `vox activate` will now prepend the absolute path of the virtualenv `bin/` directory (or `Scripts/` on Windows) to `$PATH`; before this was a relative path.

--- a/news/vox-activate-absolute-path.rst
+++ b/news/vox-activate-absolute-path.rst
@@ -1,3 +1,3 @@
 **Changed:**
 
-* `vox activate` will now prepend the absolute path of the virtualenv `bin/` directory (or `Scripts/` on Windows) to `$PATH`; before this was a relative path.
+* ``vox activate`` will now prepend the absolute path of the virtualenv ``bin/`` directory (or ``Scripts/`` on Windows) to ``$PATH``; before this was a relative path.

--- a/news/vox-activate-absolute-path.rst
+++ b/news/vox-activate-absolute-path.rst
@@ -1,3 +1,24 @@
+**Added:**
+
+* <news item>
+
 **Changed:**
 
 * ``vox activate`` will now prepend the absolute path of the virtualenv ``bin/`` directory (or ``Scripts/`` on Windows) to ``$PATH``; before this was a relative path.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -114,12 +114,20 @@ def test_activate_non_vox_venv(xonsh_builtins, tmpdir):
     assert env["PATH"][0] == vxv.bin
     assert os.path.isabs(vxv.env)
     assert env["VIRTUAL_ENV"] == vxv.env
-    assert last_event == ("activate", venv_dirname, str(pathlib.Path(tmpdir) / 'venv'))
+    assert last_event == (
+        "activate",
+        venv_dirname,
+        str(pathlib.Path(str(tmpdir)) / 'venv')
+    )
 
     vox.deactivate()
     assert not env["PATH"]
     assert "VIRTUAL_ENV" not in env
-    assert last_event == ("deactivate", tmpdir.join(venv_dirname), str(pathlib.Path(tmpdir) / 'venv'))
+    assert last_event == (
+        "deactivate",
+        tmpdir.join(venv_dirname),
+        str(pathlib.Path(str(tmpdir)) / 'venv')
+    )
 
 
 @skip_if_on_msys

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -1,9 +1,10 @@
 """Vox tests"""
 
-import builtins
 import stat
 import os
+import subprocess as sp
 import pytest
+import sys
 from xontrib.voxapi import Vox
 
 from tools import skip_if_on_conda, skip_if_on_msys
@@ -78,6 +79,47 @@ def test_activate(xonsh_builtins, tmpdir):
     vox.deactivate()
     assert "VIRTUAL_ENV" not in xonsh_builtins.__xonsh__.env
     assert last_event == ("deactivate", "spam")
+
+
+@skip_if_on_msys
+@skip_if_on_conda
+def test_activate_non_vox_venv(xonsh_builtins, tmpdir):
+    """
+    Create a virtual environment using Python's built-in venv module
+    (not in VIRTUALENV_HOME) and verify that vox can activate it correctly.
+    """
+    xonsh_builtins.__xonsh__.env.setdefault("PATH", [])
+
+    last_event = None
+
+    @xonsh_builtins.events.vox_on_activate
+    def activate(name, **_):
+        nonlocal last_event
+        last_event = "activate", name
+
+    @xonsh_builtins.events.vox_on_deactivate
+    def deactivate(name, **_):
+        nonlocal last_event
+        last_event = "deactivate", name
+
+    with tmpdir.as_cwd():
+        venv_dirname = 'venv'
+        sp.run([sys.executable, '-m', 'venv', venv_dirname])
+        vox = Vox()
+        vox.activate(venv_dirname)
+        vxv = vox[venv_dirname]
+
+    env = xonsh_builtins.__xonsh__.env
+    assert os.path.isabs(vxv.bin)
+    assert env["PATH"][0] == vxv.bin
+    assert os.path.isabs(vxv.env)
+    assert env["VIRTUAL_ENV"] == vxv.env
+    assert last_event == ("activate", venv_dirname)
+
+    vox.deactivate()
+    assert not env["PATH"]
+    assert "VIRTUAL_ENV" not in env
+    assert last_event == ("deactivate", tmpdir.join(venv_dirname))
 
 
 @skip_if_on_msys

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -93,14 +93,14 @@ def test_activate_non_vox_venv(xonsh_builtins, tmpdir):
     last_event = None
 
     @xonsh_builtins.events.vox_on_activate
-    def activate(name, **_):
+    def activate(name, path, **_):
         nonlocal last_event
-        last_event = "activate", name, _['path']
+        last_event = "activate", name, path
 
     @xonsh_builtins.events.vox_on_deactivate
-    def deactivate(name, **_):
+    def deactivate(name, path, **_):
         nonlocal last_event
-        last_event = "deactivate", name, _['path']
+        last_event = "deactivate", name, path
 
     with tmpdir.as_cwd():
         venv_dirname = 'venv'

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -95,12 +95,12 @@ def test_activate_non_vox_venv(xonsh_builtins, tmpdir):
     @xonsh_builtins.events.vox_on_activate
     def activate(name, **_):
         nonlocal last_event
-        last_event = "activate", name
+        last_event = "activate", name, _['path']
 
     @xonsh_builtins.events.vox_on_deactivate
     def deactivate(name, **_):
         nonlocal last_event
-        last_event = "deactivate", name
+        last_event = "deactivate", name, _['path']
 
     with tmpdir.as_cwd():
         venv_dirname = 'venv'
@@ -114,12 +114,12 @@ def test_activate_non_vox_venv(xonsh_builtins, tmpdir):
     assert env["PATH"][0] == vxv.bin
     assert os.path.isabs(vxv.env)
     assert env["VIRTUAL_ENV"] == vxv.env
-    assert last_event == ("activate", venv_dirname)
+    assert last_event == ("activate", venv_dirname, str(pathlib.Path(tmpdir) / 'venv'))
 
     vox.deactivate()
     assert not env["PATH"]
     assert "VIRTUAL_ENV" not in env
-    assert last_event == ("deactivate", tmpdir.join(venv_dirname))
+    assert last_event == ("deactivate", tmpdir.join(venv_dirname), str(pathlib.Path(tmpdir) / 'venv'))
 
 
 @skip_if_on_msys

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -88,7 +88,7 @@ def _mkvenv(env_dir):
 
     This only cares about the platform. No filesystem calls are made.
     """
-    env_dir = os.path.normpath(env_dir)
+    env_dir = os.path.abspath(env_dir)
     if ON_WINDOWS:
         binname = os.path.join(env_dir, "Scripts")
         incpath = os.path.join(env_dir, "Include")
@@ -358,7 +358,7 @@ class Vox(collections.abc.Mapping):
             self.deactivate()
 
         type(self).oldvars = {"PATH": list(env["PATH"])}
-        env["PATH"].insert(0, os.path.abspath(ve.bin))
+        env["PATH"].insert(0, ve.bin)
         env["VIRTUAL_ENV"] = ve.env
         if "PYTHONHOME" in env:
             type(self).oldvars["PYTHONHOME"] = env.pop("PYTHONHOME")

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -358,7 +358,7 @@ class Vox(collections.abc.Mapping):
             self.deactivate()
 
         type(self).oldvars = {"PATH": list(env["PATH"])}
-        env["PATH"].insert(0, ve.bin)
+        env["PATH"].insert(0, os.path.abspath(ve.bin))
         env["VIRTUAL_ENV"] = ve.env
         if "PYTHONHOME" in env:
             type(self).oldvars["PYTHONHOME"] = env.pop("PYTHONHOME")

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -363,7 +363,7 @@ class Vox(collections.abc.Mapping):
         if "PYTHONHOME" in env:
             type(self).oldvars["PYTHONHOME"] = env.pop("PYTHONHOME")
 
-        events.vox_on_activate.fire(name=name)
+        events.vox_on_activate.fire(name=name, path=ve.env)
 
     def deactivate(self):
         """
@@ -382,7 +382,7 @@ class Vox(collections.abc.Mapping):
 
         env.pop("VIRTUAL_ENV")
 
-        events.vox_on_deactivate.fire(name=env_name)
+        events.vox_on_deactivate.fire(name=env_name, path=self[env_name].env)
         return env_name
 
     def __delitem__(self, name):

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -4,8 +4,8 @@ API for Vox, the Python virtual environment manager for xonsh.
 Vox defines several events related to the life cycle of virtual environments:
 
 * ``vox_on_create(env: str) -> None``
-* ``vox_on_activate(env: str) -> None``
-* ``vox_on_deactivate(env: str) -> None``
+* ``vox_on_activate(env: str, path: pathlib.Path) -> None``
+* ``vox_on_deactivate(env: str, path: pathlib.Path) -> None``
 * ``vox_on_delete(env: str) -> None``
 """
 import os
@@ -37,7 +37,7 @@ Fired after an environment is created.
 events.doc(
     "vox_on_activate",
     """
-vox_on_activate(env: str) -> None
+vox_on_activate(env: str, path: pathlib.Path) -> None
 
 Fired after an environment is activated.
 """,
@@ -46,7 +46,7 @@ Fired after an environment is activated.
 events.doc(
     "vox_on_deactivate",
     """
-vox_on_deactivate(env: str) -> None
+vox_on_deactivate(env: str, path: pathlib.Path) -> None
 
 Fired after an environment is deactivated.
 """,


### PR DESCRIPTION
# Overview

Currently, when I use `vox activate venv/`, a _relative path_ is prepended to `$PATH`, and this means that if I change away from the current directory (which would typically be the project root), the path no longer resolves correctly.

This PR proposes to insert the _absolute path_ into `$PATH`.

# xonfig

```
$ xonfig
+------------------+-------------------------------------------------------+
| xonsh            | 0.9.9                                                 |
| Git SHA          | 5aac8711                                              |
| Commit Date      | Jul 19 17:43:33 2019                                  |
| Python           | 3.7.4                                                 |
| PLY              | 3.11                                                  |
| have readline    | False                                                 |
| prompt toolkit   | 2.0.9                                                 |
| shell type       | prompt_toolkit2                                       |
| pygments         | 2.3.1                                                 |
| on posix         | False                                                 |
| on linux         | False                                                 |
| on darwin        | False                                                 |
| on windows       | True                                                  |
| on cygwin        | <xonsh.lazyasd.LazyBool object at 0x000001C411D0B388> |
| on msys2         | <xonsh.lazyasd.LazyBool object at 0x000001C411D0B3C8> |
| is superuser     | False                                                 |
| default encoding | utf-8                                                 |
| xonsh encoding   | utf-8                                                 |
| encoding errors  | surrogateescape                                       |
+------------------+-------------------------------------------------------+
```

# Details

I have a project with a `venv/` directory in the project root.  This virtualenv was created with

```
$ py -3.8 -m venv venv
```

To activate the virtual environment in xonsh, I type:

```
$ vox activate venv/
```

This results in the following `$PATH`:

```
$ $PATH
EnvPath(
['venv\\Scripts',
 'C:\\ProgramData\\DockerDesktop\\version-bin',
 'C:\\Program Files\\Docker\\Docker\\Resources\\bin',
 'G:\\Programs\\Python37\\Scripts\\',
 'G:\\Programs\\Python37\\',
 'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\CLI2\\wbin',
 'C:\\Program Files\\Docker\\Docker\\resources\\bin',
 'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.0\\bin',
 'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.0\\libnvvp',
 <...snip...>
]
```

At this stage, `$which pip` and `$which python` resolve correctly to the ones inside the venv. However, if I change into a subdirectory below the root, they now resolve to my globally installed Python **even though the virtualenv is still "activated".**

After applying the change in this PR, the value of `$PATH` after `$ vox activate venv/` becomes:

```
$ $PATH
EnvPath(
['G:\\Documents\\repos\\numba-shootout\\venv\\Scripts',      # <----- absolute path
 'C:\\ProgramData\\DockerDesktop\\version-bin',
 'C:\\Program Files\\Docker\\Docker\\Resources\\bin',
 'G:\\Programs\\Python37\\Scripts\\',
 'G:\\Programs\\Python37\\',
 'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\CLI2\\wbin',
 'C:\\Program Files\\Docker\\Docker\\resources\\bin',
 'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.0\\bin',
 'C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.0\\libnvvp',
```

Now, `$ which pip` and `$ which python` continue to resolve to the correct copies inside the virtualenv even when changing in subdirectories.