### PR TITLE
Added xontrib-onepath

### DIFF
--- a/news/onepath.rst
+++ b/news/onepath.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added `xontrib-onepath <https://github.com/anki-code/xontrib-onepath>`_ to associate files with apps in xonsh shell like in graphical OS. 
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -169,6 +169,14 @@
   "description": ["Get identifiers, names, paths, URLs and words from the previous command output ",
                   "and use them for the next command."]
  },
+ {"name": "onepath",
+  "package": "xontrib-onepath",
+  "url": "https://github.com/anki-code/xontrib-onepath",
+  "description": ["When you click to a file or folder in graphical OS they will be opened in associated app.",
+                  "The xontrib-onepath brings the same logic for the xonsh shell. Type the filename or path",
+                  "without preceding command and an associated action will be executed. The actions are customizable."]
+ },
+ 
  {"name": "pdb",
   "package": "xonsh",
   "url": "http://xon.sh",

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -176,7 +176,6 @@
                   "The xontrib-onepath brings the same logic for the xonsh shell. Type the filename or path",
                   "without preceding command and an associated action will be executed. The actions are customizable."]
  },
- 
  {"name": "pdb",
   "package": "xonsh",
   "url": "http://xon.sh",


### PR DESCRIPTION
Added [xontrib-onepath](https://github.com/anki-code/xontrib-onepath) to associate files with apps in xonsh shell like in graphical OS. 