### PR TITLE
Added the exit function to the globals to avoid importing from sys every time

### DIFF
--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -75,7 +75,7 @@ line is ``#!/usr/bin/env xonsh``.
       - ``$COMPLETIONS_DISPLAY = 'readline'``
       - Display completions will emulate the behavior of readline.
     * - ``exit``
-      - ``sys.exit()``
+      - ``exit()``
       - Exiting from the current script.
 
 To understand how xonsh executes the subprocess commands try

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1749,6 +1749,8 @@ following:
 
 That's All, Folks
 ======================
+To exit from xonsh script just call the ``exit(code)`` function.
+
 To leave xonsh, hit ``Ctrl-D``, type ``EOF``, type ``quit``, or type ``exit``.
 On Windows, you can also type ``Ctrl-Z``.
 

--- a/news/exit.rst
+++ b/news/exit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``exit()`` function to xonsh scripts by default to avoid importing from ``sys`` every time.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -467,7 +467,9 @@ def main_xonsh(args):
                 sys.argv = [args.file] + args.args
                 env.update(make_args_env())  # $ARGS is not sys.argv
                 env["XONSH_SOURCE"] = path
-                shell.ctx.update({"__file__": args.file, "__name__": "__main__"})
+                shell.ctx.update(
+                    {"__file__": args.file, "__name__": "__main__", "exit": sys.exit}
+                )
                 run_script_with_cache(
                     args.file, shell.execer, glb=shell.ctx, loc=None, mode="exec"
                 )
@@ -477,6 +479,7 @@ def main_xonsh(args):
         elif args.mode == XonshMode.script_from_stdin:
             # run a script given on stdin
             code = sys.stdin.read()
+            shell.ctx.update({"exit": sys.exit})
             run_code_with_cache(
                 code, shell.execer, glb=shell.ctx, loc=None, mode="exec"
             )


### PR DESCRIPTION
Hello! Just call `exit(code)` to exit from the xonsh script. It's so simple and beauty!

Closes #3794 #3241 #3573