### PR TITLE
Fix app execution aliases on windows

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -184,10 +184,7 @@ def is_app_execution_alias(fname):
         Here try to detect if a file is an app execution alias
     """
     fname = pathlib.Path(fname)
-    return (
-        not os.path.exists(fname)
-        and fname.name in os.listdir(fname.parent)
-    )
+    return not os.path.exists(fname) and fname.name in os.listdir(fname.parent)
 
 
 def _is_binary(fname, limit=80):


### PR DESCRIPTION
@scopatz This is just a black fix to something I accidentally pushed directly to master. When rolled back it will become a proper PR. 

This fixes a problem where a running windows 10 app execution aliases causes xonsh to throw a traceback. Fixes #3752 

The reason is that app execution aliases behave weirdly with Python.  They show up when running os.listdir() and they can be used as arguments to popen (esentially CreateProcess resolves them). But we can't open them and os.path.exists() returns False. `pathlib.Path(fname).exists()` throws an invalid argument error. 

This fixes the problem and allows xonsh to run the app execution aliases on Windnows. 

