### PR TITLE
vox: Fix virtual environment removal

### DIFF
--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -214,6 +214,9 @@ class VoxHandler:
                     file=sys.stderr,
                 )
                 return
+            except KeyError:
+                print('"%s" environment doesn\'t exist.\n' % name, file=sys.stderr)
+                return
             else:
                 print('Environment "%s" removed.' % name)
         print()

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -272,7 +272,10 @@ class Vox(collections.abc.Mapping):
             the current one (throws a KeyError if there isn't one).
         """
         if name is ...:
-            env_paths = [builtins.__xonsh__.env["VIRTUAL_ENV"]]
+            env = builtins.__xonsh__.env
+            if not env["VIRTUAL_ENV"]:
+                raise KeyError()
+            env_paths = [env["VIRTUAL_ENV"]]
         elif isinstance(name, PathLike):
             env_paths = [fspath(name)]
         else:


### PR DESCRIPTION
This is a follow-up to #3702.
No news item needed.

Virtual environment was impossible to delete after activation/deactivation cycle.