### PR TITLE
Fix regression with LC_MESSAGES, don't add to environment unconditionally [no news article needed].

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -677,7 +677,7 @@ Var.__new__.__defaults__ = (
 # Please keep the following in alphabetic order - scopatz
 @lazyobject
 def DEFAULT_VARS():
-    return {
+    dv = {
         "ANSICON": Var(
             is_string,
             ensure_string,
@@ -985,14 +985,6 @@ def DEFAULT_VARS():
             locale_convert("LC_CTYPE"),
             ensure_string,
             locale.setlocale(locale.LC_CTYPE),
-        ),
-        "LC_MESSAGES": Var(
-            always_false,
-            locale_convert("LC_MESSAGES"),
-            ensure_string,
-            locale.setlocale(locale.LC_MESSAGES)
-            if hasattr(locale, "LC_MESSAGES")
-            else "",
         ),
         "LC_MONETARY": Var(
             always_false,
@@ -1675,6 +1667,16 @@ def DEFAULT_VARS():
             "Logging to a file is not enabled by default.",
         ),
     }
+
+    if hasattr(locale, "LC_MESSAGES"):
+        dv["LC_MESSAGES"] = Var(
+            always_false,
+            locale_convert("LC_MESSAGES"),
+            ensure_string,
+            locale.setlocale(locale.LC_MESSAGES),
+        )
+
+    return dv
 
 
 #


### PR DESCRIPTION
Improved fix for #3658, does not add `LC_MESSAGES` to environment if it's not defined in `locale`. Preapproved by @melund.