### PR TITLE
Issue template footer

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -34,3 +34,6 @@ traceback
 
 ## Steps to Reproduce
 <!--- Please try to write out a minimal reproducible snippet to trigger the bug, it will help us fix it! -->
+
+## For community
+⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**


### PR DESCRIPTION
I'm using this footer for issues and feature requests around a couple of years:
> **For community:**
>⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**

It works really great. People can react on issues or features and then we can [sort the list](https://github.com/xonsh/xonsh/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) of issues by count of reactions.

You can see how it works in real life if you open any issue in Metabase repo. For example - https://github.com/metabase/metabase/issues/1300

**For community:**
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
