### PR TITLE
CI: increase pytest timeout

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,5 +23,5 @@ jobs:
       - shell: bash -l {0}
         run: |
           python -m pip install . --no-deps
-          python -m xonsh run-tests.xsh --timeout=15
+          python -m xonsh run-tests.xsh --timeout=90
 


### PR DESCRIPTION
This hopefully fixes the CI timeouts on Windows.
Closes #3616 
No news entry needed.
