### PR TITLE
Fix execx / evalx trailing newline

### DIFF
--- a/news/execx-evalx-newline.rst
+++ b/news/execx-evalx-newline.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``execx`` does not require the input string to be newline-terminated.
+* ``evalx`` accepts newline-terminated input string.
+
+**Security:**
+
+* <news item>

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -2,7 +2,13 @@
 """Tests the xonsh lexer."""
 import os
 
-from tools import check_eval, check_parse, skip_if_on_unix, skip_if_on_windows
+from tools import (
+    check_eval,
+    check_exec,
+    check_parse,
+    skip_if_on_unix,
+    skip_if_on_windows,
+)
 
 import pytest
 
@@ -138,3 +144,12 @@ def test_echo_line_cont():
 )
 def test_two_echo_line_cont(code):
     assert check_parse(code)
+
+
+def test_eval_eol():
+    assert check_eval("0") and check_eval("0\n")
+
+
+def test_exec_eol():
+    locs = dict()
+    assert check_exec("a=0", locs=locs) and check_exec("a=0\n", locs=locs)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -174,8 +174,6 @@ class DummyEnv(MutableMapping):
 
 
 def check_exec(input, **kwargs):
-    if not input.endswith("\n"):
-        input += "\n"
     builtins.__xonsh__.execer.exec(input, **kwargs)
     return True
 

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -145,6 +145,7 @@ class Execer(object):
         if isinstance(input, types.CodeType):
             code = input
         else:
+            input = input.rstrip("\n")
             if filename is None:
                 filename = self.filename
             code = self.compile(
@@ -174,6 +175,8 @@ class Execer(object):
         if isinstance(input, types.CodeType):
             code = input
         else:
+            if not input.endswith("\n"):
+                input += "\n"
             if filename is None:
                 filename = self.filename
             code = self.compile(


### PR DESCRIPTION
* ``execx`` does not require the input string to be newline-terminated.
* ``evalx`` accepts newline-terminated input string.

`execx` and `evalx` now behave consistently with `exec` and `eval` respectively.
Only `"\n"` is considered to be a valid newline character in this context (see PEP 278).

Fixes #3481.