### PR TITLE
The order of sections in docs changed and "Try it" section removed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ xonsh (pronounced *conch*) is meant for the daily use of experts and novices ali
 
 Please visit https://xon.sh for more information.
 
+If you like the idea of xonsh click ⭐ on the repo and stay tuned by watching releases.
+
 Projects that use xonsh
 ***********************
 

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -4,17 +4,15 @@ the xonsh shell
 
 .. include:: intro.rst
 
-.. include:: tryitnow.rst
-
-.. include:: comparison.rst
-
 .. include:: installation.rst
 
-.. include:: news.rst
+.. include:: comparison.rst
 
 .. include:: guides.rst
 
 .. include:: setup.rst
+
+.. include:: news.rst
 
 .. include:: contributing.rst
 

--- a/news/docs_sections.rst
+++ b/news/docs_sections.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Updated sections order in the docs
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/docs_sections.rst
+++ b/news/docs_sections.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Updated sections order in the docs
+* Updated sections order in the docs.
 
 **Deprecated:**
 


### PR DESCRIPTION
Hello!

1. The order of sections in docs changed.

2. "Try it" section removed.

3. Added text to readme.

Why removed? Because:

<details>

![Screenshot_20200917_212832](https://user-images.githubusercontent.com/1708680/93512262-be9c1a00-f92c-11ea-8dfb-77b8372f3da3.png)

![Screenshot_20200917_215823](https://user-images.githubusercontent.com/1708680/93515240-f86f1f80-f930-11ea-8d76-258349d7e1d6.png)

![Screenshot_20200917_212854](https://user-images.githubusercontent.com/1708680/93512312-cf4c9000-f92c-11ea-821e-b9bafd45f769.png)

</details>