### PR TITLE
Issue 3418

### DIFF
--- a/news/appimage.rst
+++ b/news/appimage.rst
@@ -1,3 +1,24 @@
 **Added:**
 
 * Added building process of standalone rootless AppImage for xonsh.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/news/issue-3814.rst
+++ b/news/issue-3814.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Avoid crash in SubprocessSpec._run_binary() when command line has 2 real subprocesses piped together. 
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -547,3 +547,15 @@ def test_xonsh_no_close_fds():
             f.write(makefile)
         out = sp.check_output(["make", "-sj2", "SHELL=xonsh"], universal_newlines=True)
         assert "warning" not in out
+
+
+@pytest.mark.parametrize(
+    "cmd, fmt, exp",
+    [
+        ("ls | wc", lambda x: x > '', True),
+    ],
+)
+def test_pipe_between_subprocs(cmd, fmt, exp):
+    "verify pipe between subprocesses doesn't throw an exception"
+    check_run_xonsh(cmd, fmt, exp)
+

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -601,7 +601,7 @@ class SubprocSpec:
                 """Preexec function bound to a pipeline group."""
                 os.setpgid(0, pipeline_group)
                 signal.signal(
-                    signal.SIGTERM if ON_WINDOWS else signal.SIGSTP,
+                    signal.SIGTERM if ON_WINDOWS else signal.SIGTSTP,
                     default_signal_pauser,
                 )
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -829,21 +829,20 @@ class PopenThread(threading.Thread):
             return
         try:
             mode = termios.tcgetattr(0)  # only makes sense for stdin
+            self._tc_cc_vsusp = mode[CC][termios.VSUSP]
+            mode[CC][termios.VSUSP] = b"\x00"  # set ^Z (ie SIGSTOP) to undefined
+            termios.tcsetattr(0, termios.TCSANOW, mode)
         except termios.error:
             return
-        self._tc_cc_vsusp = mode[CC][termios.VSUSP]
-        mode[CC][termios.VSUSP] = b"\x00"  # set ^Z (ie SIGSTOP) to undefined
-        termios.tcsetattr(0, termios.TCSANOW, mode)
 
     def _restore_suspend_keybind(self):
         if ON_WINDOWS:
             return
         try:
             mode = termios.tcgetattr(0)  # only makes sense for stdin
-        except termios.error:
-            return
-        mode[CC][termios.VSUSP] = self._tc_cc_vsusp  # set ^Z (ie SIGSTOP) to original
-        try:
+            mode[CC][
+                termios.VSUSP
+            ] = self._tc_cc_vsusp  # set ^Z (ie SIGSTOP) to original
             # this usually doesn't work in interactive mode,
             # but we should try it anyway.
             termios.tcsetattr(0, termios.TCSANOW, mode)


### PR DESCRIPTION
Fix issue #3418 
Typo in xonsh.built_ins.py when creating subprocess; another unhandled exception when termios.setattr() fails (for some kinds of consoles).

There wasn't any existing unit test coverage, which is how we got here.  I'd love to add some, but need some help getting started.