### PR TITLE
Fix executables_in() exception on Windows

### DIFF
--- a/news/fix-executables_in.rst
+++ b/news/fix-executables_in.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug on Windows causing ``FileNotFoundError`` exception if path
+  elements contain trailing spaces.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
os.stat() on Windows seems to strip the trailing spaces off the path parameter, so noone can be sure the path does really exist.

Fixes #3504.
