### PR TITLE
Only run ci once per PR / push

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,12 @@
 name: Black
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/elm.yml
+++ b/.github/workflows/elm.yml
@@ -1,6 +1,12 @@
 name: Check Elm
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/.github/workflows/pytest-linux-3.6.yml
+++ b/.github/workflows/pytest-linux-3.6.yml
@@ -1,6 +1,13 @@
 name: pytest linux 3.6
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-linux-3.7.yml
+++ b/.github/workflows/pytest-linux-3.7.yml
@@ -1,6 +1,13 @@
 name: pytest linux 3.7
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-linux-3.8.yml
+++ b/.github/workflows/pytest-linux-3.8.yml
@@ -1,6 +1,13 @@
 name: pytest linux 3.8
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-macos-3.6.yml
+++ b/.github/workflows/pytest-macos-3.6.yml
@@ -1,6 +1,13 @@
 name: pytest macos 3.6
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-macos-3.7.yml
+++ b/.github/workflows/pytest-macos-3.7.yml
@@ -1,6 +1,13 @@
 name: pytest macos 3.7
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-macos-3.8.yml
+++ b/.github/workflows/pytest-macos-3.8.yml
@@ -1,6 +1,13 @@
 name: pytest macos 3.8
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-windows-3.6.yml
+++ b/.github/workflows/pytest-windows-3.6.yml
@@ -1,6 +1,13 @@
 name: pytest windows 3.6
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-windows-3.7.yml
+++ b/.github/workflows/pytest-windows-3.7.yml
@@ -1,6 +1,13 @@
 name: pytest windows 3.7
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest-windows-3.8.yml
+++ b/.github/workflows/pytest-windows-3.8.yml
@@ -1,6 +1,13 @@
 name: pytest windows 3.8
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:

--- a/.github/workflows/pytest.tmpl
+++ b/.github/workflows/pytest.tmpl
@@ -8,7 +8,6 @@ on:
     branches:
     - master
 
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pytest.tmpl
+++ b/.github/workflows/pytest.tmpl
@@ -1,6 +1,13 @@
 name: pytest OS_NAME PYTHON_VERSION
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
 
 jobs:
   build:


### PR DESCRIPTION
Fixes a problem with github CI running twice in pull requests

~It also removes the Appveyor CI scripts. They don't seem to be used any more~ (OK: let us do that in an other PR)

No news item needed.