### PR TITLE
Fix Windows bug when PATH entries has trailing spaces

### DIFF
--- a/news/win-scandir-trailing-space.rst
+++ b/news/win-scandir-trailing-space.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed bug on Windows if Path elements has trailing spaces. Windows in general and ``os.path.isdir()`` 
+  doesn't care about trailing spaces but ``os.scandir()`` does. 
+
+**Security:**
+
+* <news item>

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -792,8 +792,8 @@ def _executables_in_windows(path):
     if not os.path.isdir(path):
         return
     # isdir will return True even with a trailing space
-    # scandir doesn't handle this so we strip any space.
-    path = path.rstrip(" ")
+    # scandir doesn't so normalize path first
+    path = os.path.normpath(path)
     extensions = builtins.__xonsh__.env["PATHEXT"]
     if PYTHON_VERSION_INFO < (3, 5, 0):
         for fname in os.listdir(path):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -791,6 +791,9 @@ def _executables_in_posix(path):
 def _executables_in_windows(path):
     if not os.path.isdir(path):
         return
+    # isdir will return True even with a trailing space
+    # scandir doesn't handle this so we strip any space.
+    path = path.rstrip(" ")
     extensions = builtins.__xonsh__.env["PATHEXT"]
     if PYTHON_VERSION_INFO < (3, 5, 0):
         for fname in os.listdir(path):


### PR DESCRIPTION
Fixes a bug on Windows if Path elements has trailing spaces. Windows in general and ``os.path.isdir()`` 
doesn't care about trailing spaces but ``os.scandir()`` does. 

Fixes #3504