### PR TITLE
Is 3775 - ptk shell not using full height completion menu at bottom of screen

### DIFF
--- a/news/is_3775.rst
+++ b/news/is_3775.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Issue #3775.  Prompt toolkit shell now displays the full number of completion rows (COMPLETIONS_MENU_ROWS)
+  even if current prompt is at the bottom of the screen.
+  Note that it will only display this many rows if it has enough actual completions to need so many.
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -112,12 +112,12 @@ class PromptToolkitCompleter(Completer):
         render = app.renderer
         window = app.layout.container.children[0].content.children[1].content
 
-        if window and window.render_info and render._last_screen:
-            height_needed = window.render_info.content_height + builtins.__xonsh__.env.get("COMPLETIONS_MENU_ROWS")
-
-            last_h = max(render._last_screen.height, render._min_available_height)
-            if last_h < height_needed:
-                render._last_screen.height = height_needed + 2
-                # the 2 is emperical.
-                # Is this because last_h doesn't include next prompt
-                # and the 1st line of completions?
+        # FIXME: this doesn't work when cursor is near but not at the bottom of the screen.
+        # it does work when cursor is at botoom, for a variety of prompt heights and COMPLETION_MENU_ROWS values.
+        # Here, we're relying on stale rendering data and effectively modifying the iterable
+        # as PTK is looping through it, with typically "unpredictable" results.
+        # What we need is direct access to ptk's completion menu and its container (DEFAULT_BUFFER?) to do better.
+        if window and window.render_info and render and render._last_screen:
+            height_needed = builtins.__xonsh__.env.get("COMPLETIONS_MENU_ROWS")
+            if window.render_info.window_height < height_needed:
+                render._last_screen.height += height_needed + 1

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -5,7 +5,6 @@ import builtins
 
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.application.current import get_app
 
 from xonsh.completers.tools import RichCompletion
 
@@ -66,11 +65,6 @@ class PromptToolkitCompleter(Completer):
                 completions = set(completions)
                 completions.discard(sug_comp)
                 completions = (sug_comp,) + tuple(sorted(completions))
-        # reserve space, if needed.
-        if len(completions) <= 1:
-            pass
-        elif len(os.path.commonprefix(completions)) <= len(prefix):
-            self.reserve_space()
         # Find common prefix (strip quoting)
         c_prefix = os.path.commonprefix([a.strip("'\"") for a in completions])
         # Find last split symbol, do not trim the last part
@@ -105,19 +99,3 @@ class PromptToolkitCompleter(Completer):
         comp, _, _ = sug.text.partition(" ")
         _, _, prev = line.rpartition(" ")
         return prev + comp
-
-    def reserve_space(self):
-        """Adjust the height for showing autocompletion menu."""
-        app = get_app()
-        render = app.renderer
-        window = app.layout.container.children[0].content.children[1].content
-
-        if window and window.render_info:
-            h = window.render_info.content_height
-            r = builtins.__xonsh__.env.get("COMPLETIONS_MENU_ROWS")
-            size = h + r
-            last_h = render._last_screen.height if render._last_screen else 0
-            last_h = max(render._min_available_height, last_h)
-            if last_h < size:
-                if render._last_screen:
-                    render._last_screen.height = size

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -173,7 +173,7 @@ class PromptToolkitShell(BaseShell):
             "editing_mode": editing_mode,
             "prompt_continuation": self.continuation_tokens,
             "enable_history_search": enable_history_search,
-            "reserve_space_for_menu": 0,
+            "reserve_space_for_menu": env.get("COMPLETIONS_MENU_ROWS"),
             "key_bindings": self.key_bindings,
             "complete_style": complete_style,
             "complete_while_typing": complete_while_typing,


### PR DESCRIPTION
Fixes #3775.
Not proud of this fix, it relies on empirical constants of dubious justification.  But it works even if you change the default `$COMPLETIONS_MENU_ROWS`.  However, it *always* leaves that number of rows below the prompt, even if there are only a few completions -- the prior code did better in this case.

It would be nice if PTK provided a documented interface for sizing the completions window, so we could do better.