### PR TITLE
Fix TypeError triggered by unexpected return from callable alias

### DIFF
--- a/news/fix-alias-return.rst
+++ b/news/fix-alias-return.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Unhandled exception triggered by unexpected return from callable alias.
+
+**Security:**
+
+* <news item>

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1203,12 +1203,12 @@ def parse_proxy_return(r, stdout, stderr):
     elif isinstance(r, cabc.Sequence):
         rlen = len(r)
         if rlen > 0 and r[0] is not None:
-            stdout.write(r[0])
+            stdout.write(str(r[0]))
             stdout.flush()
         if rlen > 1 and r[1] is not None:
-            stderr.write(r[1])
+            stderr.write(str(r[1]))
             stderr.flush()
-        if rlen > 2 and r[2] is not None:
+        if rlen > 2 and isinstance(r[2], int):
             cmd_result = r[2]
     elif r is not None:
         # for the random object...


### PR DESCRIPTION
Callable aliases returning tuple may raise `TypeError` exception effectively hanging the shell, if the tuple contains values of unexpected type.

Fixes #3598.