### PR TITLE
Use UTF-8 encoding to write .xonshrc with webconfig

### DIFF
--- a/news/utf8.rst
+++ b/news/utf8.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use UTF-8 encoding when writing .xonshrc with webconfig for Windows compatibility
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/webconfig/main.py
+++ b/xonsh/webconfig/main.py
@@ -71,7 +71,7 @@ def insert_into_xonshrc(
     # compute new values
     new = config_to_xonsh(config, prefix=prefix, suffix=suffix)
     # write out the file
-    with open(fname, "w") as f:
+    with open(fname, "w", encoding="utf-8") as f:
         f.write(before + new + after)
     return fname
 


### PR DESCRIPTION
Solves #3542.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
