### PR TITLE
Fix error message for `vox rm`

### DIFF
--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -209,8 +209,8 @@ class VoxHandler:
                 del self.vox[name]
             except voxapi.EnvironmentInUse:
                 print(
-                    'The "%s" environment is currently active. In order to remove it, deactivate it first with "vox deactivate %s".\n'
-                    % (name, name),
+                    'The "%s" environment is currently active. In order to remove it, deactivate it first with "vox deactivate".\n'
+                    % name,
                     file=sys.stderr,
                 )
                 return


### PR DESCRIPTION
The error message for `vox rm` wrongly assumed that `vox deactivate` needs an argument.

Example of the error in action:

```
(jnov) fermigier@mbp-stefane-abilian ~/projects/jnov master $ vox rm jnov
The "jnov" environment is currently active. In order to remove it, deactivate it first with "vox deactivate jnov".

(jnov) fermigier@mbp-stefane-abilian ~/projects/jnov master $ vox deactivate jnov
usage: vox [-h] {new,create,activate,workon,enter,deactivate,exit,list,ls,remove,rm,delete,del,help} ...
vox: error: unrecognized arguments: jnov
(jnov) fermigier@mbp-stefane-abilian ~/projects/jnov master $ vox deactivate
Deactivated "jnov".
```

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
