### PR TITLE
Fix Jedi warnings (plus some bits and pieces)

### DIFF
--- a/news/fix-jedi-warnings.rst
+++ b/news/fix-jedi-warnings.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed deprecation warnings in ``jedi`` xontrib.
+
+**Security:**
+
+* <news item>

--- a/xontrib/jedi.xsh
+++ b/xontrib/jedi.xsh
@@ -1,5 +1,4 @@
 """Jedi-based completer for Python-mode."""
-import builtins
 import importlib
 
 from xonsh.lazyasd import lazyobject, lazybool
@@ -37,7 +36,7 @@ def complete_jedi(prefix, line, start, end, ctx):
     if not HAS_JEDI:
         return set()
     new_api = jedi_version >= (0, 16, 0)
-    src = builtins.__xonsh__.shell.shell.accumulated_inputs + line
+    src = __xonsh__.shell.shell.accumulated_inputs + line
     if new_api:
         script = jedi.api.Interpreter(src, [ctx])
     else:
@@ -51,7 +50,7 @@ def complete_jedi(prefix, line, start, end, ctx):
     except Exception:
         pass
 
-    if builtins.__xonsh__.env.get('CASE_SENSITIVE_COMPLETIONS'):
+    if __xonsh__.env.get('CASE_SENSITIVE_COMPLETIONS'):
         rtn = {x.name_with_symbols for x in script_comp
                if x.name_with_symbols.startswith(prefix)}
     else:

--- a/xontrib/jedi.xsh
+++ b/xontrib/jedi.xsh
@@ -60,7 +60,5 @@ def complete_jedi(prefix, line, start, end, ctx):
 
 
 # register the completer
-builtins.__xonsh__.ctx['complete_jedi'] = complete_jedi
 completer add jedi complete_jedi end
 completer remove python_mode
-del builtins.__xonsh__.ctx['complete_jedi']

--- a/xontrib/jedi.xsh
+++ b/xontrib/jedi.xsh
@@ -24,15 +24,30 @@ def jedi():
     return m
 
 
+@lazyobject
+def jedi_version():
+    if hasattr(jedi, "__version__"):
+        return tuple(int(n) for n in jedi.__version__.split("."))
+    else:
+        return (0, 0, 0)
+
+
 def complete_jedi(prefix, line, start, end, ctx):
     """Jedi-based completer for Python-mode."""
     if not HAS_JEDI:
         return set()
+    new_api = jedi_version >= (0, 16, 0)
     src = builtins.__xonsh__.shell.shell.accumulated_inputs + line
-    script = jedi.api.Interpreter(src, [ctx], column=end)
+    if new_api:
+        script = jedi.api.Interpreter(src, [ctx])
+    else:
+        script = jedi.api.Interpreter(src, [ctx], column=end)
     script_comp = set()
     try:
-        script_comp = script.completions()
+        if new_api:
+            script_comp = script.complete(column=end)
+        else:
+            script_comp = script.completions()
     except Exception:
         pass
 

--- a/xontrib/jedi.xsh
+++ b/xontrib/jedi.xsh
@@ -10,8 +10,8 @@ __all__ = ()
 @lazybool
 def HAS_JEDI():
     """``True`` if `jedi` is available, else ``False``."""
-    spec = importlib.util.find_spec('jedi')
-    return (spec is not None)
+    spec = importlib.util.find_spec("jedi")
+    return spec is not None
 
 
 @lazyobject
@@ -50,9 +50,12 @@ def complete_jedi(prefix, line, start, end, ctx):
     except Exception:
         pass
 
-    if __xonsh__.env.get('CASE_SENSITIVE_COMPLETIONS'):
-        rtn = {x.name_with_symbols for x in script_comp
-               if x.name_with_symbols.startswith(prefix)}
+    if __xonsh__.env.get("CASE_SENSITIVE_COMPLETIONS"):
+        rtn = {
+            x.name_with_symbols
+            for x in script_comp
+            if x.name_with_symbols.startswith(prefix)
+        }
     else:
         rtn = {x.name_with_symbols for x in script_comp}
     return rtn


### PR DESCRIPTION
Jedi v0.16.0 changed the completer API and started emitting deprecation warnings for the old API calls (see davidhalter/jedi@5f6a25fb5). This detects Jedi version and switches to the new API on jedi >= 0.16.0.

Plus:
- remove some strange completer registration steps.
Please correct and enlighten me if those were important.
- remove references to `xonsh.builtins` module.
- run black on xontrib/jedi.xsh.