### PR TITLE
Assume xsh scripts are in UTF-8

### DIFF
--- a/news/script_unicode.rst
+++ b/news/script_unicode.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The encoding for xonsh script are now always assumed to be utf-8, even on
+  Windows where the default encoding can be different. This allows for writing
+  real unicode characters in the xonsh script files. 
+
+**Security:**
+
+* <news item>

--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -155,7 +155,7 @@ def run_script_with_cache(filename, execer, glb=None, loc=None, mode="exec"):
     if use_cache:
         run_cached, ccode = script_cache_check(filename, cachefname)
     if not run_cached:
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             code = f.read()
         ccode = compile_code(filename, code, execer, glb, loc, mode)
         update_cache(ccode, cachefname)


### PR DESCRIPTION
This PR changes the way xonsh reads script files so they always assumed to be utf-8, even on
Windows where the default encoding can vary. 

This allows for writing unicode characters in script files on Windows (most importantly `xonshrc`). 

Read this [PEP for more info](https://discuss.python.org/t/pep-597-use-utf-8-for-default-text-file-encoding/1819).