### PR TITLE
Fix gray empty bar when updating on keypress

### DIFF
--- a/news/bottom_bar_keypress_issue.rst
+++ b/news/bottom_bar_keypress_issue.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* gray empty bottom bar when using $XONSH_UPDATE_PROMPT_ON_KEYPRESS
+

--- a/xonsh/ptk2/shell.py
+++ b/xonsh/ptk2/shell.py
@@ -100,14 +100,16 @@ class PromptToolkit2Shell(BaseShell):
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
         completer = None if completions_display == "none" else self.pt_completer
 
+        get_bottom_toolbar_tokens = self.bottom_toolbar_tokens
+
         if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
             get_prompt_tokens = self.prompt_tokens
             get_rprompt_tokens = self.rprompt_tokens
-            get_bottom_toolbar_tokens = self.bottom_toolbar_tokens
         else:
             get_prompt_tokens = self.prompt_tokens()
             get_rprompt_tokens = self.rprompt_tokens()
-            get_bottom_toolbar_tokens = self.bottom_toolbar_tokens()
+            if get_bottom_toolbar_tokens:
+                get_bottom_toolbar_tokens = get_bottom_toolbar_tokens()
 
         if env.get("VI_MODE"):
             editing_mode = EditingMode.VI
@@ -236,7 +238,7 @@ class PromptToolkit2Shell(BaseShell):
         toks = partial_color_tokenize(p)
         return PygmentsTokens(toks)
 
-    def bottom_toolbar_tokens(self):
+    def _bottom_toolbar_tokens(self):
         """Returns a list of (token, str) tuples for the current bottom
         toolbar.
         """
@@ -249,6 +251,13 @@ class PromptToolkit2Shell(BaseShell):
             print_exception()
         toks = partial_color_tokenize(p)
         return PygmentsTokens(toks)
+
+    @property
+    def bottom_toolbar_tokens(self):
+        """Returns self._bottom_toolbar_tokens if it would yield a result
+        """
+        if builtins.__xonsh__.env.get("BOTTOM_TOOLBAR"):
+            return self._bottom_toolbar_tokens
 
     def continuation_tokens(self, width, line_number, is_soft_wrap=False):
         """Displays dots in multiline prompt"""


### PR DESCRIPTION
This fixes [an issue I encountered](https://github.com/xonsh/xonsh/issues/1048#issuecomment-531497811) when using `$XONSH_UPDATE_PROMPT_ON_KEYPRESS` where the bottom bar is rendered as a grey block.

Root cause was essentially passing `"bottom_toolbar": lambda: None`. I only fixed `ptk2` because I'm not sure if it was an issue elsewhere.

The second gray bar is `tmux`, confirmed it appears outside of it though:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/8343799/64930671-a87aeb80-d7f8-11e9-8c09-c8583ff763f9.png">
