### PR TITLE
fix tab completion of cd with $CDPATH

### DIFF
--- a/news/fix-cd-completion.rst
+++ b/news/fix-cd-completion.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* tab completion for cd correctly handles the CDPATH environment variable
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Previously using tab completion for cd combined with the `$CDPATH` environment variable led to strange behaviour.

Consider the following scenario
```
mkdir -p /tmp/cdpath/outer/inner
$CDPATH = ['tmp/cdpath']
```
entering `"cd outer<tab>"` would be completed to `"cd outer "` (note the trailing space) and entering `"cd outer/<tab>"` would be completed to `"cd inner "` (also with a trailing space).

The first tab completion is of no use, while the second tab completion is simply invalid (the correct one would be `cd outer/inner/`)


This path fixes this bug by returning the path relative to the `$CDPATH` entry in `_add_cdpaths`.
Furthermore to enable repeated presses of `<tab>` `_quote_paths` had to be changed to consider paths within $CDPATH