### PR TITLE
Create python3.8 parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,8 +272,6 @@ workflows:
       - build_35
       - build_36
       - build_37
+      - build_38
       - build_elm
       - build_black
-      # conda-foge does not yet have all Python 3.8 packages available
-      # uncomment when it does
-      #- build_38

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,8 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-      # Uncomment when Python 3.8 is supported
-      #Python38:
-      #  python.version: '3.8'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:

--- a/news/parser38.rst
+++ b/news/parser38.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Moved python 3.8 parsing out of base parser
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -6,7 +6,9 @@ from xonsh.platform import PYTHON_VERSION_INFO
 
 @lazyobject
 def Parser():
-    if PYTHON_VERSION_INFO > (3, 6):
+    if PYTHON_VERSION_INFO > (3, 8):
+        from xonsh.parsers.v38 import Parser as p
+    elif PYTHON_VERSION_INFO > (3, 6):
         from xonsh.parsers.v36 import Parser as p
     elif PYTHON_VERSION_INFO > (3, 5):
         from xonsh.parsers.v35 import Parser as p

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -853,7 +853,6 @@ class BaseParser(object):
         p2 = p[2]
         if p2 is None:
             p2 = ast.arguments(
-                posonlyargs=[],
                 args=[],
                 vararg=None,
                 kwonlyargs=[],
@@ -870,26 +869,14 @@ class BaseParser(object):
     def p_typedargslist_kwarg(self, p):
         """typedargslist : POW tfpdef"""
         p[0] = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[2],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[2], defaults=[]
         )
 
     def p_typedargslist_times4_tfpdef(self, p):
         """typedargslist : TIMES tfpdef comma_pow_tfpdef_opt"""
         # *args, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[3],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[3], defaults=[]
         )
         self._set_var_args(p0, p[2], None)
         p[0] = p0
@@ -898,13 +885,7 @@ class BaseParser(object):
         """typedargslist : TIMES comma_pow_tfpdef"""
         # *, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[2],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[2], defaults=[]
         )
         p[0] = p0
 
@@ -912,13 +893,7 @@ class BaseParser(object):
         """typedargslist : TIMES tfpdef comma_tfpdef_list comma_pow_tfpdef_opt"""
         # *args, x, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[4],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[4], defaults=[]
         )
         self._set_var_args(p0, p[2], p[3])  # *args
         p[0] = p0
@@ -927,13 +902,7 @@ class BaseParser(object):
         """typedargslist : TIMES comma_tfpdef_list comma_pow_tfpdef_opt"""
         # *, x, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[3],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[3], defaults=[]
         )
         self._set_var_args(p0, None, p[2])  # *args
         p[0] = p0
@@ -942,13 +911,7 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt"""
         # x
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -957,13 +920,7 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt POW tfpdef"""
         # x, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[6],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[6], defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -971,13 +928,7 @@ class BaseParser(object):
     def p_typedargslist_t8(self, p):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt comma_tfpdef_list_opt"""
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], p[7])
@@ -987,13 +938,7 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt COMMA POW vfpdef"""
         # x, *args, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[9],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[9], defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], None)
@@ -1003,7 +948,6 @@ class BaseParser(object):
         """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt comma_tfpdef_list COMMA POW tfpdef"""
         # x, *args, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
             args=[],
             vararg=None,
             kwonlyargs=[],
@@ -1089,25 +1033,13 @@ class BaseParser(object):
     def p_varargslist_kwargs(self, p):
         """varargslist : POW vfpdef"""
         p[0] = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[2],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[2], defaults=[]
         )
 
     def p_varargslist_times4(self, p):
         """varargslist : TIMES vfpdef_opt comma_pow_vfpdef_opt"""
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[3],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[3], defaults=[]
         )
         self._set_var_args(p0, p[2], None)
         p[0] = p0
@@ -1116,13 +1048,7 @@ class BaseParser(object):
         """varargslist : TIMES vfpdef_opt comma_vfpdef_list comma_pow_vfpdef_opt"""
         # *args, x, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[4],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[4], defaults=[]
         )
         self._set_var_args(p0, p[2], p[3])  # *args
         p[0] = p0
@@ -1131,13 +1057,7 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt"""
         # x
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -1146,13 +1066,7 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt POW vfpdef"""
         # x, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[6],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[6], defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         p[0] = p0
@@ -1161,13 +1075,7 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt comma_vfpdef_list_opt"""
         # x, *args
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], p[7])
@@ -1177,13 +1085,7 @@ class BaseParser(object):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt COMMA POW vfpdef"""
         # x, *args, **kwargs
         p0 = ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=p[9],
-            defaults=[],
+            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=p[9], defaults=[]
         )
         self._set_regular_args(p0, p[1], p[2], p[3], p[4])
         self._set_var_args(p0, p[6], None)
@@ -1192,7 +1094,6 @@ class BaseParser(object):
     def p_varargslist_v11(self, p):
         """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt comma_vfpdef_list COMMA POW vfpdef"""
         p0 = ast.arguments(
-            posonlyargs=[],
             args=[],
             vararg=None,
             kwonlyargs=[],
@@ -1957,7 +1858,6 @@ class BaseParser(object):
         p1, p2, p4 = p[1], p[2], p[4]
         if p2 is None:
             args = ast.arguments(
-                posonlyargs=[],
                 args=[],
                 vararg=None,
                 kwonlyargs=[],

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -305,3 +305,15 @@ class Parser(ThreeSixParser):
             args = p2
         p0 = ast.Lambda(args=args, body=p4, lineno=p1.lineno, col_offset=p1.lexpos)
         p[0] = p0
+
+    def p_decorated(self, p):
+        """decorated : decorators classdef_or_funcdef"""
+        p1, p2 = p[1], p[2]
+        targ = p2[0]
+        targ.decorator_list = p1
+        # async functions take the col number of the 'def', unless they are
+        # decorated, in which case they have the col of the 'async'. WAT?
+        if hasattr(targ, "_async_tok"):
+            targ.col_offset = targ._async_tok.lexpos
+            del targ._async_tok
+        p[0] = p2

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Implements the xonsh parser for Python v3.6."""
+"""Implements the xonsh parser for Python v3.8."""
 import xonsh.ast as ast
 from xonsh.parsers.v36 import Parser as ThreeSixParser
 

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+"""Implements the xonsh parser for Python v3.6."""
+import xonsh.ast as ast
+from xonsh.parsers.v36 import Parser as ThreeSixParser
+
+
+class Parser(ThreeSixParser):
+    """A Python v3.8 compliant parser for the xonsh language."""
+
+    def p_parameters(self, p):
+        """parameters : LPAREN typedargslist_opt RPAREN"""
+        p2 = p[2]
+        if p2 is None:
+            p2 = ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            )
+        p[0] = p2
+
+    def p_typedargslist_kwarg(self, p):
+        """typedargslist : POW tfpdef"""
+        p[0] = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[2],
+            defaults=[],
+        )
+
+    def p_typedargslist_times4_tfpdef(self, p):
+        """typedargslist : TIMES tfpdef comma_pow_tfpdef_opt"""
+        # *args, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[3],
+            defaults=[],
+        )
+        self._set_var_args(p0, p[2], None)
+        p[0] = p0
+
+    def p_typedargslist_times4_comma(self, p):
+        """typedargslist : TIMES comma_pow_tfpdef"""
+        # *, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[2],
+            defaults=[],
+        )
+        p[0] = p0
+
+    def p_typedargslist_times5_tdpdef(self, p):
+        """typedargslist : TIMES tfpdef comma_tfpdef_list comma_pow_tfpdef_opt"""
+        # *args, x, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[4],
+            defaults=[],
+        )
+        self._set_var_args(p0, p[2], p[3])  # *args
+        p[0] = p0
+
+    def p_typedargslist_times5_comma(self, p):
+        """typedargslist : TIMES comma_tfpdef_list comma_pow_tfpdef_opt"""
+        # *, x, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[3],
+            defaults=[],
+        )
+        self._set_var_args(p0, None, p[2])  # *args
+        p[0] = p0
+
+    def p_typedargslist_t5(self, p):
+        """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt"""
+        # x
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        p[0] = p0
+
+    def p_typedargslist_t7(self, p):
+        """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt POW tfpdef"""
+        # x, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[6],
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        p[0] = p0
+
+    def p_typedargslist_t8(self, p):
+        """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt comma_tfpdef_list_opt"""
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        self._set_var_args(p0, p[6], p[7])
+        p[0] = p0
+
+    def p_typedargslist_t10(self, p):
+        """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt COMMA POW vfpdef"""
+        # x, *args, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[9],
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        self._set_var_args(p0, p[6], None)
+        p[0] = p0
+
+    def p_typedargslist_t11(self, p):
+        """typedargslist : tfpdef equals_test_opt comma_tfpdef_list_opt comma_opt TIMES tfpdef_opt comma_tfpdef_list COMMA POW tfpdef"""
+        # x, *args, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[10],
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        self._set_var_args(p0, p[6], p[7])
+        p[0] = p0
+
+    def p_varargslist_kwargs(self, p):
+        """varargslist : POW vfpdef"""
+        p[0] = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[2],
+            defaults=[],
+        )
+
+    def p_varargslist_times4(self, p):
+        """varargslist : TIMES vfpdef_opt comma_pow_vfpdef_opt"""
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[3],
+            defaults=[],
+        )
+        self._set_var_args(p0, p[2], None)
+        p[0] = p0
+
+    def p_varargslist_times5(self, p):
+        """varargslist : TIMES vfpdef_opt comma_vfpdef_list comma_pow_vfpdef_opt"""
+        # *args, x, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[4],
+            defaults=[],
+        )
+        self._set_var_args(p0, p[2], p[3])  # *args
+        p[0] = p0
+
+    def p_varargslist_v5(self, p):
+        """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt"""
+        # x
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        p[0] = p0
+
+    def p_varargslist_v7(self, p):
+        """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt POW vfpdef"""
+        # x, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[6],
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        p[0] = p0
+
+    def p_varargslist_v8(self, p):
+        """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt comma_vfpdef_list_opt"""
+        # x, *args
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        self._set_var_args(p0, p[6], p[7])
+        p[0] = p0
+
+    def p_varargslist_v10(self, p):
+        """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt COMMA POW vfpdef"""
+        # x, *args, **kwargs
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[9],
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        self._set_var_args(p0, p[6], None)
+        p[0] = p0
+
+    def p_varargslist_v11(self, p):
+        """varargslist : vfpdef equals_test_opt comma_vfpdef_list_opt comma_opt TIMES vfpdef_opt comma_vfpdef_list COMMA POW vfpdef"""
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=p[10],
+            defaults=[],
+        )
+        self._set_regular_args(p0, p[1], p[2], p[3], p[4])
+        self._set_var_args(p0, p[6], p[7])
+        p[0] = p0
+
+    def p_lambdef(self, p):
+        """lambdef : lambda_tok varargslist_opt COLON test"""
+        p1, p2, p4 = p[1], p[2], p[4]
+        if p2 is None:
+            args = ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            )
+        else:
+            args = p2
+        p0 = ast.Lambda(args=args, body=p4, lineno=p1.lineno, col_offset=p1.lexpos)
+        p[0] = p0


### PR DESCRIPTION
This builds on earlier work by @carmenbianca -- I've moved the 3.8+
specific parser code (involving the `posonlyargs`) to a python 3.8
parser class that inherits from the 3.6 parser.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
