### PR TITLE
Added printx to builtins

### DIFF
--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -54,7 +54,7 @@ line is ``#!/usr/bin/env xonsh``.
       - ``v=$(echo 1)``
       - In bash, backticks mean to run a captured subprocess - it's ``$()`` in xonsh. Backticks in xonsh
         mean regex globbing (i.e. ``ls `/etc/pass.*```).
-    * - ``echo -e "\033[0;31mRed text\033[0m"```
+    * - ``echo -e "\033[0;31mRed text\033[0m"``
       - ``printx("{RED}Red text{RESET}")``
       - Print colored text as easy as possible.
     * - ``shopt -s dotglob``

--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -54,6 +54,9 @@ line is ``#!/usr/bin/env xonsh``.
       - ``v=$(echo 1)``
       - In bash, backticks mean to run a captured subprocess - it's ``$()`` in xonsh. Backticks in xonsh
         mean regex globbing (i.e. ``ls `/etc/pass.*```).
+    * - ``echo -e "\033[0;31mRed text\033[0m"```
+      - ``printx("{RED}Red text{RESET}")``
+      - Print colored text as easy as possible.
     * - ``shopt -s dotglob``
       - ``$DOTGLOB = True``
       - Globbing files with ``*`` or ``**`` will also match dotfiles, or those ‘hidden’ files whose names 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1536,7 +1536,7 @@ For example:
     (env) >>>
 
 
-You can also color your prompt (or print colored messages using ``printx`` function) easily by inserting
+You can also color your prompt (or print colored messages using ``print_color`` function) easily by inserting
 keywords such as ``{GREEN}`` or ``{BOLD_BLUE}``.  Colors have the form shown below:
 
 * ``RESET``: Resets any previously used styling.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1502,8 +1502,8 @@ For example:
     (env) >>>
 
 
-You can also color your prompt easily by inserting keywords such as ``{GREEN}``
-or ``{BOLD_BLUE}``.  Colors have the form shown below:
+You can also color your prompt (or print colored messages using ``printx`` function) easily by inserting
+keywords such as ``{GREEN}`` or ``{BOLD_BLUE}``.  Colors have the form shown below:
 
 * ``RESET``: Resets any previously used styling.
 * ``COLORNAME``: Inserts a color code for the following basic colors,

--- a/news/printx.rst
+++ b/news/printx.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``printx`` (``xonsh.tools.print_color``) function to builtins.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/printx.rst
+++ b/news/printx.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``printx`` (``xonsh.tools.print_color``) function to builtins.
+* Added ``print_color`` and ``printx`` functions to builtins as reference to ``xonsh.tools.print_color``.
 
 **Changed:**
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1464,6 +1464,7 @@ class XonshSession:
             "execx": "__xonsh__.builtins.execx",
             "compilex": "__xonsh__.builtins.compilex",
             "events": "__xonsh__.builtins.events",
+            "print_color": "__xonsh__.builtins.print_color",
             "printx": "__xonsh__.builtins.printx",
         }
         for refname, objname in proxy_mapping.items():
@@ -1487,6 +1488,8 @@ class XonshSession:
             "compilex",
             "default_aliases",
             "events",
+            "print_color",
+            "printx",
         ]
 
         for name in names:
@@ -1503,7 +1506,7 @@ class _BuiltIns:
         self.execx = None if execer is None else execer.exec
         self.compilex = None if execer is None else execer.compile
         self.events = events
-        self.printx = print_color
+        self.print_color = self.printx = print_color
 
 
 class DynamicAccessProxy:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -44,6 +44,7 @@ from xonsh.tools import (
     globpath,
     XonshError,
     XonshCalledProcessError,
+    print_color,
 )
 from xonsh.lazyimps import pty, termios, fcntl
 from xonsh.commands_cache import CommandsCache
@@ -1463,7 +1464,7 @@ class XonshSession:
             "execx": "__xonsh__.builtins.execx",
             "compilex": "__xonsh__.builtins.compilex",
             "events": "__xonsh__.builtins.events",
-            "printx": "__xonsh__.shell.shell.print_color",
+            "printx": "__xonsh__.builtins.printx",
         }
         for refname, objname in proxy_mapping.items():
             proxy = DynamicAccessProxy(refname, objname)
@@ -1502,6 +1503,7 @@ class _BuiltIns:
         self.execx = None if execer is None else execer.exec
         self.compilex = None if execer is None else execer.compile
         self.events = events
+        self.printx = print_color
 
 
 class DynamicAccessProxy:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -44,7 +44,6 @@ from xonsh.tools import (
     globpath,
     XonshError,
     XonshCalledProcessError,
-    print_color,
 )
 from xonsh.lazyimps import pty, termios, fcntl
 from xonsh.commands_cache import CommandsCache
@@ -1464,12 +1463,11 @@ class XonshSession:
             "execx": "__xonsh__.builtins.execx",
             "compilex": "__xonsh__.builtins.compilex",
             "events": "__xonsh__.builtins.events",
+            "printx": "__xonsh__.shell.shell.print_color",
         }
         for refname, objname in proxy_mapping.items():
             proxy = DynamicAccessProxy(refname, objname)
             setattr(builtins, refname, proxy)
-
-        builtins.printx = print_color
 
         # sneak the path search functions into the aliases
         # Need this inline/lazy import here since we use locate_binary that

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -44,6 +44,7 @@ from xonsh.tools import (
     globpath,
     XonshError,
     XonshCalledProcessError,
+    print_color,
 )
 from xonsh.lazyimps import pty, termios, fcntl
 from xonsh.commands_cache import CommandsCache
@@ -1467,6 +1468,8 @@ class XonshSession:
         for refname, objname in proxy_mapping.items():
             proxy = DynamicAccessProxy(refname, objname)
             setattr(builtins, refname, proxy)
+
+        builtins.printx = print_color
 
         # sneak the path search functions into the aliases
         # Need this inline/lazy import here since we use locate_binary that


### PR DESCRIPTION
Hi! xonsh is better and better after every PR!

The second thing (after builtin exit) I really miss while writing xonsh scripts is a simplest way to print colored messages. Colors make terminal alive and this is the good way to give developers easiest way to do print with colors without imports/xonshrc/xontribs.

Before this PR:
```python
from xonsh.tools import print_color   # imports... I love imports... but when I'm doing it every day...
print_color('{RED}Color!')      # long names... I love long names... but my keys are erased already...
```

After this PR:
```python
printx('{RED}Color!')    # any time, everywhere, just when the thought got into the head
```