### PR TITLE
xontrib: don't stop loading xontribs on error

### DIFF
--- a/news/xontrib-failok.rst
+++ b/news/xontrib-failok.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``xontrib load`` does not stop loading modules on error any more.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
`xontrib load` action can load multiple xontribs at once. If, however, one of the xontribs fails to load, because, for instance, of a missing dependency, the command exits and the rest of the modules is not attempted to load at all.
This patch modifies the `load` action behavior to only print exception on error, but to continue loading remaining xontribs.