### PR TITLE
Path complete given path literal

### DIFF
--- a/news/path_complete_path_literal.rst
+++ b/news/path_complete_path_literal.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Remove p-string prefix from partial string detected in ``xonsh.completers.path_path_from_partial_string``, such that partial string is returned.
+* Strip leading ``p`` from quote used by ``xonsh.completers.path_path_from_partial_string`` to obtain the start of the path. This allows path completion to work as before, but preserves the leading ``p`` of the path literal already present on the command line.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/path_complete_path_literal.rst
+++ b/news/path_complete_path_literal.rst
@@ -1,10 +1,10 @@
 **Added:**
 
-* `_get_normalized_pstring_quote` returns a consistent set of prefixes, and the quote, for all path-string variants e.g. inputs `pr'` and `rp'` both produce the tuple `("pr", "'")`. This function is used by ``xonsh.completers.complete_path`` and ``xonsh.completers._path_from_partial_string``.
+* ``_get_normalized_pstring_quote`` returns a consistent set of prefixes, and the quote, for all path-string variants e.g. inputs ``pr'`` and ``rp'`` both produce the tuple ``("pr", "'")``. This function is used by ``xonsh.completers.complete_path`` and ``xonsh.completers._path_from_partial_string``.
 
 **Changed:**
 
-* Remove `p`, `rp` and `pr` prefix from partial p-string used in ``xonsh.completers._path_from_partial_string``, such that ``ast.literal_eval`` does not raise ``SyntaxError``. `pr` and `rp` strings are now treated internally as raw strings, but the p-string quote is correctly returned.
+* Remove ``p``, ``rp`` and ``pr`` prefix from partial p-string used in ``xonsh.completers._path_from_partial_string``, such that ``ast.literal_eval`` does not raise ``SyntaxError``. ``pr`` and ``rp`` strings are now treated internally as raw strings, but the p-string quote is correctly returned.
 * Increment the prefix length when the prefix input to ``xonsh.completers.complete_path`` is a p-string. This preserves the length of the prefix for path-string variants.
 
 **Deprecated:**

--- a/news/path_complete_path_literal.rst
+++ b/news/path_complete_path_literal.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Remove p-string prefix from partial string detected in ``xonsh.completers.path_path_from_partial_string``, such that partial string is returned.
+* Remove p-string prefix from partial string used in ``xonsh.completers._path_from_partial_string``, such that ``ast.literal_eval`` does not raise ``SyntaxError``.
 * Strip leading ``p`` from quote used by ``xonsh.completers.path_path_from_partial_string`` to obtain the start of the path. This allows path completion to work as before, but preserves the leading ``p`` of the path literal already present on the command line.
 
 **Deprecated:**

--- a/news/path_complete_path_literal.rst
+++ b/news/path_complete_path_literal.rst
@@ -1,11 +1,11 @@
 **Added:**
 
-* <news item>
+* `_get_normalized_pstring_quote` returns a consistent set of prefixes, and the quote, for all path-string variants e.g. inputs `pr'` and `rp'` both produce the tuple `("pr", "'")`. This function is used by ``xonsh.completers.complete_path`` and ``xonsh.completers._path_from_partial_string``.
 
 **Changed:**
 
-* Remove p-string prefix from partial string used in ``xonsh.completers._path_from_partial_string``, such that ``ast.literal_eval`` does not raise ``SyntaxError``.
-* Strip leading ``p`` from quote used by ``xonsh.completers.path_path_from_partial_string`` to obtain the start of the path. This allows path completion to work as before, but preserves the leading ``p`` of the path literal already present on the command line.
+* Remove `p`, `rp` and `pr` prefix from partial p-string used in ``xonsh.completers._path_from_partial_string``, such that ``ast.literal_eval`` does not raise ``SyntaxError``. `pr` and `rp` strings are now treated internally as raw strings, but the p-string quote is correctly returned.
+* Increment the prefix length when the prefix input to ``xonsh.completers.complete_path`` is a p-string. This preserves the length of the prefix for path-string variants.
 
 **Deprecated:**
 

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -57,3 +57,15 @@ def test_complete_path_when_prefix_is_raw_path_string(quote, xonsh_builtins):
         out = xcp.complete_path(prefix, line, line.find(prefix), len(line), dict())
         expected = f"pr{quote}{tmp.name}{quote}"
         assert expected == out[0].pop()
+
+
+@pytest.mark.parametrize("prefix", ("", "r", "p", "pr", "rp"))
+def test_path_from_partial_string(prefix):
+    string = "hello"
+    quote = "'"
+    out = xcp._path_from_partial_string(f"{prefix}{quote}{string}{quote}")
+    if "r" in prefix:
+        expected = (f"r{quote}{string}{quote}", string, f"{prefix}{quote}", quote)
+    else:
+        expected = (f"{quote}{string}{quote}", string, f"{prefix}{quote}", quote)
+    assert out == expected

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import tempfile
 from xonsh.platform import ON_WINDOWS
 import xonsh.completers.path as xcp
-
+import pathlib
 
 
 @pytest.fixture(autouse=True)
@@ -58,8 +58,11 @@ def test_complete_path_when_prefix_is_path_literal(quote, xonsh_builtins):
         prefix = f"p{quote}{prefix_file_name}"
         line = f"ls {prefix}"
         out = xcp.complete_path(prefix, line, line.find(prefix), len(line), dict())
-        completed_filename = out[0].pop()
-        if ON_WINDOWS:
-            assert filename == completed_filename[2:-1]
+
+        if ON_WINDOWS:  # We get a raw string
+            quote_prefix = "rp"
         else:
-            assert filename == completed_filename[1:-1]
+            quote_prefix = "p"
+        expected = f"{quote_prefix}{quote}{tmp.name}{quote}"
+
+        assert expected == out[0].pop()

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -43,7 +43,7 @@ def test_cd_path_no_cd(mock_add_cdpaths, xonsh_builtins):
 @pytest.mark.parametrize("quote", ('"', "'"))
 def test_complete_path_when_prefix_is_raw_path_string(quote, xonsh_builtins):
     xonsh_builtins.__xonsh__.env = {
-        "CASE_SENSITIVE_COMPLETIONS": False,
+        "CASE_SENSITIVE_COMPLETIONS": True,
         "GLOB_SORTED": True,
         "SUBSEQUENCE_PATH_COMPLETION": False,
         "FUZZY_PATH_COMPLETION": False,

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -1,9 +1,7 @@
 import pytest
 from unittest.mock import patch
 import tempfile
-from xonsh.platform import ON_WINDOWS
 import xonsh.completers.path as xcp
-import pathlib
 
 
 @pytest.fixture(autouse=True)
@@ -43,7 +41,7 @@ def test_cd_path_no_cd(mock_add_cdpaths, xonsh_builtins):
 
 
 @pytest.mark.parametrize("quote", ('"', "'"))
-def test_complete_path_when_prefix_is_path_literal(quote, xonsh_builtins):
+def test_complete_path_when_prefix_is_raw_path_string(quote, xonsh_builtins):
     xonsh_builtins.__xonsh__.env = {
         "CASE_SENSITIVE_COMPLETIONS": False,
         "GLOB_SORTED": True,
@@ -53,16 +51,9 @@ def test_complete_path_when_prefix_is_path_literal(quote, xonsh_builtins):
         "CDPATH": set(),
     }
     with tempfile.NamedTemporaryFile(suffix="_dummySuffix") as tmp:
-        filename = pathlib.Path(tmp.name).as_posix()
-        prefix_file_name = filename.replace("_dummySuffix", "")
-        prefix = f"p{quote}{prefix_file_name}"
+        prefix_file_name = tmp.name.replace("_dummySuffix", "")
+        prefix = f"pr{quote}{prefix_file_name}"
         line = f"ls {prefix}"
         out = xcp.complete_path(prefix, line, line.find(prefix), len(line), dict())
-
-        if ON_WINDOWS:  # We get a raw string
-            quote_prefix = "rp"
-        else:
-            quote_prefix = "p"
-        expected = f"{quote_prefix}{quote}{tmp.name}{quote}"
-
+        expected = f"pr{quote}{tmp.name}{quote}"
         assert expected == out[0].pop()

--- a/tests/test_path_completers.py
+++ b/tests/test_path_completers.py
@@ -56,5 +56,5 @@ def test_complete_path_when_prefix_is_path_literal(quote, xonsh_builtins):
         prefix = f"p{quote}{prefix_file_name}"
         line = f"ls {prefix}"
         out = xcp.complete_path(prefix, line, line.find(prefix), len(line), dict())
-        expected = [f"p{quote}{tmp.name}{quote}"]
+        expected = [f"{quote}{tmp.name}{quote}"]
         assert list(out[0]) == expected

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -38,6 +38,9 @@ def _path_from_partial_string(inp, pos=None):
         pos = len(inp)
     partial = inp[:pos]
     startix, endix, quote = xt.check_for_partial_string(partial)
+    # if pathlib literal, strip leading `p`
+    if quote in ('p"', "p'"):
+        startix += 1
     _post = ""
     if startix is None:
         return None
@@ -51,6 +54,7 @@ def _path_from_partial_string(inp, pos=None):
             else:
                 return None
         string = partial[startix:endix]
+
     end = xt.RE_STRING_START.sub("", quote)
     _string = string
     if not _string.endswith(end):
@@ -280,7 +284,7 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
     if p is not None:
         lprefix = len(p[0])
         prefix = p[1]
-        path_str_start = p[2]
+        path_str_start = p[2].lstrip("p")
         path_str_end = p[3]
         if len(line) >= end + 1 and line[end] == path_str_end:
             append_end = False


### PR DESCRIPTION
Hey,

Thanks for all your great work - this is my first PR to `xonsh`, so let's see how I do ;-)

This is a PR to enable path completion of path literals, which without can be very frustrating
```
path = p"some/super/duper/long/path/to/comple<TAB> # :-(
```

I've added some minor modifications such that the `p` prefix is removed from the string passed to `ast.literal_eval` in `xonsh.completers._path_from_partial_string`, and also removed from the start of the path used by `xonsh.completers.complete_path`.

Please note that I don't have a deep understanding of these functions, but have implemented a few tests.

Let me know what you think.

Many thanks