### PR TITLE
Added get_path to environment

### DIFF
--- a/news/env_get_path.rst
+++ b/news/env_get_path.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``${...}.get_path`` function to simplify getting Path object from environment variable.
+* Added ``${...}.get_path`` function to simplify getting Path-object from environment variable.
 
 **Changed:**
 

--- a/news/env_get_path.rst
+++ b/news/env_get_path.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``${...}.get_path`` function to simplify getting Path variable from environment variable.
+* Added ``${...}.get_path`` function to simplify getting Path object from environment variable.
 
 **Changed:**
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -13,8 +13,8 @@ import collections
 import collections.abc as cabc
 import subprocess
 import platform
+import pathlib
 
-from pathlib import Path
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.lazyasd import LazyObject, lazyobject
 from xonsh.codecache import run_script_with_cache
@@ -2004,8 +2004,11 @@ class Env(cabc.MutableMapping):
             return default
 
     def get_path(self, *args, **kwargs):
+        """The environment will look up default values from its own defaults if a
+        default is not given here and then Path-object will return.
+        """
         v = self.get(*args, **kwargs)
-        return Path(v) if v is not None else None
+        return pathlib.Path(v) if v else None
 
     def rawkeys(self):
         """An iterator that returns all environment keys in their original form.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -14,6 +14,7 @@ import collections.abc as cabc
 import subprocess
 import platform
 
+from pathlib import Path
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.lazyasd import LazyObject, lazyobject
 from xonsh.codecache import run_script_with_cache
@@ -2002,6 +2003,9 @@ class Env(cabc.MutableMapping):
         else:
             return default
 
+    def get_path(self, *args, **kwargs):
+        return Path(self.get(*args, **kwargs))
+                
     def rawkeys(self):
         """An iterator that returns all environment keys in their original form.
         This include string & compiled regular expression keys.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2004,7 +2004,8 @@ class Env(cabc.MutableMapping):
             return default
 
     def get_path(self, *args, **kwargs):
-        return Path(self.get(*args, **kwargs))
+        v = self.get(*args, **kwargs)
+        return Path(v) if v is not None else None
 
     def rawkeys(self):
         """An iterator that returns all environment keys in their original form.


### PR DESCRIPTION
Hi!

This PR adds `get_path` function to env.

Before:
```python
penv = p"{${...}.get('ENV','/default')}"   # overloaded syntax

if penv.exists():
    ...
```

or
```python
from pathlib import Path                    # overloaded imports
penv = Path(${...}.get('ENV','/default'))   # overloaded calls

if penv.exists():
    ...
```


After:
```python
penv = ${...}.get_path('ENV','/default')   # the clean view

if penv.exists():
    ...
```
