### PR TITLE
Create ExecAlias for aliases that contain IO operators

### DIFF
--- a/news/exec-aliases-on-io-operators.rst
+++ b/news/exec-aliases-on-io-operators.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Setting an alias with IO redirections (e.g ``ls | wc``) now works correctly.
+
+**Security:**
+
+* <news item>

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -128,3 +128,20 @@ def test_subprocess_logical_operators(xonsh_execer, xonsh_builtins, alias):
     ales = make_aliases()
     ales["echocat"] = alias
     assert isinstance(ales["echocat"], ExecAlias)
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "echo 'hi' | grep h",
+        "echo 'hi' > file",
+        "cat < file",
+        "COMMAND1 e>o < input.txt | COMMAND2 > output.txt e>> errors.txt",
+        "echo 'h|i' | grep h",
+        "echo 'h|i << x > 3' | grep x",
+    ],
+)
+def test_subprocess_io_operators(xonsh_execer, xonsh_builtins, alias):
+    ales = make_aliases()
+    ales["echocat"] = alias
+    assert isinstance(ales["echocat"], ExecAlias)

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -48,8 +48,8 @@ if ON_POSIX:
 
 
 @lazyobject
-def SUB_EXEC_ALIAS_RE():
-    return re.compile(r"@\(|\$\(|!\(|\$\[|!\[|\&\&|\|\||\s+and\s+|\s+or\s+")
+def EXEC_ALIAS_RE():
+    return re.compile(r"@\(|\$\(|!\(|\$\[|!\[|\&\&|\|\||\s+and\s+|\s+or\s+|[>|<]")
 
 
 class Aliases(cabc.MutableMapping):
@@ -128,8 +128,8 @@ class Aliases(cabc.MutableMapping):
     def __setitem__(self, key, val):
         if isinstance(val, str):
             f = "<exec-alias:" + key + ">"
-            if SUB_EXEC_ALIAS_RE.search(val) is not None:
-                # We have a sub-command, e.g. $(cmd), to evaluate
+            if EXEC_ALIAS_RE.search(val) is not None:
+                # We have a sub-command (e.g. $(cmd)) or IO redirect (e.g. >>)
                 self._raw[key] = ExecAlias(val, filename=f)
             elif isexpression(val):
                 # expansion substitution


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Currently after setting
```python
aliases['test'] = 'ls | wc'
```
Running `test` will result in `ls | wc` being printed to the screen.

The reason is `Aliases.__setitem__` parses this into a list instead of into an `ExecAlias` object.
The fix is to add the IO operators (`>`, `<`, and `|`) to the regex that decides whether to create an `ExecAlias` or not.