### PR TITLE
xontrib-ssh-agent moved to github

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -181,7 +181,7 @@
  },
  {"name": "ssh_agent",
   "package": "xontrib-ssh-agent",
-  "url": "https://bitbucket.org/dyuri/xontrib-ssh-agent",
+  "url": "https://github.com/dyuri/xontrib-ssh-agent",
   "description": ["ssh-agent integration"]
  },
  {"name": "vox",
@@ -361,7 +361,7 @@
   },
   "xontrib-ssh-agent": {
    "license": "MIT",
-   "url": "https://bitbucket.org/dyuri/xontrib-ssh-agent",
+   "url": "https://github.com/dyuri/xontrib-ssh-agent",
    "install": {
     "pip": "xpip install xontrib-ssh-agent"
    }


### PR DESCRIPTION
I've migrated my repositories from bitbucket to github (due to the end of mercurial support on bitbucket).
