### PR TITLE
Python 3.9 support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest]
+        python-version: [3.8]
     name: Python ${{ matrix.python-version }} ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -100,7 +100,6 @@ from ast import (
     literal_eval,
     dump,
     walk,
-    increment_lineno,
 )
 from ast import Ellipsis as EllipsisNode
 
@@ -322,6 +321,19 @@ def isexpression(node, ctx=None, *args, **kwargs):
         isexpr = False
     return isexpr
 
+def increment_lineno(node, n=1):
+    """
+    Increment the line number and end line number of each node in the tree
+    starting at *node* by *n*. This is useful to "move code" to a different
+    location in a file.
+    """
+    for child in walk(node):
+        if 'lineno' in child._attributes:
+            child.lineno = getattr(child, 'lineno', 0) + n
+        end_lineno = getattr(child, "end_lineno", 0)
+        if 'end_lineno' in child._attributes and end_lineno is not None:
+            child.end_lineno = getattr(child, 'end_lineno', 0) + n
+    return node
 
 class CtxAwareTransformer(NodeTransformer):
     """Transforms a xonsh AST based to use subprocess calls when

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -121,9 +121,9 @@ else:
 if PYTHON_VERSION_INFO >= (3, 6, 0):
     # pylint: disable=unused-import
     # pylint: disable=no-name-in-module
-    from ast import JoinedStr, FormattedValue, AnnAssign
+    from ast import JoinedStr, FormattedValue, AnnAssign, Constant
 else:
-    JoinedStr = FormattedValue = AnnAssign = None
+    JoinedStr = FormattedValue = AnnAssign = Constant = None
 
 STATEMENTS = (
     FunctionDef,

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2199,7 +2199,7 @@ class BaseParser(object):
             return leader
         p0 = leader
         for trailer in trailers:
-            if isinstance(trailer, (ast.Index, ast.Slice, ast.ExtSlice)):
+            if isinstance(trailer, (ast.Index, ast.Slice, ast.ExtSlice, ast.Constant)):
                 p0 = ast.Subscript(
                     value=leader,
                     slice=trailer,

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2199,7 +2199,9 @@ class BaseParser(object):
             return leader
         p0 = leader
         for trailer in trailers:
-            if isinstance(trailer, (ast.Index, ast.Slice, ast.ExtSlice, ast.Constant)):
+            if isinstance(
+                trailer, (ast.Index, ast.Slice, ast.ExtSlice, ast.Constant, ast.Name)
+            ):
                 p0 = ast.Subscript(
                     value=leader,
                     slice=trailer,

--- a/xonsh/parsers/v35.py
+++ b/xonsh/parsers/v35.py
@@ -130,7 +130,10 @@ class Parser(BaseParser):
 
     def p_argument_kwargs(self, p):
         """argument : POW test"""
-        p[0] = ast.keyword(arg=None, value=p[2])
+        p2 = p[2]
+        p[0] = ast.keyword(
+            arg=None, value=p2, lineno=p2.lineno, col_offset=p2.col_offset
+        )
 
     def p_argument_args(self, p):
         """argument : TIMES test"""
@@ -145,4 +148,7 @@ class Parser(BaseParser):
 
     def p_argument_eq(self, p):
         """argument : test EQUALS test"""
-        p[0] = ast.keyword(arg=p[1].id, value=p[3])
+        p3 = p[3]
+        p[0] = ast.keyword(
+            arg=p[1].id, value=p3, lineno=p3.lineno, col_offset=p3.col_offset
+        )


### PR DESCRIPTION
**Preliminary.** Python is still in 3.9.0b1 by now.
No prerelease conda packages to run the tests on.
Currently blocked by python/cpython#20312.

There's currently a lot of unexpected `ast.Constant` occurences in the AST.
~~`apply-trailers` still asserts in some cases.~~

The tests do, however, at least run for me in docker, which is an improvement compared to the master branch state.
The tests are limited to v3.8 on ubuntu-latest - there's no point in stressing the CI.