### PR TITLE
fix(signals): Fix SIGSTP not an attribute on Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,6 @@ Xonsh Change Log
 
 .. current developments
 
-**Fixed:**
-
-* Fix Ctrl-C event causing Atribute error on Windows. (for reals this time)
-
 v0.9.13
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Xonsh Change Log
 
 .. current developments
 
+**Fixed:**
+
+* Fix Ctrl-C event causing Atribute error on Windows. (for reals this time)
+
 v0.9.13
 ====================
 

--- a/news/sigstp.rst
+++ b/news/sigstp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix Ctrl-C event causing Atribute error on Windows (for reals this time).
+
+**Security:**
+
+* <news item>

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -600,7 +600,10 @@ class SubprocSpec:
             def xonsh_preexec_fn():
                 """Preexec function bound to a pipeline group."""
                 os.setpgid(0, pipeline_group)
-                signal.signal(signal.SIGTERM if ON_WINDOWS else signal.SIGSTP, default_signal_pauser)
+                signal.signal(
+                    signal.SIGTERM if ON_WINDOWS else signal.SIGSTP,
+                    default_signal_pauser,
+                )
 
         kwargs["preexec_fn"] = xonsh_preexec_fn
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -600,7 +600,7 @@ class SubprocSpec:
             def xonsh_preexec_fn():
                 """Preexec function bound to a pipeline group."""
                 os.setpgid(0, pipeline_group)
-                signal.signal(signal.SIGTSTP, default_signal_pauser)
+                signal.signal(signal.SIGTERM if ON_WINDOWS else signal.SIGSTP, default_signal_pauser)
 
         kwargs["preexec_fn"] = xonsh_preexec_fn
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1780,12 +1780,14 @@ def SIGNAL_MESSAGES():
         signal.SIGSEGV: "Segmentation fault",
     }
     if ON_POSIX:
-        sm.update({
+        sm.update(
+            {
                 signal.SIGQUIT: "Quit",
                 signal.SIGHUP: "Hangup",
                 signal.SIGKILL: "Killed",
                 signal.SIGTSTP: "Stopped",
-        })
+            }
+        )
     return sm
 
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1778,12 +1778,14 @@ def SIGNAL_MESSAGES():
         signal.SIGILL: "Illegal instructions",
         signal.SIGTERM: "Terminated",
         signal.SIGSEGV: "Segmentation fault",
-        signal.SIGTSTP: "Stopped",
     }
     if ON_POSIX:
-        sm.update(
-            {signal.SIGQUIT: "Quit", signal.SIGHUP: "Hangup", signal.SIGKILL: "Killed"}
-        )
+        sm.update({
+                signal.SIGQUIT: "Quit",
+                signal.SIGHUP: "Hangup",
+                signal.SIGKILL: "Killed",
+                signal.SIGTSTP: "Stopped",
+        })
     return sm
 
 


### PR DESCRIPTION
I kept getting `AttributeError: module 'signal' has no attribute 'SIGTSTP'` exceptions when I `^C`d out of a process and turns out there are a few places where we forgot to protect `signal.SIGSTP` on Windows.

This patch fixes those remaining places.

Follow up to #3344.