### PR TITLE
Fix behavior of cd -P and dot-dot paths

### DIFF
--- a/news/cd_symlinks.rst
+++ b/news/cd_symlinks.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Correctly follow symlinks when using dot-dot paths with cd -P.
+
+**Security:**
+
+* <news item>

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -147,10 +147,10 @@ def _change_working_directory(newdir, follow_symlinks=False):
     env = builtins.__xonsh__.env
     old = env["PWD"]
     new = os.path.join(old, newdir)
-    absnew = os.path.abspath(new)
 
     if follow_symlinks:
-        absnew = os.path.realpath(absnew)
+        new = os.path.realpath(new)
+    absnew = os.path.abspath(new)
 
     try:
         os.chdir(absnew)


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Calling abspath() before realpath() suppresses some information about symbolic links in some cases. To illustrate this case here is what is expected to happen (and what happens in the standard /usr/bin/cd) with `$PROMPT = "{cwd} >>> "`:

```
/ >>> ls -l lib
lrwxrwxrwx 1 root root 7 13. Nov 17:23 lib -> usr/lib
/ >>> cd lib
/lib >>> cd -P ..
/usr >>> 
```
But this is what the current version brings:
```
/ >>> ls -l lib
lrwxrwxrwx 1 root root 7 13. Nov 17:23 lib -> usr/lib
/ >>> cd lib
/lib >>> cd -P ..
/ >>> 
```
This change implements the first behavior instead. 