### PR TITLE
Cat stdin

### DIFF
--- a/news/cat_stdin.rst
+++ b/news/cat_stdin.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fix coreutils `cat` behaviour on empty input "cat -". 
+* Fix coreutils ``cat`` behaviour on empty input (e.g. ``cat -``). 
 
 * Fix Ctrl-C event causing Atribute error on Windows.
 

--- a/news/cat_stdin.rst
+++ b/news/cat_stdin.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix coreutils `cat` behaviour on empty input "cat -". 
+
+* Fix Ctrl-C event causing Atribute error on Windows.
+
+**Security:**
+
+* <news item>

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1487,7 +1487,7 @@ class ProcProxyThread(threading.Thread):
             safe_fdclose(handle)
         if self.poll() is not None:
             self._restore_sigint(frame=frame)
-        if on_main_thread():
+        if on_main_thread() and not ON_WINDOWS:
             signal.pthread_kill(threading.get_ident(), signal.SIGINT)
 
     def _restore_sigint(self, frame=None):

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -1,5 +1,6 @@
 """Implements a cat command for xonsh."""
 import os
+import sys
 import time
 import builtins
 
@@ -10,7 +11,7 @@ from xonsh.xoreutils.util import arg_handler
 def _cat_line(
     f, sep, last_was_blank, line_count, opts, out, enc, enc_errors, read_size
 ):
-    _r = r = f.readline(size=80)
+    _r = r = f.readline(80)
     restore_newline = False
     if isinstance(_r, str):
         _r = r = _r.encode(enc, enc_errors)
@@ -44,7 +45,7 @@ def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
     read_size = 0
     file_size = fobj = None
     if fname == "-":
-        f = stdin
+        f = stdin or sys.stdin
     elif os.path.isdir(fname):
         print("cat: {}: Is a directory.".format(fname), file=err)
         return True, line_count


### PR DESCRIPTION
This fixes running coreutils `cat` with no input or `cat -`. 

Fixes: #2365

@scopatz you better take a look if the fix makes sense. I am not really sure I know what I am doing here. 

It also fixes an Attribute error when pressing ctrl-C on windows. A followup to the [fix](#3327) by @cjrh the other day. 

