### PR TITLE
Fix ctx-free parser stripping the trailing newline

### DIFF
--- a/news/fix-linecont.rst
+++ b/news/fix-linecont.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed syntax error in scripts containing line continuation syntax.
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -289,10 +289,11 @@ def _echo(args):
     print(' '.join(args))
 aliases['echo'] = _echo
 
-echo --option1 \
+echo --option1 \\
 --option2
-""",
-        "--option1 --option2\n",
+echo missing \\
+EOL""",
+        "--option1 --option2\nmissing EOL\n",
         0,
     ),
     #

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -242,6 +242,8 @@ class Execer(object):
                 last_error_line = e.loc.lineno
                 idx = last_error_line - 1
                 lines = input.splitlines()
+                if input.endswith("\n"):
+                    lines.append("")
                 line, nlogical, idx = get_logical_line(lines, idx)
                 if nlogical > 1 and not logical_input:
                     _, sbpline = self._parse_ctx_free(
@@ -254,8 +256,6 @@ class Execer(object):
                     last_error_col += 3
                     input = "\n".join(lines)
                     continue
-                if input.endswith("\n"):
-                    lines.append("")
                 if len(line.strip()) == 0:
                     # whitespace only lines are not valid syntax in Python's
                     # interactive mode='single', who knew?! Just ignore them.


### PR DESCRIPTION
Fixes #3629. 

`_parse_ctx_free` uses `str.splitlines` to separate lines of the input for subsequent processing. `splitlines`, however ignores the trailing newline character, which is later missing in the re-assembled input string. This change makes sure that we don't lose the trailing newline.