### PR TITLE
Failback shell env

### DIFF
--- a/news/failback_shell_env.rst
+++ b/news/failback_shell_env.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* xonsh.main _failback_to_other_shells now tries user's login shell (in $SHELL) before trying system wide shells from /etc/shells.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -306,7 +306,7 @@ def test_delitem_default():
     assert env[a_key] == a_value
 
 
-def test_lscolors_target():
+def test_lscolors_target(xonsh_builtins):
     lsc = LsColors.fromstring("ln=target")
     assert lsc["ln"] == ("NO_COLOR",)
     assert lsc.is_target("ln")

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -427,7 +427,7 @@ class LsColors(cabc.MutableMapping):
         env_style_name = env.get("XONSH_COLOR_STYLE", "default")
         if self._style_name is None or self._style_name != env_style_name:
             self._style_name = env_style_name
-            self._style = self._dtyped = None
+            self._style = self._detyped = None
         return self._style_name
 
     @property

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -369,26 +369,43 @@ def _failback_to_other_shells(args, err):
     # as an interactive one for safe.
     if hasattr(args, "mode") and args.mode != XonshMode.interactive:
         raise err
+
     foreign_shell = None
-    shells_file = "/etc/shells"
-    if not os.path.exists(shells_file):
-        # right now, it will always break here on Windows
-        raise err
-    excluded_list = ["xonsh", "screen"]
-    with open(shells_file) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "/" not in line:
-                continue
-            _, shell = line.rsplit("/", 1)
-            if shell in excluded_list:
-                continue
-            if not os.path.exists(line):
-                continue
-            foreign_shell = line
-            break
+
+    # look first in users login shell $SHELL.
+    # use real os.environ, in case Xonsh hasn't initialized yet
+    # but don't fail back to same shell that just failed.
+
+    try:
+        env_shell = os.getenv("SHELL")
+        if env_shell and os.path.exists(env_shell) and env_shell != sys.argv[0]:
+            foreign_shell = env_shell
+    except Exception:
+        pass
+
+    # otherwise, find acceptable shell from (unix) list of installed shells.
+
+    if not foreign_shell:
+        excluded_list = ["xonsh", "screen"]
+        shells_file = "/etc/shells"
+        if not os.path.exists(shells_file):
+            # right now, it will always break here on Windows
+            raise err
+        with open(shells_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "/" not in line:
+                    continue
+                _, shell = line.rsplit("/", 1)
+                if shell in excluded_list:
+                    continue
+                if not os.path.exists(line):
+                    continue
+                foreign_shell = line
+                break
+
     if foreign_shell:
         traceback.print_exc()
         print("Xonsh encountered an issue during launch", file=sys.stderr)


### PR DESCRIPTION
Re: #3523 

Proposed enhancement to try $SHELL (user's login shell) as first failback shell before trying ``/etc/shells``.
It requires the shell path to to exist and be different from the current (failing) Xonsh shell or it falls through to the system-wide file.
