### PR TITLE
runthis

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ extensions = [
     #'sphinx.ext.autosummary',
     "numpydoc",
     "cmdhelp",
+    "runthis.sphinxext",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -277,6 +278,8 @@ autosummary_generate = []
 # Prevent numpy from making silly tables
 numpydoc_show_class_members = False
 
+# runthis
+runthis_server = "https://runthis.xonsh.org:80"
 
 #
 # Auto-generate some docs

--- a/docs/tryitnow.rst
+++ b/docs/tryitnow.rst
@@ -1,9 +1,17 @@
 Try It Now!
 ===========
-Try out xonsh right here in the browser. Just press the triangle play button in
-the bottom right of the `Repl.it <https://repl.it>`_ frame below.
-**Note:** this is not a fully featured xonsh instance due to repl.it limitations.
+Try out xonsh right here in the browser. Just press the "Run This"
+button below!
 
 .. raw:: html
 
-    <iframe height="400px" width="100%" src="https://repl.it/@scopatz/xonsh?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <div id="tryitnow"></div>
+    <script>
+      var app = Elm.Main.init({
+        node: document.getElementById('tryitnow'),
+          flags: {
+            placeholder: "<img src=\"_static/better_colors_windows.png\">",
+            serverUrl: "https://runthis.xonsh.org:80",
+        }
+      });
+    </script>

--- a/news/runthis.rst
+++ b/news/runthis.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Replaced Repl.It with RunThis on the front page of the docs.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,3 +10,4 @@ doctr
 tornado
 black
 pre-commit
+runthis-sphinxext


### PR DESCRIPTION
This replaces the repl.it launcher on the home screen of the docs with [RunThis](https://regro.github.io/runthis-docs/), a new collection of related [regro](https://regro.github.io/) projects that I built out specifically for xonsh (but that hopefully have use elsewhere too).  

If anyone on @xonsh/xore wants access to the terraform config, or if anyone would like to have help setting this up elsewhere. 

Also, I'd love help making this project and display in the docs more beautiful, but I the priority for me has been to get something working :wink: 

Let me know what you think!

Closes #3448 and related PRs