### PR TITLE
Allow logical operators within aliases

### DIFF
--- a/news/logical_op_aliases.rst
+++ b/news/logical_op_aliases.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Logical operators in aliases are now executed as expected, e.g.
+  ``aliases['echocat'] = 'echo "hi" and echo "there"'`` will, when run, return
+
+  .. code-block::
+     hi
+     there
+
+**Security:**
+
+* <news item>

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 import xonsh.built_ins as built_ins
-from xonsh.aliases import Aliases
+from xonsh.aliases import Aliases, ExecAlias
 from xonsh.environ import Env
 
 from tools import skip_if_on_windows
@@ -113,3 +113,18 @@ def test_recursive_callable_partial_none(xonsh_execer, xonsh_builtins):
     args, obs = alias()
     assert args == "wakka"
     assert len(obs) == 0
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "echo 'hi' and echo 'there'",
+        "echo 'hi' or echo 'there'",
+        "echo 'hi' && echo 'there'",
+        "echo 'hi' || echo 'there'",
+        "echo 'hi';  echo 'there'",
+    ],
+)
+def test_subprocess_logical_operators(xonsh_execer, xonsh_builtins, alias):
+    ales = make_aliases()
+    ales["echocat"] = alias
+    assert isinstance(ales["echocat"], ExecAlias)

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -44,7 +44,7 @@ import xonsh.xoreutils.which as xxw
 
 @lazyobject
 def SUB_EXEC_ALIAS_RE():
-    return re.compile(r"@\(|\$\(|!\(|\$\[|!\[")
+    return re.compile(r"@\(|\$\(|!\(|\$\[|!\[|\&\&|\|\||and|or")
 
 
 class Aliases(cabc.MutableMapping):


### PR DESCRIPTION
This fixes #3270 and logical operators within aliases now resolve correctly.

I've added in `&&`, `||`, `and`, and `or`

```
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ aliases['echocat'] = 'echo "hi" and echo "there"'
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ echocat
hi
there
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ aliases['echocat'] = 'echo "hi" or echo "there"'
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ echocat
hi
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ aliases['echocat'] = 'echo "hi" && echo "there"'
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ echocat
hi
there
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ aliases['echocat'] = 'echo "hi" || echo "there"'
(base)   ~/githu/xonsh/xonsh logical_op_aliases $ echocat
hi
```

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
