### PR TITLE
Add optional variable initializers preceding command

### DIFF
--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -55,9 +55,9 @@ line is ``#!/usr/bin/env xonsh``.
       - ``_.rtn``
       - Returns the exit code, or status, of the previous command.
     * - ``N=V command``
-      - ``with ${...}.swap(N=V): command``
-      - Set temporary environment variable(s) and execute for command.
-        Use an indented block to execute many commands in the same context.
+      - ``$N=V command`` or ``with ${...}.swap(N=V): command``
+      - Set temporary environment variable(s) and execute the command.
+        Use the second notation with an indented block to execute many commands in the same context.
     * - ``!$``
       - ``__xonsh__.history[-1, -1]``
       - Get the last argument of the last command

--- a/news/simple-variables.rst
+++ b/news/simple-variables.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Xonsh now supports bash-style variable assignments preceding
+  subprocess commands (e.g. ``$FOO = "bar" bash -c r"echo $FOO"``).
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -499,6 +499,7 @@ def test_script_stderr(case):
         ("pwd", None, lambda: os.getcwd() + "\n"),
         ("echo WORKING", None, "WORKING\n"),
         ("ls -f", lambda out: out.splitlines().sort(), os.listdir().sort()),
+        ("$FOO='foo' $BAR=2 xonsh -c r'echo -n $FOO$BAR'", None, "foo2",),
     ],
 )
 def test_single_command_no_windows(cmd, fmt, exp):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2501,6 +2501,10 @@ def test_ls_quotes_3_space():
     check_xonsh_ast({}, '$[ls "wakka jawaka baraka"]', False)
 
 
+def test_leading_envvar_assignment():
+    check_xonsh_ast({}, "![$FOO= 'foo' $BAR =2 echo r'$BAR']", False)
+
+
 def test_echo_comma():
     check_xonsh_ast({}, "![echo ,]", False)
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -454,7 +454,13 @@ class SubprocSpec:
         self.universal_newlines = universal_newlines
         self.close_fds = close_fds
         self.captured = captured
-        self.env = env
+        if env is not None:
+            self.env = {
+                k: v if not (isinstance(v, list)) or len(v) > 1 else v[0]
+                for (k, v) in env.items()
+            }
+        else:
+            self.env = None
         # pure attrs
         self.args = list(cmd)
         self.alias = None

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -3333,15 +3333,15 @@ class BaseParser(object):
         p[0] = p[1]
 
     def p_envvar_assign(self, p):
-        """envvar_assign : envvar_assign_left test WS"""
+        """envvar_assign : envvar_assign_left test WS
+                         | envvar_assign_left subproc_atom WS
+        """
         p1, p2 = p[1], p[2]
         p[0] = ast.Dict(
             keys=[
                 ast.Constant(value=p1.value[1:], lineno=p1.lineno, col_offset=p1.lexpos)
             ],
-            values=[
-                ast.Constant(value=p2.value, lineno=p2.lineno, col_offset=p2.col_offset)
-            ],
+            values=[p2],
             lineno=p1.lineno,
             col_offset=p1.lexpos,
         )

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2885,6 +2885,26 @@ class BaseParser(object):
     # subprocess
     #
 
+    def _get_envvars(self, p, lineno, col):
+        """Get replacement environment from subproc_atoms, return None or
+        ast.List containing ast.Dict for each subproc_atom in the pipeline.
+        """
+        if not isinstance(p, list):
+            return None
+        has_env = False
+        envs = empty_list(lineno=lineno, col=col)
+        for subproc in p:
+            if hasattr(subproc, "_xenvvars"):
+                has_env = True
+                envs.elts.append(subproc._xenvvars)
+            else:
+                envs.elts.append(
+                    ast.Constant(
+                        value=None, lineno=subproc.lineno, col_offset=subproc.col_offset
+                    )
+                )
+        return envs if has_env else None
+
     def _dollar_rules(self, p):
         """These handle the special xonsh $ shell atoms by looking up
         in a special __xonsh__.env dictionary injected in the __builtin__.
@@ -2920,6 +2940,11 @@ class BaseParser(object):
             p0 = xonsh_call("__xonsh__.subproc_uncaptured", p2, lineno=lineno, col=col)
         else:
             assert False
+
+        envs = self._get_envvars(p2, lineno, col)
+        if envs is not None:
+            p0.keywords.append(ast.keyword(arg="envs", value=envs))
+
         return p0
 
     def _envvar_getter_by_name(self, var, lineno=None, col=None):
@@ -2974,6 +2999,8 @@ class BaseParser(object):
             else:
                 raise ValueError("action not understood: " + action)
             del arg._cliarg_action
+        if hasattr(args[0], "_xenvvars"):
+            setattr(cliargs, "_xenvvars", args[0]._xenvvars)
         return cliargs
 
     def p_pipe(self, p):
@@ -3042,6 +3069,18 @@ class BaseParser(object):
         for arg in p0:
             arg._cliarg_action = "append"
         p[0] = p0
+
+    def p_envvar_assign_subproc_atoms(self, p):
+        """subproc_atoms : envvar_assign subproc_atoms
+                         | envvar_assign subproc_atoms WS
+        """
+        p1, p20 = p[1], p[2][0]
+        if hasattr(p20, "_xenvvars"):
+            p20._xenvvars.keys.append(p1.keys[0])
+            p20._xenvvars.values.append(p1.values[0])
+        else:
+            setattr(p20, "_xenvvars", p1)
+        p[0] = p[2]
 
     #
     # Subproc atom rules
@@ -3142,11 +3181,14 @@ class BaseParser(object):
         """subproc_atom : atdollar_lparen_tok subproc RPAREN
            subproc_arg_part : atdollar_lparen_tok subproc RPAREN
         """
-        p1 = p[1]
+        p1, p2 = p[1], p[2]
         p0 = xonsh_call(
-            "__xonsh__.subproc_captured_inject", p[2], lineno=p1.lineno, col=p1.lexpos
+            "__xonsh__.subproc_captured_inject", p2, lineno=p1.lineno, col=p1.lexpos
         )
         p0._cliarg_action = "extend"
+        envs = self._get_envvars(p2, lineno=p2[0].lineno, col=p2[0].col_offset)
+        if envs is not None:
+            p0.keywords.append(ast.keyword(arg="envs", value=envs))
         p[0] = p0
 
     def p_subproc_atom_subproc_inject_bang_empty(self, p):
@@ -3281,6 +3323,28 @@ class BaseParser(object):
         # Use a string atom instead. See above attachment functions
         p1 = p[1]
         p[0] = ast.Str(s=p1.value, lineno=p1.lineno, col_offset=p1.lexpos)
+
+    def p_envvar_assign_left(self, p):
+        """envvar_assign_left : dollar_name_tok EQUALS
+                              | dollar_name_tok WS EQUALS
+                              | dollar_name_tok EQUALS WS
+                              | dollar_name_tok WS EQUALS WS
+        """
+        p[0] = p[1]
+
+    def p_envvar_assign(self, p):
+        """envvar_assign : envvar_assign_left test WS"""
+        p1, p2 = p[1], p[2]
+        p[0] = ast.Dict(
+            keys=[
+                ast.Constant(value=p1.value[1:], lineno=p1.lineno, col_offset=p1.lexpos)
+            ],
+            values=[
+                ast.Constant(value=p2.value, lineno=p2.lineno, col_offset=p2.col_offset)
+            ],
+            lineno=p1.lineno,
+            col_offset=p1.lexpos,
+        )
 
     #
     # Helpers


### PR DESCRIPTION
This adds support for bash-like environment variable assignments preceding subprocess command.
```
$ $FOO="foo" $BAR=2 xonsh -c r"echo $FOO$BAR"
foo2
$ # Also works in pipelines...
$ $FOO="foo" $BAR=2 xonsh -c r"echo -n $FOO$BAR" | $FOO="nofoo" xonsh -c r"cat; echo $FOO"
foo2nofoo
```