### PR TITLE
Fix `pip` completer misfires for `pipx`

### DIFF
--- a/news/fix_pip_completer.rst
+++ b/news/fix_pip_completer.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``pip`` completer no longer erroneously fires for ``pipx``
+
+**Security:**
+
+* <news item>

--- a/tests/completers/test_pip_completer.py
+++ b/tests/completers/test_pip_completer.py
@@ -33,6 +33,9 @@ def test_pip_list_re(line):
         "![thewholepipandpaboodle uninstall",
         "$[littlebopip show",
         "!(boxpip uninstall",
+        "pipx",
+        "vim pip_",
+        "pip_",
     ],
 )
 def test_pip_list_re(line):

--- a/xonsh/completers/pip.py
+++ b/xonsh/completers/pip.py
@@ -9,12 +9,12 @@ import xonsh.lazyasd as xl
 
 @xl.lazyobject
 def PIP_RE():
-    return re.compile(r"\bx?pip(?:\d|\.)*")
+    return re.compile(r"\bx?pip(?:\d|\.)*\b")
 
 
 @xl.lazyobject
 def PIP_LIST_RE():
-    return re.compile(r"\bx?pip(?:\d|\.)* (?:uninstall|show)")
+    return re.compile(r"\bx?pip(?:\d|\.)*\b (?:uninstall|show)")
 
 
 @xl.lazyobject


### PR DESCRIPTION
Need a word-boundary now after the initial match

Resolves #3526
Resolves #3379

Signed-off-by: Gil Forsyth <gil@forsyth.dev>
