### PR TITLE
Fix error on xontribs loading

### DIFF
--- a/news/xontrib-shift-select.rst
+++ b/news/xontrib-shift-select.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed issue where xontribs were failing from `AttributeError: '_MergedKeyBindings' object has no attribute 'add'`
+
+**Security:**
+
+* <news item>

--- a/news/xontrib-shift-select.rst
+++ b/news/xontrib-shift-select.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed issue where xontribs were failing from `AttributeError: '_MergedKeyBindings' object has no attribute 'add'`
+* Fixed issue where xontribs were failing from ``AttributeError: '_MergedKeyBindings' object has no attribute 'add'``
 
 **Security:**
 

--- a/xonsh-in-docker.py
+++ b/xonsh-in-docker.py
@@ -11,7 +11,7 @@ parser = argparse.ArgumentParser(description=program_description)
 parser.add_argument("env", nargs="*", default=[], metavar="ENV=value")
 parser.add_argument("--python", "-p", default="3.6", metavar="python_version")
 parser.add_argument("--pypy", default=None, metavar="pypy_version")
-parser.add_argument("--ptk", "-t", default="2.0.4", metavar="ptk_version")
+parser.add_argument("--ptk", "-t", default="3.0.7", metavar="ptk_version")
 parser.add_argument("--keep", action="store_true")
 parser.add_argument("--build", action="store_true")
 parser.add_argument("--command", "-c", default="xonsh", metavar="command")
@@ -30,7 +30,9 @@ WORKDIR /xonsh
 ADD ./ ./
 RUN python setup.py install
 """.format(
-    python_version=args.python, ptk_version=args.ptk, pytest="pytest" if args.pytest else ""
+    python_version=args.python,
+    ptk_version=args.ptk,
+    pytest="pytest" if args.pytest else "",
 )
 
 if args.pypy:
@@ -46,7 +48,9 @@ WORKDIR /xonsh
 ADD ./ ./
 RUN pypy3 setup.py install
     """.format(
-        python_version=args.pypy, ptk_version=args.ptk, pytest="pytest" if args.pytest else ""
+        python_version=args.pypy,
+        ptk_version=args.ptk,
+        pytest="pytest" if args.pytest else "",
     )
 
 print("Building and running Xonsh")

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -21,7 +21,6 @@ from prompt_toolkit import ANSI
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.enums import EditingMode
-from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.bindings.emacs import (
     load_emacs_shift_selection_bindings,
 )

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -21,6 +21,7 @@ from prompt_toolkit import ANSI
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.enums import EditingMode
+from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.bindings.emacs import (
     load_emacs_shift_selection_bindings,
 )
@@ -94,9 +95,7 @@ class PromptToolkitShell(BaseShell):
         self.history = ThreadedHistory(PromptToolkitHistory())
         self.prompter = PromptSession(history=self.history)
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx, self)
-        self.key_bindings = merge_key_bindings(
-            [load_xonsh_bindings(), load_emacs_shift_selection_bindings()]
-        )
+        self.key_bindings = load_xonsh_bindings()
 
         # Store original `_history_matches` in case we need to restore it
         self._history_matches_orig = self.prompter.default_buffer._history_matches
@@ -106,6 +105,11 @@ class PromptToolkitShell(BaseShell):
             history=self.history,
             completer=self.pt_completer,
             bindings=self.key_bindings,
+        )
+        # Goes at the end, since _MergedKeyBindings objects do not have
+        # an add() function, which is necessary for on_ptk_create events
+        self.key_bindings = merge_key_bindings(
+            [self.key_bindings, load_emacs_shift_selection_bindings()]
         )
 
     def singleline(


### PR DESCRIPTION
Resolves #3759. Caused because https://github.com/xonsh/xonsh/pull/3697/ created a regression on xontrib loading -- sorry! This feels like not a great fix, but just wanted to leave xontribs in a not-broken state on master.

```
$ gst
xonsh: subprocess mode: command not found: gst
Did you mean one of the following?
    ls:   Alias
    gtb:  Alias
    git:  Command (/usr/local/bin/git)
    rs:   Command (/usr/bin/rs)
    su:   Command (/usr/bin/su)
$ xontrib load abbrevs
$ abbrevs['gst'] = 'git status'
$ [typed gst, turned into git status] git status
On branch abbrevs
Your branch is up to date with 'origin/abbrevs'.

nothing to commit, working tree clean
$
```