### PR TITLE
Update links to xontrib-fzf-widgets

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -131,7 +131,7 @@
   },
  {"name": "fzf-widgets",
   "package": "xontrib-fzf-widgets",
-  "url": "https://github.com/shahinism/xontrib-fzf-widgets",
+  "url": "https://github.com/laloch/xontrib-fzf-widgets",
   "description": ["Adds some fzf widgets to your xonsh shell."]
  },
  {"name": "histcpy",
@@ -327,7 +327,7 @@
   },
   "xontrib-fzf-widgets": {
    "license": "GPLv3",
-   "url": "https://github.com/shahinism/xontrib-fzf-widgets",
+   "url": "https://github.com/laloch/xontrib-fzf-widgets",
    "install": {
     "pip": "xpip install xontrib-fzf-widgets"
    }


### PR DESCRIPTION
I'm now the owner of the [PyPI package](https://pypi.org/project/xontrib-fzf-widgets).

Thanks @shahinism for the contribution and for handing the ownership to me!

No news entry needed.