### PR TITLE
Raise error if non-default argument follows default argument

### DIFF
--- a/news/non-default-follows-default.rst
+++ b/news/non-default-follows-default.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Non-default parameters can not follow defaults anymore.
+
+**Security:**
+
+* <news item>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3138,10 +3138,36 @@ def test_syntax_error_bar_kwonlyargs():
     with pytest.raises(SyntaxError):
         PARSER.parse("def spam(*):\n   pass\n", mode="exec")
 
+
+@skip_if_pre_3_8
 def test_syntax_error_bar_posonlyargs():
     with pytest.raises(SyntaxError):
         PARSER.parse("def spam(/):\n   pass\n", mode="exec")
 
+
+@skip_if_pre_3_8
 def test_syntax_error_bar_posonlyargs_no_comma():
     with pytest.raises(SyntaxError):
         PARSER.parse("def spam(x /, y):\n   pass\n", mode="exec")
+
+
+def test_syntax_error_nondefault_follows_default():
+    with pytest.raises(SyntaxError):
+        PARSER.parse("def spam(x=1, y):\n   pass\n", mode="exec")
+
+
+@skip_if_pre_3_8
+def test_syntax_error_posonly_nondefault_follows_default():
+    with pytest.raises(SyntaxError):
+        PARSER.parse("def spam(x, y=1, /, z):\n   pass\n", mode="exec")
+
+
+def test_syntax_error_lambda_nondefault_follows_default():
+    with pytest.raises(SyntaxError):
+        PARSER.parse("lambda x=1, y: x", mode="exec")
+
+
+@skip_if_pre_3_8
+def test_syntax_error_lambda_posonly_nondefault_follows_default():
+    with pytest.raises(SyntaxError):
+        PARSER.parse("lambda x, y=1, /, z: x", mode="exec")

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -963,8 +963,7 @@ class BaseParser(object):
             if kwargs or (d is not None):
                 defs.append(d)
             elif defs:
-                loc = self.currloc(self.lineno, self.col)
-                self._parse_error("non-default argument follows default argument", loc)
+                self._set_error("non-default argument follows default argument")
 
     def _set_regular_args(self, p0, p1, p2, p3, p4):
         if p2 is None and p3 is None:

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -962,6 +962,9 @@ class BaseParser(object):
             d = v["default"]
             if kwargs or (d is not None):
                 defs.append(d)
+            elif defs:
+                loc = self.currloc(self.lineno, self.col)
+                self._parse_error("non-default argument follows default argument", loc)
 
     def _set_regular_args(self, p0, p1, p2, p3, p4):
         if p2 is None and p3 is None:

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -58,8 +58,7 @@ class Parser(ThreeSixParser):
             if d is not None:
                 argmts.defaults.append(d)
             elif argmts.defaults:
-                loc = self.currloc(self.lineno, self.col)
-                self._parse_error("non-default argument follows default argument", loc)
+                self._set_error("non-default argument follows default argument")
 
     def _set_posonly_args(self, p0, p1, p2, p3):
         if p2 is None and p3 is None:
@@ -251,8 +250,7 @@ class Parser(ThreeSixParser):
             p0.posonlyargs = p[1].posonlyargs
             # If posonlyargs contain default arguments, all following arguments must have defaults.
             if p[1].defaults and (len(p[3].defaults) != len(p[3].args)):
-                loc = self.currloc(self.lineno, self.col)
-                self._parse_error("non-default argument follows default argument", loc)
+                self._set_error("non-default argument follows default argument")
         else:
             p0 = p[1]
         p[0] = p0
@@ -402,8 +400,7 @@ class Parser(ThreeSixParser):
             p0.posonlyargs = p[1].posonlyargs
             # If posonlyargs contain default arguments, all following arguments must have defaults.
             if p[1].defaults and (len(p[3].defaults) != len(p[3].args)):
-                loc = self.currloc(self.lineno, self.col)
-                self._parse_error("non-default argument follows default argument", loc)
+                self._set_error("non-default argument follows default argument")
         else:
             p0 = p[1]
         p[0] = p0

--- a/xonsh/parsers/v38.py
+++ b/xonsh/parsers/v38.py
@@ -57,6 +57,9 @@ class Parser(ThreeSixParser):
             d = v["default"]
             if d is not None:
                 argmts.defaults.append(d)
+            elif argmts.defaults:
+                loc = self.currloc(self.lineno, self.col)
+                self._parse_error("non-default argument follows default argument", loc)
 
     def _set_posonly_args(self, p0, p1, p2, p3):
         if p2 is None and p3 is None:
@@ -246,6 +249,10 @@ class Parser(ThreeSixParser):
         if len(p) == 4:
             p0 = p[3]
             p0.posonlyargs = p[1].posonlyargs
+            # If posonlyargs contain default arguments, all following arguments must have defaults.
+            if p[1].defaults and (len(p[3].defaults) != len(p[3].args)):
+                loc = self.currloc(self.lineno, self.col)
+                self._parse_error("non-default argument follows default argument", loc)
         else:
             p0 = p[1]
         p[0] = p0
@@ -393,6 +400,10 @@ class Parser(ThreeSixParser):
         if len(p) == 4:
             p0 = p[3]
             p0.posonlyargs = p[1].posonlyargs
+            # If posonlyargs contain default arguments, all following arguments must have defaults.
+            if p[1].defaults and (len(p[3].defaults) != len(p[3].args)):
+                loc = self.currloc(self.lineno, self.col)
+                self._parse_error("non-default argument follows default argument", loc)
         else:
             p0 = p[1]
         p[0] = p0


### PR DESCRIPTION
Prevents parser from accepting argument lists where non-default parameter follows default parameter (`def foo(x=1, y):`)

Closes #3721