### PR TITLE
xontrib-powerline-binding added to xontrib list

### DIFF
--- a/news/xontrib-powerline-binding.rst
+++ b/news/xontrib-powerline-binding.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added xontrib `powerline-binding <https://github.com/dyuri/xontrib-powerline-binding>`_ - uses `powerline <https://github.com/powerline/powerline>`_ to render the prompt.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/xontrib-powerline-binding.rst
+++ b/news/xontrib-powerline-binding.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added xontrib `powerline-binding <https://github.com/dyuri/xontrib-powerline-binding>`_ - uses `powerline <https://github.com/powerline/powerline>`_ to render the prompt.
+* Added xontrib ``powerline-binding`` (https://github.com/dyuri/xontrib-powerline-binding) - uses ``powerline`` to render the prompt.
 
 **Changed:**
 

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -186,6 +186,11 @@
   "url": "https://github.com/santagada/xontrib-powerline",
   "description": ["Powerline for Xonsh shell"]
  },
+ {"name": "powerline-binding",
+  "package": "xontrib-powerline-binding",
+  "url": "https://github.com/dyuri/xontrib-powerline-binding",
+  "description": ["Uses powerline to render the xonsh prompt"]
+ },
  {"name": "prompt_ret_code",
   "package": "xonsh",
   "url": "http://xon.sh",
@@ -374,6 +379,13 @@
    "url": "https://github.com/santagada/xontrib-powerline",
    "install": {
     "pip": "xpip install xontrib-powerline"
+   }
+  },
+  "xontrib-powerline-binding": {
+   "license": "MIT",
+   "url": "https://github.com/dyuri/xontrib-powerline-binding",
+   "install": {
+    "pip": "xpip install xontrib-powerline-binding"
    }
   },
   "xontrib-prompt-ret-code": {


### PR DESCRIPTION
Added `xontrib-powerline-binding` to xontrib list.

It's not a *yet another* powerline like prompt theme, but actually uses `powerline` to render the prompt (+ the bottom toolbar, if configured).