### PR TITLE
Fixed error in getting current working directory

### DIFF
--- a/news/fix-cwd.rst
+++ b/news/fix-cwd.rst
@@ -19,5 +19,4 @@
 * <news item>
 
 **Security:**
-base.py
 * <news item>

--- a/news/fix-cwd.rst
+++ b/news/fix-cwd.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The current working directory is now correctly obtained in line 501 of xonsh/parsers/base.py
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+base.py
+* <news item>

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -498,7 +498,7 @@ class BaseParser(object):
         if not yacc_debug:
             yacc_kwargs["errorlog"] = yacc.NullLogger()
         if outputdir is None:
-            outputdir = os.path.dirname(os.path.dirname(__file__))
+            outputdir = os.path.dirname(os.path.realpath(__file__))
         yacc_kwargs["outputdir"] = outputdir
         if yacc_debug:
             # create parser on main thread


### PR DESCRIPTION
`os.path.dirname(__file__)` returns nothing because `__file__` contains only the file name. `os.path.realpath` has to be called first in order to retrieve the base path.