### PR TITLE
Fix environment variable assignment grammar ambiguity

### DIFF
--- a/news/simple-variables.rst
+++ b/news/simple-variables.rst
@@ -1,7 +1,7 @@
 **Added:**
 
 * Xonsh now supports bash-style variable assignments preceding
-  subprocess commands (e.g. ``$FOO = "bar" bash -c r"echo $FOO"``).
+  subprocess commands (e.g. ``$FOO="bar" bash -c r"echo $FOO"``).
 
 **Changed:**
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2502,7 +2502,7 @@ def test_ls_quotes_3_space():
 
 
 def test_leading_envvar_assignment():
-    check_xonsh_ast({}, "![$FOO= 'foo' $BAR =2 echo r'$BAR']", False)
+    check_xonsh_ast({}, "![$FOO='foo' $BAR=2 echo r'$BAR']", False)
 
 
 def test_echo_comma():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2240,6 +2240,10 @@ def test_bang_ls_envvar_listval():
     check_xonsh_ast({"WAKKA": [".", "."]}, "!(ls $WAKKA)", False)
 
 
+def test_bang_envvar_args():
+    check_xonsh_ast({"LS": "ls"}, "!($LS .)", False)
+
+
 def test_question():
     check_xonsh_ast({}, "range?")
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -3325,11 +3325,7 @@ class BaseParser(object):
         p[0] = ast.Str(s=p1.value, lineno=p1.lineno, col_offset=p1.lexpos)
 
     def p_envvar_assign_left(self, p):
-        """envvar_assign_left : dollar_name_tok EQUALS
-                              | dollar_name_tok WS EQUALS
-                              | dollar_name_tok EQUALS WS
-                              | dollar_name_tok WS EQUALS WS
-        """
+        """envvar_assign_left : dollar_name_tok EQUALS"""
         p[0] = p[1]
 
     def p_envvar_assign(self, p):


### PR DESCRIPTION
#3745 introduced huge amount of shift/reduce conflicts around DOLLAR_NAME token breaking the parser in some cases. This restricts the leading variable assignment (`$FOO="bar" command`) syntax by forbidding whitespace around the `=` equals operator.

I'm sorry about breaking the parser and I really dislike this change. Perhaps, there's a better solution, but it's currently beyond my parser-fu to find it.

Fixes #3764
Thanks @anki-code for reporting the bug.