### PR TITLE
add cwd args on_postcommand event

### DIFF
--- a/news/dev_on_postcommand.rst
+++ b/news/dev_on_postcommand.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* events.on_postcommand args now has cwd where command executed
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -393,6 +393,7 @@ class BaseShell(object):
         """
         hist = builtins.__xonsh__.history  # pylint: disable=no-member
         info["rtn"] = hist.last_cmd_rtn if hist is not None else None
+        info["cwd"] = os.getcwd()
         tee_out = tee_out or None
         last_out = hist.last_cmd_out if hist is not None else None
         if last_out is None and tee_out is None:
@@ -404,7 +405,11 @@ class BaseShell(object):
         else:
             info["out"] = tee_out + "\n" + last_out
         events.on_postcommand.fire(
-            cmd=info["inp"], rtn=info["rtn"], out=info.get("out", None), ts=info["ts"]
+            cmd=info["inp"],
+            rtn=info["rtn"],
+            out=info.get("out", None),
+            ts=info["ts"],
+            cwd=info["cwd"]
         )
         if hist is not None:
             hist.append(info)

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -409,7 +409,7 @@ class BaseShell(object):
             rtn=info["rtn"],
             out=info.get("out", None),
             ts=info["ts"],
-            cwd=info["cwd"]
+            cwd=info["cwd"],
         )
         if hist is not None:
             hist.append(info)

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -44,7 +44,7 @@ Fires just before a command is executed.
 events.doc(
     "on_postcommand",
     """
-on_postcommand(cmd: str, rtn: int, out: str or None, ts: list) -> None
+on_postcommand(cmd: str, rtn: int, out: str or None, ts: list, cwd: str) -> None
 
 Fires just after a command is executed. The arguments are the same as history.
 
@@ -54,6 +54,7 @@ Parameters:
 * ``rtn``: The result of the command executed (``0`` for success)
 * ``out``: If xonsh stores command output, this is the output
 * ``ts``: Timestamps, in the order of ``[starting, ending]``
+* ``cwd``: The absolute path to where command executed
 """,
 )
 


### PR DESCRIPTION
Hi, I want to save `open file history` by command. 
But `events.on_postcommand` doesn't have absolute path to where command executed. So we can't save path to file now.

example:
```
@events.on_postcommand
def open_file_history(cmd, rtn, **kw):
    if rtn == 0:
        cmd = cmd.split(' ')
        if cmd[0] in ['vim', 'v'] and len(cmd)==2:
            with open($OPEN_FILE_HIST_PATH, 'a') as dh:
                print(expanduser(cmd[1]), file=dh)    # cmd[1] is not necessarily absolute path
```

I changed on_postcommand args. Thanks:)