### PR TITLE
Fix ctrl-c traceback on windows

### DIFF
--- a/news/kill-win.rst
+++ b/news/kill-win.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed an issue on Windows where pressing ctrl-c could sometimes result
+  in a traceback if the process had already quit before being killed by xonsh.
+
+**Security:**
+
+* <news item>

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -71,7 +71,10 @@ if ON_WINDOWS:
         job["status"] = "running"
 
     def _kill(job):
-        subprocess.check_output(["taskkill", "/F", "/T", "/PID", str(job["obj"].pid)])
+        subprocess.check_output(
+            ["taskkill", "/F", "/T", "/PID", str(job["obj"].pid)],
+            stderr=subprocess.STDOUT,
+        )
 
     def ignore_sigtstp():
         pass
@@ -96,7 +99,10 @@ if ON_WINDOWS:
             except subprocess.TimeoutExpired:
                 pass
             except KeyboardInterrupt:
-                _kill(active_task)
+                try:
+                    _kill(active_task)
+                except subprocess.CalledProcessError:
+                    pass  # ignore error if process closed before we got here
         return wait_for_active_job(last_task=active_task)
 
 


### PR DESCRIPTION
This fixes an issue on Windows where pressing ctrl-c could sometimes result   in a traceback if the process had already quit before being killed by xonsh.

It also prevent the taskkill command from printing its error messages. 