### PR TITLE
TAB key automatically selects first completion when starting completion.

### DIFF
--- a/news/ptk-complete-select-first.rst
+++ b/news/ptk-complete-select-first.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ptk key binding for TAB -- hitting TAB to start completion now automatically selects the first displayed completion (if any).
+  hitting TAB when in insert mode inserts TAB, as heretofore.  This more exactly follows behavior of readline ``menu-complete``.
+  There is no configuration option for tailoring this behavior.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -206,6 +206,15 @@ def load_xonsh_bindings() -> KeyBindingsBase:
         env = builtins.__xonsh__.env
         event.cli.current_buffer.insert_text(env.get("INDENT"))
 
+    @handle(Keys.Tab, filter=~tab_insert_indent)
+    def start_complete(event):
+        """If starting completions, automatically move to first option"""
+        buff = event.app.current_buffer
+        if buff.complete_state:
+            buff.complete_next()
+        else:
+            buff.start_completion(select_first=True)
+
     @handle(Keys.ControlX, Keys.ControlE, filter=~has_selection)
     def open_editor(event):
         """ Open current buffer in editor """


### PR DESCRIPTION
An unsolicited "enhancement" to ptk completion.

TAB character now automatically selects first completion when it starts completion, rather than simply displaying the completion options.  This more closely mimics behavior of `TAB menu-complete` in readline.  I'd argue this is more in the nature of a bug fix than enabling new behavior, so  I didn't implement a configuration option, simply changed the behavior.  
