### PR TITLE
Black ptk_shell

### DIFF
--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -95,10 +95,7 @@ class PromptToolkitShell(BaseShell):
         self.prompter = PromptSession(history=self.history)
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx, self)
         self.key_bindings = merge_key_bindings(
-            [
-                load_xonsh_bindings(),
-                load_emacs_shift_selection_bindings(),
-            ]
+            [load_xonsh_bindings(), load_emacs_shift_selection_bindings()]
         )
 
         # Store original `_history_matches` in case we need to restore it


### PR DESCRIPTION
This only fixes formatting in xonsh/ptk_shell/shell.py, that someone recently merged despite the black test failing.

No news item needed.