### PR TITLE
Add support for PEP 570 positional-only parameters

### DIFF
--- a/news/pos-only-args.rst
+++ b/news/pos-only-args.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for PEP 570 positional-only parameters.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,7 +11,7 @@ from xonsh.ast import AST, With, Pass, Str, Call
 from xonsh.parser import Parser
 from xonsh.parsers.fstring_adaptor import FStringAdaptor
 
-from tools import nodes_equal, skip_if_no_walrus, VER_MAJOR_MINOR
+from tools import nodes_equal, skip_if_pre_3_8, VER_MAJOR_MINOR
 
 
 @pytest.fixture(autouse=True)
@@ -1209,12 +1209,12 @@ def test_rshift_op_three():
     check_ast("42 >> 65 >> 1 >> 7")
 
 
-@skip_if_no_walrus
+@skip_if_pre_3_8
 def test_named_expr():
     check_ast("(x := 42)")
 
 
-@skip_if_no_walrus
+@skip_if_pre_3_8
 def test_named_expr_list():
     check_ast("[x := 42, x + 1, x + 2]")
 
@@ -1560,10 +1560,7 @@ def test_yield_x_y():
     check_stmts("yield x, y", False)
 
 
-@pytest.mark.skipif(
-    VER_MAJOR_MINOR < (3, 8),
-    reason="Python 3.8 feature"
-)
+@skip_if_pre_3_8
 def test_return_x_starexpr():
     check_stmts("yield x, *[y, z]", False)
 
@@ -1588,10 +1585,7 @@ def test_return_x_y():
     check_stmts("return x, y", False)
 
 
-@pytest.mark.skipif(
-    VER_MAJOR_MINOR < (3, 8),
-    reason="Python 3.8 feature"
-)
+@skip_if_pre_3_8
 def test_return_x_starexpr():
     check_stmts("return x, *[y, z]", False)
 
@@ -1943,10 +1937,12 @@ def test_func_x_star_y_kwargs():
     check_stmts("def f(x, *, y, **kwargs):\n  return 42")
 
 
+@skip_if_pre_3_8
 def test_func_x_divide():
     check_stmts("def f(x, /):\n  return 42")
 
 
+@skip_if_pre_3_8
 def test_func_x_divide_y_star_z_kwargs():
     check_stmts("def f(x, /, y, *, z, **kwargs):\n  return 42")
 
@@ -2057,22 +2053,22 @@ def test_async_await():
     check_stmts("async def f():\n    await fut\n", False)
 
 
-@skip_if_no_walrus
+@skip_if_pre_3_8
 def test_named_expr_args():
     check_stmts("id(x := 42)")
 
 
-@skip_if_no_walrus
+@skip_if_pre_3_8
 def test_named_expr_if():
     check_stmts("if (x := 42) > 0:\n  x += 1")
 
 
-@skip_if_no_walrus
+@skip_if_pre_3_8
 def test_named_expr_elif():
     check_stmts("if False:\n  pass\nelif x := 42:\n  x += 1")
 
 
-@skip_if_no_walrus
+@skip_if_pre_3_8
 def test_named_expr_while():
     check_stmts("y = 42\nwhile (x := y) < 43:\n  y += 1")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1041,6 +1041,11 @@ def test_lambda_x_star_y_kwargs():
     check_ast("lambda x, *, y, **kwargs: 42")
 
 
+@skip_if_pre_3_8
+def test_lambda_x_divide_y_star_z_kwargs():
+    check_ast("lambda x, /, y, *, z, **kwargs: 42")
+
+
 def test_call_range():
     check_ast("range(6)")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3132,3 +3132,11 @@ def test_syntax_error_augassign_cmp(exp):
 def test_syntax_error_bar_kwonlyargs():
     with pytest.raises(SyntaxError):
         PARSER.parse("def spam(*):\n   pass\n", mode="exec")
+
+def test_syntax_error_bar_posonlyargs():
+    with pytest.raises(SyntaxError):
+        PARSER.parse("def spam(/):\n   pass\n", mode="exec")
+
+def test_syntax_error_bar_posonlyargs_no_comma():
+    with pytest.raises(SyntaxError):
+        PARSER.parse("def spam(x /, y):\n   pass\n", mode="exec")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1943,6 +1943,14 @@ def test_func_x_star_y_kwargs():
     check_stmts("def f(x, *, y, **kwargs):\n  return 42")
 
 
+def test_func_x_divide():
+    check_stmts("def f(x, /):\n  return 42")
+
+
+def test_func_x_divide_y_star_z_kwargs():
+    check_stmts("def f(x, /, y, *, z, **kwargs):\n  return 42")
+
+
 def test_func_tx():
     check_stmts("def f(x:int):\n  return x")
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -30,7 +30,6 @@ ON_AZURE_PIPELINES = os.environ.get("TF_BUILD", "") == "True"
 print("ON_AZURE_PIPELINES", repr(ON_AZURE_PIPELINES))
 print("os.environ['TF_BUILD']", repr(os.environ.get("TF_BUILD", "")))
 TEST_DIR = os.path.dirname(__file__)
-HAS_WALRUS = VER_FULL > (3, 8)
 
 # pytest skip decorators
 skip_if_on_conda = pytest.mark.skipif(
@@ -53,7 +52,7 @@ skip_if_on_darwin = pytest.mark.skipif(ON_DARWIN, reason="not Mac friendly")
 
 skip_if_on_travis = pytest.mark.skipif(ON_TRAVIS, reason="not Travis CI friendly")
 
-skip_if_no_walrus = pytest.mark.skipif(not HAS_WALRUS, reason="no assignment expr.")
+skip_if_pre_3_8 = pytest.mark.skipif(VER_FULL < (3, 8), reason="Python >= 3.8 feature")
 
 
 def sp(cmd):

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -240,16 +240,19 @@ class Parser(ThreeSixParser):
         p[0] = p0
 
     def p_typedargslist_t12(self, p):
-        """typedargslist : posonlyargslist typedargslist_opt"""
-        if p[2] is None:
-            p0 = p[1]
-        else:
-            p0 = p[2]
+        """typedargslist : posonlyargslist comma_opt
+                         | posonlyargslist COMMA typedargslist
+        """
+        if len(p) == 4:
+            p0 = p[3]
             p0.posonlyargs = p[1].posonlyargs
+        else:
+            p0 = p[1]
         p[0] = p0
 
     def p_posonlyargslist(self, p):
-        """posonlyargslist : tfpdef equals_test_opt comma_tfpdef_list_opt DIVIDE comma_opt"""
+        """posonlyargslist : tfpdef equals_test_opt COMMA DIVIDE
+                           | tfpdef equals_test_opt comma_tfpdef_list COMMA DIVIDE"""
         p0 = ast.arguments(
             posonlyargs=[],
             args=[],
@@ -259,7 +262,10 @@ class Parser(ThreeSixParser):
             kwarg=None,
             defaults=[],
         )
-        self._set_posonly_args(p0, p[1], p[2], p[3])
+        if p[3] == ",":
+            self._set_posonly_args(p0, p[1], p[2], None)
+        else:
+            self._set_posonly_args(p0, p[1], p[2], p[3])
         p[0] = p0
 
     def p_varargslist_kwargs(self, p):

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -386,6 +386,35 @@ class Parser(ThreeSixParser):
         self._set_var_args(p0, p[6], p[7])
         p[0] = p0
 
+    def p_varargslist_t12(self, p):
+        """varargslist : posonlyvarargslist comma_opt
+                       | posonlyvarargslist COMMA varargslist
+        """
+        if len(p) == 4:
+            p0 = p[3]
+            p0.posonlyargs = p[1].posonlyargs
+        else:
+            p0 = p[1]
+        p[0] = p0
+
+    def p_posonlyvarargslist(self, p):
+        """posonlyvarargslist : vfpdef equals_test_opt COMMA DIVIDE
+                              | vfpdef equals_test_opt comma_vfpdef_list COMMA DIVIDE"""
+        p0 = ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
+        if p[3] == ",":
+            self._set_posonly_args(p0, p[1], p[2], None)
+        else:
+            self._set_posonly_args(p0, p[1], p[2], p[3])
+        p[0] = p0
+
     def p_lambdef(self, p):
         """lambdef : lambda_tok varargslist_opt COLON test"""
         p1, p2, p4 = p[1], p[2], p[4]


### PR DESCRIPTION
Adds Python 3.8 PEP 570 positional-only parameters:
```python
def foo(x, /, y):
    pass

min = lambda x, y, /: y if y < x else x
min(1, x=1)
TypeError: <lambda>() got some positional-only arguments passed as keyword arguments: 'x'
```