### PR TITLE
Refactor jedi and fix pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
--   repo: https://github.com/ambv/black
+  - repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
-      language_version: python3.5
+      language_version: python3

--- a/xontrib/jedi.xsh
+++ b/xontrib/jedi.xsh
@@ -30,14 +30,17 @@ def complete_jedi(prefix, line, start, end, ctx):
         return set()
     src = builtins.__xonsh__.shell.shell.accumulated_inputs + line
     script = jedi.api.Interpreter(src, [ctx], column=end)
+    script_comp = set()
+    try:
+        script_comp = script.completions()
+    except Exception:
+        pass
+
     if builtins.__xonsh__.env.get('CASE_SENSITIVE_COMPLETIONS'):
-       rtn = {x.name_with_symbols for x in script.completions()
-              if x.name_with_symbols.startswith(prefix)}
+        rtn = {x.name_with_symbols for x in script_comp
+               if x.name_with_symbols.startswith(prefix)}
     else:
-        try:
-            rtn = {x.name_with_symbols for x in script.completions()}
-        except Exception:
-            rtn = set()
+        rtn = {x.name_with_symbols for x in script_comp}
     return rtn
 
 


### PR DESCRIPTION
This is just a followup to #3331 to fix both cases of jedi loops. Also, because I couldn't commit since I didn't have python 3.5, I needed to relax the version to just `3.x`. Sorry for putting two things into one pull request.
