### PR TITLE
Fix json history

### DIFF
--- a/news/fix-json-history.rst
+++ b/news/fix-json-history.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed JSON history indexing error.
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -430,7 +430,7 @@ class JsonHistory(History):
         hf = JsonHistoryFlusher(
             self.filename, tuple(self.buffer), self._queue, self._cond, at_exit=at_exit
         )
-        self.buffer.clear()
+        self.buffer = []
         return hf
 
     def items(self, newest_first=False):


### PR DESCRIPTION
Due to $HISTCONTROL setting some history entries may not be always flushed to the file and the on-disk history may actually be shorter than it was in the in-memory buffer. This patch fixes the indexing error occuring under such condition.

This also fixes race condition between `JSONHistory` and `JSONHistoryFlusher` leading to on-disk history truncation.

Closes #3562 