### PR TITLE
Allow for setting cursor position within expanded abbrev

### DIFF
--- a/news/abbrevs-set-cursor.rst
+++ b/news/abbrevs-set-cursor.rst
@@ -1,0 +1,31 @@
+**Added:**
+
+* ``abbrevs`` expansion now allows for setting cursor to a specific
+  position within the expanded abbrev. For instance
+  ::
+
+    abbrevs["eswap"] = "with ${...}.swap(<edit>):\n    "
+
+  expands ``eswap`` as you type to environment context manager
+  ``swap()`` syntax and places the cursor at the position of the
+  ``<edit>`` mark removing the mark itself in the process.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
`abbrevs` expansion now allows for setting cursor to a specific position within the expanded abbrev. For instance
```
abbrevs["eswap"] = "with ${...}.swap(<edit>):\n    "
```
 expands `eswap` as you type to environment context manager ``swap()`` syntax and places the cursor at the position of the `<edit>` mark removing the mark itself in the process.