### PR TITLE
Update reference to xontrib cookiecutter repo

### DIFF
--- a/docs/tutorial_xontrib.rst
+++ b/docs/tutorial_xontrib.rst
@@ -60,7 +60,7 @@ Here is a sample file system layout and what the xontrib names would be::
 
 
 You can also use `cookiecutter <https://github.com/audreyr/cookiecutter>`_ with
-the `xontrib template <https://github.com/laerus/cookiecutter-xontrib>`_ to easily
+the `xontrib template <https://github.com/xonsh/xontrib-cookiecutter>`_ to easily
 create the layout for your xontrib package.
 
 


### PR DESCRIPTION
Since laerus seems to have left github, and took the cookiecutter repo with him, I recreated it under the xonsh org from my fork.

This updates the docs to the new URL.

Docs-only change, no news required.