### PR TITLE
xxh is for using xonsh wherever you go through the ssh.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,4 @@ Projects that use xonsh
 - `gitsome <https://github.com/donnemartin/gitsome>`_: A supercharged Git/shell autocompleter with GitHub integration.
 - `rever <https://regro.github.io/rever-docs/>`_: Cross-platform software release tool.
 - `Regro autotick bot <https://github.com/regro/cf-scripts>`_: Regro Conda-Forge autoticker.
+- `xxh <https://github.com/xonssh/xxh>`_: Using xonsh wherever you go through the ssh.


### PR DESCRIPTION
Added [xxh](https://github.com/xonssh/xxh) to the list of projects that use xonsh.