### PR TITLE
New xontrib-output-search

### DIFF
--- a/news/xontrib-output-search.rst
+++ b/news/xontrib-output-search.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New `xontrib-output-search <https://github.com/anki-code/xontrib-output-search>`_ to get identifiers, names, paths, URLs and words from the previous command output and use them for the next command.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -144,6 +144,12 @@
   "description": ["Matplotlib hooks for xonsh, including the new 'mpl' alias ",
                   "that displays the current figure on the screen."]
   },
+ {"name": "output_search",
+  "package": "git+https://github.com/anki-code/xontrib-output-search.git",
+  "url": "https://github.com/anki-code/xontrib-output-search",
+  "description": ["Get identifiers, names, paths, URLs and words from the previous command output ",
+                  "and use them for the next command."]
+ },
  {"name": "powerline",
   "package": "xontrib-powerline",
   "url": "https://github.com/santagada/xontrib-powerline",


### PR DESCRIPTION
**[xontrib-output-search](https://github.com/anki-code/xontrib-output-search)** is to get identifiers, names, paths, URLs and words from the previous command output and use them for the next command.

* <b>Save time</b>. Forget about using mouse, touchpad or trackball to get any words from output to the next command.
* <b>Secure</b>. The xontrib-output-search is not writing any output on the hard disk. Only latest not empty output stored in the memory. It works the same way as xonsh shell and the security level is the same.
* <b>Universal</b>. Forget about searching autocomplete plugins for every app you use and get the identifiers from the output.

![Screenshot_20200426_141924](https://user-images.githubusercontent.com/1708680/80305969-f6ad8f80-87c8-11ea-923f-5a574aae42e0.png)

Details in the [README](https://github.com/anki-code/xontrib-output-search).