### PR TITLE
fix(completer): Add bounds check in path completer

### DIFF
--- a/news/fix-completion-out-of-bounds.rst
+++ b/news/fix-completion-out-of-bounds.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix path completer throwing exception sometimes
+
+**Security:**
+
+* <news item>

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -298,11 +298,12 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
         # e.g., ~/u/ro completes to ~/lou/carcolh
         # see above functions for details.
         p = _splitpath(os.path.expanduser(prefix))
-        if len(p) != 0:
+        p_len = len(p)
+        if p_len != 0:
             relative_char = ["", ".", ".."]
             if p[0] in relative_char:
                 i = 0
-                while p[i] in relative_char:
+                while i < p_len and p[i] in relative_char:
                     i += 1
                 basedir = p[:i]
                 p = p[i:]


### PR DESCRIPTION
I got the following exception:
```
Unhandled exception in event loop:
  File "C:\<redacted>\Python38\lib\concurrent\futures\thread.py", line 57
, in run
    result = self.fn(*self.args, **self.kwargs)
  File "C:\<redacted>\Python38\lib\site-packages\prompt_toolkit\eventloop
\async_generator.py", line 43, in runner
    for item in get_iterable():
  File "C:\<redacted>\Python38\lib\site-packages\xonsh\ptk_shell\complete
r.py", line 44, in get_completions
    completions, l = self.completer.complete(
  File "C:\<redacted>\Python38\lib\site-packages\xontrib\free_cwd.py", li
ne 86, in wrapper
    out = func(*args, **kwargs)
  File "C:\<redacted>\Python38\lib\site-packages\xonsh\__amalgam__.py", l
ine 126, in complete
    out = func(prefix, line, begidx, endidx, ctx)
  File "C:\<redacted>\Python38\lib\site-packages\xonsh\completers\__amalg
am__.py", line 1738, in complete_cd
    return complete_dir(prefix, line, start, end, ctx, True)
  File "C:\<redacted>\Python38\lib\site-packages\xonsh\completers\__amalg
am__.py", line 1365, in complete_dir
    return complete_path(prefix, line, start, end, cdpath, filtfunc=os.path.isdir)
  File "C:\<redacted>\Python38\lib\site-packages\xonsh\completers\__amalg
am__.py", line 1331, in complete_path
    while p[i] in relative_char:

Exception tuple index out of range
```

Seems like this is due to the missing bounds check on `i` when doing the `while` loop. This patch adds the necessary check.