### PR TITLE
Fix help operator not displaying definitions

### DIFF
--- a/news/fix-help-def.rst
+++ b/news/fix-help-def.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed help operator not displaying definition for callables.
+
+**Security:**
+
+* <news item>

--- a/xonsh/inspectors.py
+++ b/xonsh/inspectors.py
@@ -356,7 +356,7 @@ class Inspector(object):
         exception is suppressed.
         """
         try:
-            hdef = oname + inspect.signature(*getargspec(obj))
+            hdef = oname + str(inspect.signature(obj))
             return cast_unicode(hdef)
         except:  # pylint:disable=bare-except
             return None


### PR DESCRIPTION
This was broken two years ago by exceptionally inapt commit in #2918, that somehow passed completely unchecked and untested.

Closes #3621 