### PR TITLE
Add useful tricks with Path object to the tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1026,6 +1026,15 @@ handled implicitly in subprocess mode.
     >>> echo @(mypath)
     /foo/bar
 
+Path object allows do some tricks with paths. Globbing certain path, checking and getting info:
+
+.. code-block:: xonshcon
+   
+    >>> mypath = p'/etc'
+    >>> sorted(mypath.glob('**/*bashrc*')) 
+    [Path('/etc/bash.bashrc'), Path('/etc/skel/.bashrc')]
+    >>> [mypath.exists(), mypath.is_dir(), mypath.is_file(), mypath.parent, mypath.owner()]
+    [True, True, False, Path('/'), 'root']
 
 Help & Superhelp with ``?`` & ``??``
 =====================================================


### PR DESCRIPTION
Hi!

After reading the tutorial about ``g`...` `` and `p"..."` there is a question: how to globbing certain path because `` g`{mypath}/**` `` is not working (and gp/gf/gpf too). I've added info about one elegant way how to do it with Path object. And a bit more.

Thanks!