### PR TITLE
Call repr() when pretty() fails in _pprint_displayhook

### DIFF
--- a/news/print-mocks-correctly.rst
+++ b/news/print-mocks-correctly.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Viewing mock objects in the shell
+
+**Security:**
+
+* <news item>

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -251,9 +251,11 @@ def _pprint_displayhook(value):
         builtins._ = value
         return
     env = builtins.__xonsh__.env
+    printed_val = None
     if env.get("PRETTY_PRINT_RESULTS"):
         printed_val = pretty(value)
-    else:
+    if not isinstance(printed_val, str):
+        # pretty may fail (i.e for unittest.mock.Mock)
         printed_val = repr(value)
     if HAS_PYGMENTS and env.get("COLOR_RESULTS"):
         tokens = list(pygments.lex(printed_val, lexer=pyghooks.XonshLexer()))


### PR DESCRIPTION
When evaluating mock objects, `pretty` returns the object's `.xonsh_display` attr which is itself a mock, and this fails later on:

![image](https://user-images.githubusercontent.com/18242949/89427183-a2109d80-d743-11ea-9410-9f6a10bf8c26.png)

We can handle it by calling `repr()` when it fails.