### PR TITLE
Restore correct behavior to DEFAULT_VARS that should not have defaults

### DIFF
--- a/news/env-no-default.rst
+++ b/news/env-no-default.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Values in DEFAULT_VARS that should not have defaults no longer have defaults.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Code that relies on certain environment variables not having defaults now
+  work again.
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1721,7 +1721,9 @@ class Env(cabc.MutableMapping):
         self._no_value = object()
         self._orig_env = None
         self._vars = {k: v for k, v in DEFAULT_VARS.items()}
-        self._defaults = {k: v.default for k, v in self._vars.items() if v.default is not None}
+        self._defaults = {
+            k: v.default for k, v in self._vars.items() if v.default is not None
+        }
 
         if len(args) == 0 and len(kwargs) == 0:
             args = (os_environ,)


### PR DESCRIPTION
This pull request addresses #3703, and probably some other related issues related to #3377. It restores pre-#3377 behavior to `environ.Env.__getitem__`, `__setitem__`, `__iter__`, and `__contains__` by removing the default values from the env vars `$XONSH_SOURCE`, `$OLDPWD`, `$VIRTUAL_ENV`, `$TERM`, `$XONSH_INTERACTIVE`, `$XONSH_GITSTATUS_*`, and `$ANSICON`. 

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
