### PR TITLE
Revert abbrevs expansion on the second consecutive space keypress

### DIFF
--- a/news/revert-abbrev.rst
+++ b/news/revert-abbrev.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* ``abbrevs`` word expasion can now be reverted by pressing
+  the space bar second time immediately after the previous
+  word got expanded.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
`abbrevs` word expasion can now be reverted by pressing the space bar second time immediately after the previous word got expanded.

Relates to (but does not close) #3642.