### PR TITLE
remove dependency on 'random` library

### DIFF
--- a/news/no-random.rst
+++ b/news/no-random.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* ``random`` shell type is deprecated and now falls back to ``best``.
+  This affects the parameter ``random`` of ``xonsh``'s ``--shell-type`` option
+  and the value ``random`` of ``SHELL_TYPE`` enviroment variable.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1103,7 +1103,6 @@ def DEFAULT_DOCS():
             "Which shell is used. Currently two base shell types are supported:\n\n"
             "    - ``readline`` that is backed by Python's readline module\n"
             "    - ``prompt_toolkit`` that uses external library of the same name\n"
-            "    - ``random`` selects a random shell from the above on startup\n"
             "    - ``best`` selects the most feature-rich shell available on the\n"
             "       user's system\n\n"
             "To use the ``prompt_toolkit`` shell you need to have the "

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -211,10 +211,9 @@ def parser():
     p.add_argument(
         "--shell-type",
         help="What kind of shell should be used. "
-        "Possible options: readline, prompt_toolkit, random. "
         "Warning! If set this overrides $SHELL_TYPE variable.",
         dest="shell_type",
-        choices=tuple(Shell.shell_type_aliases.keys()),
+        choices=sorted(set(Shell.shell_type_aliases.values())),
         default=None,
     )
     p.add_argument(

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """The xonsh shell"""
 import sys
-import random
 import time
 import difflib
 import builtins
@@ -128,8 +127,8 @@ class Shell(object):
         "prompt_toolkit": "prompt_toolkit",
         "prompt-toolkit1": "prompt_toolkit1",
         "prompt-toolkit2": "prompt_toolkit2",
-        "rand": "random",
-        "random": "random",
+        "rand": "best",  # DEPRECATED
+        "random": "best",  # DEPRECATED
         "rl": "readline",
         "readline": "readline",
     }
@@ -146,8 +145,7 @@ class Shell(object):
             this no additional context is computed and this is used
             directly.
         shell_type : str, optional
-            The shell type to start, such as 'readline', 'prompt_toolkit1',
-            or 'random'.
+            The shell type to start, such as 'readline' or 'prompt_toolkit2'.
         """
         self.execer = execer
         self.ctx = {} if ctx is None else ctx
@@ -170,8 +168,6 @@ class Shell(object):
             shell_type = best_shell_type()
         elif env.get("TERM", "") == "dumb":
             shell_type = "dumb"
-        elif shell_type == "random":
-            shell_type = random.choice(("readline", "prompt_toolkit"))
         if shell_type == "prompt_toolkit":
             if not has_prompt_toolkit():
                 warnings.warn(


### PR DESCRIPTION
I wonder what the use case was for a 'random' shell type feature,
nevertheless removing it will reduce start-up time and memory usage.
Apart from this obscure feature, there are no other uses of `import random`
in the main app.

This patch also includes a change in generation of choices for the `--shell-type`
argument. Prior to this patch the `--help` output looked like this:

```
  --shell-type {b,best,d,dumb,ptk,ptk1,ptk2,prompt-toolkit,prompt_toolkit,prompt-toolkit1,prompt-toolkit2,rand,random,rl,readline}
```

After this patch it looks like this:

```
  --shell-type {best,dumb,prompt_toolkit,prompt_toolkit1,prompt_toolkit2,readline}
```

I've changed it since it would still contain 'random' option otherwise,
but I think it also improves the readability of the `--help` output.

And for completeness sake, this feature was introduced in a9c606b8252c3b8ad50ac1735e32528940c9ed5e.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
