### PR TITLE
Four changes around registered environment path types

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -222,12 +222,12 @@ PATH examples:
 .. code-block:: xonshcon
 
     >>> $PATH
-    ['/home/snail/.local/bin', '/home/snail/sandbox/bin',
+    ['/home/snail/.local/bin', '/home/anki/sandbox/bin',
     '/home/snail/miniconda3/bin', '/usr/local/bin', '/usr/local/sbin',
     '/usr/bin', '/usr/sbin', '/bin', '/sbin', '.']
     >>> $PATH.paths()
     [PosixPath('/home/snail/.local/bin'),
-     PosixPath('/home/snail/sandbox/bin'),
+     PosixPath('/home/anki/sandbox/bin'),
      #...
     >>> $PATH.paths()[0].exists()
     True

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -253,9 +253,9 @@ does not exist:
 
 .. code-block:: xonshcon
 
-    ${...}.register('MY_HOSTS_FILE', type='path', default=p'/etc/hosts')
-    if $MY_HOSTS_FILE.exists():
-        wc -l $MY_HOSTS_FILE
+    ${...}.register('MY_HOSTS', type='path', default=p'/etc/hosts')
+    if $MY_HOSTS.exists():
+        wc -l $MY_HOSTS
 
 Learn more about `register function <environ.html#xonsh.environ.Env.register>`_.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -226,9 +226,7 @@ PATH examples:
     '/home/snail/miniconda3/bin', '/usr/local/bin', '/usr/local/sbin',
     '/usr/bin', '/usr/sbin', '/bin', '/sbin', '.']
     >>> $PATH.paths()
-    [PosixPath('/home/snail/.local/bin'),
-     PosixPath('/home/anki/sandbox/bin'),
-     #...
+    [PosixPath('/home/snail/.local/bin'), PosixPath('/home/anki/sandbox/bin'), ...]
     >>> $PATH.paths()[0].exists()
     True
     >>> $LD_LIBRARY_PATH

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -238,6 +238,21 @@ They can be seen on the `Environment Variables page <envvars.html>`_.
           ``KeyError`` will be raised if the variable does not exist in the
           environment.
 
+Register typed environment variables
+------------------------------------
+
+Before using environment variable you can register it. Xonsh will automatically
+convert the value to appropriate format or set default value if variable
+does not exist:
+
+.. code-block:: xonshcon
+
+    ${...}.register('MY_HOSTS_FILE', type='path', default=p'/etc/hosts')
+    if $MY_HOSTS_FILE.exists():
+        wc -l $MY_HOSTS_FILE
+
+Learn more about `register function <environ.html#xonsh.environ.Env.register>`_.
+
 Running Commands
 ==============================
 As a shell, xonsh is meant to make running commands easy and fun.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -209,8 +209,8 @@ Like other variables in Python, environment variables have a type. Sometimes
 this type is imposed based on the variable name. The current rules are pretty
 simple:
 
-* ``\w*PATH``: any variable whose name ends in PATH is a list of strings.
-* ``\w*DIRS``: any variable whose name ends in DIRS is a list of strings.
+* ``\w*PATH``, ``\w*_DIRS``, ``\w*_FILES``: any variable whose name ends in PATH is a list of strings.
+* ``\w*_FILE``, ``\w*_DIR``: any variable whose name ends in _FILE is a file path.
 * ``XONSH_HISTORY_SIZE``: this variable is an int.
 * ``CASE_SENSITIVE_COMPLETIONS``: this variable is a boolean.
 
@@ -225,6 +225,12 @@ PATH examples:
     ['/home/snail/.local/bin', '/home/snail/sandbox/bin',
     '/home/snail/miniconda3/bin', '/usr/local/bin', '/usr/local/sbin',
     '/usr/bin', '/usr/sbin', '/bin', '/sbin', '.']
+    >>> $PATH.paths()
+    [PosixPath('/home/snail/.local/bin'),
+     PosixPath('/home/snail/sandbox/bin'),
+     #...
+    >>> $PATH.paths()[0].exists()
+    True
     >>> $LD_LIBRARY_PATH
     ['/home/snail/.local/lib', '']
 

--- a/news/docs_register.rst
+++ b/news/docs_register.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added "Register typed environment variables" to the Tutorial
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/paths.rst
+++ b/news/paths.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* Added ``_DIRS``,``_FILES``,``_FILE``, ``_DIR`` to registered env_path and path types.
+
+**Changed:**
+
+* ``$EXAMPLE_PATH.paths`` is now function that returns list of Path objects by default.
+  And the ``type`` argument could be set to ``str`` to get list of strings -
+  it's the same as ``list($EXAMPLE_PATH)``.
+* ``str_to_path`` function returns the value without changes if it's not a ``str`` type
+  to save environment variables that detected as path but not a path (e.g. ``$I_LIKE_PATH=True`` stay as ``True``)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -435,8 +435,9 @@ def test_register_var_path():
     env["MY_PATH_VAR"] = path
     assert env["MY_PATH_VAR"] == None
 
-    with pytest.raises(TypeError):
-        env["MY_PATH_VAR"] = 42
+    path = 42
+    env["MY_PATH_VAR"] = path
+    assert env["MY_PATH_VAR"] == 42
 
 
 def test_register_custom_var_env_path():

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -34,7 +34,7 @@ def test_env_contains():
 @pytest.mark.parametrize("path", [["/home/wakka"], ["wakka"]])
 def test_env_path_list(path):
     env = Env(MYPATH=path)
-    assert path == env["MYPATH"].paths
+    assert path == env["MYPATH"].paths(type=str)
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_env_path_list(path):
 )
 def test_env_path_str(path):
     env = Env(MYPATH=path)
-    assert path == env["MYPATH"].paths
+    assert path == env["MYPATH"].paths(type=str)
 
 
 def test_env_detype():
@@ -447,7 +447,7 @@ def test_register_custom_var_env_path():
     env["MY_SPECIAL_VAR"] = paths
 
     assert hasattr(env["MY_SPECIAL_VAR"], "paths")
-    assert env["MY_SPECIAL_VAR"].paths == paths
+    assert env["MY_SPECIAL_VAR"].paths(type=str) == paths
 
     with pytest.raises(TypeError):
         env["MY_SPECIAL_VAR"] = 32

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -837,7 +837,7 @@ def test_is_env_path(inp, exp):
     assert exp == obs
 
 
-@pytest.mark.parametrize("inp, exp", [("/tmp", pathlib.Path("/tmp")), ("", None)])
+@pytest.mark.parametrize("inp, exp", [("/tmp", pathlib.Path("/tmp")), ("", None), (False, False)])
 def test_str_to_path(inp, exp):
     obs = str_to_path(inp)
     assert exp == obs
@@ -853,7 +853,7 @@ def test_str_to_path(inp, exp):
 )
 def test_str_to_env_path(inp, exp):
     obs = str_to_env_path(inp)
-    assert exp == obs.paths
+    assert exp == obs.paths(type=str)
 
 
 @pytest.mark.parametrize("inp, exp", [(pathlib.Path("///tmp"), "/tmp")])

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1985,10 +1985,11 @@ class Env(cabc.MutableMapping):
         ):
             self._detyped = None
 
-        validator = self.get_validator(key)
-        converter = self.get_converter(key)
-        if not validator(val):
-            val = converter(val)
+        if val:
+            validator = self.get_validator(key)
+            converter = self.get_converter(key)
+            if not validator(val):
+                val = converter(val)
         return val
 
     def __setitem__(self, key, val):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1143,6 +1143,10 @@ def DEFAULT_VARS():
             "'/usr/bin', '/sbin', '/bin', '/usr/games', '/usr/local/games')``",
         ),
         re.compile(r"\w*PATH$"): Var(is_env_path, str_to_env_path, env_path_to_str),
+        re.compile(r"\w*_DIRS$"): Var(is_env_path, str_to_env_path, env_path_to_str),
+        re.compile(r"\w*_FILES$"): Var(is_env_path, str_to_env_path, env_path_to_str),
+        re.compile(r"\w*_FILE$"): Var(is_path, str_to_path, path_to_str),
+        re.compile(r"\w*_DIR$"): Var(is_path, str_to_path, path_to_str),
         "PATHEXT": Var(
             is_nonstring_seq_of_strings,
             pathsep_to_upper_seq,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1985,7 +1985,7 @@ class Env(cabc.MutableMapping):
         ):
             self._detyped = None
 
-        if val:
+        if val is not None:
             validator = self.get_validator(key)
             converter = self.get_converter(key)
             if not validator(val):

--- a/xonsh/jsonutils.py
+++ b/xonsh/jsonutils.py
@@ -16,4 +16,4 @@ def serialize_xonsh_json(val):
 
 @serialize_xonsh_json.register(EnvPath)
 def _serialize_xonsh_json_env_path(val):
-    return val.paths
+    return val.paths(type=str)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -208,12 +208,11 @@ class EnvPath(cabc.MutableSequence):
     def insert(self, index, value):
         self._l.insert(index, value)
 
-    @property
-    def paths(self):
+    def paths(self, type=pathlib.Path):
         """
         Returns the list of directories that this EnvPath contains.
         """
-        return list(self)
+        return [type(p) for p in list(self)]
 
     def __repr__(self):
         return repr(self._l)
@@ -1183,8 +1182,12 @@ def is_env_path(x):
 
 def str_to_path(x):
     """Converts a string to a path."""
-    # checking x is needed to avoid uncontrolled converting empty string to Path('.')
-    return pathlib.Path(x) if x else None
+    if isinstance(x, str):
+        # checking x is needed to avoid uncontrolled converting empty string to Path('.')
+        return pathlib.Path(x) if x else None
+    else:
+        # if variable set to non string value, leave it as is
+        return x
 
 
 def str_to_env_path(x):


### PR DESCRIPTION
In this PR:
1. Fix and docs from #3816
2. Added ``_DIRS``,``_FILES``,``_FILE``, ``_DIR`` to registered env_path and path types.
3. ``$EXAMPLE_PATH.paths`` is now function that returns list of Path objects by default. And the ``type`` argument could be set to ``str`` to get list of strings - it's the same as ``list($EXAMPLE_PATH)``.
4. ``str_to_path`` function returns the value without changes if it's not a ``str`` type to save environment variables that detected as path but not a path (e.g. ``$I_LIKE_PATH=True`` stay as ``True`` and ``$REAL_DIR='/tmp'`` will be `Path('/tmp')`).
5. Tests fixed, docs added, news painted

This allows:

1. Add `_FILE` postfix and the registering of env variable as path variable is not needed. 

2. And on Linux I see improvement for detection (e.g. `GTK_RC_FILES`, `XDG_CONFIG_DIRS`, `XDG_RUNTIME_DIR`).

3. `$ENV_PATH.paths()` allows iterate Path objects it's more useful:

    Before:
    ```python
    for p in $ENV_PATH:
        if pf'{p}'.exists(): ...     # syntax and string modifiers overhead
    ```
    or
    ```python
    from pathlib import Path     # import overhead
    for p in $ENV_PATH:
        if Path(p).exists(): ... # better but import
    ```

    After:
    ```python
    for p in $ENV_PATH.paths():      # pretty sane
        if p.exists(): ...
    ```

As result we've got great interface between path environment variables and xonsh.