### PR TITLE
Minor performance improvements to the prompt

### DIFF
--- a/news/prompt-speed.rst
+++ b/news/prompt-speed.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Minor improvements to the get prompt speed. (Mostly in git.)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -179,7 +179,7 @@ def _git_dirty_working_directory(q, include_untracked):
         else:
             unindexed = ["git", "diff", "--no-ext-diff", "--quiet"]
             indexed = unindexed + ["--cached", "HEAD"]
-            cmd = indexed + ["||"] + unindexed
+            cmd = unindexed + ["||"] + indexed
         child = subprocess.run(cmd, stderr=subprocess.DEVNULL, env=denv)
         # "--quiet" git commands imply "--exit-code", which returns:
         # 1 if there are differences

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -166,7 +166,7 @@ def current_branch():
 def _git_dirty_working_directory(q, include_untracked):
     denv = builtins.__xonsh__.env.detype()
     try:
-        # Borrowing this conversation
+        # Borrowed from this conversation
         # https://github.com/sindresorhus/pure/issues/115
         if include_untracked:
             cmd = [
@@ -179,6 +179,9 @@ def _git_dirty_working_directory(q, include_untracked):
         else:
             cmd = ["git", "diff", "--no-ext-diff", "--quiet"]
         child = subprocess.run(cmd, stderr=subprocess.DEVNULL, env=denv)
+        # "--quiet" git commands imply "--exit-code", which returns:
+        # 1 if there are differences
+        # 0 if there are no differences
         dwd = bool(child.returncode)
     except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         q.put(None)

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -137,7 +137,7 @@ def _first_branch_timeout_message():
     )
 
 
-def _has(binary):
+def _vc_has(binary):
     """ This allows us to locate binaries after git only if necessary """
     cmds = builtins.__xonsh__.commands_cache
     if cmds.is_empty():
@@ -153,9 +153,9 @@ def current_branch():
     '<branch-timeout>' is returned.
     """
     branch = None
-    if _has("git"):
+    if _vc_has("git"):
         branch = get_git_branch()
-    if not branch and _has("hg"):
+    if not branch and _vc_has("hg"):
         branch = get_hg_branch()
     if isinstance(branch, subprocess.TimeoutExpired):
         branch = "<branch-timeout>"
@@ -237,9 +237,9 @@ def dirty_working_directory():
     None. Currently supports git and hg.
     """
     dwd = None
-    if _has("git"):
+    if _vc_has("git"):
         dwd = git_dirty_working_directory()
-    if dwd is None and _has("hg"):
+    if dwd is None and _vc_has("hg"):
         dwd = hg_dirty_working_directory()
     return dwd
 

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -177,7 +177,9 @@ def _git_dirty_working_directory(q, include_untracked):
                 "--untracked-files=normal",
             ]
         else:
-            cmd = ["git", "diff", "--no-ext-diff", "--quiet"]
+            unindexed = ["git", "diff", "--no-ext-diff", "--quiet"]
+            indexed = unindexed + ["--cached", "HEAD"]
+            cmd = indexed + ["||"] + unindexed
         child = subprocess.run(cmd, stderr=subprocess.DEVNULL, env=denv)
         # "--quiet" git commands imply "--exit-code", which returns:
         # 1 if there are differences


### PR DESCRIPTION
There is a fraction of a delay on the prompt when you press enter. I imagine this is quite a tough case to crack, so this is just a start!

1. Showing the branch name seems to re-roll the `git rev-parse --abbrev-ref HEAD` function. This probably isn't great if there's lots of local branches for a user. I swapped it.
2. Locate binaries even more lazily. To be honest, I can't really track that much of a performance increase from this one, so down to revert it.
3. More efficient ways of finding whether a dirty working directory. Borrowed this from [this github conversation](https://github.com/sindresorhus/pure/issues/115).

**Results**:

Hard to evaluate this since the terminal speed is different each time ya run it. But for me, when in the xonsh repo, it seems to switch from an average of `0.025 < x < 0.030 seconds`, to `0.021 < x < 0.027` seconds. But it really varies widely, it would be cool if I had a better way of verifying!