### PR TITLE
Improve completers and Jedi xontrib

### DIFF
--- a/news/improve-completers.rst
+++ b/news/improve-completers.rst
@@ -1,0 +1,33 @@
+**Added:**
+
+* RichCompletion for completions with different display value, description and prefix_len.
+* Allow completer access to multiline document when available via ``xonsh.completers.tools.get_ptk_completer().current_document``.
+
+**Changed:**
+
+* Major improvements to Jedi xontrib completer:
+    * Use new Jedi API
+    * Replace the existing python completer
+    * Create rich completions with extra info
+    * Use entire multiline document if available
+    * Complete xonsh special tokens
+    * Be aware of _ (last result)
+    * Only show dunder attrs when prefix ends with '_'
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Typo in 'source' alias.
+* Crash in 'completer' completer.
+* Don't complete unnecessarily in 'base' completer
+
+**Security:**
+
+* <news item>

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -560,7 +560,7 @@ def source_alias(args, stdin=None):
                     print("source: {}: No such file".format(fname), file=sys.stderr)
                 if i == 0:
                     raise RuntimeError(
-                        "must source at least one file, " + fname + "does not exist."
+                        "must source at least one file, " + fname + " does not exist."
                     )
                 break
         _, fext = os.path.splitext(fpath)

--- a/xonsh/completers/base.py
+++ b/xonsh/completers/base.py
@@ -11,6 +11,10 @@ def complete_base(prefix, line, start, end, ctx):
     and paths.  If we are completing the first argument, complete based on
     valid commands and python names.
     """
+    if line.strip() and prefix != line:
+        # don't do unnecessary completions
+        return set()
+
     # get and unpack python completions
     python_comps = complete_python(prefix, line, start, end, ctx)
     if isinstance(python_comps, cabc.Sequence):

--- a/xonsh/completers/completer.py
+++ b/xonsh/completers/completer.py
@@ -8,7 +8,14 @@ def complete_completer(prefix, line, start, end, ctx):
     args = line.split(" ")
     if len(args) == 0 or args[0] != "completer":
         return None
+
+    if end < len(line) and line[end] != " ":
+        # completing in a middle of a word
+        # (e.g. "completer some<TAB>thing")
+        return None
+
     curix = args.index(prefix)
+
     compnames = set(builtins.__xonsh__.completers.keys())
     if curix == 1:
         possible = {"list", "help", "add", "remove"}

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -33,6 +33,41 @@ def justify(s, max_length, left_pad=0):
     return "\n".join(txt)
 
 
+class RichCompletion(str):
+    """A rich completion that completers can return instead of a string
+
+    Parameters
+    ----------
+    value : str
+        The completion's actual value.
+    prefix_len : int
+        Length of the prefix to be replaced in the completion.
+        If None, the default prefix len will be used.
+    display : str
+        Text to display in completion option list.
+        If None, ``value`` will be used.
+    description : str
+        Extra text to display when the completion is selected.
+    """
+
+    def __new__(cls, value, prefix_len=None, display=None, description=""):
+        completion = super().__new__(cls, value)
+
+        completion.prefix_len = prefix_len
+        completion.display = display or value
+        completion.description = description
+
+        return completion
+
+    def __repr__(self):
+        return "RichCompletion({}, prefix_len={}, display={}, description={})".format(
+            repr(str(self)),
+            self.prefix_len,
+            repr(self.display),
+            repr(self.description),
+        )
+
+
 def get_ptk_completer():
     """Get the current PromptToolkitCompleter
 

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -31,3 +31,21 @@ def justify(s, max_length, left_pad=0):
     """
     txt = textwrap.wrap(s, width=max_length, subsequent_indent=" " * left_pad)
     return "\n".join(txt)
+
+
+def get_ptk_completer():
+    """Get the current PromptToolkitCompleter
+
+    This is usefull for completers that want to use
+    PromptToolkitCompleter.current_document (the current multiline document).
+
+    Call this function lazily since in '.xonshrc' the shell doesn't exist.
+
+    Returns
+    -------
+    The PromptToolkitCompleter if running with ptk, else returns None
+    """
+    if __xonsh__.shell is None or __xonsh__.shell.shell_type != "prompt_toolkit":
+        return None
+
+    return __xonsh__.shell.shell.pt_completer

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -7,6 +7,8 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.application.current import get_app
 
+from xonsh.completers.tools import RichCompletion
+
 
 class PromptToolkitCompleter(Completer):
     """Simple prompt_toolkit Completer object.
@@ -83,8 +85,16 @@ class PromptToolkitCompleter(Completer):
             pre = len(c_prefix)
         for comp in completions:
             # do not display quote
-            disp = comp[pre:].strip("'\"")
-            yield Completion(comp, -l, display=disp)
+            if isinstance(comp, RichCompletion):
+                yield Completion(
+                    comp,
+                    -comp.prefix_len if comp.prefix_len is not None else -l,
+                    display=comp.display,
+                    display_meta=comp.description,
+                )
+            else:
+                disp = comp[pre:].strip("'\"")
+                yield Completion(comp, -l, display=disp)
 
     def suggestion_completion(self, document, line):
         """Provides a completion based on the current auto-suggestion."""

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -22,6 +22,7 @@ class PromptToolkitCompleter(Completer):
         self.ctx = ctx
         self.shell = shell
         self.hist_suggester = AutoSuggestFromHistory()
+        self.current_document = None
 
     def get_completions(self, document, complete_event):
         """Returns a generator for list of completions."""
@@ -40,10 +41,17 @@ class PromptToolkitCompleter(Completer):
         begidx = line[:endidx].rfind(" ") + 1 if line[:endidx].rfind(" ") >= 0 else 0
         prefix = line[begidx:endidx]
         expand_offset = len(line_ex) - len(line)
+
+        # enable completers to access entire document
+        self.current_document = document
+
         # get normal completions
         completions, l = self.completer.complete(
             prefix, line_ex, begidx + expand_offset, endidx + expand_offset, self.ctx
         )
+
+        self.current_document = None
+
         # completions from auto suggest
         sug_comp = None
         if env.get("AUTO_SUGGEST") and env.get("AUTO_SUGGEST_IN_COMPLETIONS"):

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -145,7 +145,7 @@
  {"name": "jedi",
   "package": "xonsh",
   "url": "http://xon.sh",
-  "description": ["Jedi tab completion hooks for xonsh."]
+  "description": ["Use Jedi as xonsh's python completer."]
   },
  {"name": "kitty",
   "package": "xontrib-kitty",

--- a/xontrib/jedi.xsh
+++ b/xontrib/jedi.xsh
@@ -1,51 +1,141 @@
-"""Jedi-based completer for Python-mode."""
-import builtins
-import importlib
+"""Use Jedi as xonsh's python completer."""
+import itertools
 
+import xonsh
 from xonsh.lazyasd import lazyobject, lazybool
+from xonsh.completers.tools import (
+    get_filter_function,
+    get_ptk_completer,
+    RichCompletion,
+)
 
 
 __all__ = ()
 
-
-@lazybool
-def HAS_JEDI():
-    """``True`` if `jedi` is available, else ``False``."""
-    spec = importlib.util.find_spec('jedi')
-    return (spec is not None)
+# an error will be printed in xontribs
+# if jedi isn't installed
+import jedi
 
 
 @lazyobject
-def jedi():
-    if HAS_JEDI:
-        import jedi as m
+def PTK_COMPLETER():
+    return get_ptk_completer()
+
+
+@lazybool
+def JEDI_NEW_API():
+    if hasattr(jedi, "__version__"):
+        return tuple(map(int, jedi.__version__.split("."))) >= (0, 16, 0)
     else:
-        m = None
-    return m
+        return False
+
+
+@lazyobject
+def XONSH_SPECIAL_TOKENS():
+    return {
+        "?",
+        "??",
+        "$(",
+        "${",
+        "$[",
+        "![",
+        "!(",
+        "@(",
+        "@$(",
+        "@",
+    }
 
 
 def complete_jedi(prefix, line, start, end, ctx):
-    """Jedi-based completer for Python-mode."""
-    if not HAS_JEDI:
-        return set()
-    src = builtins.__xonsh__.shell.shell.accumulated_inputs + line
-    script = jedi.api.Interpreter(src, [ctx], column=end)
+    """Completes python code using Jedi and xonsh operators"""
+
+    # if this is the first word and it's a known command, don't complete.
+    # taken from xonsh/completers/python.py
+    if line.lstrip() != "":
+        first = line.split(maxsplit=1)[0]
+        if prefix == first and first in __xonsh__.commands_cache and first not in ctx:
+            return set()
+
+    filter_func = get_filter_function()
+    jedi.settings.case_insensitive_completion = not __xonsh__.env.get(
+        "CASE_SENSITIVE_COMPLETIONS"
+    )
+
+    if PTK_COMPLETER:  # 'is not None' won't work with lazyobject
+        document = PTK_COMPLETER.current_document
+        source = document.text
+        row = document.cursor_position_row + 1
+    else:
+        source = line
+        row = 1
+
+    extra_ctx = {"__xonsh__": __xonsh__}
+    try:
+        extra_ctx['_'] = _
+    except NameError:
+        pass
+
+    if JEDI_NEW_API:
+        script = jedi.Interpreter(source, [ctx, extra_ctx])
+    else:
+        script = jedi.Interpreter(source, [ctx, extra_ctx], line=row, column=end)
+
     script_comp = set()
     try:
-        script_comp = script.completions()
+        if JEDI_NEW_API:
+            script_comp = script.complete(row, end)
+        else:
+            script_comp = script.completions()
     except Exception:
         pass
 
-    if builtins.__xonsh__.env.get('CASE_SENSITIVE_COMPLETIONS'):
-        rtn = {x.name_with_symbols for x in script_comp
-               if x.name_with_symbols.startswith(prefix)}
+    # make sure _* names are completed only when
+    # the user writes the first underscore
+    complete_underscores = prefix.endswith("_")
+
+    return set(
+        itertools.chain(
+            (
+                create_completion(comp, prefix)
+                for comp in script_comp
+                if complete_underscores or 
+                    not comp.name.startswith('_') or 
+                    not comp.complete.startswith("_")
+            ),
+            (t for t in XONSH_SPECIAL_TOKENS if filter_func(t, prefix)),
+        )
+    )
+
+
+def create_completion(comp, prefix):
+    """Create a RichCompletion from Jedi Completion object"""
+    comp_type = None
+    description = None
+
+    sigs = comp.get_signatures()
+    if sigs:
+        comp_type = comp.type
+        description = sigs[0].to_string()
     else:
-        rtn = {x.name_with_symbols for x in script_comp}
-    return rtn
+        # jedi doesn't know exactly what this is
+        inf = comp.infer()
+        if inf:
+            comp_type = inf[0].type
+            description = inf[0].description
+
+    display = comp.name + ("()" if comp_type == "function" else "")
+    description = description or comp.type
+
+    return RichCompletion(
+        comp.complete, display=display, description=description, prefix_len=0
+    )
 
 
-# register the completer
-builtins.__xonsh__.ctx['complete_jedi'] = complete_jedi
-completer add jedi complete_jedi end
+# monkey-patch the original python completer in 'base'.
+xonsh.completers.base.complete_python = complete_jedi
+
+# Jedi ignores leading '@(' and friends
 completer remove python_mode
-del builtins.__xonsh__.ctx['complete_jedi']
+
+completer add jedi_python complete_jedi '<python'
+completer remove python


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Hi!

This PR contains a few changes to the completers ecosystem:

## Enable more advanced completers

These are two proposed API changes for completers.

### Enable display and description texts with RichCompletion

A completer can return a `RichCompletion` object that can create better completion displays:

```python
return set(
    RichCompleter(value, prefix_len, display, description)
    for c in completions
)
```

### Enable access to ptk's multiline document (*from a completer call*)

```python
ptk_completer = xonsh.completers.tools.get_ptk_completer()
if ptk_completer is not None:
    full_text = ptk_completer.current_document.text
    row = ptk_completer.current_document.cursor_position_row + 1
```

## Improvements to the Jedi xontrib

* Use new Jedi API (inspired by #3594)
* Replace the existing python completer
* Create rich completions with extra info (inspired by IPython)
* Use entire multiline document if available (so the completion is more accurate)
* Complete xonsh special tokens
* Be aware of _ (last result)
* Only show dunder attrs when prefix ends with '_' (also like in IPython)

## Other small fixes to other completers

* base completer: Don't complete unnecessarily
* completer: Fix crash in 'completer' completer
* aliases: Fix typo in 'source' alias