### PR TITLE
On Windows, don't sent SIGINT, send CTRL_C_EVENT instead

### DIFF
--- a/news/fix-ctrl-c-event-windows.rst
+++ b/news/fix-ctrl-c-event-windows.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* On Windows, send ``CTRL_C_EVENT`` to subprocesses instead of ``SIGINT``.
+
+**Security:**
+
+* <news item>

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -784,10 +784,10 @@ class PopenThread(threading.Thread):
 
     def _signal_int(self, signum, frame):
         """Signal handler for SIGINT - Ctrl+C may have been pressed."""
-        self.send_signal(signum)
+        self.send_signal(signal.CTRL_C_EVENT if ON_WINDOWS else signum)
         if self.proc is not None and self.proc.poll() is not None:
             self._restore_sigint(frame=frame)
-        if on_main_thread():
+        if on_main_thread() and not ON_WINDOWS:
             signal.pthread_kill(threading.get_ident(), signal.SIGINT)
 
     def _restore_sigint(self, frame=None):


### PR DESCRIPTION
```
+------------------+-------------------------------------------------------+
| xonsh            | 0.9.11                                                |
| Git SHA          | 6724d418                                              |
| Commit Date      | Dec 15 12:12:56 2018                                  |
| Python           | 3.7.1                                                 |
| PLY              | 3.11                                                  |
| have readline    | False                                                 |
| prompt toolkit   | 2.0.9                                                 |
| shell type       | prompt_toolkit2                                       |
| pygments         | 2.4.2                                                 |
| on posix         | False                                                 |
| on linux         | False                                                 |
| on darwin        | False                                                 |
| on windows       | True                                                  |
| on cygwin        | <xonsh.lazyasd.LazyBool object at 0x00000202F9FB17F0> |
| on msys2         | <xonsh.lazyasd.LazyBool object at 0x00000202F9FB16D8> |
| is superuser     | False                                                 |
| default encoding | utf-8                                                 |
| xonsh encoding   | utf-8                                                 |
| encoding errors  | surrogateescape                                       |
+------------------+-------------------------------------------------------+
```

^^ This is what I get when I type `xonfig`, however, the git info is wrong. I am on commit 9b23723b.

# Overview

I have a test script that represents a "running process" that I want to cancel with CTRL-C:

```
import time
try:
 [print(i) or time.sleep(1) for i in range(10)]
except KeyboardInterrupt:
 print('bye!')"
```

For convenience, I just run it as a cmd line parameter like this:

```
$ python -c "import time\ntry:\n [print(i) or time.sleep(1) for i in range(10)]\nexcept KeyboardInterrupt:\n print('bye!')"
```

On Xonsh master, when I press CTRL-C before the loop is done, the following results:

```
$ python -c "import time\ntry:\n [print(i) or time.sleep(1) for i in range(10)]\nexcept KeyboardInterrupt:\n print('bye!')"
0
1
2
bye!
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "G:\Documents\repos\xonsh\xonsh\base_shell.py", line 360, in default
    run_compiled_code(code, self.ctx, None, "single")
  File "G:\Documents\repos\xonsh\xonsh\codecache.py", line 67, in run_compiled_code
    func(code, glb, loc)
  File "<xonsh-code>", line 1, in <module>
  File "G:\Documents\repos\xonsh\xonsh\built_ins.py", line 1003, in subproc_captured_hiddenobject
    return run_subproc(cmds, captured="hiddenobject")
  File "G:\Documents\repos\xonsh\xonsh\built_ins.py", line 966, in run_subproc
    command.end()
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 2117, in end
    self._end(tee_output=tee_output)
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 2125, in _end
    for _ in self.tee_stdout():
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 2038, in tee_stdout
    for line in self.iterraw():
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 1970, in iterraw
    stdout_lines = safe_readlines(stdout, 1024)
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 1763, in safe_readlines
    lines = handle.readlines(hint)
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 183, in readlines
    chunk = self.read_queue()
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 134, in read_queue
    return self.queue.get(block=True, timeout=self.timeout)
  File "G:\Programs\Python37\lib\queue.py", line 179, in get
    self.not_empty.wait(remaining)
  File "G:\Programs\Python37\lib\threading.py", line 300, in wait
    gotit = waiter.acquire(True, timeout)
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 787, in _signal_int
    self.send_signal(signum)
  File "G:\Documents\repos\xonsh\xonsh\proc.py", line 941, in send_signal
    rtn = self.proc.send_signal(signal)
  File "G:\Programs\Python37\lib\subprocess.py", line 1306, in send_signal
    raise ValueError("Unsupported signal: {}".format(sig))
ValueError: Unsupported signal: 2
```

This appears to happen for all subprocesses, and is very annoying! With my PR, the following results:

```
$ python -c "import time\ntry:\n [print(i) or time.sleep(1) for i in range(10)]\nexcept KeyboardInterrupt:\n print('bye!')"
0
1
2
bye!
```

Other programs, e.g. `fzf` and similar, also receive the CTRL-C signal and cancel correctly.

# Discussion

On Windows, Python does special handling for CTRL-C. Python allows you to set a signal handler for `SIGINT`, but when you want to _send_ a CTRL-C to a subprocess, you cannot send `SIGINT`; instead, you have to send `CTRL_C_EVENT` (also defined in the `signal` module in the stdlib).

I have a little experience with this. In one of my packages, aiorun, I added some rudimentary support for signal handling on Windows. See https://github.com/cjrh/aiorun/blob/master/README.rst#windows-support in the README, and in the code here: https://github.com/cjrh/aiorun/blob/master/aiorun.py#L195 

We can't fix all signal handling on Windows, the support just isn't there. But we can at least get working the ones that are there. There are only two signals you can send and handle for cmdline programs on windows: `CTRL_C_EVENT` (which raises `KeyboardError` in Python by default, or calls the signal handler for `SIGINT`, if defined) and `CTRL_BREAK_EVENT` (see here how to send one: https://github.com/cjrh/aiorun/blob/master/tests/test_win.py#L25). The `CTRL_BREAK_EVENT` is a little tricky, because when you create the subprocess you have to set `creationflags=subprocess.CREATE_NEW_PROCESS_GROUP`, which is annoying.

Anyhow, the code I've added in the PR is very small, and as I said, seems to resolve the annoying `ValueError` I see every time I CTRL-C a job.

The other change on line 790 is simply because `signal.pthread_kill()` is not defined on Windows. I'm not sure what that line is supposed to do.