### PR TITLE
Set argv[0] of a subprocess to the command as inserted by the user

### DIFF
--- a/news/argv0.rst
+++ b/news/argv0.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Xonsh now launches subprocesses with their ``argv[0]`` argument containing
+  the command exactly as inserted by the user instead of setting it to the
+  resolved path of the executable. This is for consistency with bash and other
+  shells.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/bin/checkargv0.xsh
+++ b/tests/bin/checkargv0.xsh
@@ -1,0 +1,25 @@
+#!/usr/bin/env xonsh
+res = True
+script = """import os
+path = "/proc/{}/cmdline".format(os.getpid())
+with open(path, "r") as f:
+    lines = f.read().split("\x00")
+    print(lines[0])"""
+
+def check(python):
+    argv0 = $(@(python) -c @(script)).rstrip()
+
+    if argv0 == python:
+        return True
+
+    print("Unexpected argv[0]: {} != {}".format(argv0, python))
+    return False
+
+
+python = "python"
+res &= check(python)
+
+python = $(which -s python)
+res &= check(python)
+if res:
+    print("OK")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,7 +10,9 @@ import xonsh
 from xonsh.lib.os import indir
 
 from tools import (
+    skip_if_on_msys,
     skip_if_on_windows,
+    skip_if_on_darwin,
     ON_WINDOWS,
     ON_DARWIN,
     ON_TRAVIS,
@@ -681,3 +683,10 @@ aliases['echo'] = _echo
 def test_single_command_return_code(cmd, exp_rtn):
     _, _, rtn = run_xonsh(cmd, single_command=True)
     assert rtn == exp_rtn
+
+
+@skip_if_on_msys
+@skip_if_on_windows
+@skip_if_on_darwin
+def test_argv0():
+    check_run_xonsh("checkargv0.xsh", None, "OK\n")


### PR DESCRIPTION
Currently Xonsh passes a resolved path of an executable as argv[0] argument. This changes the argv[0] to contain the command as inserted by the user. The new behavior is consistent with bash and other shells. Some programs behave differently in dependence on the argv[0] value.
Fixes #3617.