### PR TITLE
Fix video playback on xon.sh landing page

### DIFF
--- a/docs/_static/landing/js/theme.js
+++ b/docs/_static/landing/js/theme.js
@@ -77,7 +77,16 @@
         mainClass: 'mfp-fade',
         removalDelay: 160,
         preloader: false,
-        fixedContentPos: false
+        fixedContentPos: false,
+        iframe: {
+            patterns: {
+                youtube_short: {
+                    index: 'youtu.be/',
+                    id: 'youtu.be/',
+                    src: 'http://www.youtube.com/embed/%id%?autoplay=1'
+                }
+            }
+        }
     });
 
 


### PR DESCRIPTION
This fixes browsers complaining about
> Refused to display 'https://www.youtube.com/watch?v=uaje5I22kgE&feature=youtu.be' in a frame because it set 'X-Frame-Options' to 'sameorigin'."

We need to expand the shortened youtu.be link ourselves in order to be able to play it within an iframe.

No news item needed.