### PR TITLE
Add support for Python 3.8's starred expressions in return statement

### DIFF
--- a/news/return-star-expr.rst
+++ b/news/return-star-expr.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Support for starred expressions within return statement
+  (``return x, *my_list``).
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1580,6 +1580,10 @@ def test_return_x_y():
     check_stmts("return x, y", False)
 
 
+def test_return_x_starexpr():
+    check_stmts("return x, *[y, z]", False)
+
+
 def test_if_true():
     check_stmts("if True:\n  pass")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1560,6 +1560,14 @@ def test_yield_x_y():
     check_stmts("yield x, y", False)
 
 
+@pytest.mark.skipif(
+    VER_MAJOR_MINOR < (3, 8),
+    reason="Python 3.8 feature"
+)
+def test_return_x_starexpr():
+    check_stmts("yield x, *[y, z]", False)
+
+
 def test_yield_from_x():
     check_stmts("yield from x", False)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1580,6 +1580,10 @@ def test_return_x_y():
     check_stmts("return x, y", False)
 
 
+@pytest.mark.skipif(
+    VER_MAJOR_MINOR < (3, 8),
+    reason="Python 3.8 feature"
+)
 def test_return_x_starexpr():
     check_stmts("return x, *[y, z]", False)
 

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -429,3 +429,11 @@ class Parser(ThreeSixParser):
             lineno=p1.lineno,
             col_offset=p1.lexpos,
         )
+
+    def p_yield_arg_testlist(self, p):
+        # remove pre 3.8 grammar
+        pass
+
+    def p_yield_arg_testlist_star_expr(self, p):
+        """yield_arg : testlist_star_expr"""
+        p[0] = {"from": False, "val": p[1][0]}

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -33,6 +33,9 @@ class Parser(ThreeSixParser):
             The directory to place generated tables within.
         """
         # Rule creation and modification *must* take place before super()
+        opt_rules = ["testlist_star_expr"]
+        for rule in opt_rules:
+            self._opt_rule(rule)
         list_rules = ["comma_namedexpr_test_or_star_expr"]
         for rule in list_rules:
             self._list_rule(rule)
@@ -417,3 +420,12 @@ class Parser(ThreeSixParser):
                       | WHILE namedexpr_test COLON suite else_part
         """
         super().p_while_stmt(p)
+
+    def p_return_stmt(self, p):
+        """return_stmt : return_tok testlist_star_expr_opt"""
+        p1 = p[1]
+        p[0] = ast.Return(
+            value=p[2][0] if p[2] is not None else None,
+            lineno=p1.lineno,
+            col_offset=p1.lexpos,
+        )


### PR DESCRIPTION
Working towards Python 3.8 full compatibility.
This enables `return`s and `yield`s with starred expressions:
```python
def foo():
    mylist = [2, 3]
    return 1, *mylist
```
 