### PR TITLE
abbrevs: only trigger completion if the word is preceded by space

### DIFF
--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -23,7 +23,7 @@ def expand_abbrev(buffer):
     if abbrevs is None:
         return
     document = buffer.document
-    word = document.get_word_before_cursor()
+    word = document.get_word_before_cursor(WORD=True)
     if word in abbrevs.keys():
         partial = document.text[: document.cursor_position]
         startix, endix, quote = check_for_partial_string(partial)


### PR DESCRIPTION
The abbrevs expansion may be especially annoying if triggered after dash or equality sign. Let's reduce it to space-delimited word completion.
No news entry needed - alters unreleased code.