### PR TITLE
Space for menu

### DIFF
--- a/manual_tests/readme.rst
+++ b/manual_tests/readme.rst
@@ -1,0 +1,6 @@
+# Manual Tests
+Contents are tests we don't currently know how to automate via pytest.
+Pytest is configured in `setup.cfg` to ignore this folder and children.
+
+Each test should be packaged as a (xonsh) script of no arguments 
+so any dev can run the test.

--- a/manual_tests/test_async.xsh
+++ b/manual_tests/test_async.xsh
@@ -1,0 +1,8 @@
+import time
+$ENABLE_ASYNC_PROMPT = True
+
+def _in_future():
+    time.sleep(5)
+    return "{GREEN} awake "
+$PROMPT_FIELDS['in_future'] = _in_future
+$PROMPT = '{user}@{hostname}:{cwd} {localtime} {in_future}> '

--- a/manual_tests/test_manual_test_folder.py
+++ b/manual_tests/test_manual_test_folder.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Testing manual folder exclusion"""
+
+
+def test_ignore_this_test():
+    assert False, "pytest did not ignore this test, despite configuration to the contrary!"

--- a/manual_tests/tst_async_prompt.xsh
+++ b/manual_tests/tst_async_prompt.xsh
@@ -1,0 +1,18 @@
+import time
+$ENABLE_ASYNC_PROMPT = True
+
+def red_green(delay):
+    start = time.time()
+    time.sleep(delay)
+    end = time.time()
+    return f"{{GREEN}} done in {(end-start):.2F}"
+
+# $PROMPT_FIELDS.update({...}) didn't work?
+$PROMPT_FIELDS['d5_sec'] = (lambda: red_green(5))
+$PROMPT_FIELDS['d10_sec'] = (lambda: red_green(10))
+$PROMPT_FIELDS['d1_sec'] = (lambda:red_green(1))
+
+$PROMPT_FIELDS['in_future'] = _in_future
+$PROMPT = 'xx {user}@{hostname}:{cwd} {d5sec}> '
+$RIGHT_PROMPT = '< {RED} {d1_sec}'
+$BOTTOM_TOOLBAR = 'normal stuff {RED} {d1_sec}  {NO_COLOR}   {RED} {d5_sec} {NO_COLOR}  {RED} {d10_sec} {NO_COLOR}'

--- a/news/space-for-menu.rst
+++ b/news/space-for-menu.rst
@@ -1,0 +1,32 @@
+**Added:**
+
+* Note: all these fixes require changes in ``prompt-toolkit`` which have not been released.
+  For now, merge `prompt-toolkit/python-prompt-toolkit#1259 <https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1259>`_ for yourself,
+  or install private build https://github.com/bobhy/python-prompt-toolkit/tree/space-for-menu.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Code in ``ptk_shell/completer.py`` that was attempting to enforce ``$COMPLETION_MENU_ROWS`` via
+  internal hacks.
+
+**Fixed:**
+
+* ``$COMPLETION_MENU_ROWS`` now works as expected, even at bottom of screen.
+* Multi-column completion menu no longer displays an empty line at the bottom of the menu.
+  This row is used to display metadata about the selected completion and should not be
+  displayed if none of the completions has metadata.
+* ``$RIGHT_PROMPT, $BOTTOM_TOOLBAR`` and ``$PROMPT`` can now be cleared, once set in a session.
+  To clear, set to ``""``, not ``None``.  (``None`` means leave the prior value unchanged to PTK.
+  and ``""`` is consistant with new registered defaults for these environment variables, anyway.)
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ exclude = '''
      )/
 )
 '''
+
+[tool.pytest.ini_options]
+norecursedirs = "manual_tests"

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -5,7 +5,6 @@ import builtins
 
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.application.current import get_app
 
 from xonsh.completers.tools import RichCompletion
 
@@ -66,11 +65,6 @@ class PromptToolkitCompleter(Completer):
                 completions = set(completions)
                 completions.discard(sug_comp)
                 completions = (sug_comp,) + tuple(sorted(completions))
-        # reserve space, if needed.
-        if len(completions) <= 1:
-            pass
-        elif len(os.path.commonprefix(completions)) <= len(prefix):
-            self.reserve_space()
         # Find common prefix (strip quoting)
         c_prefix = os.path.commonprefix([a.strip("'\"") for a in completions])
         # Find last split symbol, do not trim the last part
@@ -105,19 +99,3 @@ class PromptToolkitCompleter(Completer):
         comp, _, _ = sug.text.partition(" ")
         _, _, prev = line.rpartition(" ")
         return prev + comp
-
-    def reserve_space(self):
-        """Adjust the height for showing autocompletion menu."""
-        app = get_app()
-        render = app.renderer
-        window = app.layout.container.children[0].content.children[1].content
-
-        if window and window.render_info:
-            h = window.render_info.content_height
-            r = builtins.__xonsh__.env.get("COMPLETIONS_MENU_ROWS")
-            size = h + r
-            last_h = render._last_screen.height if render._last_screen else 0
-            last_h = max(render._min_available_height, last_h)
-            if last_h < size:
-                if render._last_screen:
-                    render._last_screen.height = size

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -142,6 +142,7 @@ class PromptToolkitShell(BaseShell):
         refresh_interval = env.get("PROMPT_REFRESH_INTERVAL")
         refresh_interval = refresh_interval if refresh_interval > 0 else None
         complete_in_thread = env.get("COMPLETION_IN_THREAD")
+        completions_menu_rows = env.get("COMPLETIONS_MENU_ROWS")
         completions_display = env.get("COMPLETIONS_DISPLAY")
         complete_style = self.completion_displays_to_styles[completions_display]
 
@@ -190,7 +191,7 @@ class PromptToolkitShell(BaseShell):
             "editing_mode": editing_mode,
             "prompt_continuation": self.continuation_tokens,
             "enable_history_search": enable_history_search,
-            "reserve_space_for_menu": 0,
+            "reserve_space_for_menu": completions_menu_rows,
             "key_bindings": self.key_bindings,
             "complete_style": complete_style,
             "complete_while_typing": complete_while_typing,

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -39,6 +39,10 @@ from prompt_toolkit.styles.pygments import (
 )
 
 
+class PtkFormattedText:  # represents PTK `AnyFormattedText` type union
+    pass  # used only in type hinting, since PTK does not publish this API
+
+
 ANSI_OSC_PATTERN = re.compile("\x1b].*?\007")
 Token = _TokenType()
 
@@ -53,7 +57,7 @@ Fired after prompt toolkit has been initialized
 )
 
 
-def tokenize_ansi(tokens):
+def tokenize_ansi(tokens) -> PtkFormattedText:
     """Checks a list of (token, str) tuples for ANSI escape sequences and
     extends the token list with the new formatted entries.
     During processing tokens are converted to ``prompt_toolkit.FormattedText``.
@@ -142,6 +146,7 @@ class PromptToolkitShell(BaseShell):
         refresh_interval = env.get("PROMPT_REFRESH_INTERVAL")
         refresh_interval = refresh_interval if refresh_interval > 0 else None
         complete_in_thread = env.get("COMPLETION_IN_THREAD")
+        completions_menu_rows = env.get("COMPLETIONS_MENU_ROWS")
         completions_display = env.get("COMPLETIONS_DISPLAY")
         complete_style = self.completion_displays_to_styles[completions_display]
 
@@ -158,11 +163,15 @@ class PromptToolkitShell(BaseShell):
         if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
             get_prompt_tokens = lambda: self.prompt_tokens("PROMPT", "message")
             get_rprompt_tokens = lambda: self.prompt_tokens("RIGHT_PROMPT", "rprompt")
-            get_bottom_toolbar_tokens = lambda: self.prompt_tokens("BOTTOM_TOOLBAR", "bottom_toolbar")
+            get_bottom_toolbar_tokens = lambda: self.prompt_tokens(
+                "BOTTOM_TOOLBAR", "bottom_toolbar"
+            )
         else:
             get_prompt_tokens = self.prompt_tokens("PROMPT", "message")
             get_rprompt_tokens = self.prompt_tokens("RIGHT_PROMPT", "rprompt")
-            get_bottom_toolbar_tokens = self.prompt_tokens("BOTTOM_TOOLBAR", "bottom_toolbar")
+            get_bottom_toolbar_tokens = self.prompt_tokens(
+                "BOTTOM_TOOLBAR", "bottom_toolbar"
+            )
 
         if env.get("VI_MODE"):
             editing_mode = EditingMode.VI
@@ -182,15 +191,12 @@ class PromptToolkitShell(BaseShell):
         prompt_args = {
             "mouse_support": mouse_support,
             "auto_suggest": auto_suggest,
-            "message": get_prompt_tokens,
-            "rprompt": get_rprompt_tokens,
-            "bottom_toolbar": get_bottom_toolbar_tokens,
             "completer": completer,
             "multiline": multiline,
             "editing_mode": editing_mode,
             "prompt_continuation": self.continuation_tokens,
             "enable_history_search": enable_history_search,
-            "reserve_space_for_menu": 0,
+            "reserve_space_for_menu": completions_menu_rows,
             "key_bindings": self.key_bindings,
             "complete_style": complete_style,
             "complete_while_typing": complete_while_typing,
@@ -198,6 +204,27 @@ class PromptToolkitShell(BaseShell):
             "refresh_interval": refresh_interval,
             "complete_in_thread": complete_in_thread,
         }
+        if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
+            prompt_args.update(
+                dict(
+                    message=lambda: self.prompt_tokens("PROMPT", "message"),
+                    rprompt=lambda: self.prompt_tokens("RIGHT_PROMPT", "rprompt"),
+                    bottom_toolbar=lambda: self.prompt_tokens(
+                        "BOTTOM_TOOLBAR", "bottom_toolbar"
+                    ),
+                )
+            )
+        else:
+            prompt_args.update(
+                dict(
+                    message=self.prompt_tokens("PROMPT", "message"),
+                    rprompt=self.prompt_tokens("RIGHT_PROMPT", "rprompt"),
+                    bottom_toolbar=self.prompt_tokens(
+                        "BOTTOM_TOOLBAR", "bottom_toolbar"
+                    ),
+                )
+            )
+
         if env.get("COLOR_INPUT"):
             if HAS_PYGMENTS:
                 prompt_args["lexer"] = PygmentsLexer(pyghooks.XonshLexer)
@@ -247,8 +274,13 @@ class PromptToolkitShell(BaseShell):
         """Enters a loop that reads and execute input from user."""
         if intro:
             print(intro)
+        if self._first_prompt:
+            carriage_return()
+            self._first_prompt = False
+
         auto_suggest = AutoSuggestFromHistory()
         self.push = self._push
+
         while not builtins.__xonsh__.exit:
             try:
                 line = self.singleline(auto_suggest=auto_suggest)
@@ -284,61 +316,33 @@ class PromptToolkitShell(BaseShell):
         except Exception:  # pylint: disable=broad-except
             print_exception()
 
+        # handle OSC tokens
         p, osc_tokens = remove_ansi_osc(p)
-
-        if kwargs.get("handle_osc_tokens"):
-            # handle OSC tokens
-            for osc in osc_tokens:
-                if osc[2:4] == "0;":
-                    env["TITLE"] = osc[4:-1]
-                else:
-                    print(osc, file=sys.__stdout__, flush=True)
+        for osc in osc_tokens:
+            if osc[2:4] == "0;":
+                env["TITLE"] = osc[4:-1]
+                self.settitle()
+            else:
+                print(osc, file=sys.__stdout__, flush=True)
 
         toks = partial_color_tokenize(p)
-
         return tokenize_ansi(PygmentsTokens(toks))
 
-    def prompt_tokens(self):
-        """Returns a list of (token, str) tuples for the current prompt."""
-        if self._first_prompt:
-            carriage_return()
-            self._first_prompt = False
-
-        tokens = self._get_prompt_tokens("PROMPT", "message", handle_osc_tokens=True)
-        self.settitle()
-        return tokens
-
-    def rprompt_tokens(self):
-        """Returns a list of (token, str) tuples for the current right
-        prompt.
-        """
-        return self._get_prompt_tokens("RIGHT_PROMPT", "rprompt", default=[])
-
-    def _bottom_toolbar_tokens(self):
-        """Returns a list of (token, str) tuples for the current bottom
-        toolbar.
-        """
-        return self._get_prompt_tokens("BOTTOM_TOOLBAR", "bottom_toolbar", default=None)
-
-    @property
-    def bottom_toolbar_tokens(self):
-        """Returns self._bottom_toolbar_tokens if it would yield a result"""
-        if builtins.__xonsh__.env.get("BOTTOM_TOOLBAR"):
-            return self._bottom_toolbar_tokens
-
-    def continuation_tokens(self, width, line_number, is_soft_wrap=False):
+    def continuation_tokens(
+        self, width, line_number, is_soft_wrap=False
+    ) -> PtkFormattedText:
         """Displays dots in multiline prompt"""
         if is_soft_wrap:
-            return ""
+            return []
         width = width - 1
         dots = builtins.__xonsh__.env.get("MULTILINE_PROMPT")
         dots = dots() if callable(dots) else dots
         if not dots:
-            return ""
+            return []
         basetoks = self.format_color(dots)
         baselen = sum(len(t[1]) for t in basetoks)
         if baselen == 0:
-            return [(Token, " " * (width + 1))]
+            return PygmentsTokens([(Token, " " * (width + 1))])
         toks = basetoks * (width // baselen)
         n = width % baselen
         count = 0

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -158,21 +158,6 @@ class PromptToolkitShell(BaseShell):
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
         completer = None if completions_display == "none" else self.pt_completer
 
-        get_bottom_toolbar_tokens = self.bottom_toolbar_tokens
-
-        if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
-            get_prompt_tokens = lambda: self.prompt_tokens("PROMPT", "message")
-            get_rprompt_tokens = lambda: self.prompt_tokens("RIGHT_PROMPT", "rprompt")
-            get_bottom_toolbar_tokens = lambda: self.prompt_tokens(
-                "BOTTOM_TOOLBAR", "bottom_toolbar"
-            )
-        else:
-            get_prompt_tokens = self.prompt_tokens("PROMPT", "message")
-            get_rprompt_tokens = self.prompt_tokens("RIGHT_PROMPT", "rprompt")
-            get_bottom_toolbar_tokens = self.prompt_tokens(
-                "BOTTOM_TOOLBAR", "bottom_toolbar"
-            )
-
         if env.get("VI_MODE"):
             editing_mode = EditingMode.VI
         else:


### PR DESCRIPTION
A bunch of layout changes in prompt toolkit shell.
* Ensure completion menu displays a minimum of $MENU_COMPLETIONS_ROWS, even at bottom of screen (superseding doomed hack of #3778)
* Allow bottom toolbar to be cleared if set to something visible earlier in the session (#3810)
* Display right prompt at *top* of prompt, not at bottom of screen (#3810)

Fixes currently require changes in prompt-toolkit: see pending PR from prompt-toolkit/python-prompt-toolkit#1259.
However, this PR won't crash if run with published PTK.

@jnoortheen, please give this a careful look, My changes overlapped with yours, but I think I reconciled them all happily.
@anki-code, would also appreciate you giving this a try.