### PR TITLE
command-not-found: fix lookup of command-not-found in Ubuntu

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -830,15 +830,16 @@ def command_not_found(cmd):
     """Uses the debian/ubuntu command-not-found utility to suggest packages for a
     command that cannot currently be found.
     """
-    import shutil
-
     if not ON_LINUX:
         return ""
 
-    cnf = shutil.which("command-not-found")
-    if cnf is None:
-        # utility is not on PATH
+    cnf = builtins.__xonsh__.commands_cache.lazyget(
+        "command-not-found", ("/usr/lib/command-not-found",)
+    )[0]
+
+    if not os.path.isfile(cnf):
         return ""
+
     c = "{0} {1}; exit 0"
     s = subprocess.check_output(
         c.format(cnf, cmd),


### PR DESCRIPTION
The last change in #3249 has introduced a regression as
command-not-found does not reside on the $PATH on Ubuntu systems.

Additionally `CommandsCache` is introduced instead of `shutil.which` to
cache the result of $PATH lookup.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
---
Question does a repeated failing lookup in `CommandsCache` hurt on Ubuntu? 