### PR TITLE
linting fixes

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,4 +12,4 @@ jobs:
     - name: Black Check
       uses: "lgeiger/black-action@master"
       with:
-        args: "--check xonsh/ xontrib/"
+        args: "--check --exclude=xonsh/ply/ xonsh/ xontrib/"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,5 +23,5 @@ jobs:
       - shell: bash -l {0}
         run: |
           python -m pip install . --no-deps
-          python -m xonsh run-tests.xsh --timeout=90
+          python -m xonsh run-tests.xsh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,5 @@ script:
       doctr deploy --deploy-repo xonsh/xonsh-docs .;
     else
       xonsh run-tests.xsh --timeout=10;
+      flake8
     fi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -128,7 +128,7 @@ If you want to lint the entire code base run::
 We also use `black <https://github.com/psf/black>`_ for formatting the code base (which includes running in
 our tests)::
 
-    $ black --check xonsh/ xontrib/
+    $ black --check --exclude=xonsh/ply/ xonsh/ xontrib/
 
 To add this as a git pre-commit hook::
 

--- a/news/flake8-2.rst
+++ b/news/flake8-2.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Added global flake8 exception for global __xonsh__, but do we really want to encourage bare global reference to "internal" field?
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Resolved flake8 errors F821 (undefined name) and F841 (defined but never used).
+  setup.cfg: Removed per-file-ignores for these.
+
+**Security:**
+
+* <news item>

--- a/news/flake8-2.rst
+++ b/news/flake8-2.rst
@@ -1,10 +1,11 @@
 **Added:**
 
-* Added global flake8 exception for global __xonsh__, but do we really want to encourage bare global reference to "internal" field?
+* <news item>
 
 **Changed:**
 
-* <news item>
+* Added flake8 builtins exception for ``__xonsh__``, 
+  should not need ``import builtins``, ``builtins.__xonsh__`` any more
 
 **Deprecated:**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,23 +39,25 @@ per-file-ignores =
     # flake8 gives incorrect unused import errors, F401
     tests/tools.py:E128,
     xonsh/ast.py:F401,
-    xonsh/built_ins.py:F821 E721,
+    ##xonsh/built_ins.py:F821 E721,
     xonsh/built_ins.py:E721,
-    xonsh/commands_cache.py:F841,
-    xonsh/history.py:F821,
+    ##xonsh/commands_cache.py:F841,
+    ##xonsh/history.py:F821,
     xonsh/jupyter_kernel.py:E203,
+    # e305 later
     xonsh/platform.py:F401 E305,
     xonsh/proc.py:E261 E265,
-    xonsh/ptk/key_bindings.py:F841,
+    ##xonsh/ptk/key_bindings.py:F841,
     xonsh/ptk/shell.py:E731,
-    xonsh/pyghooks.py:F821,
+    ##xonsh/pyghooks.py:F821,
     xonsh/readline_shell.py:F401,
-    xonsh/style_tools.py:F821 E305,
+     # E305 later
+    ##xonsh/style_tools.py:F821 E305,
     xonsh/timings.py:F401,
-    xonsh/tokenize.py:F821 F841,
+#    xonsh/tokenize.py:F821 F841,
     xonsh/tools.py:E731 E305,
     xonsh/xonfig.py:E731,
-    xontrib/vox.py:F821,
+    ##xontrib/vox.py:F821,
     # remove these later
     xonsh/color_tools.py:E305
     xonsh/completers/_aliases.py:E305,

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -3,8 +3,8 @@
 import os
 import re
 import sys
-import builtins
 import stat
+import builtins
 from collections import ChainMap
 from collections.abc import MutableMapping
 from keyword import iskeyword
@@ -215,7 +215,7 @@ def color_token_by_name(xc: tuple, styles=None) -> Color:
     """Returns (color) token corresponding to Xonsh color tuple, side effect: defines token is defined in styles"""
     if not styles:
         try:
-            styles = builtins.__xonsh__.shell.shell.styler.styles
+            styles = __xonsh__.shell.shell.styler.styles
         except AttributeError:
             return Color
 
@@ -236,7 +236,7 @@ def partial_color_tokenize(template):
     of tuples mapping the token to the string which has that color.
     These sub-strings maybe templates themselves.
     """
-    if builtins.__xonsh__.shell is not None:
+    if __xonsh__.shell is not None:
         styles = __xonsh__.shell.shell.styler.styles
     else:
         styles = None
@@ -362,7 +362,7 @@ class XonshStyle(Style):
                     file=sys.stderr,
                 )
                 value = "default"
-                builtins.__xonsh__.env["XONSH_COLOR_STYLE"] = value
+                __xonsh__.env["XONSH_COLOR_STYLE"] = value
         cmap = STYLES[value]
         if value == "default":
             self._smap = XONSH_BASE_STYLE.copy()
@@ -378,13 +378,11 @@ class XonshStyle(Style):
         self.styles = ChainMap(self.trap, cmap, PTK_STYLE, self._smap, compound)
         self._style_name = value
 
-        for file_type, xonsh_color in builtins.__xonsh__.env.get(
-            "LS_COLORS", {}
-        ).items():
+        for file_type, xonsh_color in __xonsh__.env.get("LS_COLORS", {}).items():
             color_token = color_token_by_name(xonsh_color, self.styles)
             file_color_tokens[file_type] = color_token
 
-        if ON_WINDOWS and "prompt_toolkit" in builtins.__xonsh__.shell.shell_type:
+        if ON_WINDOWS and "prompt_toolkit" in __xonsh__.shell.shell_type:
             self.enhance_colors_for_cmd_exe()
 
     @style_name.deleter
@@ -396,7 +394,7 @@ class XonshStyle(Style):
             When using the default style all blue and dark red colors
             are changed to CYAN and intense red.
         """
-        env = builtins.__xonsh__.env
+        env = __xonsh__.env
         # Ensure we are not using the new Windows Terminal, ConEmu or Visual Stuio Code
         if "WT_SESSION" in env or "CONEMUANSI" in env or "VSCODE_PID" in env:
             return
@@ -1378,7 +1376,7 @@ def color_file(file_path: str, mode: int) -> (Color, str):
 
     """
 
-    lsc = builtins.__xonsh__.env["LS_COLORS"]
+    lsc = __xonsh__.env["LS_COLORS"]
     color_key = "rs"
 
     if stat.S_ISLNK(mode):  # must test link before S_ISREG (esp execute)
@@ -1435,13 +1433,13 @@ def _command_is_valid(cmd):
         cmd_abspath = os.path.abspath(os.path.expanduser(cmd))
     except (FileNotFoundError, OSError):
         return False
-    return (cmd in builtins.__xonsh__.commands_cache and not iskeyword(cmd)) or (
+    return (cmd in __xonsh__.commands_cache and not iskeyword(cmd)) or (
         os.path.isfile(cmd_abspath) and os.access(cmd_abspath, os.X_OK)
     )
 
 
 def _command_is_autocd(cmd):
-    if not builtins.__xonsh__.env.get("AUTO_CD", False):
+    if not __xonsh__.env.get("AUTO_CD", False):
         return False
     try:
         cmd_abspath = os.path.abspath(os.path.expanduser(cmd))
@@ -1489,14 +1487,14 @@ class XonshLexer(Python3Lexer):
             from argparse import Namespace
 
             setattr(builtins, "__xonsh__", Namespace())
-        if not hasattr(builtins.__xonsh__, "env"):
-            setattr(builtins.__xonsh__, "env", {})
+        if not hasattr(__xonsh__, "env"):
+            setattr(__xonsh__, "env", {})
             if ON_WINDOWS:
                 pathext = os_environ.get("PATHEXT", [".EXE", ".BAT", ".CMD"])
-                builtins.__xonsh__.env["PATHEXT"] = pathext.split(os.pathsep)
-        if not hasattr(builtins.__xonsh__, "commands_cache"):
-            setattr(builtins.__xonsh__, "commands_cache", CommandsCache())
-        _ = builtins.__xonsh__.commands_cache.all_commands  # NOQA
+                __xonsh__.env["PATHEXT"] = pathext.split(os.pathsep)
+        if not hasattr(__xonsh__, "commands_cache"):
+            setattr(__xonsh__, "commands_cache", CommandsCache())
+        _ = __xonsh__.commands_cache.all_commands  # NOQA
         super().__init__(*args, **kwargs)
 
     tokens = {

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -1,5 +1,4 @@
 """Xonsh color styling tools that simulate pygments, when it is unavailable."""
-import builtins
 from collections import defaultdict
 
 from xonsh.platform import HAS_PYGMENTS
@@ -64,9 +63,9 @@ def partial_color_tokenize(template):
     of tuples mapping the token to the string which has that color.
     These sub-strings maybe templates themselves.
     """
-    if HAS_PYGMENTS and builtins.__xonsh__.shell is not None:
+    if HAS_PYGMENTS and __xonsh__.shell is not None:
         styles = __xonsh__.shell.shell.styler.styles
-    elif builtins.__xonsh__.shell is not None:
+    elif __xonsh__.shell is not None:
         styles = DEFAULT_STYLE_DICT
     else:
         styles = None

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -881,19 +881,28 @@ def _tokenize(readline, encoding):
         pos, max = 0, len(line)
 
         if contstr:  # continued string
+            # Depends on locals initialized in prev string, hence many noqa
             if not line:
-                raise TokenError("EOF in multi-line string", strstart)
-            endmatch = endprog.match(line)
+                raise TokenError("EOF in multi-line string", strstart)  # noqa F821
+            endmatch = endprog.match(line)  # noqa F821
             if endmatch:
                 pos = end = endmatch.end(0)
                 yield TokenInfo(
-                    STRING, contstr + line[:end], strstart, (lnum, end), contline + line
+                    STRING,
+                    contstr + line[:end],
+                    strstart,  # noqa F821
+                    (lnum, end),
+                    contline + line,
                 )
                 contstr, needcont = "", 0
                 contline = None
             elif needcont and line[-2:] != "\\\n" and line[-3:] != "\\\r\n":
                 yield TokenInfo(
-                    ERRORTOKEN, contstr + line, strstart, (lnum, len(line)), contline
+                    ERRORTOKEN,
+                    contstr + line,
+                    strstart,  # noqa F821
+                    (lnum, len(line)),
+                    contline,
                 )
                 contstr = ""
                 contline = None
@@ -1025,7 +1034,7 @@ def _tokenize(readline, encoding):
                     or token[:3] in single_quoted
                 ):
                     if token[-1] == "\n":  # continued string
-                        strstart = (lnum, start)
+                        strstart = (lnum, start)  # noqa F841
                         endprog = _compile(
                             endpats[initial] or endpats[token[1]] or endpats[token[2]]
                         )

--- a/xonsh/xoreutils/_which.py
+++ b/xonsh/xoreutils/_which.py
@@ -28,7 +28,6 @@ import os
 import sys
 import stat
 import getopt
-import builtins
 import collections.abc as cabc
 
 r"""Find the full path to commands.
@@ -191,7 +190,7 @@ def whichgen(command, path=None, verbose=0, exts=None):
     # Windows has the concept of a list of extensions (PATHEXT env var).
     if sys.platform.startswith("win"):
         if exts is None:
-            exts = builtins.__xonsh__.env["PATHEXT"]
+            exts = __xonsh__.env["PATHEXT"]
             # If '.exe' is not in exts then obviously this is Win9x and
             # or a bogus PATHEXT, then use a reasonable default.
             for ext in exts:

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import time
-import builtins
 
 import xonsh.proc as xproc
 from xonsh.xoreutils.util import arg_handler
@@ -39,7 +38,7 @@ def _cat_line(
 
 
 def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
-    env = builtins.__xonsh__.env
+    env = __xonsh__.env
     enc = env.get("XONSH_ENCODING")
     enc_errors = env.get("XONSH_ENCODING_ERRORS")
     read_size = 0

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -75,7 +75,7 @@ def _which_create_parser():
 
 def print_global_object(arg, stdout):
     """Print the object."""
-    obj = builtins.__xonsh__.ctx.get(arg)
+    obj = __xonsh__.ctx.get(arg)
     print("global object of {}".format(type(obj)), file=stdout)
 
 
@@ -87,7 +87,7 @@ def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
         p, f = os.path.split(abs_name)
         f = next(s.name for s in xp.scandir(p) if s.name.lower() == f.lower())
         abs_name = os.path.join(p, f)
-        if builtins.__xonsh__.env.get("FORCE_POSIX_PATHS", False):
+        if __xonsh__.env.get("FORCE_POSIX_PATHS", False):
             abs_name.replace(os.sep, os.altsep)
     if verbose:
         print("{} ({})".format(abs_name, from_where), file=stdout)
@@ -110,7 +110,7 @@ def print_alias(arg, stdout, verbose=False):
             file=stdout,
         )
         if callable(builtins.aliases[arg]):
-            builtins.__xonsh__.superhelp(builtins.aliases[arg])
+            __xonsh__.superhelp(builtins.aliases[arg])
 
 
 def which(args, stdin=None, stdout=None, stderr=None, spec=None):
@@ -137,13 +137,13 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         if pargs.exts:
             exts = pargs.exts
         else:
-            exts = builtins.__xonsh__.env["PATHEXT"]
+            exts = __xonsh__.env["PATHEXT"]
     else:
         exts = None
     failures = []
     for arg in pargs.args:
         nmatches = 0
-        if pargs.all and arg in builtins.__xonsh__.ctx:
+        if pargs.all and arg in __xonsh__.ctx:
             print_global_object(arg, stdout)
             nmatches += 1
         if arg in builtins.aliases and not pargs.skip:
@@ -155,7 +155,7 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         # from os.environ so we temporarily override it with
         # __xosnh_env__['PATH']
         original_os_path = xp.os_environ["PATH"]
-        xp.os_environ["PATH"] = builtins.__xonsh__.env.detype()["PATH"]
+        xp.os_environ["PATH"] = __xonsh__.env.detype()["PATH"]
         matches = _which.whichgen(arg, exts=exts, verbose=verbose)
         for abs_name, from_where in matches:
             print_path(abs_name, from_where, stdout, verbose, captured)

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -2,7 +2,6 @@
 import shlex
 import sys
 import re
-import builtins
 
 
 __all__ = ()
@@ -63,4 +62,4 @@ def alias(args, stdin=None):
 
 
 aliases["alias"] = alias
-builtins.__xonsh__.env["THREAD_SUBPROCS"] = False
+__xonsh__.env["THREAD_SUBPROCS"] = False


### PR DESCRIPTION
Reducing ad-hoc flake8 ignores, step 2 of hopefully 3.
This PR is not complete yet, need senior contributor feedback to resolve questions below:

1. `xonsh/tokenize.py` is showing uninitialized variables once I stop suppressing F821 and I cannot figure out how this should be fixed.  Yet the tokenizer works?  @scopatz, @santagada could you please take a look?  This causes `pytest -flake8` failure, here are the details:

```xonsh
$ flake8                                                                                                                                                                                                                 
./xonsh/tokenize.py:885:62: F821 undefined name 'strstart'
./xonsh/tokenize.py:886:24: F821 undefined name 'endprog'
./xonsh/tokenize.py:890:51: F821 undefined name 'strstart'
./xonsh/tokenize.py:896:49: F821 undefined name 'strstart'
./xonsh/tokenize.py:1028:25: F841 local variable 'strstart' is assigned to but never used
```

2. Many modules refer to `__xonsh__` as a bare global, this is a big class of F821 errors.
For internal modules, I fixed by `import builtins` and refer to `builtins.__xonsh__`.    

Question to the project: is this good enough for xontribs as well?  Or should there be a more formal API for them?  `builtins.events` and `builtins.aliases` would work, are already first-class global objects and have a documented API.  But for shell and history, it's fish them out of `builtins.__xonsh__`, which seems a bit rude.  