### PR TITLE
Add fish-like command abbreviations

### DIFF
--- a/news/abbrevs.rst
+++ b/news/abbrevs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``abbrevs`` xontrib.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -2,7 +2,15 @@
  {"name": "abbrevs",
   "package": "xonsh",
   "url": "http://xon.sh",
-  "description": ["Command abbreviations."]
+  "description": [
+    "Adds ``abbrevs`` dictionary to hold user-defined command abbreviations. ",
+    "The dictionary is searched as you type and the matching words are replaced ",
+    "at the command line by the corresponding dictionary contents once you hit ",
+    "'Space' or 'Return' key. For instance a frequently used command such as ",
+    "``git status`` can be abbreviated to ``gst`` as follows::\n\n",
+    "    $ xontrib load abbrevs\n",
+    "    $ abbrevs['gst'] = 'git status'\n",
+    "    $ gst # Once you hit <space> or <return>, 'gst' gets expanded to 'git status'.\n\n"]
  },
  {"name": "apt_tabcomplete",
   "package": "xonsh-apt-tabcomplete",

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -1,4 +1,9 @@
 {"xontribs": [
+ {"name": "abbrevs",
+  "package": "xonsh",
+  "url": "http://xon.sh",
+  "description": ["Command abbreviations."]
+ },
  {"name": "apt_tabcomplete",
   "package": "xonsh-apt-tabcomplete",
   "url": "https://github.com/DangerOnTheRanger/xonsh-apt-tabcomplete",

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -1,4 +1,8 @@
-"""Command abbreviations."""
+"""
+Command abbreviations.
+
+This expands input words from `abbrevs` disctionary as you type.
+"""
 
 import builtins
 from prompt_toolkit.filters import IsMultiline

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -1,0 +1,33 @@
+"""Command abbreviations."""
+
+import builtins
+from xonsh.platform import ptk_shell_type
+
+__all__ = ()
+
+builtins.__xonsh__.ctx["abbrevs"] = dict()
+
+
+def expand_abbrev(buffer):
+    word = buffer.document.get_word_before_cursor()
+    if "abbrevs" not in builtins.__xonsh__.ctx.keys():
+        return
+    abbrevs = builtins.__xonsh__.ctx["abbrevs"]
+    if word in abbrevs.keys():
+        buffer.delete_before_cursor(count=len(word))
+        buffer.insert_text(abbrevs[word])
+
+
+@events.on_ptk_create
+def custom_keybindings(bindings, **kw):
+
+    if ptk_shell_type() == "prompt_toolkit2":
+        handler = bindings.add
+    else:
+        handler = bindings.registry.add_binding
+
+    @handler(" ")
+    def space(event):
+        buffer = event.app.current_buffer
+        expand_abbrev(buffer)
+        buffer.insert_text(" ")

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -12,7 +12,8 @@ from xonsh.tools import check_for_partial_string
 
 __all__ = ()
 
-builtins.__xonsh__.ctx["abbrevs"] = dict()
+if "abbrevs" not in builtins.__xonsh__.ctx.keys():
+    builtins.__xonsh__.ctx["abbrevs"] = dict()
 
 
 def expand_abbrev(buffer):

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -4,6 +4,7 @@ import builtins
 from prompt_toolkit.filters import IsMultiline
 from prompt_toolkit.keys import Keys
 from xonsh.platform import ptk_shell_type
+from xonsh.tools import check_for_partial_string
 
 __all__ = ()
 
@@ -11,11 +12,16 @@ builtins.__xonsh__.ctx["abbrevs"] = dict()
 
 
 def expand_abbrev(buffer):
-    word = buffer.document.get_word_before_cursor()
     if "abbrevs" not in builtins.__xonsh__.ctx.keys():
         return
+    document = buffer.document
+    word = document.get_word_before_cursor()
     abbrevs = builtins.__xonsh__.ctx["abbrevs"]
     if word in abbrevs.keys():
+        partial = document.text[: document.cursor_position]
+        startix, endix, quote = check_for_partial_string(partial)
+        if startix is not None and endix is None:
+            return
         buffer.delete_before_cursor(count=len(word))
         buffer.insert_text(abbrevs[word])
 

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -7,21 +7,23 @@ This expands input words from `abbrevs` disctionary as you type.
 import builtins
 from prompt_toolkit.filters import IsMultiline
 from prompt_toolkit.keys import Keys
+from xonsh.built_ins import DynamicAccessProxy
 from xonsh.platform import ptk_shell_type
 from xonsh.tools import check_for_partial_string
 
 __all__ = ()
 
-if "abbrevs" not in builtins.__xonsh__.ctx.keys():
-    builtins.__xonsh__.ctx["abbrevs"] = dict()
-
+builtins.__xonsh__.abbrevs = dict()
+proxy = DynamicAccessProxy("abbrevs", "__xonsh__.abbrevs")
+setattr(builtins, "abbrevs", proxy)
 
 def expand_abbrev(buffer):
-    if "abbrevs" not in builtins.__xonsh__.ctx.keys():
+    abbrevs = getattr(builtins, "abbrevs")
+    if abbrevs is None:
         return
     document = buffer.document
     word = document.get_word_before_cursor()
-    abbrevs = builtins.__xonsh__.ctx["abbrevs"]
+    abbrevs = builtins.abbrevs
     if word in abbrevs.keys():
         partial = document.text[: document.cursor_position]
         startix, endix, quote = check_for_partial_string(partial)

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -45,5 +45,7 @@ def custom_keybindings(bindings, **kw):
     @handler(Keys.ControlM, filter=IsMultiline() & insert_mode)
     def multiline_carriage_return(event):
         buffer = event.app.current_buffer
-        expand_abbrev(buffer)
+        current_char = buffer.document.current_char
+        if not current_char or current_char.isspace():
+            expand_abbrev(buffer)
         carriage_return(buffer, event.cli)

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -42,9 +42,10 @@ def custom_keybindings(bindings, **kw):
         insert_mode = ViInsertMode() | EmacsInsertMode()
     else:
         from xonsh.ptk.key_bindings import carriage_return
+        from prompt_toolkit.filters import to_filter
 
         handler = bindings.registry.add_binding
-        insert_mode = True
+        insert_mode = to_filter(True)
 
     @handler(" ", filter=IsMultiline() & insert_mode)
     def handle_space(event):

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -17,6 +17,7 @@ builtins.__xonsh__.abbrevs = dict()
 proxy = DynamicAccessProxy("abbrevs", "__xonsh__.abbrevs")
 setattr(builtins, "abbrevs", proxy)
 
+
 def expand_abbrev(buffer):
     abbrevs = getattr(builtins, "abbrevs")
     if abbrevs is None:


### PR DESCRIPTION
Closes #3471.
Expands abbreviations from `abbrevs` dictionary on <kbd>Space</kbd> key press. I did not ~~(and will not)~~ implement expanding abbreviations on <kbd>Return</kbd>, ~~because I don't like it - it is too dangerous in my opinion.~~

To test it:
```
$ xontrib load abbrevs
$ abbrevs["gst"] = "git status"
$ gst # hit <space> and "gst" should get epanded into "git status"
```