### PR TITLE
New default for THREAD_SUBPROC on Win

### DIFF
--- a/news/THREAD_SUBPROC-win.rst
+++ b/news/THREAD_SUBPROC-win.rst
@@ -5,7 +5,7 @@
 **Changed:**
 
 * Running Subprocesses in threads are no longer the default on Windows to prevent a
-  number of issues. (e.g. on Windows: :ref:`$THREAD_SUBPROCS=False <thread_subprocs>`). 
+  number of issues. (e.g. on Windows: ``$THREAD_SUBPROCS=False <thread_subprocs>``). 
 
 **Deprecated:**
 

--- a/news/THREAD_SUBPROC-win.rst
+++ b/news/THREAD_SUBPROC-win.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Running Subprocesses in threads are no longer the default on Windows to prevent a
+  number of issues. (e.g. on Windows: :ref:`$THREAD_SUBPROCS=False <thread_subprocs>`). 
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -779,7 +779,7 @@ def DEFAULT_VALUES():
         "SUGGEST_COMMANDS": True,
         "SUGGEST_MAX_NUM": 5,
         "SUGGEST_THRESHOLD": 3,
-        "THREAD_SUBPROCS": True,
+        "THREAD_SUBPROCS": False if ON_WINDOWS else True,
         "TITLE": DEFAULT_TITLE,
         "UPDATE_COMPLETIONS_ON_KEYPRESS": False,
         "UPDATE_OS_ENVIRON": False,
@@ -1205,7 +1205,11 @@ def DEFAULT_DOCS():
             "* Stopping the thread with ``Ctrl+Z`` yields to job control.\n"
             "* Threadable commands are run with ``Popen`` and threadable \n"
             "  alias are run with ``ProcProxy``.\n\n"
-            "The desired effect is often up to the command, user, or use case."
+            "The desired effect is often up to the command, user, or use case.\n\n"
+            ".. note: This is ``False`` by default on Windows as as this feature has\n"
+            "   a number of issues and bugs on Windows.\n"
+            "",
+            default="``True`` on Posix / ``False`` on Windows",
         ),
         "TITLE": VarDocs(
             "The title text for the window in which xonsh is running. Formatted "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1206,7 +1206,7 @@ def DEFAULT_DOCS():
             "* Threadable commands are run with ``Popen`` and threadable \n"
             "  alias are run with ``ProcProxy``.\n\n"
             "The desired effect is often up to the command, user, or use case.\n\n"
-            ".. note: This is ``False`` by default on Windows as as this feature has\n"
+            ".. note: This is ``False`` by default on Windows as  this feature has\n"
             "   a number of issues and bugs on Windows.\n"
             "",
             default="``True`` on Posix / ``False`` on Windows",


### PR DESCRIPTION
This changes the default value for $THREAD_SUBPROC on Windows.

Fixes #3498