### PR TITLE
Stick to Black v19.10b0 for now

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Black Check
-      uses: "lgeiger/black-action@master"
+      uses: "laloch/black-action@master"
       with:
         args: "--check xonsh/ xontrib/"


### PR DESCRIPTION
Current Black 20.8b0 version doesn't quite suite our needs right now.
This reverts back to v19.10b0 to make our CI green again.

It uses adjusted black-action from [laloch/black-action](http://github.com/laloch/black-action).