### PR TITLE
Correct completer tutorial

### DIFF
--- a/docs/tutorial_completers.rst
+++ b/docs/tutorial_completers.rst
@@ -55,7 +55,7 @@ Completers are implemented as Python functions that take five arguments:
 * ``prefix``: the string to be matched (the last whitespace-separated token in the current line)
 * ``line``: a string representing the entire current line
 * ``begidx``: the index at which ``prefix`` starts in ``line``
-* ``endidx``: the index at which ``prefix`` ends in ``line``
+* ``endidx``: the length of the ``prefix`` in ``line``
 * ``ctx``: the current Python environment, as a dictionary mapping names to values
 
 This function should return a Python set of possible completions for ``prefix``
@@ -95,7 +95,7 @@ xonsh actually uses, in the ``xonsh.completers`` module.
         Replaces "lou carcolh" with "snail" if tab is pressed after typing
         "lou" and when typing "carcolh"
         '''
-        if 'carcolh'.startswith(prefix) and line[:begidx].split()[-1] == 'lou':
+        if 'carcolh'.startswith(prefix) or 'lou' in line[:begidx].split()[-1:]:
             return ({'snail'}, len('lou ') + len(prefix))
 
 

--- a/docs/tutorial_completers.rst
+++ b/docs/tutorial_completers.rst
@@ -92,10 +92,10 @@ xonsh actually uses, in the ``xonsh.completers`` module.
 
     def unbeliever_completer(prefix, line, begidx, endidx, ctx):
         '''
-        Replaces "lou carcolh" with "snail" if tab is pressed after typing
-        "lou" and when typing "carcolh"
+        Replaces "lou carcolh" with "snail" if tab is pressed after at least
+        typing the "lou " part.
         '''
-        if 'carcolh'.startswith(prefix) or 'lou' in line[:begidx].split()[-1:]:
+        if  'carcolh'.startswith(prefix) and 'lou' in line[:begidx].split()[-1:]:
             return ({'snail'}, len('lou ') + len(prefix))
 
 

--- a/news/correct_completer_tutorial.rst
+++ b/news/correct_completer_tutorial.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* "lou carcolh" example and description of ``endidx`` in completer tutorial

--- a/news/correct_completer_tutorial.rst
+++ b/news/correct_completer_tutorial.rst
@@ -1,3 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
 **Fixed:**
 
 * "lou carcolh" example and description of ``endidx`` in completer tutorial
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Corrects the code in the "lou carcolh" example for custom xonsh <kbd>TAB</kbd>-completers. Previously it would not correct on "lou", despite what the docstring said. Also it would throw an `IndexError` if empty.

Also corrects the description of `endidx`, which is not actually the index of the last character in prefix, but the length (i.e. "index of last character plus one").

Btw., I have written this decorator to debug completers more readily:

<details>
<summary>Completer debug decorator</summary>

    import tempfile, time
    from functools import wraps
    from pprint import pformat
    from pathlib import Path as P

    def complete_watcher(
        func=None, dirname=tempfile.gettempdir(),
        filename='xonsh_complete_watcher.txt',
        context=False
    ):
        if func is None:
            return functools.partial(complete_watcher,
                dirname=dirname, filename=filename, context=context )

        tmpfl = P(dirname) / filename
        tmpfl.write_text("\n** Opened on {} **\n".format(time.ctime()))

        def vertical_number(line, prefix=''):
            rows = len(str(len(line)))
            nums = ["{:<{r}d}".format(i,r=rows) for i in range(len(line))]
            return ("\n" + prefix).join([''.join(x) for x in zip(*nums)])

        @functools.wraps(func)
        def completer_(prefix, line, begidx, endidx, ctx, *args, **kwargs):
            compl = func(prefix, line, begidx, endidx, ctx, *args, **kwargs)
            complstr = pformat(compl)
            ctime = time.ctime()
            vernum = vertical_number(line+' ', ' '*6)
            markers = ' '*begidx + 'b' + ' '*(endidx-begidx-1) + 'e'
            ctxstr = pformat(ctx) + '\n' if context is True else ''
            tmpfl.write_text(
                "\n===========\n"
                "{ctxstr}"
                "{ctime}\n"
                "prefix: {prefix}\n"
                "line: {line}\n"
                "indx: {vernum}\n"
                "      {markers}\n"
                "------------\n"
                "{complstr}\n"
                "===========\n".format(**locals()) )
            return compl

        return completer_

    @completer_watcher
    def unbeliever_completer(prefix, line, begidx, endidx, ctx):
        # ...

use it with:

    tail -f /tmp/xonsh_completer_watcher.txt

</details>
