### PR TITLE
Only return string keys while iterating over __xonsh__.env

### DIFF
--- a/news/env-yield-str.rst
+++ b/news/env-yield-str.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Iterating over ``${...}`` or ``__xonsh__.env`` yields only string
+  values again.
+
+**Security:**
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals, print_function
 import os
 import itertools
+import re
 from tempfile import TemporaryDirectory
 from xonsh.tools import always_true
 
@@ -455,3 +456,10 @@ def test_deregister_custom_var():
     # gives it only default permissive validation, conversion
     del env["MY_SPECIAL_VAR"]
     env["MY_SPECIAL_VAR"] = 32
+
+
+def test_env_iterate():
+    env = Env(TEST=0)
+    env.register(re.compile("re"))
+    for key in env:
+        assert isinstance(key, str)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1971,7 +1971,9 @@ class Env(cabc.MutableMapping):
             return default
 
     def __iter__(self):
-        yield from (set(self._d) | set(self._vars))
+        for key in set(self._d) | set(self._vars):
+            if isinstance(key, str):
+                yield key
 
     def __contains__(self, item):
         return item in self._d or item in self._vars


### PR DESCRIPTION
Since #3377, the environment contains compiled regular expression patterns. Those `re.Pattern` objects are being returned as environment variable keys while iterating over `__xonsh__.env`. That unfortunately breaks the existing code, that expects the keys to be strings. For instance
```
  File "/home/str/code/xonsh/xonsh/completer.py", line 36, in complete
    out = func(prefix, line, begidx, endidx, ctx)
  File "/home/str/code/xonsh/xonsh/completers/path.py", line 335, in complete_path
    paths.update(filter(filtfunc, _env(prefix)))
  File "/home/str/code/xonsh/xonsh/completers/path.py", line 103, in _env
    return {
  File "/home/str/code/xonsh/xonsh/completers/path.py", line 104, in <setcomp>
    "$" + k for k in builtins.__xonsh__.env if get_filter_function()(k, key)
  File "/home/str/code/xonsh/xonsh/completers/tools.py", line 7, in _filter_normal
    return s.startswith(x)

Exception 're.Pattern' object has no attribute 'startswith'
```
This fixes the issue.