### PR TITLE
XonshLexer: skip leading whitespace

### DIFF
--- a/news/pyghooks-whitespace.rst
+++ b/news/pyghooks-whitespace.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Command line with leading whitespace improperly formated (PTK2/PTK3).
+
+**Security:**
+
+* <news item>

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -199,6 +199,7 @@ class XonshLexer(Python3Lexer):
         m = re.match(r"(\s*)({})".format(COMMAND_TOKEN_RE), text)
         if m is not None:
             yield m.start(1), Whitespace, m.group(1)
+            start = m.end(1)
             cmd = m.group(2)
             cmd_is_valid = _command_is_valid(cmd)
             cmd_is_autocd = _command_is_autocd(cmd)


### PR DESCRIPTION
Pygments lexer yields an extra whitespace token for inputs with leading whitespace. This probably was not a problem for PTK2/Pygments, but breaks command line rendering on PTK3.

Relates to #3391