### PR TITLE
Improve handling of f-strings

### DIFF
--- a/news/fstrings.rst
+++ b/news/fstrings.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Xonsh can now fully handle special Xonsh syntax within f-strings, including
+  environmnent variables within ``${}`` operator and captured subprocess
+  expansion within f-string expressions.
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ from xonsh.built_ins import (
     enter_macro,
     path_literal,
     _BuiltIns,
-    fstring_fields,
     eval_fstring_field,
 )
 from xonsh.execer import Execer
@@ -134,7 +133,6 @@ def xonsh_builtins(monkeypatch, xonsh_events):
     builtins.__xonsh__.list_of_list_of_strs_outer_product = (
         list_of_list_of_strs_outer_product
     )
-    builtins.__xonsh__.fstring_fields = fstring_fields
     builtins.__xonsh__.eval_fstring_field = eval_fstring_field
     builtins.__xonsh__.history = DummyHistory()
     builtins.__xonsh__.subproc_captured_stdout = sp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ from xonsh.built_ins import (
     enter_macro,
     path_literal,
     _BuiltIns,
+    fstring_fields,
+    eval_fstring_field,
 )
 from xonsh.execer import Execer
 from xonsh.jobs import tasks
@@ -132,6 +134,8 @@ def xonsh_builtins(monkeypatch, xonsh_events):
     builtins.__xonsh__.list_of_list_of_strs_outer_product = (
         list_of_list_of_strs_outer_product
     )
+    builtins.__xonsh__.fstring_fields = fstring_fields
+    builtins.__xonsh__.eval_fstring_field = eval_fstring_field
     builtins.__xonsh__.history = DummyHistory()
     builtins.__xonsh__.subproc_captured_stdout = sp
     builtins.__xonsh__.subproc_captured_inject = sp
@@ -160,5 +164,5 @@ def xonsh_builtins(monkeypatch, xonsh_events):
 
 def pytest_configure(config):
     """Abort test run if --flake8 requested, since it would hang on parser_test.py"""
-    if config.getoption('--flake8', ''):
+    if config.getoption("--flake8", ""):
         pytest.exit("pytest-flake8 no longer supported, use flake8 instead.")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -129,6 +129,7 @@ fstring_adaptor_parameters = [
     ('f"{$HOME}"', "/foo/bar"),
     ('f"{ $HOME }"', "/foo/bar"),
     ("f\"{'$HOME'}\"", "$HOME"),
+    ("f\"$HOME  = {$HOME}\"", "$HOME  = /foo/bar"),
     ("f\"{${'HOME'}}\"", "/foo/bar"),
     ("f'{${$FOO+$BAR}}'", "/foo/bar"),
     ("f\"${$FOO}{$BAR}={f'{$HOME}'}\"", "$HOME=/foo/bar"),

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -101,6 +101,7 @@ from ast import (
     dump,
     walk,
     increment_lineno,
+    Constant,
 )
 from ast import Ellipsis as EllipsisNode
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1061,13 +1061,8 @@ def list_of_list_of_strs_outer_product(x):
     return rtn
 
 
-fstring_fields = {}
-
-
-def eval_fstring_field(field_id):
-    """Looks up its argument in the fstring_fields and evaluates the result
-    in Xonsh context."""
-    field = fstring_fields.pop(field_id)
+def eval_fstring_field(field):
+    """Evaluates the argument in Xonsh context."""
     res = __xonsh__.execer.eval(
         field[0].strip(), glbs=globals(), locs=builtins.__xonsh__.ctx, filename=field[1]
     )
@@ -1417,8 +1412,6 @@ class XonshSession:
         self.ensure_list_of_strs = ensure_list_of_strs
         self.list_of_strs_or_callables = list_of_strs_or_callables
         self.list_of_list_of_strs_outer_product = list_of_list_of_strs_outer_product
-
-        self.fstring_fields = fstring_fields
         self.eval_fstring_field = eval_fstring_field
 
         self.completers = xonsh.completers.init.default_completers()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1061,6 +1061,19 @@ def list_of_list_of_strs_outer_product(x):
     return rtn
 
 
+fstring_fields = {}
+
+
+def eval_fstring_field(field_id):
+    """Looks up its argument in the fstring_fields and evaluates the result
+    in Xonsh context."""
+    field = fstring_fields.pop(field_id)
+    res = __xonsh__.execer.eval(
+        field[0].strip(), glbs=globals(), locs=builtins.__xonsh__.ctx, filename=field[1]
+    )
+    return res
+
+
 @lazyobject
 def MACRO_FLAG_KINDS():
     return {
@@ -1403,8 +1416,10 @@ class XonshSession:
         self.all_jobs = {}
         self.ensure_list_of_strs = ensure_list_of_strs
         self.list_of_strs_or_callables = list_of_strs_or_callables
-
         self.list_of_list_of_strs_outer_product = list_of_list_of_strs_outer_product
+
+        self.fstring_fields = fstring_fields
+        self.eval_fstring_field = eval_fstring_field
 
         self.completers = xonsh.completers.init.default_completers()
         self.call_macro = call_macro

--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -65,6 +65,7 @@ def run_compiled_code(code, glb, loc, mode):
     else:
         func = eval
     func(code, glb, loc)
+    builtins.__xonsh__.fstring_fields.clear()
 
 
 def get_cache_filename(fname, code=True):

--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -65,7 +65,6 @@ def run_compiled_code(code, glb, loc, mode):
     else:
         func = eval
     func(code, glb, loc)
-    builtins.__xonsh__.fstring_fields.clear()
 
 
 def get_cache_filename(fname, code=True):

--- a/xonsh/parsers/fstring_adaptor.py
+++ b/xonsh/parsers/fstring_adaptor.py
@@ -11,9 +11,9 @@ from xonsh.platform import PYTHON_VERSION_INFO
 @lazyobject
 def RE_FSTR_FIELD_WRAPPER():
     if PYTHON_VERSION_INFO > (3, 8):
-        return re.compile(r"__xonsh__\.eval_fstring_field\((\d+)\)\s*[^=]")
+        return re.compile(r"(__xonsh__\.eval_fstring_field\((\d+)\))\s*[^=]")
     else:
-        return re.compile(r"__xonsh__\.eval_fstring_field\((\d+)\)")
+        return re.compile(r"(__xonsh__\.eval_fstring_field\((\d+)\))")
 
 
 if PYTHON_VERSION_INFO > (3, 8):
@@ -96,10 +96,10 @@ class FStringAdaptor:
             match = RE_FSTR_FIELD_WRAPPER.search(value)
             if match is None:
                 continue
-            field = self.fields.pop(int(match.group(1)), None)
+            field = self.fields.pop(int(match.group(2)), None)
             if field is None:
                 continue
-            self.repl = self.repl.replace(match.group(0), field[0], 1)
+            self.repl = self.repl.replace(match.group(1), field[0], 1)
             reparse = True
 
         if reparse:

--- a/xonsh/parsers/fstring_adaptor.py
+++ b/xonsh/parsers/fstring_adaptor.py
@@ -1,0 +1,182 @@
+import re
+from xonsh.lazyasd import lazyobject
+from ast import parse as pyparse
+from xonsh import ast
+from xonsh.platform import PYTHON_VERSION_INFO
+
+
+@lazyobject
+def RE_FSTR_FIELD_WRAPPER():
+    if PYTHON_VERSION_INFO > (3, 8):
+        return re.compile(r"__xonsh__\.eval_fstring_field\((\d+)\)\s*[^=]")
+    else:
+        return re.compile(r"__xonsh__\.eval_fstring_field\((\d+)\)")
+
+
+if PYTHON_VERSION_INFO > (3, 8):
+
+    @lazyobject
+    def RE_FSTR_SELF_DOC_FIELD_WRAPPER():
+        return re.compile(r"(__xonsh__\.eval_fstring_field\((\d+)\)\s*)=")
+
+
+class FStringAdaptor:
+    def __init__(self, fstring, prefix, filename=None):
+        self.fstring = fstring
+        self.prefix = prefix
+        self.filename = filename
+        self.fields = {}
+        self.repl = ""
+        self.res = None
+
+    def _patch_special_syntax(self):
+        """Takes an fstring (and its prefix, ie f") that may contain
+        xonsh expressions as its field values and substitues them for
+        a call to __xonsh__.eval_fstring_field as needed.
+        """
+        prelen = len(self.prefix)
+        quote = self.fstring[prelen]
+        if self.fstring[prelen + 1] == quote:
+            quote *= 3
+        template = self.fstring[prelen + len(quote) : -len(quote)]
+        while True:
+            repl = self.prefix + quote + template + quote
+            try:
+                res = pyparse(repl)
+                break
+            except SyntaxError as e:
+                # The e.text attribute is expected to contain the failing
+                # expression, e.g. "($HOME)" for f"{$HOME}" string.
+                if e.text is None or e.text[0] != "(":
+                    raise
+                error_expr = e.text[1:-1]
+                epos = template.find(error_expr)
+                if epos < 0:
+                    raise
+            # We can olny get here in the case of handled SyntaxError.
+            # Patch the last error and start over.
+            xonsh_field = (error_expr, self.filename if self.filename else None)
+            field_id = id(xonsh_field)
+            self.fields[field_id] = xonsh_field
+            eval_field = f"__xonsh__.eval_fstring_field({field_id})"
+            template = template[:epos] + eval_field + template[epos + len(error_expr) :]
+
+        self.repl = repl
+        self.res = res.body[0].value
+
+    def _unpatch_strings(self):
+        """Reverts false-positive field matches within strings."""
+        reparse = False
+        for node in ast.walk(self.res):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                value = node.value
+            elif isinstance(node, ast.Str):
+                value = node.s
+            else:
+                continue
+
+            match = RE_FSTR_FIELD_WRAPPER.search(value)
+            if match is None:
+                continue
+            try:
+                field = self.fields.pop(int(match.group(1)))
+            except KeyError:
+                continue
+            self.repl = self.repl.replace(match.group(0), field[0], 1)
+            reparse = True
+
+        if reparse:
+            self.res = pyparse(self.repl).body[0].value
+
+    def _unpatch_selfdoc_strings(self):
+        """Reverts false-positive matches within Python 3.8 sef-documenting
+        f-string expressions."""
+        for node in ast.walk(self.res):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                value = node.value
+            elif isinstance(node, ast.Str):
+                value = node.s
+            else:
+                continue
+
+            match = RE_FSTR_SELF_DOC_FIELD_WRAPPER.search(value)
+            if match is None:
+                continue
+            field_id = int(match.group(2))
+            try:
+                field = self.fields[field_id]
+            except KeyError:
+                continue
+            value = value.replace(match.group(1), field[0], 1)
+            if isinstance(node, ast.Str):
+                node.s = value
+            else:
+                node.value = value
+
+    def _fix_eval_field_params(self):
+        """Replace f-string field ID placeholders with the actual field
+        expressions."""
+        for node in ast.walk(self.res):
+            if not (
+                isinstance(node, ast.Call)
+                and node.func.value.id == "__xonsh__"
+                and node.func.attr == "eval_fstring_field"
+                and len(node.args) > 0
+            ):
+                continue
+
+            if PYTHON_VERSION_INFO > (3, 8):
+                if isinstance(node.args[0], ast.Constant) and isinstance(
+                    node.args[0].value, int
+                ):
+                    try:
+                        field = self.fields.pop(node.args[0].value)
+                    except KeyError:
+                        continue
+                    lineno = node.args[0].lineno
+                    col_offset = node.args[0].col_offset
+                    field_node = ast.Tuple(
+                        elts=[
+                            ast.Constant(
+                                value=field[0], lineno=lineno, col_offset=col_offset
+                            ),
+                            ast.Constant(
+                                value=field[1], lineno=lineno, col_offset=col_offset
+                            ),
+                        ],
+                        ctx=ast.Load(),
+                        lineno=lineno,
+                        col_offset=col_offset,
+                    )
+                    node.args[0] = field_node
+            elif isinstance(node.args[0], ast.Num):
+                try:
+                    field = self.fields.pop(node.args[0].n)
+                except KeyError:
+                    continue
+                lineno = node.args[0].lineno
+                col_offset = node.args[0].col_offset
+                elts = [ast.Str(s=field[0], lineno=lineno, col_offset=col_offset)]
+                if field[1] is not None:
+                    elts.append(
+                        ast.Str(s=field[1], lineno=lineno, col_offset=col_offset)
+                    )
+                else:
+                    elts.append(
+                        ast.NameConstant(
+                            value=None, lineno=lineno, col_offset=col_offset
+                        )
+                    )
+                field_node = ast.Tuple(
+                    elts=elts, ctx=ast.Load(), lineno=lineno, col_offset=col_offset,
+                )
+                node.args[0] = field_node
+
+    def run(self):
+        self._patch_special_syntax()
+        self._unpatch_strings()
+        if PYTHON_VERSION_INFO > (3, 8):
+            self._unpatch_selfdoc_strings()
+        self._fix_eval_field_params()
+        assert len(self.fields) == 0
+        return self.res


### PR DESCRIPTION
This replaces the current method of scanning f-strings for special Xonsh syntax using `string.Formatter`. The current code does only work in the simplest cases, because the syntax of `__format__` fields is just not the same as the syntax of f-string expressions plus the current code is simply buggy.
The replacement code tries to parse the f-string using `ast.parse` and only steps in if the parser raises `SyntaxError`. It then attempts to locate the offending expression and replaces it by a wrapper call which in turn calls `evalx` with the failing expression as an argument. It can already handle complex strings:
```
$ a=18
$ f"""foo {$TERM!s:{a}} {f"hot {${'LA'+'NG'}:{a}} dog"} bar"""
'foo xterm-256color     hot en_US.UTF-8        dog bar'
```
It can even handle captured subprocess expansion within expressions:
```
$ echo f"""\"{${'TERM'}!s:10.{$(printf 5)}}\""""
"xterm     "
```

Closes #2822
Closes #3454
Closes #3572
Closes #3611
Closes #3655