### PR TITLE
Non-zero exit code when script path not found

### DIFF
--- a/news/fnf_exit_1.rst
+++ b/news/fnf_exit_1.rst
@@ -1,0 +1,31 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``xonsh`` will return a non-zero exit code if it is run in file mode and
+  cannot find the file specified, e.g.
+
+  .. code-block::
+
+     $ xonsh thisfiledoesntexist.xsh
+     xonsh: thisfiledoesntexist.xsh: No such file or directory.
+     $ _.returncode
+     1
+
+**Security:**
+
+* <news item>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -186,3 +186,9 @@ def test_xonsh_failback_script_from_file(shell, monkeypatch, monkeypatch_stderr)
     with pytest.raises(Exception):
         xonsh.main.main()
     assert len(checker) == 0
+
+
+def test_xonsh_no_file_returncode(shell, monkeypatch, monkeypatch_stderr):
+    monkeypatch.setattr(sys, "argv", ["xonsh", "foobazbarzzznotafileatall.xsh"])
+    with pytest.raises(SystemExit):
+        xonsh.main.main()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -447,6 +447,8 @@ def main_xonsh(args):
                 )
             else:
                 print("xonsh: {0}: No such file or directory.".format(args.file))
+                events.on_exit.fire()
+                sys.exit(1)
         elif args.mode == XonshMode.script_from_stdin:
             # run a script given on stdin
             code = sys.stdin.read()


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Fixes #3292 

Not sure if we want the `on_exit` event to still fire for this -- I've put it in for now. 