### PR TITLE
Fix appimage news entry

### DIFF
--- a/news/appimage.rst
+++ b/news/appimage.rst
@@ -1,3 +1,23 @@
 **Added:**
 
 * Added building process of standalone rootless AppImage for xonsh.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Restoring missing entries to the news entry from the appimage PR since it's breaking CI on all subsequent PRs.

We really need to move the news checker to a separate place.