### PR TITLE
Fixed incorrect reference to XONSH_HIST_SIZE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,9 +87,9 @@ v0.9.19
 * JsonHistoryGC: display following warning when garbage collection would delete "too" much data and don't delete anything.
 
   "Warning: History garbage collection would discard more history ({size_over} {units}) than it would keep ({limit_size}).\n"
-  "Not removing any history for now. Either increase your limit ($XONSH_HIST_SIZE), or run ``history gc --force``.",
+  "Not removing any history for now. Either increase your limit ($XONSH_HISTORY_SIZE), or run ``history gc --force``.",
 
-  It is displayed when the amount of history on disk is more than double the limit configured (or defaulted) for $XONSH_HIST_SIZE.
+  It is displayed when the amount of history on disk is more than double the limit configured (or defaulted) for $XONSH_HISTORY_SIZE.
 * $LS_COLORS code 'mh' now recognized for (multi) hard-linked files.
 * $LS_COLORS code 'ca' now recognized for files with security capabilities (linux only).
 * CI step to run flake8 after pytest.

--- a/news/incorrect-XONSH_HIST_SIZE-env.rst
+++ b/news/incorrect-XONSH_HIST_SIZE-env.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed incorrect reference to XONSH_HIST_SIZE instead of XONSH_HISTORY_SIZE
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -162,7 +162,7 @@ class JsonHistoryGC(threading.Thread):
         else:
             print(
                 f"Warning: History garbage collection would discard more history ({size_over} {units}) than it would keep ({hsize}).\n"
-                "Not removing any history for now. Either increase your limit ($XONSH_HIST_SIZE), or run `history gc --force`."
+                "Not removing any history for now. Either increase your limit ($XONSH_HISTORY_SIZE), or run `history gc --force`."
             )
 
     def files(self, only_unlocked=False):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Fixed incorrect reference to $XONSH_HIST_SIZE instead of $XONSH_HISTORY_SIZE