### PR TITLE
THREAD_SUBPROCS=None for xonshrc files

### DIFF
--- a/news/nothreadrc.rst
+++ b/news/nothreadrc.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Run control files are now read in with ``$THREAD_SUBPROCS`` off.
+  This prevents a weird error when starting xonsh from Bash (and
+  possibly other shells) where the top-level xonsh process would
+  be stopped and placed into the background during startup. It
+  may be necessary to set ``$THREAD_SUBPROCS=False`` in downstream
+  xonsh scripts and modules.
+
+**Security:**
+
+* <news item>

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,6 +19,7 @@ from xonsh.tools import (
     always_true,
     argvquote,
     bool_or_int_to_str,
+    bool_or_none_to_str,
     bool_to_str,
     check_for_partial_string,
     dynamic_cwd_tuple_to_str,
@@ -32,6 +33,7 @@ from xonsh.tools import (
     find_next_break,
     is_bool,
     is_bool_or_int,
+    is_bool_or_none,
     is_callable,
     is_dynamic_cwd_width,
     is_env_path,
@@ -46,6 +48,7 @@ from xonsh.tools import (
     subproc_toks,
     to_bool,
     to_bool_or_int,
+    to_bool_or_none,
     to_dynamic_cwd_tuple,
     to_logfile_opt,
     pathsep_to_set,
@@ -1088,6 +1091,42 @@ def test_to_bool_or_int(inp, exp):
 def test_bool_or_int_to_str(inp, exp):
     obs = bool_or_int_to_str(inp)
     assert exp == obs
+
+
+@pytest.mark.parametrize("inp", [True, False, None])
+def test_is_bool_or_none_true(inp):
+    assert is_bool_or_none(inp)
+
+
+@pytest.mark.parametrize("inp", [1, "yooo hooo!"])
+def test_is_bool_or_none_false(inp):
+    assert not is_bool_or_none(inp)
+
+
+@pytest.mark.parametrize(
+    "inp, exp",
+    [
+        (True, True),
+        (False, False),
+        (None, None),
+        ("", False),
+        ("0", False),
+        ("False", False),
+        ("NONE", None),
+        ("TRUE", True),
+        ("1", True),
+        (0, False),
+        (1, True),
+    ],
+)
+def test_to_bool_or_none(inp, exp):
+    obs = to_bool_or_none(inp)
+    assert exp == obs
+
+
+@pytest.mark.parametrize("inp, exp", [(True, "1"), (False, ""), (None, "None")])
+def test_bool_or_none_to_str(inp, exp):
+    assert bool_or_none_to_str(inp) == exp
 
 
 @pytest.mark.parametrize(

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -41,6 +41,9 @@ from xonsh.tools import (
     is_bool,
     to_bool,
     bool_to_str,
+    is_bool_or_none,
+    to_bool_or_none,
+    bool_or_none_to_str,
     is_history_tuple,
     to_history_tuple,
     history_tuple_to_str,
@@ -1298,9 +1301,9 @@ def DEFAULT_VARS():
             doc_configurable=False,
         ),
         "THREAD_SUBPROCS": Var(
-            is_bool,
-            to_bool,
-            bool_to_str,
+            is_bool_or_none,
+            to_bool_or_none,
+            bool_or_none_to_str,
             True,
             "Whether or not to try to run subrocess mode in a Python thread, "
             "when applicable. There are various trade-offs, which normally "
@@ -1319,7 +1322,8 @@ def DEFAULT_VARS():
             "* Stopping the thread with ``Ctrl+Z`` yields to job control.\n"
             "* Threadable commands are run with ``Popen`` and threadable \n"
             "  alias are run with ``ProcProxy``.\n\n"
-            "The desired effect is often up to the command, user, or use case.",
+            "The desired effect is often up to the command, user, or use case.\n",
+            "None values are for internal use only.",
         ),
         "TITLE": Var(
             is_string,
@@ -2134,6 +2138,8 @@ def xonshrc_context(rcfiles=None, execer=None, ctx=None, env=None, login=True):
     ctx = {} if ctx is None else ctx
     if rcfiles is None:
         return env
+    orig_thread = env.get("THREAD_SUBPROCS")
+    env["THREAD_SUBPROCS"] = None
     env["XONSHRC"] = tuple(rcfiles)
     for rcfile in rcfiles:
         if not os.path.isfile(rcfile):
@@ -2142,6 +2148,8 @@ def xonshrc_context(rcfiles=None, execer=None, ctx=None, env=None, login=True):
         _, ext = os.path.splitext(rcfile)
         status = xonsh_script_run_control(rcfile, ctx, env, execer=execer, login=login)
         loaded.append(status)
+    if env["THREAD_SUBPROCS"] is None:
+        env["THREAD_SUBPROCS"] = orig_thread
     return ctx
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1171,6 +1171,11 @@ def is_bool(x):
     return isinstance(x, bool)
 
 
+def is_bool_or_none(x):
+    """Tests if something is a boolean or None."""
+    return (x is None) or isinstance(x, bool)
+
+
 def is_logfile_opt(x):
     """
     Checks if x is a valid $XONSH_TRACEBACK_LOGFILE option. Returns False
@@ -1234,6 +1239,20 @@ def to_bool(x):
         return bool(x)
 
 
+def to_bool_or_none(x):
+    """"Converts to a boolean or none in a semantically meaningful way."""
+    if x is None or isinstance(x, bool):
+        return x
+    elif isinstance(x, str):
+        low_x = x.lower()
+        if low_x == "none":
+            return None
+        else:
+            return False if x.lower() in _FALSES else True
+    else:
+        return bool(x)
+
+
 def to_itself(x):
     """No conversion, returns itself."""
     return x
@@ -1244,6 +1263,14 @@ def bool_to_str(x):
     True.
     """
     return "1" if x else ""
+
+
+def bool_or_none_to_str(x):
+    """Converts a bool or None value to a string."""
+    if x is None:
+        return "None"
+    else:
+        return "1" if x else ""
 
 
 _BREAKS = LazyObject(


### PR DESCRIPTION
This is related to the issue at https://github.com/regro/rever/issues/217.  I independently verified that even xonsh itself was having trouble starting up if any threaded subproc was used in rc files.  Super weird and hard to diagnose. The issue seems to have first arrived in the environment refactor (a8d4a57f01a25b1ce77f0a3adec1c0b11f49ad1a), but seems to be a side effect of that commit rather than directly caused by it.