### PR TITLE
Make autovox work with Python 3.5

### DIFF
--- a/news/autovox-fstrings.rst
+++ b/news/autovox-fstrings.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* autovox xontrib now works with Python 3.5
+
+**Security:**
+
+* <news item>

--- a/xontrib/autovox.py
+++ b/xontrib/autovox.py
@@ -53,7 +53,9 @@ def get_venv(vox, dirpath):
             if len(venvs) > 1:
                 warnings.warn(
                     MultipleVenvsWarning(
-                        f"Found {len(venvs)} venvs for {path}; using the first"
+                        "Found {numvenvs} venvs for {path}; using the first".format(
+                            numvenvs=len(venvs), path=path
+                        )
                     )
                 )
             return venvs[0]


### PR DESCRIPTION
We still can't use f-strings because of Python 3.5 support.