### PR TITLE
Docs for keyboard shortcuts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -440,5 +440,5 @@ builtins.__xonsh__.commands_cache = CommandsCache()
 def setup(app):
     from xonsh.pyghooks import XonshConsoleLexer
 
-    app.add_lexer("xonshcon", XonshConsoleLexer())
+    app.add_lexer("xonshcon", XonshConsoleLexer)
     app.add_css_file("custom.css")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -440,5 +440,5 @@ builtins.__xonsh__.commands_cache = CommandsCache()
 def setup(app):
     from xonsh.pyghooks import XonshConsoleLexer
 
-    app.add_lexer("xonshcon", XonshConsoleLexer)
+    app.add_lexer("xonshcon", XonshConsoleLexer())
     app.add_css_file("custom.css")

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -19,3 +19,4 @@ Guides
     bash_to_xsh
     subproc_types
     python_virtual_environments
+    keyboard_shortcuts

--- a/docs/keyboard_shortcuts.rst
+++ b/docs/keyboard_shortcuts.rst
@@ -1,0 +1,34 @@
+.. _keyboard_shortcuts:
+
+******************
+Keyboard Shortcuts
+******************
+Xonsh comes pre-baked with a few keyboard shortcuts. The following is only available under the prompt-toolkit shell.
+
+.. list-table::
+    :widths: 40 60
+    :header-rows: 1
+
+    * - Shortcut
+      - Description
+    * - Ctrl-X + Ctrl-E
+      - Open the current buffer in your default text editor.
+    * - Ctrl-D
+      - Exit xonsh and return to original terminal. If not called by another terminal, then exit current terminal window. Similar to ``exit``.
+    * - Ctrl-J
+      - | Similar to enter in a few respects:
+        | 1. Execute the current buffer.
+        | 2. End and execute a multiline statement.
+    * - Ctrl-M
+      - Same as Ctrl-J
+    * - Shift-Left OR Shift-Right *[Beta]*
+      - Highlight one character in either direction
+    * - Ctrl-Shift-Left OR Ctrl-Shift-Right *[Beta]*
+      - Highlight one word in either direction
+    * - Ctrl-X + Ctrl-C *[Beta]*
+      - Copy highlighted section
+    * - Ctrl-X + Ctrl-X *[Beta]*
+      - Cut highlighted section
+    * - Ctrl-V *[Beta]*
+      - Paste clipboard contents
+

--- a/news/shortcut-docs.rst
+++ b/news/shortcut-docs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Documentation for keyboard shortcuts
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Figured it might be nice to follow up the shift-selection ticket with a doc page on all the various keyboard shortcuts available to xonsh.