### PR TITLE
Commands to easily manage deletion of history from the current session.

### DIFF
--- a/docs/tutorial_hist.rst
+++ b/docs/tutorial_hist.rst
@@ -255,6 +255,21 @@ may be useful to share entries between shell sessions. In such a case, one can u
 the ``flush`` action to immediately save the session history to disk and make it
 accessible from other shell sessions.
 
+``clear`` action
+================
+Deletes the history from the current session up until this point. Later commands
+will still be saved.
+
+``off`` action
+================
+Deletes the history from the current session and turns off history saving for the
+rest of the session. Only session metadata will be saved, not commands or output.
+
+``on`` action
+================
+Turns history saving back on. Previous commands won't be saved, but future
+commands will be.
+
 ``gc`` action
 ===============
 Last, but certainly not least, the ``gc`` action is a manual hook into executing

--- a/news/history_testing-ead.rst
+++ b/news/history_testing-ead.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+`history clear`, `history off` and `history on` actions, for managing whether history in the current session is saved.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/history_testing-ead.rst
+++ b/news/history_testing-ead.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-``history clear``, ``history off`` and ``history on`` actions, for managing whether history in the current session is saved.
+* history clear, history off and history on actions, for managing whether history in the current session is saved.
 
 **Changed:**
 

--- a/news/history_testing-ead.rst
+++ b/news/history_testing-ead.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-`history clear`, `history off` and `history on` actions, for managing whether history in the current session is saved.
+``history clear``, ``history off`` and ``history on`` actions, for managing whether history in the current session is saved.
 
 **Changed:**
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -483,3 +483,65 @@ def test__xhj_gc_xx_to_rmfiles(
         assert minute_diff <= 60
     else:
         assert act_size == exp_size
+
+
+def test_hist_clear_cmd(hist, xonsh_builtins, capsys, tmpdir):
+    """Verify that the CLI history clear command works."""
+    xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xonsh_builtins.__xonsh__.history = hist
+    xonsh_builtins.__xonsh__.env["HISTCONTROL"] = set()
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+    assert len(xonsh_builtins.__xonsh__.history) == 6
+
+    history_main(["clear"])
+
+    out, err = capsys.readouterr()
+    assert err.rstrip() == "History cleared"
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+
+def test_hist_off_cmd(hist, xonsh_builtins, capsys, tmpdir):
+    """Verify that the CLI history off command works."""
+    xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xonsh_builtins.__xonsh__.history = hist
+    xonsh_builtins.__xonsh__.env["HISTCONTROL"] = set()
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+    assert len(xonsh_builtins.__xonsh__.history) == 6
+
+    history_main(["off"])
+
+    out, err = capsys.readouterr()
+    assert err.rstrip() == "History off"
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+    for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+
+def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
+    """Verify that the CLI history on command works."""
+    xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xonsh_builtins.__xonsh__.history = hist
+    xonsh_builtins.__xonsh__.env["HISTCONTROL"] = set()
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+    assert len(xonsh_builtins.__xonsh__.history) == 6
+
+    history_main(["off"])
+    history_main(["on"])
+
+    out, err = capsys.readouterr()
+    assert err.rstrip().endswith("History on")
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+    for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+
+    assert len(xonsh_builtins.__xonsh__.history) == 6

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -541,7 +541,7 @@ def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
     assert err.rstrip().endswith("History on")
     assert len(xonsh_builtins.__xonsh__.history) == 0
 
-    for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
         hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
 
     assert len(xonsh_builtins.__xonsh__.history) == 6

--- a/tests/test_history_sqlite.py
+++ b/tests/test_history_sqlite.py
@@ -217,8 +217,6 @@ def test_history_getitem(index, exp, hist, xonsh_builtins):
         assert (entry.cmd, entry.out, entry.rtn, entry.ts) == exp
 
 
-
-
 def test_hist_clear_cmd(hist, xonsh_builtins, capsys, tmpdir):
     """Verify that the CLI history clear command works."""
     xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
@@ -233,7 +231,7 @@ def test_hist_clear_cmd(hist, xonsh_builtins, capsys, tmpdir):
 
     out, err = capsys.readouterr()
     assert err.rstrip() == "History cleared"
-    assert len(xonsh_builtins.__xonsh__.history) == 0
+    assert len(xonsh_builtins.__xonsh__.history) == 1
 
 
 def test_hist_off_cmd(hist, xonsh_builtins, capsys, tmpdir):
@@ -250,12 +248,12 @@ def test_hist_off_cmd(hist, xonsh_builtins, capsys, tmpdir):
 
     out, err = capsys.readouterr()
     assert err.rstrip() == "History off"
-    assert len(xonsh_builtins.__xonsh__.history) == 0
+    assert len(xonsh_builtins.__xonsh__.history) == 1
 
     for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
         hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
 
-    assert len(xonsh_builtins.__xonsh__.history) == 0
+    assert len(xonsh_builtins.__xonsh__.history) == 1
 
 
 def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
@@ -273,9 +271,9 @@ def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
 
     out, err = capsys.readouterr()
     assert err.rstrip().endswith("History on")
-    assert len(xonsh_builtins.__xonsh__.history) == 0
+    assert len(xonsh_builtins.__xonsh__.history) == 1
 
     for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
         hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
 
-    assert len(xonsh_builtins.__xonsh__.history) == 6
+    assert len(xonsh_builtins.__xonsh__.history) == 7

--- a/tests/test_history_sqlite.py
+++ b/tests/test_history_sqlite.py
@@ -231,7 +231,7 @@ def test_hist_clear_cmd(hist, xonsh_builtins, capsys, tmpdir):
 
     out, err = capsys.readouterr()
     assert err.rstrip() == "History cleared"
-    assert len(xonsh_builtins.__xonsh__.history) == 1
+    assert len(xonsh_builtins.__xonsh__.history) == 0
 
 
 def test_hist_off_cmd(hist, xonsh_builtins, capsys, tmpdir):
@@ -248,12 +248,12 @@ def test_hist_off_cmd(hist, xonsh_builtins, capsys, tmpdir):
 
     out, err = capsys.readouterr()
     assert err.rstrip() == "History off"
-    assert len(xonsh_builtins.__xonsh__.history) == 1
+    assert len(xonsh_builtins.__xonsh__.history) == 0
 
     for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
         hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
 
-    assert len(xonsh_builtins.__xonsh__.history) == 1
+    assert len(xonsh_builtins.__xonsh__.history) == 0
 
 
 def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
@@ -271,9 +271,9 @@ def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
 
     out, err = capsys.readouterr()
     assert err.rstrip().endswith("History on")
-    assert len(xonsh_builtins.__xonsh__.history) == 1
+    assert len(xonsh_builtins.__xonsh__.history) == 0
 
     for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
         hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
 
-    assert len(xonsh_builtins.__xonsh__.history) == 7
+    assert len(xonsh_builtins.__xonsh__.history) == 6

--- a/tests/test_history_sqlite.py
+++ b/tests/test_history_sqlite.py
@@ -273,7 +273,7 @@ def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
     assert err.rstrip().endswith("History on")
     assert len(xonsh_builtins.__xonsh__.history) == 0
 
-    for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
         hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
 
     assert len(xonsh_builtins.__xonsh__.history) == 6

--- a/tests/test_history_sqlite.py
+++ b/tests/test_history_sqlite.py
@@ -215,3 +215,67 @@ def test_history_getitem(index, exp, hist, xonsh_builtins):
         assert [(e.cmd, e.out, e.rtn, e.ts) for e in entry] == exp
     else:
         assert (entry.cmd, entry.out, entry.rtn, entry.ts) == exp
+
+
+
+
+def test_hist_clear_cmd(hist, xonsh_builtins, capsys, tmpdir):
+    """Verify that the CLI history clear command works."""
+    xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xonsh_builtins.__xonsh__.history = hist
+    xonsh_builtins.__xonsh__.env["HISTCONTROL"] = set()
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+    assert len(xonsh_builtins.__xonsh__.history) == 6
+
+    history_main(["clear"])
+
+    out, err = capsys.readouterr()
+    assert err.rstrip() == "History cleared"
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+
+def test_hist_off_cmd(hist, xonsh_builtins, capsys, tmpdir):
+    """Verify that the CLI history off command works."""
+    xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xonsh_builtins.__xonsh__.history = hist
+    xonsh_builtins.__xonsh__.env["HISTCONTROL"] = set()
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+    assert len(xonsh_builtins.__xonsh__.history) == 6
+
+    history_main(["off"])
+
+    out, err = capsys.readouterr()
+    assert err.rstrip() == "History off"
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+    for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+
+def test_hist_on_cmd(hist, xonsh_builtins, capsys, tmpdir):
+    """Verify that the CLI history on command works."""
+    xonsh_builtins.__xonsh__.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xonsh_builtins.__xonsh__.history = hist
+    xonsh_builtins.__xonsh__.env["HISTCONTROL"] = set()
+
+    for ts, cmd in enumerate(CMDS):  # populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+    assert len(xonsh_builtins.__xonsh__.history) == 6
+
+    history_main(["off"])
+    history_main(["on"])
+
+    out, err = capsys.readouterr()
+    assert err.rstrip().endswith("History on")
+    assert len(xonsh_builtins.__xonsh__.history) == 0
+
+    for ts, cmd in enumerate(CMDS):  # attempt to populate the shell history
+        hist.append({"inp": cmd, "rtn": 0, "ts": (ts + 1, ts + 1.5)})
+
+    assert len(xonsh_builtins.__xonsh__.history) == 6

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1615,6 +1615,15 @@ def DEFAULT_VARS():
             "xonsh process threads sleep for while running command pipelines. "
             "The value has units of seconds [s].",
         ),
+        "XONSH_REMEMBER_HISTORY": Var(
+            is_bool,
+            to_bool,
+            bool_to_str,
+            True,
+            "If False, Xonsh will not save history."
+            "History for the session will be deleted if it exists",
+            doc_configurable=True
+        ),
         "XONSH_SHOW_TRACEBACK": Var(
             is_bool,
             to_bool,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1615,15 +1615,6 @@ def DEFAULT_VARS():
             "xonsh process threads sleep for while running command pipelines. "
             "The value has units of seconds [s].",
         ),
-        "XONSH_REMEMBER_HISTORY": Var(
-            is_bool,
-            to_bool,
-            bool_to_str,
-            True,
-            "If False, Xonsh will not save history."
-            "History for the session will be deleted if it exists",
-            doc_configurable=True
-        ),
         "XONSH_SHOW_TRACEBACK": Var(
             is_bool,
             to_bool,

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -157,9 +157,12 @@ class History:
 
     @staticmethod
     def remember_history_check(f):
-        def new_f(self, at_exit=False):
+        """Allows the decorated function to run only if
+           self.remember_history is True.
+        """
+        def new_f(self, *args, **kwargs):
             if self.remember_history:
-                return f(self, at_exit=at_exit)
+                return f(self, *args, **kwargs)
             else:
                 return
 
@@ -176,4 +179,8 @@ class History:
 
     def wipe_memory(self):
         """Reinitialises History object with blank commands."""
+        pass
+
+    def remake_file(self):
+        """Makes new file if required, after old one gets deleted."""
         pass

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -170,4 +170,9 @@ class History:
 
     def clear(self):
         """Wipes the current session from both the disk and memory."""
-        pass
+        self.buffer = None
+        self.inps = None
+        self.rtns = None
+        self.tss = None
+        self.outs = None
+

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -170,15 +170,6 @@ class History:
 
     def clear(self):
         """Wipes the current session from both the disk and memory."""
-        self.wipe_disk()
-        self.wipe_memory()
-
-    def wipe_disk(self):
-        """Wipes the current session's history from the disk."""
-        pass
-
-    def wipe_memory(self):
-        """Reinitialises History object with blank commands."""
         pass
 
     def remake_file(self):

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -170,9 +170,4 @@ class History:
 
     def clear(self):
         """Wipes the current session from both the disk and memory."""
-        self.buffer = None
-        self.inps = None
-        self.rtns = None
-        self.tss = None
-        self.outs = None
-
+        pass

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -50,7 +50,7 @@ class History:
     is the newest.
     """
 
-    def __init__(self, sessionid=None, remember_history=None, **kwargs):
+    def __init__(self, sessionid=None, **kwargs):
         """Represents a xonsh session's history.
 
         Parameters
@@ -71,7 +71,7 @@ class History:
         self.last_cmd_out = None
         self.hist_size = None
         self.hist_units = None
-        self.remember_history = remember_history
+        self.remember_history = True
 
     def __len__(self):
         """Return the number of items in current session."""
@@ -164,3 +164,16 @@ class History:
                 return
 
         return new_f
+
+    def clear(self):
+        """Wipes the current session from both the disk and memory."""
+        self.wipe_disk()
+        self.wipe_memory()
+
+    def wipe_disk(self):
+        """Wipes the current session's history from the disk."""
+        pass
+
+    def wipe_memory(self):
+        """Reinitialises History object with blank commands."""
+        pass

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -2,7 +2,6 @@
 """Base class of Xonsh History backends."""
 import types
 import uuid
-import builtins
 
 
 class HistoryEntry(types.SimpleNamespace):
@@ -51,7 +50,7 @@ class History:
     is the newest.
     """
 
-    def __init__(self, sessionid=None, **kwargs):
+    def __init__(self, sessionid=None, remember_history=None, **kwargs):
         """Represents a xonsh session's history.
 
         Parameters
@@ -72,6 +71,7 @@ class History:
         self.last_cmd_out = None
         self.hist_size = None
         self.hist_units = None
+        self.remember_history = remember_history
 
     def __len__(self):
         """Return the number of items in current session."""
@@ -158,7 +158,7 @@ class History:
     @staticmethod
     def remember_history_check(f):
         def new_f(self, at_exit=False):
-            if builtins.__xonsh__.env["XONSH_REMEMBER_HISTORY"]:
+            if self.remember_history:
                 return f(self, at_exit=at_exit)
             else:
                 return

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -157,6 +157,6 @@ class History:
 
     def clear(self):
         """Clears the history of the current session from both the disk and
-           memory.
+        memory.
         """
         pass

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -157,17 +157,18 @@ class History:
 
     @staticmethod
     def remember_history_check(f):
-        """Allows the decorated function to run only if
-           self.remember_history is True.
+        """Jumps over the decorated function if self.remember_history is False.
         """
-        def new_f(self, *args, **kwargs):
+        def out_f(self, *args, **kwargs):
             if self.remember_history:
                 return f(self, *args, **kwargs)
             else:
                 return
 
-        return new_f
+        return out_f
 
     def clear(self):
-        """Wipes the current session from both the disk and memory."""
+        """Clears the history of the current session from both the disk and
+           memory.
+        """
         pass

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -155,18 +155,6 @@ class History:
         """
         pass
 
-    @staticmethod
-    def remember_history_check(f):
-        """Jumps over the decorated function if self.remember_history is False.
-        """
-        def out_f(self, *args, **kwargs):
-            if self.remember_history:
-                return f(self, *args, **kwargs)
-            else:
-                return
-
-        return out_f
-
     def clear(self):
         """Clears the history of the current session from both the disk and
            memory.

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -171,7 +171,3 @@ class History:
     def clear(self):
         """Wipes the current session from both the disk and memory."""
         pass
-
-    def remake_file(self):
-        """Makes new file if required, after old one gets deleted."""
-        pass

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -2,6 +2,7 @@
 """Base class of Xonsh History backends."""
 import types
 import uuid
+import builtins
 
 
 class HistoryEntry(types.SimpleNamespace):
@@ -153,3 +154,13 @@ class History:
             If set blocking, then wait until gc action finished.
         """
         pass
+
+    @staticmethod
+    def remember_history_check(f):
+        def new_f(self, at_exit=False):
+            if builtins.__xonsh__.env["XONSH_REMEMBER_HISTORY"]:
+                return f(self, at_exit=at_exit)
+            else:
+                return
+
+        return new_f

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -269,9 +269,6 @@ class JsonHistoryFlusher(threading.Thread):
         load_hist_len = len(hist["cmds"])
         hist["cmds"].extend(cmds)
         if self.at_exit:
-            #print(hist["ts"])
-            print(hist.__class__)
-            print(hist)
             hist["ts"][1] = time.time()  # apply end time
             hist["locked"] = False
         if not builtins.__xonsh__.env.get("XONSH_STORE_STDOUT", False):
@@ -512,16 +509,15 @@ class JsonHistory(History):
                 time.sleep(0.1)  # don't monopolize the thread (or Python GIL?)
 
     def clear(self):
-        def wipe_disk(hist):
-            with open(self.filename, "r") as f:
-                backup_metadata = json.load(f)
-            backup_metadata["data"]["cmds"] = []
-            print(backup_metadata)
-            with open(self.filename, "w") as f:
-                json.dump(backup_metadata, f)
 
         def wipe_memory(hist):  # todo is this enough?
             hist.buffer = []
+            self.tss = JsonCommandField("ts", self)
+            self.inps = JsonCommandField("inp", self)
+            self.outs = JsonCommandField("out", self)
+            self.rtns = JsonCommandField("rtn", self)
 
-        wipe_disk(self)
         wipe_memory(self)
+
+        # Flush empty history object to disk. This overwrites the old commands.
+        self.flush()

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -511,18 +511,14 @@ class JsonHistory(History):
     def clear(self):
         """Clears the current session's history from both memory and disk."""
 
-        def wipe_memory(hist):
-            """Wipes history entries from memory. Keeps sessionid and other
-               metadata."""
-            hist.buffer = []
-            self.tss = JsonCommandField("ts", self)
-            self.inps = JsonCommandField("inp", self)
-            self.outs = JsonCommandField("out", self)
-            self.rtns = JsonCommandField("rtn", self)
-            self._len = 0
-            self._skipped = 0
-
-        wipe_memory(self)
+        # Wipe history from memory. Keep sessionid and other metadata.
+        self.buffer = []
+        self.tss = JsonCommandField("ts", self)
+        self.inps = JsonCommandField("inp", self)
+        self.outs = JsonCommandField("out", self)
+        self.rtns = JsonCommandField("rtn", self)
+        self._len = 0
+        self._skipped = 0
 
         # Flush empty history object to disk, overwriting previous data.
         self.flush()

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -202,12 +202,7 @@ class JsonHistoryGC(threading.Thread):
                 # info: file size, closing timestamp, number of commands, filename
                 ts = lj.get("ts", (0.0, None))
                 files.append(
-                    (
-                        ts[1] or ts[0],
-                        len(lj.sizes["cmds"]) - 1,
-                        f,
-                        cur_file_size,
-                    ),
+                    (ts[1] or ts[0], len(lj.sizes["cmds"]) - 1, f, cur_file_size,),
                 )
                 lj.close()
                 if xonsh_debug:

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -318,7 +318,7 @@ class JsonCommandField(cabc.Sequence):
         # now we know we have to go into the file
         queue = self.hist._queue
         queue.append(self)
-        if self.hist.remember_history:  # todo make sure this works after clear. Reinitialise file.
+        if self.hist.remember_history:  # todo is this necessary and elegant?
             with self.hist._cond:
                 self.hist._cond.wait_for(self.i_am_at_the_front)
                 with open(self.hist.filename, "r", newline="\n") as f:

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -510,14 +510,17 @@ class JsonHistory(History):
 
     def clear(self):
 
-        def wipe_memory(hist):  # todo is this enough?
+        def wipe_memory(hist):
             hist.buffer = []
             self.tss = JsonCommandField("ts", self)
             self.inps = JsonCommandField("inp", self)
             self.outs = JsonCommandField("out", self)
             self.rtns = JsonCommandField("rtn", self)
+            self._len = 0
+            self._skipped = 0
 
         wipe_memory(self)
 
-        # Flush empty history object to disk. This overwrites the old commands.
+        # Flush empty history object to disk. This overwrites the old commands,
+        # but keeps basic session metadata to prevent things from breaking.
         self.flush()

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -394,7 +394,6 @@ class JsonHistory(History):
     def __len__(self):
         return self._len - self._skipped
 
-    @History.remember_history_check
     def append(self, cmd):
         """Appends command to history. Will periodically flush the history to file.
 
@@ -411,6 +410,8 @@ class JsonHistory(History):
         hf : JsonHistoryFlusher or None
             The thread that was spawned to flush history
         """
+        if not self.remember_history:
+            return
         self.buffer.append(cmd)
         self._len += 1  # must come before flushing
         if len(self.buffer) >= self.buffersize:
@@ -419,7 +420,6 @@ class JsonHistory(History):
             hf = None
         return hf
 
-    @History.remember_history_check
     def flush(self, at_exit=False):
         """Flushes the current command buffer to disk.
 
@@ -434,6 +434,7 @@ class JsonHistory(History):
         hf : JsonHistoryFlusher or None
             The thread that was spawned to flush history
         """
+        # Implicitly covers case of self.remember_history being False.
         if len(self.buffer) == 0:
             return
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -509,8 +509,11 @@ class JsonHistory(History):
                 time.sleep(0.1)  # don't monopolize the thread (or Python GIL?)
 
     def clear(self):
+        """Clears the current session's history from both memory and disk."""
 
         def wipe_memory(hist):
+            """Wipes history entries from memory. Keeps sessionid and other
+               metadata."""
             hist.buffer = []
             self.tss = JsonCommandField("ts", self)
             self.inps = JsonCommandField("inp", self)
@@ -521,6 +524,5 @@ class JsonHistory(History):
 
         wipe_memory(self)
 
-        # Flush empty history object to disk. This overwrites the old commands,
-        # but keeps basic session metadata to prevent things from breaking.
+        # Flush empty history object to disk, overwriting previous data.
         self.flush()

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -391,6 +391,7 @@ class JsonHistory(History):
     def __len__(self):
         return self._len - self._skipped
 
+    @History.remember_history_check
     def append(self, cmd):
         """Appends command to history. Will periodically flush the history to file.
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -202,7 +202,12 @@ class JsonHistoryGC(threading.Thread):
                 # info: file size, closing timestamp, number of commands, filename
                 ts = lj.get("ts", (0.0, None))
                 files.append(
-                    (ts[1] or ts[0], len(lj.sizes["cmds"]) - 1, f, cur_file_size,),
+                    (
+                        ts[1] or ts[0],
+                        len(lj.sizes["cmds"]) - 1,
+                        f,
+                        cur_file_size,
+                    ),
                 )
                 lj.close()
                 if xonsh_debug:

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -327,9 +327,9 @@ class JsonCommandField(cabc.Sequence):
                     if isinstance(rtn, xlj.LJNode):
                         rtn = rtn.load()
                 queue.popleft()
+            return rtn
         else:
             return ""
-        return rtn
 
     def i_am_at_the_front(self):
         """Tests if the command field is at the front of the queue."""
@@ -508,14 +508,18 @@ class JsonHistory(History):
             while self.gc.is_alive():  # while waiting for gc.
                 time.sleep(0.1)  # don't monopolize the thread (or Python GIL?)
 
-    def wipe_disk(self):
-        try:
-            os.remove(self.filename)
-        except FileNotFoundError:
-            pass
+    def clear(self):
+        def wipe_disk(hist):
+            try:
+                os.remove(hist.filename)
+            except FileNotFoundError:
+                pass
 
-    def wipe_memory(self):  # todo is this enough?
-        self.buffer = []
+        def wipe_memory(hist):  # todo is this enough?
+            hist.buffer = []
+
+        wipe_disk(self)
+        wipe_memory(self)
 
     def remake_file(self):
         meta = dict()

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -269,6 +269,9 @@ class JsonHistoryFlusher(threading.Thread):
         load_hist_len = len(hist["cmds"])
         hist["cmds"].extend(cmds)
         if self.at_exit:
+            #print(hist["ts"])
+            print(hist.__class__)
+            print(hist)
             hist["ts"][1] = time.time()  # apply end time
             hist["locked"] = False
         if not builtins.__xonsh__.env.get("XONSH_STORE_STDOUT", False):
@@ -510,20 +513,15 @@ class JsonHistory(History):
 
     def clear(self):
         def wipe_disk(hist):
-            try:
-                os.remove(hist.filename)
-            except FileNotFoundError:
-                pass
+            with open(self.filename, "r") as f:
+                backup_metadata = json.load(f)
+            backup_metadata["data"]["cmds"] = []
+            print(backup_metadata)
+            with open(self.filename, "w") as f:
+                json.dump(backup_metadata, f)
 
         def wipe_memory(hist):  # todo is this enough?
             hist.buffer = []
 
         wipe_disk(self)
         wipe_memory(self)
-
-    def remake_file(self):
-        meta = dict()
-        meta["cmds"] = []
-        meta["sessionid"] = str(self.sessionid)
-        with open(self.filename, "w", newline="\n") as f:
-            xlj.ljdump(meta, f, sort_keys=True)

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -415,6 +415,7 @@ class JsonHistory(History):
             hf = None
         return hf
 
+    @History.remember_history_check
     def flush(self, at_exit=False):
         """Flushes the current command buffer to disk.
 

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -354,6 +354,13 @@ def _xh_create_parser():
     # 'flush' subcommand
     subp.add_parser("flush", help="flush the current history to disk")
 
+    subp.add_parser("off", help="history will not be saved for this session")
+
+    subp.add_parser("on", help="history will be saved for the rest of this"
+                               " session (default)")
+
+    subp.add_parser("clear", help="one-time wipe of session history")
+
     return p
 
 
@@ -417,5 +424,12 @@ def history_main(
         hf = hist.flush()
         if isinstance(hf, threading.Thread):
             hf.join()
+    elif ns.action == "off":
+        hist.remember_history = False
+        hist.clear()
+    elif ns.action == "on":
+        hist.remember_history = True
+    elif ns.action == "clear":
+        hist.clear()
     else:
         print("Unknown history action {}".format(ns.action), file=sys.stderr)

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -432,10 +432,13 @@ def history_main(
         if hist.remember_history:
             hist.clear()
             hist.remember_history = False
+            print("History off", file=sys.stderr)
     elif ns.action == "on":
         if not hist.remember_history:
             hist.remember_history = True
+            print("History on", file=sys.stderr)
     elif ns.action == "clear":
         hist.clear()
+        print("History cleared", file=sys.stderr)
     else:
         print("Unknown history action {}".format(ns.action), file=sys.stderr)

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -224,8 +224,18 @@ def _XH_HISTORY_SESSIONS():
     }
 
 
-_XH_MAIN_ACTIONS = {"show", "id", "file", "info", "diff", "gc", "flush",
-                    "off", "on", "clear"}
+_XH_MAIN_ACTIONS = {
+    "show",
+    "id",
+    "file",
+    "info",
+    "diff",
+    "gc",
+    "flush",
+    "off",
+    "on",
+    "clear",
+}
 
 
 @functools.lru_cache()
@@ -359,8 +369,9 @@ def _xh_create_parser():
     subp.add_parser("off", help="history will not be saved for this session")
 
     # 'on' subcommand
-    subp.add_parser("on", help="history will be saved for the rest of this"
-                               " session (default)")
+    subp.add_parser(
+        "on", help="history will be saved for the rest of the session (default)"
+    )
 
     # 'clear' subcommand
     subp.add_parser("clear", help="one-time wipe of session history")

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -224,7 +224,8 @@ def _XH_HISTORY_SESSIONS():
     }
 
 
-_XH_MAIN_ACTIONS = {"show", "id", "file", "info", "diff", "gc", "flush"}
+_XH_MAIN_ACTIONS = {"show", "id", "file", "info", "diff", "gc", "flush",
+                    "off", "on", "clear"}
 
 
 @functools.lru_cache()
@@ -354,11 +355,14 @@ def _xh_create_parser():
     # 'flush' subcommand
     subp.add_parser("flush", help="flush the current history to disk")
 
+    # 'off' subcommand
     subp.add_parser("off", help="history will not be saved for this session")
 
+    # 'on' subcommand
     subp.add_parser("on", help="history will be saved for the rest of this"
                                " session (default)")
 
+    # 'clear' subcommand
     subp.add_parser("clear", help="one-time wipe of session history")
 
     return p
@@ -425,11 +429,15 @@ def history_main(
         if isinstance(hf, threading.Thread):
             hf.join()
     elif ns.action == "off":
-        hist.remember_history = False
-        hist.clear()
+        if hist.remember_history:
+            hist.remember_history = False
+            hist.clear()
     elif ns.action == "on":
-        hist.remember_history = True
+        if not hist.remember_history:
+            hist.remember_history = True
+            hist.remake_file()
     elif ns.action == "clear":
         hist.clear()
+        hist.remake_file()
     else:
         print("Unknown history action {}".format(ns.action), file=sys.stderr)

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -430,14 +430,12 @@ def history_main(
             hf.join()
     elif ns.action == "off":
         if hist.remember_history:
-            hist.remember_history = False
             hist.clear()
+            hist.remember_history = False
     elif ns.action == "on":
         if not hist.remember_history:
             hist.remember_history = True
-            hist.remake_file()
     elif ns.action == "clear":
         hist.clear()
-        hist.remake_file()
     else:
         print("Unknown history action {}".format(ns.action), file=sys.stderr)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -304,5 +304,8 @@ class SqliteHistory(History):
         self.outs = []
         self.tss = []
 
+        # Add in dummy command. Delete items has to leave one.
+        self.append({"inp": "", "rtn": 0, "ts": (0, 0.5)})
+
         # Wipe data from disk.
-        xh_sqlite_delete_items(size_to_keep=0, filename=self.filename)
+        xh_sqlite_delete_items(size_to_keep=1, filename=self.filename)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -221,7 +221,7 @@ class SqliteHistoryGC(threading.Thread):
         xh_sqlite_delete_items(hsize, filename=self.filename)
 
 
-class SqliteHistory(History):
+class SqliteHistory(History):  # todo work out how to block flush on sqlite.
     """Xonsh history backend implemented with sqlite3."""
 
     def __init__(self, gc=True, filename=None, **kwargs):
@@ -239,6 +239,7 @@ class SqliteHistory(History):
         # during init rerun create command
         setattr(XH_SQLITE_CACHE, XH_SQLITE_CREATED_SQL_TBL, False)
 
+    @History.remember_history_check
     def append(self, cmd):
         envs = builtins.__xonsh__.env
         inp = cmd["inp"].rstrip()

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -299,21 +299,16 @@ class SqliteHistory(History):
                 continue
 
     def clear(self):
+        """Clears the current session's history from both memory and disk."""
+        # Wipe memory
         self.inps = []
         self.rtns = []
         self.outs = []
         self.tss = []
 
-        # Add in dummy command. Delete items has to leave one.
-        #self.append({"inp": "", "rtn": 0, "ts": (0, 0.5)})
-
-        # Wipe data from disk.
-
-        #xh_sqlite_delete_items(size_to_keep=1, filename=self.filename)  # todo this leads to data loss from other sessions. Need to fix.
+        # Wipe the current session's entries from the database.
         sql = "DELETE FROM xonsh_history WHERE sessionid = ?"
         with _xh_sqlite_get_conn(filename=self.filename) as conn:
             c = conn.cursor()
             _xh_sqlite_create_history_table(c)
             c.execute(sql, (str(self.sessionid),))
-
-        # "DELETE FROM xonsh_history WHERE sessionid == ?", self.sessionid # check

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -221,7 +221,7 @@ class SqliteHistoryGC(threading.Thread):
         xh_sqlite_delete_items(hsize, filename=self.filename)
 
 
-class SqliteHistory(History):  # todo work out how to block flush on sqlite.
+class SqliteHistory(History):
     """Xonsh history backend implemented with sqlite3."""
 
     def __init__(self, gc=True, filename=None, **kwargs):
@@ -299,4 +299,10 @@ class SqliteHistory(History):  # todo work out how to block flush on sqlite.
                 continue
 
     def clear(self):
-        pass  # todo implement
+        self.inps = []
+        self.rtns = []
+        self.outs = []
+        self.tss = []
+
+        # Wipe data from disk.
+        xh_sqlite_delete_items(size_to_keep=0, filename=self.filename)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -305,7 +305,15 @@ class SqliteHistory(History):
         self.tss = []
 
         # Add in dummy command. Delete items has to leave one.
-        self.append({"inp": "", "rtn": 0, "ts": (0, 0.5)})
+        #self.append({"inp": "", "rtn": 0, "ts": (0, 0.5)})
 
         # Wipe data from disk.
-        xh_sqlite_delete_items(size_to_keep=1, filename=self.filename)  # todo this leads to data loss from other sessions. Need to fix.
+
+        #xh_sqlite_delete_items(size_to_keep=1, filename=self.filename)  # todo this leads to data loss from other sessions. Need to fix.
+        sql = "DELETE FROM xonsh_history WHERE sessionid = ?"
+        with _xh_sqlite_get_conn(filename=self.filename) as conn:
+            c = conn.cursor()
+            _xh_sqlite_create_history_table(c)
+            c.execute(sql, (str(self.sessionid),))
+
+        # "DELETE FROM xonsh_history WHERE sessionid == ?", self.sessionid # check

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -297,3 +297,6 @@ class SqliteHistory(History):  # todo work out how to block flush on sqlite.
         if blocking:
             while self.gc.is_alive():
                 continue
+
+    def clear(self):
+        pass  # todo implement

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -308,4 +308,4 @@ class SqliteHistory(History):
         self.append({"inp": "", "rtn": 0, "ts": (0, 0.5)})
 
         # Wipe data from disk.
-        xh_sqlite_delete_items(size_to_keep=1, filename=self.filename)
+        xh_sqlite_delete_items(size_to_keep=1, filename=self.filename)  # todo this leads to data loss from other sessions. Need to fix.

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -239,8 +239,9 @@ class SqliteHistory(History):
         # during init rerun create command
         setattr(XH_SQLITE_CACHE, XH_SQLITE_CREATED_SQL_TBL, False)
 
-    @History.remember_history_check
     def append(self, cmd):
+        if not self.remember_history:
+            return
         envs = builtins.__xonsh__.env
         inp = cmd["inp"].rstrip()
         self.inps.append(inp)


### PR DESCRIPTION
Solves #3033.

Provides `history clear` which purges past commands from the current session; `history off`, which stops any history from being saved from the entire current session; and `history on`, which re-enables history saving in the current session. 

Works for both JSON and SQLite backends, and it works on both the history buffer and on history already saved to disk.

Builds off of #3691. Thank you @Itay4 for starting out.