### PR TITLE
Use commands_cache when finding suggestions

### DIFF
--- a/news/cache-executables-in.rst
+++ b/news/cache-executables-in.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added cache on finding executable files, to speedup command-not-found suggestions
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/cache-executables-in.rst
+++ b/news/cache-executables-in.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added cache on finding executable files, to speedup command-not-found suggestions
+* Use command_cache when finding available commands, to speedup command-not-found suggestions
 
 **Changed:**
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1462,6 +1462,7 @@ def test_executables_in(xonsh_builtins):
                 result = set(executables_in(test_path))
             else:
                 result = set(executables_in(test_path))
+            executables_in.cache_clear()
     assert expected == result
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1462,7 +1462,6 @@ def test_executables_in(xonsh_builtins):
                 result = set(executables_in(test_path))
             else:
                 result = set(executables_in(test_path))
-            executables_in.cache_clear()
     assert expected == result
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -802,7 +802,6 @@ def _executables_in_windows(path):
         return
 
 
-@functools.lru_cache(128)
 def executables_in(path):
     """Returns a generator of files in path that the user could execute. """
     if ON_WINDOWS:
@@ -883,13 +882,10 @@ def suggest_commands(cmd, env, aliases):
             if levenshtein(alias.lower(), cmd, thresh) < thresh:
                 suggested[alias] = "Alias"
 
-    for path in filter(os.path.isdir, env.get("PATH")):
-        for _file in executables_in(path):
-            if (
-                _file not in suggested
-                and levenshtein(_file.lower(), cmd, thresh) < thresh
-            ):
-                suggested[_file] = "Command ({0})".format(os.path.join(path, _file))
+    for _cmd in builtins.__xonsh__.commands_cache.all_commands:
+        if _cmd not in suggested:
+            if levenshtein(_cmd.lower(), cmd, thresh) < thresh:
+                suggested[_cmd] = "Command ({0})".format(_cmd)
 
     suggested = collections.OrderedDict(
         sorted(

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -802,6 +802,7 @@ def _executables_in_windows(path):
         return
 
 
+# @functools.lru_cache(128)
 def executables_in(path):
     """Returns a generator of files in path that the user could execute. """
     if ON_WINDOWS:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -802,7 +802,7 @@ def _executables_in_windows(path):
         return
 
 
-# @functools.lru_cache(128)
+@functools.lru_cache(128)
 def executables_in(path):
     """Returns a generator of files in path that the user could execute. """
     if ON_WINDOWS:


### PR DESCRIPTION
When you put a not-recognized command, it takes a second to respond the error. The vast majority of this time seems to be finding command suggestions. If we use the commands_cache instead, it speeds up ~6x when there's no suggestions.

BEFORE:
```
$ timeit "asdfasdfasdf"
...
xonsh: subprocess mode: command not found: asdfasdfasdf
1 loops, best of 3: 544 ms per loop
```

AFTER:
```
$ timeit "asdfasdfasdf"
...
xonsh: subprocess mode: command not found: asdfasdfasdf
10 loops, best of 3: 90.4 ms per loop
```

On the other hand, there's basically no change in performance when it does find a suggestion.