### PR TITLE
Register xontrib-pyenv in list of available xontribs.

### DIFF
--- a/news/add-xontrib-pyenv.rst
+++ b/news/add-xontrib-pyenv.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added `xontrib-pyenv <https://github.com/dyuri/xontrib-pyenv>`_ to list of registered xontribs.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -146,11 +146,16 @@
   "url": "https://github.com/t184256/xontrib-prompt-vi-mode",
   "description": ["vi-mode status formatter for xonsh prompt"]
  },
+ {"name": "pyenv",
+  "package": "xontrib-pyenv",
+  "url": "https://github.com/dyuri/xontrib-pyenv",
+  "description": ["pyenv integration for xonsh."]
+ },
  {"name": "readable-traceback",
   "package": "xontrib-readable-traceback",
   "url": "https://github.com/6syun9/xontrib-readable-traceback",
   "description": ["Make traceback easier to see for xonsh."]
-  },
+ },
  {"name": "schedule",
   "package": "xontrib-schedule",
   "url": "https://github.com/astronouth7303/xontrib-schedule",
@@ -299,6 +304,13 @@
     "pip": "xpip install xontrib-kitty"
    }
   },
+  "xontrib-powerline": {
+   "license": "MIT",
+   "url": "https://github.com/santagada/xontrib-powerline",
+   "install": {
+    "pip": "xpip install xontrib-powerline"
+   }
+  },
   "xontrib-prompt-ret-code": {
    "license": "MIT",
    "url": "https://github.com/Siecje/xontrib-prompt-ret-code",
@@ -313,11 +325,11 @@
     "pip": "xpip install xontrib-prompt-vi-mode"
    }
   },
-  "xontrib-powerline": {
+  "xontrib-pyenv": {
    "license": "MIT",
-   "url": "https://github.com/santagada/xontrib-powerline",
+   "url": "https://github.com/dyuri/xontrib-pyenv",
    "install": {
-    "pip": "xpip install xontrib-powerline"
+    "pip": "xpip install xontrib-pyenv"
    }
   },
   "xontrib-readable-traceback": {


### PR DESCRIPTION
This PR adds [xontrib-pyenv](https://github.com/dyuri/xontrib-pyenv) to the list of registered xontribs.