### PR TITLE
Remove `xonda` from `xontrib` list

### DIFF
--- a/news/no_more_xonda.rst
+++ b/news/no_more_xonda.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed deprecated ``xonda`` ``xontrib`` from list 
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -191,11 +191,6 @@
                   "bit of the startup time when running your favorite, minimal ",
                   "text editor."]
   },
- {"name": "xonda",
-  "package": "xonda",
-  "url": "https://github.com/gforsyth/xonda",
-  "description": ["A thin wrapper around conda with tab completion"]
- },
  {"name": "z",
   "package": "xontrib-z",
   "url": "https://github.com/astronouth7303/xontrib-z",


### PR DESCRIPTION
It was great while it lasted.

(For context, `xonda` functionality has been folded into upstream `conda` so there is no longer a need for a standalone `xontrib`)

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
