### PR TITLE
Fix superhelp

### DIFF
--- a/news/superhelp.rst
+++ b/news/superhelp.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a regession with xonsh superhelp ``??`` operator and ``which -v`` which showed Pythons builtin
+  doc strings. 
+
+**Security:**
+
+* <news item>

--- a/xonsh/inspectors.py
+++ b/xonsh/inspectors.py
@@ -33,9 +33,10 @@ _func_call_docstring = LazyObject(
 _object_init_docstring = LazyObject(
     lambda: object.__init__.__doc__, globals(), "_object_init_docstring"
 )
+
 _builtin_type_docstrings = LazyObject(
     lambda: {
-        t.__doc__ for t in (types.ModuleType, types.MethodType, types.FunctionType)
+        inspect.getdoc(t) for t in (types.ModuleType, types.MethodType, types.FunctionType, property)
     },
     globals(),
     "_builtin_type_docstrings",

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -104,7 +104,7 @@ def print_alias(arg, stdout, verbose=False):
         else:
             print(arg, file=stdout)
     else:
-        print("aliases['{}'] = {}".format(arg, builtins.aliases[arg]), file=stdout)
+        print("aliases['{}'] = {}".format(arg, builtins.aliases[arg]), flush=True, file=stdout)
         if callable(builtins.aliases[arg]):
             builtins.__xonsh__.superhelp(builtins.aliases[arg])
 


### PR DESCRIPTION
This fixes a regression with superhelp and `which -v` which would print some of Python builtin docstrings instead of the user defined doctrings. 

![image](https://user-images.githubusercontent.com/1038978/66339800-2b005200-e944-11e9-8ec6-ac03f040d768.png)
