### PR TITLE
Pin `sphinx` so the docs don't break

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 cloud_sptheme
 numpydoc
-Sphinx
+Sphinx==2.4.4
 prompt_toolkit
 pygments>=2.2
 psutil


### PR DESCRIPTION
Workaround for #3506 

No news entry 