### PR TITLE
ANSI terminal title setter escape sequence support (fixes #1403)

### DIFF
--- a/news/issue-1403.rst
+++ b/news/issue-1403.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for ANSI terminal title setting escape sequences. (#1403)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_ptk_shell.py
+++ b/tests/test_ptk_shell.py
@@ -8,7 +8,7 @@ from xonsh.platform import minimum_required_ptk_version
 
 # verify error if ptk not installed or below min
 
-from xonsh.ptk_shell.shell import tokenize_ansi
+from xonsh.ptk_shell.shell import tokenize_ansi, check_ansi_title
 from xonsh.shell import Shell
 
 
@@ -103,6 +103,25 @@ def test_tokenize_ansi(prompt_tokens, ansi_string_parts):
     ansi_tokens = tokenize_ansi(prompt_tokens)
     for token, text in zip(ansi_tokens, ansi_string_parts):
         assert token[1] == text
+
+
+@pytest.mark.parametrize(
+    "raw_prompt, prompt, title",
+    [
+        # no title
+        ("test prompt", "test prompt", None),
+        # starts w/ title
+        ("\033]0;TITLE THIS\007test prompt", "test prompt", "TITLE THIS"),
+        # ends w/ title
+        ("test prompt\033]0;TITLE THIS\007", "test prompt", "TITLE THIS"),
+        # title in the middle
+        ("test \033]0;TITLE THIS\007prompt", "test prompt", "TITLE THIS"),
+    ],
+)
+def test_check_ansi_title(raw_prompt, prompt, title):
+    checked_prompt, ansi_title = check_ansi_title(raw_prompt)
+    assert prompt == checked_prompt
+    assert title == ansi_title
 
 
 # someday: initialize PromptToolkitShell and have it actually do something.

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -76,6 +76,19 @@ def tokenize_ansi(tokens):
     return ansi_tokens
 
 
+def remove_ansi_title(prompt):
+    """Checks and removes ANSI terminal title setting escape sequences"""
+
+    title_idx = prompt.find("\x1b]")
+    if title_idx > -1:
+        title_end = prompt.find("\007", title_idx)
+        if title_end > -1:
+            prompt = prompt[:title_idx] + prompt[title_end + 1 :]
+            # TODO check $TITLE ?
+
+    return prompt
+
+
 class PromptToolkitShell(BaseShell):
     """The xonsh shell for prompt_toolkit v2 and later."""
 
@@ -250,6 +263,7 @@ class PromptToolkitShell(BaseShell):
             p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
+        p = remove_ansi_title(p)
         toks = partial_color_tokenize(p)
         if self._first_prompt:
             carriage_return()

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -76,15 +76,17 @@ def tokenize_ansi(tokens):
     return ansi_tokens
 
 
-def remove_ansi_title(prompt):
-    """Checks and removes ANSI terminal title setting escape sequences"""
+def set_ansi_title(prompt):
+    """Sets $TITLE based on the ANSI terminal title setting escape sequence"""
 
-    title_idx = prompt.find("\x1b]")
+    title_idx = prompt.find("\x1b]0;")
     if title_idx > -1:
         title_end = prompt.find("\007", title_idx)
         if title_end > -1:
+            title = prompt[title_idx + 4 : title_end]
             prompt = prompt[:title_idx] + prompt[title_end + 1 :]
-            # TODO check $TITLE ?
+
+            builtins.__xonsh__.env["TITLE"] = title
 
     return prompt
 
@@ -263,7 +265,7 @@ class PromptToolkitShell(BaseShell):
             p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
-        p = remove_ansi_title(p)
+        p = set_ansi_title(p)
         toks = partial_color_tokenize(p)
         if self._first_prompt:
             carriage_return()

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -76,9 +76,10 @@ def tokenize_ansi(tokens):
     return ansi_tokens
 
 
-def set_ansi_title(prompt):
-    """Sets $TITLE based on the ANSI terminal title setting escape sequence"""
+def check_ansi_title(prompt):
+    """Checks the prompt string for ANSI terminal title setting escape sequence"""
 
+    title = None
     title_idx = prompt.find("\x1b]0;")
     if title_idx > -1:
         title_end = prompt.find("\007", title_idx)
@@ -86,9 +87,7 @@ def set_ansi_title(prompt):
             title = prompt[title_idx + 4 : title_end]
             prompt = prompt[:title_idx] + prompt[title_end + 1 :]
 
-            builtins.__xonsh__.env["TITLE"] = title
-
-    return prompt
+    return prompt, title
 
 
 class PromptToolkitShell(BaseShell):
@@ -265,7 +264,11 @@ class PromptToolkitShell(BaseShell):
             p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except
             print_exception()
-        p = set_ansi_title(p)
+
+        p, title = check_ansi_title(p)
+        if title:
+            builtins.__xonsh__.env["TITLE"] = title
+
         toks = partial_color_tokenize(p)
         if self._first_prompt:
             carriage_return()


### PR DESCRIPTION
Fixes #1403 - removes the ANSI terminal title setter escape sequence from `$PROMPT` and sets `$TITLE` to it.
