### PR TITLE
test: regression to improve test suit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from xonsh.jobs import tasks
 from xonsh.events import events
 from xonsh.platform import ON_WINDOWS
 
-from tools import DummyShell, sp, DummyCommandsCache, DummyEnv, DummyHistory
+from .tools import DummyShell, sp, DummyCommandsCache, DummyEnv, DummyHistory, ON_WINDOWS
 
 
 @pytest.fixture
@@ -164,3 +164,9 @@ def pytest_configure(config):
     """Abort test run if --flake8 requested, since it would hang on parser_test.py"""
     if config.getoption("--flake8", ""):
         pytest.exit("pytest-flake8 no longer supported, use flake8 instead.")
+
+
+@pytest.fixture
+def skip_on_windows():
+    if ON_WINDOWS:
+        pytest.skip("Unix stuff")

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -9,7 +9,7 @@ import pytest
 from xonsh.aliases import Aliases, ExecAlias
 from xonsh.environ import Env
 
-from tools import skip_if_on_windows
+from .tools import skip_if_on_windows
 
 
 def cd(args, stdin=None, **kwargs):

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -6,7 +6,7 @@ from xonsh.ast import Tuple, Name, Store, min_line, Call, BinOp, isexpression
 
 import pytest
 
-from tools import check_parse, nodes_equal
+from .tools import check_parse, nodes_equal
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -28,7 +28,7 @@ from xonsh.built_ins import (
 from xonsh.environ import Env
 from xonsh.proc import PopenThread, ProcProxy, ProcProxyThread
 
-from tools import skip_if_on_windows
+from .tools import skip_if_on_windows
 
 
 HOME_PATH = os.path.expanduser("~")

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -10,7 +10,7 @@ from xonsh.commands_cache import (
     predict_true,
     predict_false,
 )
-from tools import skip_if_on_windows
+from .tools import skip_if_on_windows
 
 
 def test_commands_cache_lazy(xonsh_builtins):

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -1,7 +1,7 @@
 """Tests xonsh contexts."""
 from textwrap import dedent
 
-from tools import check_exec
+from .tools import check_exec
 from xonsh.contexts import Block, Functor
 
 import pytest

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -17,7 +17,7 @@ from xonsh.environ import (
     LsColors,
 )
 
-from tools import skip_if_on_unix
+from .tools import skip_if_on_unix
 
 
 def test_env_normal():

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -2,7 +2,7 @@
 """Tests the xonsh lexer."""
 import os
 
-from tools import (
+from .tools import (
     check_eval,
     check_exec,
     check_parse,

--- a/tests/test_foreign_shells.py
+++ b/tests/test_foreign_shells.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 
 import pytest  # noqa F401
-from tools import skip_if_on_windows, skip_if_on_unix
+from .tools import skip_if_on_windows, skip_if_on_unix
 
 from xonsh.foreign_shells import foreign_shell_data, parse_env, parse_aliases
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,7 +10,7 @@ import pytest
 
 from xonsh.lib.os import indir
 
-from tools import (
+from .tools import (
     skip_if_on_msys,
     skip_if_on_windows,
     skip_if_on_darwin,

--- a/tests/test_lib/test_os.xsh
+++ b/tests/test_lib/test_os.xsh
@@ -1,45 +1,35 @@
 import os
-import tempfile
 
 from xonsh.lib.os import indir, rmtree
 
-import pytest
-
-from tools import ON_WINDOWS
 
 
-def test_indir():
-    if ON_WINDOWS:
-        pytest.skip("On Windows")
-    with tempfile.TemporaryDirectory() as tmpdir:
-        assert ![pwd].output.strip() != tmpdir
+def test_indir(tmpdir, skip_on_windows):
+    assert ![pwd].output.strip() != tmpdir
+    with indir(tmpdir):
+        assert ![pwd].output.strip() == tmpdir
+    assert ![pwd].output.strip() != tmpdir
+    try:
         with indir(tmpdir):
-            assert ![pwd].output.strip() == tmpdir
+            raise Exception
+    except Exception:
         assert ![pwd].output.strip() != tmpdir
-        try:
-            with indir(tmpdir):
-                raise Exception
-        except Exception:
-            assert ![pwd].output.strip() != tmpdir
 
 
-def test_rmtree():
-    if ON_WINDOWS:
-        pytest.skip("On Windows")
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with indir(tmpdir):
-            mkdir rmtree_test
-            pushd rmtree_test
-            git init
-            git config user.email "test@example.com"
-            git config user.name "Code Monkey"
-            touch thing.txt
-            git add thing.txt
-            git commit -a --no-gpg-sign -m "add thing"
-            popd
-            assert os.path.exists('rmtree_test')
-            assert os.path.exists('rmtree_test/thing.txt')
-            rmtree('rmtree_test', force=True)
-            assert not os.path.exists('rmtree_test')
-            assert not os.path.exists('rmtree_test/thing.txt')
+def test_rmtree(tmpdir, skip_on_windows):
+    with indir(tmpdir):
+        mkdir rmtree_test
+        pushd rmtree_test
+        git init
+        git config user.email "test@example.com"
+        git config user.name "Code Monkey"
+        touch thing.txt
+        git add thing.txt
+        git commit -a --no-gpg-sign -m "add thing"
+        popd
+        assert os.path.exists('rmtree_test')
+        assert os.path.exists('rmtree_test/thing.txt')
+        rmtree('rmtree_test', force=True)
+        assert not os.path.exists('rmtree_test')
+        assert not os.path.exists('rmtree_test/thing.txt')
 

--- a/tests/test_lib/test_subprocess.xsh
+++ b/tests/test_lib/test_subprocess.xsh
@@ -6,7 +6,7 @@ from xonsh.lib.subprocess import run, check_call, check_output, CalledProcessErr
 
 import pytest
 
-from tools import ON_WINDOWS
+from ..tools import ON_WINDOWS
 
 
 def test_run():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 """Tests the xonsh main function."""
 from __future__ import unicode_literals, print_function
-from contextlib import contextmanager
 
 import builtins
 import gc
 import os
 import os.path
 import sys
+from contextlib import contextmanager
 
+import pytest
 import xonsh.main
 from xonsh.main import XonshMode
-import pytest
-from tools import TEST_DIR, skip_if_on_windows
+
+from .tools import TEST_DIR, skip_if_on_windows
 
 
 def Shell(*args, **kwargs):

--- a/tests/test_man.py
+++ b/tests/test_man.py
@@ -3,7 +3,7 @@ import os
 import pytest  # noqa F401
 from xonsh.completers.man import complete_from_man
 
-from tools import skip_if_on_windows
+from .tools import skip_if_on_windows
 
 
 @skip_if_on_windows

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,7 +11,7 @@ from xonsh.ast import AST, With, Pass, Str, Call
 from xonsh.parser import Parser
 from xonsh.parsers.fstring_adaptor import FStringAdaptor
 
-from tools import nodes_equal, skip_if_pre_3_8, VER_MAJOR_MINOR
+from .tools import nodes_equal, skip_if_pre_3_8, VER_MAJOR_MINOR
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -9,7 +9,7 @@ from xonsh.environ import Env
 from xonsh.prompt.base import PromptFormatter, PROMPT_FIELDS
 from xonsh.prompt import vc
 
-from tools import DummyEnv
+from .tools import DummyEnv
 
 
 @pytest.fixture

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Test XonshLexer for pygments"""
 
-import gc
 import builtins
+import gc
 
 import pytest
 from pygments.token import (
@@ -16,14 +16,13 @@ from pygments.token import (
     Text,
     Literal,
 )
-from tools import skip_if_on_windows
-
-from xonsh.platform import ON_WINDOWS
 from xonsh.built_ins import load_builtins, unload_builtins
-from xonsh.pyghooks import XonshLexer, Color, XonshStyle, on_lscolors_change
 from xonsh.environ import LsColors
 from xonsh.events import events, EventManager
-from tools import DummyShell
+from xonsh.platform import ON_WINDOWS
+from xonsh.pyghooks import XonshLexer, Color, XonshStyle, on_lscolors_change
+
+from .tools import DummyShell, skip_if_on_windows
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_ptk_multiline.py
+++ b/tests/test_ptk_multiline.py
@@ -12,7 +12,7 @@ from prompt_toolkit.buffer import Buffer
 from xonsh.tools import ON_WINDOWS
 from xonsh.built_ins import XonshSession
 
-from tools import DummyEnv
+from .tools import DummyEnv
 
 Context = namedtuple("Context", ["indent", "buffer", "accept", "cli", "cr"])
 

--- a/tests/test_ptk_shell.py
+++ b/tests/test_ptk_shell.py
@@ -28,15 +28,14 @@ from xonsh.shell import Shell
     ],
 )
 def test_prompt_toolkit_version_checks(
-    ptk_ver,
-    ini_shell_type,
-    exp_shell_type,
-    warn_snip,
-    using_vended_ptk,
-    monkeypatch,
-    xonsh_builtins,
+        ptk_ver,
+        ini_shell_type,
+        exp_shell_type,
+        warn_snip,
+        using_vended_ptk,
+        monkeypatch,
+        xonsh_builtins,
 ):
-
     mocked_warn = ""
 
     def mock_warning(msg):
@@ -94,8 +93,8 @@ def test_prompt_toolkit_version_checks(
         ([("s1", "\x1b[33mansi \x1b[1monly")], ["", "ansi ", "only"]),
         # mixed
         (
-            [("s1", "no ansi"), ("s2", "mixed \x1b[33mansi")],
-            ["no ansi", "mixed ", "ansi"],
+                [("s1", "no ansi"), ("s2", "mixed \x1b[33mansi")],
+                ["no ansi", "mixed ", "ansi"],
         ),
     ],
 )
@@ -118,9 +117,9 @@ def test_tokenize_ansi(prompt_tokens, ansi_string_parts):
         ("test \033]0;TITLE THIS\007prompt", "test prompt", ["\033]0;TITLE THIS\007"]),
         # title + iTerm2 OSC exapmle
         (
-            "test \033]0;TITLE THIS\007prompt \033]133;A\007here",
-            "test prompt here",
-            ["\033]0;TITLE THIS\007", "\033]133;A\007"],
+                "test \033]0;TITLE THIS\007prompt \033]133;A\007here",
+                "test prompt here",
+                ["\033]0;TITLE THIS\007", "\033]133;A\007"],
         ),
     ],
 )
@@ -133,3 +132,18 @@ def test_remove_ansi_osc(raw_prompt, prompt, osc_tokens):
 
 
 # someday: initialize PromptToolkitShell and have it actually do something.
+
+def test_xonsh_shell(capsys):
+    # todo: make sure that shell executes and prompt is getting loaded as expected
+    import xonsh
+    from xonsh.built_ins import load_builtins, unload_builtins
+    load_builtins()
+    import xonsh.main
+    # args = premain(['exit'])
+    # main_xonsh(args)
+
+    with pytest.raises(SystemExit):
+        xonsh.main.main(['exit'])
+
+    capture = capsys.readouterr()
+    print(capture.out, capture.err)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -79,7 +79,7 @@ from xonsh.tools import (
 )
 from xonsh.environ import Env
 
-from tools import skip_if_on_windows
+from .tools import skip_if_on_windows
 
 LEXER = Lexer()
 LEXER.build()

--- a/tests/test_vox.py
+++ b/tests/test_vox.py
@@ -7,7 +7,7 @@ import pytest
 import sys
 from xontrib.voxapi import Vox
 
-from tools import skip_if_on_conda, skip_if_on_msys
+from .tools import skip_if_on_conda, skip_if_on_msys
 from xonsh.platform import ON_WINDOWS
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
I am looking to add tests for the prompt rendering. 

When I try something like this 
```py
def test_xonsh_shell(capsys):
    # todo: make sure that shell executes and prompt is getting loaded as expected
    import xonsh
    from xonsh.built_ins import load_builtins, unload_builtins
    load_builtins()
    import xonsh.main
    # args = premain(['exit'])
    # main_xonsh(args)

    with pytest.raises(SystemExit):
        xonsh.main.main(['exit'])

    capture = capsys.readouterr()
    print(capture.out, capture.err)
```

it results in error saying builtins AttributeError. How should I test them ?

also I am curious why the tests are split and run separately. Any help and insight is appreciated.