### PR TITLE
Run in Python 3.9

### DIFF
--- a/news/run-on-python39.rst
+++ b/news/run-on-python39.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Xonsh now runs in Python 3.9
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -484,6 +484,9 @@ class Lexer(object):
     @property
     def tokens(self):
         if self._tokens is None:
+            kwlist = kwmod.kwlist[:]
+            if PYTHON_VERSION_INFO >= (3, 9, 0) and PYTHON_VERSION_INFO < (3, 10):
+                kwlist.remove("__peg_parser__")
             t = (
                 tuple(token_map.values())
                 + (
@@ -505,7 +508,7 @@ class Lexer(object):
                     "ATDOLLAR_LPAREN",  # @$(
                     "ERRORTOKEN",  # whoops!
                 )
-                + tuple(i.upper() for i in kwmod.kwlist)
+                + tuple(i.upper() for i in kwlist)
             )
             self._tokens = t
         return self._tokens

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2169,7 +2169,9 @@ class BaseParser(object):
             return leader
         p0 = leader
         for trailer in trailers:
-            if isinstance(trailer, (ast.Index, ast.Slice, ast.ExtSlice)):
+            if isinstance(
+                trailer, (ast.Index, ast.Slice, ast.ExtSlice, ast.Constant, ast.Name)
+            ):
                 p0 = ast.Subscript(
                     value=leader,
                     slice=trailer,

--- a/xonsh/parsers/v36.py
+++ b/xonsh/parsers/v36.py
@@ -130,7 +130,10 @@ class Parser(BaseParser):
 
     def p_argument_kwargs(self, p):
         """argument : POW test"""
-        p[0] = ast.keyword(arg=None, value=p[2])
+        p2 = p[2]
+        p[0] = ast.keyword(
+            arg=None, value=p2, lineno=p2.lineno, col_offset=p2.col_offset
+        )
 
     def p_argument_args(self, p):
         """argument : TIMES test"""
@@ -145,7 +148,10 @@ class Parser(BaseParser):
 
     def p_argument_eq(self, p):
         """argument : test EQUALS test"""
-        p[0] = ast.keyword(arg=p[1].id, value=p[3])
+        p3 = p[3]
+        p[0] = ast.keyword(
+            arg=p[1].id, value=p3, lineno=p3.lineno, col_offset=p3.col_offset
+        )
 
     def p_comp_for(self, p):
         """comp_for : FOR exprlist IN or_test comp_iter_opt"""


### PR DESCRIPTION
Make Xonsh run in Python 3.9

There's a lot of parser test cases failing in Python 3.9, but at least the shell runs and integration tests are green.

Closes #3618