### PR TITLE
Fix regression with LC_MESSAGES missing in locale [No news entry needed.]

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -990,7 +990,9 @@ def DEFAULT_VARS():
             always_false,
             locale_convert("LC_MESSAGES"),
             ensure_string,
-            locale.setlocale(locale.LC_MESSAGES) if hasattr(locale, "LC_MESSAGES") else "",
+            locale.setlocale(locale.LC_MESSAGES)
+            if hasattr(locale, "LC_MESSAGES")
+            else "",
         ),
         "LC_MONETARY": Var(
             always_false,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -990,7 +990,7 @@ def DEFAULT_VARS():
             always_false,
             locale_convert("LC_MESSAGES"),
             ensure_string,
-            locale.setlocale(locale.LC_MESSAGES),
+            locale.setlocale(locale.LC_MESSAGES) if hasattr(locale, "LC_MESSAGES") else "",
         ),
         "LC_MONETARY": Var(
             always_false,


### PR DESCRIPTION
This fixes a regression introduced in #3377, 

The fact that LC_MESSAGES could be missing was handled before. 
https://github.com/xonsh/xonsh/pull/3377/files#diff-b08c376dd29024ccd6f9aef90f2ea96fL836-L838