### PR TITLE
xontrib-argcomplete

### DIFF
--- a/news/argcomplete.rst
+++ b/news/argcomplete.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added xontrib-argcomplete to support kislyuk/argcomplete - tab completion for argparse.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -17,6 +17,11 @@
   "url": "https://github.com/DangerOnTheRanger/xonsh-apt-tabcomplete",
   "description": ["Adds tabcomplete functionality to apt-get/apt-cache inside of xonsh."]
  },
+ {"name": "argcomplete",
+  "package": "xontrib-argcomplete",
+  "url": "https://github.com/anki-code/xontrib-argcomplete",
+  "description": ["Adding support of kislyuk/argcomplete to xonsh."]
+ },
  {"name": "autojump",
   "package": "xontrib-autojump",
   "url": "https://github.com/sagartewari01/autojump-xonsh",


### PR DESCRIPTION
Added [xontrib-argcomplete](https://github.com/anki-code/xontrib-argcomplete) to support [kislyuk/argcomplete](https://github.com/kislyuk/argcomplete) - tab completion for argparse.

Closes  #1409