### PR TITLE
Fix list comprehensions with multiple if clauses

### DIFF
--- a/news/fix-multi-if-comps.rst
+++ b/news/fix-multi-if-comps.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* List comprehensions do not ignore the second and subsequent ``if`` clauses
+  in multi-if comprehension expressions any more.
+
+**Security:**
+
+* <news item>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -793,6 +793,10 @@ def test_listcomp_if_and():
     check_ast('[x for x in "mom" if True and x == "m"]')
 
 
+def test_listcomp_multi_if():
+    check_ast('[x for x in "mom" if True if x in "mo" if x == "m"]')
+
+
 def test_dbl_listcomp():
     check_ast('[x+y for x in "mom" for y in "dad"]')
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2844,6 +2844,7 @@ class BaseParser(object):
         p0 = {"if": [p2]}
         if p3 is not None:
             p0["comps"] = p3.get("comps", [])
+            p0["if"] += p3.get("if", [])
         p[0] = p0
 
     def p_yield_expr(self, p):

--- a/xonsh/parsers/v36.py
+++ b/xonsh/parsers/v36.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh parser for Python v3.6."""
 import xonsh.ast as ast
-from xonsh.parsers.base import store_ctx, ensure_has_elts, lopen_loc, BaseParser
+from xonsh.parsers.base import store_ctx, lopen_loc, BaseParser
 
 
 class Parser(BaseParser):
@@ -149,20 +149,9 @@ class Parser(BaseParser):
 
     def p_comp_for(self, p):
         """comp_for : FOR exprlist IN or_test comp_iter_opt"""
-        targs, it, p5 = p[2], p[4], p[5]
-        if len(targs) == 1:
-            targ = targs[0]
-        else:
-            targ = ensure_has_elts(targs)
-        store_ctx(targ)
+        super().p_comp_for(p)
         # only difference with base should be the is_async=0
-        comp = ast.comprehension(target=targ, iter=it, ifs=[], is_async=0)
-        comps = [comp]
-        p0 = {"comps": comps}
-        if p5 is not None:
-            comps += p5.get("comps", [])
-            comp.ifs += p5.get("if", [])
-        p[0] = p0
+        p[0]["comps"][0].is_async = 0
 
     def p_expr_stmt_annassign(self, p):
         """expr_stmt : testlist_star_expr COLON test EQUALS test"""


### PR DESCRIPTION
List comprehensions do not ignore the second and subsequent ``if`` clauses in multi-if comprehension expressions anymore.
For instance `[x for x in "mom" if True if x in "mo" if x == "m"]` comprehension now correctly yields `['m', 'm']`, whereas previously it yielded `['m', 'o', 'm']`, because the parser was only generating AST for the first `if True` condition.

Closes #3713