### PR TITLE
Add shift selection from prompt-toolkit

### DIFF
--- a/news/shift-arrow.rst
+++ b/news/shift-arrow.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Borrow shift-selection from prompt-toolkit. Shift-arrow (selects a letter) and control-shift-arrow (selects a word) should now be supported.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -3,6 +3,7 @@
 import builtins
 
 from prompt_toolkit import search
+from prompt_toolkit.application.current import get_app
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import (
     Condition,
@@ -13,7 +14,8 @@ from prompt_toolkit.filters import (
     IsSearching,
 )
 from prompt_toolkit.keys import Keys
-from prompt_toolkit.application.current import get_app
+from prompt_toolkit.key_binding.key_bindings import KeyBindings, KeyBindingsBase
+from prompt_toolkit.key_binding.bindings.named_commands import get_by_name
 
 from xonsh.aliases import xonsh_exit
 from xonsh.tools import check_for_partial_string, get_line_continuation
@@ -165,7 +167,7 @@ def autopair_condition():
 @Condition
 def whitespace_or_bracket_before():
     """Check if there is whitespace or an opening
-       bracket to the left of the cursor"""
+    bracket to the left of the cursor"""
     d = get_app().current_buffer.document
     return bool(
         d.cursor_position == 0
@@ -177,7 +179,7 @@ def whitespace_or_bracket_before():
 @Condition
 def whitespace_or_bracket_after():
     """Check if there is whitespace or a closing
-       bracket to the right of the cursor"""
+    bracket to the right of the cursor"""
     d = get_app().current_buffer.document
     return bool(
         d.is_cursor_at_the_end_of_line
@@ -186,10 +188,11 @@ def whitespace_or_bracket_after():
     )
 
 
-def load_xonsh_bindings(key_bindings):
+def load_xonsh_bindings() -> KeyBindingsBase:
     """
     Load custom key bindings.
     """
+    key_bindings = KeyBindings()
     handle = key_bindings.add
     has_selection = HasSelection()
     insert_mode = ViInsertMode() | EmacsInsertMode()
@@ -357,3 +360,25 @@ def load_xonsh_bindings(key_bindings):
         during the previous command.
         """
         pass
+
+    @handle(Keys.ControlX, Keys.ControlX, filter=has_selection)
+    def _cut(event):
+        """ Cut selected text. """
+        data = event.current_buffer.cut_selection()
+        event.app.clipboard.set_data(data)
+
+    @handle(Keys.ControlX, Keys.ControlC, filter=has_selection)
+    def _copy(event):
+        """ Copy selected text. """
+        data = event.current_buffer.copy_selection()
+        event.app.clipboard.set_data(data)
+
+    @handle(Keys.ControlV, filter=insert_mode)
+    def _yank(event):
+        """ Paste selected text. """
+        buff = event.current_buffer
+        if buff.selection_state:
+            buff.cut_selection()
+        get_by_name("yank").call(event)
+
+    return key_bindings

--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -373,7 +373,7 @@ def load_xonsh_bindings() -> KeyBindingsBase:
         data = event.current_buffer.copy_selection()
         event.app.clipboard.set_data(data)
 
-    @handle(Keys.ControlV, filter=insert_mode)
+    @handle(Keys.ControlV, filter=insert_mode | has_selection)
     def _yank(event):
         """ Paste selected text. """
         buff = event.current_buffer

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -21,7 +21,10 @@ from prompt_toolkit import ANSI
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.enums import EditingMode
-from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.bindings.emacs import (
+    load_emacs_shift_selection_bindings,
+)
+from prompt_toolkit.key_binding.key_bindings import merge_key_bindings
 from prompt_toolkit.history import ThreadedHistory
 from prompt_toolkit.shortcuts import print_formatted_text as ptk_print
 from prompt_toolkit.shortcuts import CompleteStyle
@@ -91,8 +94,13 @@ class PromptToolkitShell(BaseShell):
         self.history = ThreadedHistory(PromptToolkitHistory())
         self.prompter = PromptSession(history=self.history)
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx, self)
-        self.key_bindings = KeyBindings()
-        load_xonsh_bindings(self.key_bindings)
+        self.key_bindings = merge_key_bindings(
+            [
+                load_xonsh_bindings(),
+                load_emacs_shift_selection_bindings(),
+            ]
+        )
+
         # Store original `_history_matches` in case we need to restore it
         self._history_matches_orig = self.prompter.default_buffer._history_matches
         # This assumes that PromptToolkitShell is a singleton
@@ -282,8 +290,7 @@ class PromptToolkitShell(BaseShell):
 
     @property
     def bottom_toolbar_tokens(self):
-        """Returns self._bottom_toolbar_tokens if it would yield a result
-        """
+        """Returns self._bottom_toolbar_tokens if it would yield a result"""
         if builtins.__xonsh__.env.get("BOTTOM_TOOLBAR"):
             return self._bottom_toolbar_tokens
 


### PR DESCRIPTION
This incorporates shift-selection from prompt-toolkit, as suggested here https://github.com/xonsh/xonsh/issues/3515

![Shift Selection](https://user-images.githubusercontent.com/3710083/90354492-7335d980-e017-11ea-9b49-052a90b5edeb.gif)

Sample of the functionality. I don't know why the gif is so slow 😛 

Note: this issue https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1157 will need to be fixed before shift-selection will work. I gave it a shot here https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1212/files