### PR TITLE
Python 3.8: Prevent posonlyargs error

### DIFF
--- a/news/posonlyargs.rst
+++ b/news/posonlyargs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Defining functions inside of the shell no longer crashes on Python 3.8.
+
+**Security:**
+
+* <news item>

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -853,6 +853,7 @@ class BaseParser(object):
         p2 = p[2]
         if p2 is None:
             p2 = ast.arguments(
+                posonlyargs=[],
                 args=[],
                 vararg=None,
                 kwonlyargs=[],
@@ -869,14 +870,26 @@ class BaseParser(object):
     def p_typedargslist_kwarg(self, p):
         """typedargslist : POW tfpdef"""
         p[0] = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[2], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[2],
+            defaults=[],
         )
 
     def p_typedargslist_times4_tfpdef(self, p):
         """typedargslist : TIMES tfpdef comma_pow_tfpdef_opt"""
         # *args, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[3], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[3],
+            defaults=[],
         )
         self._set_var_args(p0, p[2], None)
         p[0] = p0
@@ -885,7 +898,13 @@ class BaseParser(object):
         """typedargslist : TIMES comma_pow_tfpdef"""
         # *, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[2], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[2],
+            defaults=[],
         )
         p[0] = p0
 
@@ -893,7 +912,13 @@ class BaseParser(object):
         """typedargslist : TIMES tfpdef comma_tfpdef_list comma_pow_tfpdef_opt"""
         # *args, x, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[4], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[4],
+            defaults=[],
         )
         self._set_var_args(p0, p[2], p[3])  # *args
         p[0] = p0
@@ -902,7 +927,13 @@ class BaseParser(object):
         """typedargslist : TIMES comma_tfpdef_list comma_pow_tfpdef_opt"""
         # *, x, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[3], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[3],
+            defaults=[],
         )
         self._set_var_args(p0, None, p[2])  # *args
         p[0] = p0
@@ -911,7 +942,13 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt"""
         # x
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -920,7 +957,13 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt POW tfpdef"""
         # x, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[6], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[6],
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -928,7 +971,13 @@ class BaseParser(object):
     def p_typedargslist_t8(self, p):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt comma_tfpdef_list_opt"""
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], p[7])
@@ -938,7 +987,13 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt COMMA POW vfpdef"""
         # x, *args, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[9], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[9],
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], None)
@@ -948,6 +1003,7 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt comma_tfpdef_list COMMA POW tfpdef"""
         # x, *args, **kwargs
         p0 = ast.arguments(
+            posonlyargs=[],
             args=[],
             vararg=None,
             kwonlyargs=[],
@@ -1033,13 +1089,25 @@ class BaseParser(object):
     def p_varargslist_kwargs(self, p):
         """varargslist : POW vfpdef"""
         p[0] = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[2], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[2],
+            defaults=[],
         )
 
     def p_varargslist_times4(self, p):
         """varargslist : TIMES vfpdef_opt comma_pow_vfpdef_opt"""
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[3], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[3],
+            defaults=[],
         )
         self._set_var_args(p0, p[2], None)
         p[0] = p0
@@ -1048,7 +1116,13 @@ class BaseParser(object):
         """varargslist : TIMES vfpdef_opt comma_vfpdef_list comma_pow_vfpdef_opt"""
         # *args, x, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[4], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[4],
+            defaults=[],
         )
         self._set_var_args(p0, p[2], p[3])  # *args
         p[0] = p0
@@ -1057,7 +1131,13 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt"""
         # x
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -1066,7 +1146,13 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt POW vfpdef"""
         # x, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[6], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[6],
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -1075,7 +1161,13 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt comma_vfpdef_list_opt"""
         # x, *args
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], p[7])
@@ -1085,7 +1177,13 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt COMMA POW vfpdef"""
         # x, *args, **kwargs
         p0 = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[9], defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[9],
+            defaults=[],
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], None)
@@ -1094,6 +1192,7 @@ class BaseParser(object):
     def p_varargslist_v11(self, p):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt comma_vfpdef_list COMMA POW vfpdef"""
         p0 = ast.arguments(
+            posonlyargs=[],
             args=[],
             vararg=None,
             kwonlyargs=[],
@@ -1858,6 +1957,7 @@ class BaseParser(object):
         p1, p2, p4 = p[1], p[2], p[4]
         if p2 is None:
             args = ast.arguments(
+                posonlyargs=[],
                 args=[],
                 vararg=None,
                 kwonlyargs=[],


### PR DESCRIPTION
Fixes #3271 

I thought I'd give that issue a spin, even though I'm not at all familiar with the codebase. Please keep in mind that this PR is purely touching in the dark, but I hope that it gives some insights to someone who knows the codebase better.

I learnt from the Python docs that `ast.arguments` was changed to also take `posonlyargs` as argument. So I figured I'd look up all the places where `ast.arguments` pop up, and simply plug in `posonlyargs` as argument. Sure enough, this fixed the raised exception. And curiously enough, it doesn't break on Python 3.7 for me.

This PR doesn't actually implement posonlyargs, however. See the following output:

```
(xonsh38) carmenbianca@thinkpad-x395 ~/Projektoj/xonsh posonlyargs $ def f(a, b, /, c, d, *, e, f): 
....................................................................     print(a, b, c, d, e, f) 
....................................................................                                                                                             
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/ptk2/shell.py", line 173, in _push
    code = self.execer.compile(src, mode="single", glbs=self.ctx, locs=None)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/execer.py", line 135, in compile
    tree = self.parse(input, ctx, mode=mode, filename=filename, transform=transform)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/execer.py", line 96, in parse
    tree, input = self._parse_ctx_free(input, mode=mode, filename=filename)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/execer.py", line 235, in _parse_ctx_free
    raise original_error from None
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/execer.py", line 216, in _parse_ctx_free
    tree = self.parser.parse(
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/parsers/base.py", line 543, in parse
    tree = self.parser.parse(input=s, lexer=self.lexer, debug=debug_level)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/ply/ply/yacc.py", line 335, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/ply/ply/yacc.py", line 1203, in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/ply/ply/yacc.py", line 194, in call_errorfunc
    r = errorfunc(token)
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/parsers/base.py", line 3399, in p_error
    self._parse_error(msg, self.currloc(lineno=p.lineno, column=p.lexpos))
  File "/home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xonsh/parsers/base.py", line 676, in _parse_error
    raise err
  File "<string>", line None
SyntaxError: /home/carmenbianca/.virtualenvs/xonsh38/lib64/python3.8/site-packages/xontrib/jedi.xsh:1:12: ('code: /',)
def f(a, b, /, c, d, *, e, f):
```

I also noticed one other place where I might plug in `posonlyargs`, but this doesn't appear to actually do anything. For posterity's sake, see the diff here:

```
diff --git a/xonsh/parsers/v35.py b/xonsh/parsers/v35.py
index 6faf0f2d..620f49aa 100644
--- a/xonsh/parsers/v35.py
+++ b/xonsh/parsers/v35.py
@@ -103,14 +103,14 @@ class Parser(BaseParser):
 
     def p_arglist_single(self, p):
         """arglist : argument comma_opt"""
-        p0 = {"args": [], "keywords": []}
+        p0 = {"posonlyargs": [], "args": [], "keywords": []}
         self._set_arg(p0, p[1])
         p[0] = p0
 
     def p_arglist_many(self, p):
         """arglist : argument comma_argument_list comma_opt
         """
-        p0 = {"args": [], "keywords": []}
+        p0 = {"posonlyargs": [], "args": [], "keywords": []}
         self._set_arg(p0, p[1])
         for arg in p[2]:
             self._set_arg(p0, arg)
```