### PR TITLE
Environment fixes -for unregistered, undefined env vars, return empty string, yet don't consider them "in" environ either.

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -2,10 +2,9 @@
 """Tests the xonsh environment."""
 from __future__ import unicode_literals, print_function
 import os
-import itertools
 import re
 from tempfile import TemporaryDirectory
-from xonsh.tools import always_true
+from xonsh.tools import always_true, DefaultNotGiven
 
 import pytest
 
@@ -13,7 +12,6 @@ from xonsh.commands_cache import CommandsCache
 from xonsh.environ import (
     Env,
     locate_binary,
-    DEFAULT_VARS,
     default_env,
     make_args_env,
     LsColors,
@@ -357,7 +355,7 @@ def test_register_custom_var_generic():
     assert env["MY_SPECIAL_VAR"] == 32
 
     env["MY_SPECIAL_VAR"] = True
-    assert env["MY_SPECIAL_VAR"] == True
+    assert env["MY_SPECIAL_VAR"] == True  # NOQA E712
 
 
 def test_register_custom_var_int():
@@ -480,3 +478,24 @@ def test_env_iterate_rawkeys():
         elif isinstance(key, type(r)) and key.pattern == "re":
             saw_regex = True
     assert saw_regex
+
+
+def test_env_get_defaults():
+    """Verify the rather complex rules for env.get("<envvar>",default) value when envvar is not defined.
+    """
+
+    env = Env(TEST1=0)
+    env.register("TEST_REG", default="abc")
+    env.register("TEST_REG_DNG", default=DefaultNotGiven)
+
+    # var is defined, registered is don't-care => value is defined value
+    assert env.get("TEST1", 22) == 0
+    # var not defined, not registered => value is immediate default
+    assert env.get("TEST2", 22) == 22
+    assert "TEST2" not in env
+    # var not defined, is registered, reg default is not sentinel => value is *registered* default
+    assert env.get("TEST_REG", 22) == "abc"
+    assert "TEST_REG" in env
+    # var not defined, is registered, reg default is sentinel => value is *immediate* default
+    assert env.get("TEST_REG_DNG", 22) == 22
+    assert "TEST_REG_DNG" not in env

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -109,7 +109,7 @@ class DummyEnv(MutableMapping):
     DEFAULTS = {
         "XONSH_DEBUG": 1,
         "XONSH_COLOR_STYLE": "default",
-        "VIRTUAL_ENV": "",
+        # "VIRTUAL_ENV": "",
     }
 
     def __init__(self, *args, **kwargs):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2018,7 +2018,7 @@ class Env(cabc.MutableMapping):
 
     def __contains__(self, item):
         return item in self._d or (
-            item in self._vars and self._vars[item] is not DefaultNotGiven
+            item in self._vars and self._vars[item].default is not DefaultNotGiven
         )
 
     def __len__(self):

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -273,8 +273,6 @@ class Vox(collections.abc.Mapping):
         """
         if name is ...:
             env = builtins.__xonsh__.env
-            if not env["VIRTUAL_ENV"]:
-                raise KeyError()
             env_paths = [env["VIRTUAL_ENV"]]
         elif isinstance(name, PathLike):
             env_paths = [fspath(name)]
@@ -336,7 +334,7 @@ class Vox(collections.abc.Mapping):
         Returns None if no environment is active.
         """
         env = builtins.__xonsh__.env
-        if not env["VIRTUAL_ENV"]:
+        if "VIRTUAL_ENV" not in env:
             return
         env_path = env["VIRTUAL_ENV"]
         if env_path.startswith(self.venvdir):
@@ -358,7 +356,7 @@ class Vox(collections.abc.Mapping):
         """
         env = builtins.__xonsh__.env
         ve = self[name]
-        if env["VIRTUAL_ENV"]:
+        if "VIRTUAL_ENV" in env:
             self.deactivate()
 
         type(self).oldvars = {"PATH": list(env["PATH"])}
@@ -374,7 +372,7 @@ class Vox(collections.abc.Mapping):
         Deactivate the active virtual environment. Returns its name.
         """
         env = builtins.__xonsh__.env
-        if not env["VIRTUAL_ENV"]:
+        if "VIRTUAL_ENV" not in env:
             raise NoEnvironmentActive("No environment currently active.")
 
         env_name = self.active()


### PR DESCRIPTION
Proposed fix for #3739 and #3703 
Draft status, pending one pesky problem..