### PR TITLE
xontrib whole_word_jumping: Delete whole word with Shift+Delete

### DIFF
--- a/news/shift_del.rst
+++ b/news/shift_del.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added to xontrib whole_word_jumping: Shift+Delete hotkey to delete whole word.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -61,10 +61,7 @@ class RichCompletion(str):
 
     def __repr__(self):
         return "RichCompletion({}, prefix_len={}, display={}, description={})".format(
-            repr(str(self)),
-            self.prefix_len,
-            repr(self.display),
-            repr(self.description),
+            repr(str(self)), self.prefix_len, repr(self.display), repr(self.description)
         )
 
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -202,7 +202,7 @@ class JsonHistoryGC(threading.Thread):
                 # info: file size, closing timestamp, number of commands, filename
                 ts = lj.get("ts", (0.0, None))
                 files.append(
-                    (ts[1] or ts[0], len(lj.sizes["cmds"]) - 1, f, cur_file_size,),
+                    (ts[1] or ts[0], len(lj.sizes["cmds"]) - 1, f, cur_file_size)
                 )
                 lj.close()
                 if xonsh_debug:

--- a/xonsh/parsers/fstring_adaptor.py
+++ b/xonsh/parsers/fstring_adaptor.py
@@ -181,7 +181,7 @@ class FStringAdaptor:
                         )
                     )
                 field_node = ast.Tuple(
-                    elts=elts, ctx=ast.Load(), lineno=lineno, col_offset=col_offset,
+                    elts=elts, ctx=ast.Load(), lineno=lineno, col_offset=col_offset
                 )
                 node.args[0] = field_node
 

--- a/xonsh/xoreutils/ulimit.py
+++ b/xonsh/xoreutils/ulimit.py
@@ -159,13 +159,7 @@ def _ul_add_action(actions, opt, res_type, stderr):
     actions.append(
         [
             _ul_show,
-            {
-                "res": r[0],
-                "res_type": res_type,
-                "desc": r[3],
-                "unit": r[4],
-                "opt": opt,
-            },
+            {"res": r[0], "res_type": res_type, "desc": r[3], "unit": r[4], "opt": opt},
         ]
     )
     return True

--- a/xontrib/whole_word_jumping.py
+++ b/xontrib/whole_word_jumping.py
@@ -39,4 +39,3 @@ def custom_keybindings(bindings, **kw):
         endpos = endpos + 1 if startpos == 0 else endpos
         buff.text = buff.text[:startpos] + buff.text[endpos:]
         buff.cursor_position = startpos
-            

--- a/xontrib/whole_word_jumping.py
+++ b/xontrib/whole_word_jumping.py
@@ -28,3 +28,15 @@ def custom_keybindings(bindings, **kw):
         pos = buff.document.find_next_word_ending(count=event.arg, WORD=True)
         if pos:
             buff.cursor_position += pos
+
+    @bindings.add(Keys.ShiftDelete)
+    def shift_delete(event):
+        buff = event.current_buffer
+        startpos, endpos = buff.document.find_boundaries_of_current_word(WORD=True)
+        startpos = buff.cursor_position + startpos - 1
+        startpos = 0 if startpos < 0 else startpos
+        endpos = buff.cursor_position + endpos
+        endpos = endpos + 1 if startpos == 0 else endpos
+        buff.text = buff.text[:startpos] + buff.text[endpos:]
+        buff.cursor_position = startpos
+            


### PR DESCRIPTION
xi! xonsh is amaxing and xool! xanks!

Added Shift+Delete hotkey to delete whole word in xontrib whole_word_jumping.

The hotkey should be Control+Backspace like in many editors (i.e. Kate) but https://github.com/prompt-toolkit/python-prompt-toolkit/issues/257#issuecomment-190328366