### PR TITLE
Tutorial: note about $UPDATE_OS_ENVIRON

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -136,6 +136,11 @@ variable in Python.  The same is true for deleting them too.
 
 Very nice.
 
+.. note::
+
+   To update ``os.environ`` when the xonsh environment changes set 
+   `$UPDATE_OS_ENVIRON <envvars.html#update-os-environ>`_ to ``True``.
+
 The Environment Itself ``${...}``
 ---------------------------------
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -139,7 +139,7 @@ Very nice.
 .. note::
 
    To update ``os.environ`` when the xonsh environment changes set 
-   `$UPDATE_OS_ENVIRON <envvars.html#update-os-environ>`_ to ``True``.
+   :ref:`$UPDATE_OS_ENVIRON <update_os_environ>` to ``True``.
 
 The Environment Itself ``${...}``
 ---------------------------------


### PR DESCRIPTION
Hi!
The description of `${...}` is looks like that it is the synonym of `os.environ`. But it's not exectly true.
In this PR added the note about $UPDATE_OS_ENVIRON to the tutorial. It is great to know about special flags in the beginning of the tutorial and save time to understanding why:
```
# $TEST='test'
# 'TEST' in ${...}
True
# 'TEST' in os.environ
False
```