### PR TITLE
Fix logic in working directory check

### DIFF
--- a/news/dwd-bugfix.rst
+++ b/news/dwd-bugfix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed logic in git dirty working directory
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Oops! The "||" did not do what I thought it did.

(It ran the first command, and if that command gave a 1, then ran the second command and returned the result of the second command.) Instead, I'll just keep the two checks in their own commands.