### PR TITLE
Update xontribs.json

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -38,11 +38,6 @@
   "url": "https://github.com/ErickTucto/xontrib-base16-shell",
   "description": ["Change base16 shell themes"]
  },
- {"name": "click_tabcomplete",
-  "package": "xonsh-click-tabcomplete",
-  "url": "https://github.com/Granitosaurus/xonsh-click-tabcomplete",
-  "description": ["Adds tabcomplete functionality to click based python applications inside of xonsh."]
- },
  {"name": "coreutils",
   "package": "xonsh",
   "url": "http://xon.sh",


### PR DESCRIPTION
Recommend removal of click_tabcomplete because it's not working for a year now. It just decreases the new user experience creating error messages after launching xonsh if this is loaded.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
