### PR TITLE
Added "Advanced String Literals" to the "Tutorial".

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -914,16 +914,16 @@ Advanced String Literals
 For fine control of envvar substitutions, brace substitutions and backslash escapes
 there are extended list of literals:
 
- - ``"foo"`` - regular string: backslash escapes.
- - ``r"foo"`` - raw string: unmodified.
- - ``f"foo"`` - formatted string: brace substitutions, backslash escapes.
- - ``fr"foo"`` - raw formatted string: brace substitutions.
- - ``p"foo"`` - path string: backslash escapes, envvar substitutions, returns Path.
- - ``pr"foo"`` - raw Path string: envvar substitutions, returns Path.
- - ``pf"foo"`` - formatted Path string: backslash escapes, brace substitutions, envvar substitutions, returns Path.
+- ``"txt"`` - regular string: backslash escapes. Envvar substitutions in subprocess-mode.
+- ``r"txt"`` - raw string: unmodified.
+- ``f"txt"`` - formatted string: brace substitutions, backslash escapes. Envvar substitutions in subprocess-mode.
+- ``fr"txt"`` - raw formatted string: brace substitutions.
+- ``p"txt"`` - path string: backslash escapes, envvar substitutions, returns Path.
+- ``pr"txt"`` - raw Path string: envvar substitutions, returns Path.
+- ``pf"txt"`` - formatted Path string: backslash escapes, brace and envvar substitutions, returns Path.
 
 To complete understanding let's set environment variable ``$EVAR`` to ``1`` and local variable ``var`` to ``2``
-and make a table that shows how literal changes the string in Python and subprocess mode:
+and make a table that shows how literal changes the string in Python- and subprocess-mode:
 
 .. table::
 
@@ -931,8 +931,8 @@ and make a table that shows how literal changes the string in Python and subproc
          String literal            As python object       print(<String literal>)  echo <String literal>
     ========================  ==========================  =======================  =====================
     ``"/$EVAR/\'{var}\'"``    ``"/$EVAR/'{var}'"``        ``/$EVAR/'{var}'``       ``/1/'{var}'``
-    ``f"/$EVAR/\'{var}\'"``   ``"/$EVAR/'2'"``            ``/$EVAR/'2'``           ``/1/'2'``
     ``r"/$EVAR/\'{var}\'"``   ``"/$EVAR/\\'{var}\\'"``    ``/$EVAR/\'{var}\'``     ``/$EVAR/\'{var}\'``
+    ``f"/$EVAR/\'{var}\'"``   ``"/$EVAR/'2'"``            ``/$EVAR/'2'``           ``/1/'2'``
     ``fr"/$EVAR/\'{var}\'"``  ``"/$EVAR/\\'2\\'"``        ``/$EVAR/\'2\'``         ``/$EVAR/\'2\'``
     ``p"/$EVAR/\'{var}\'"``   ``Path("/1/'{var}'")``      ``/1/'{var}'``           ``/1/'{var}'``
     ``pr"/$EVAR/\'{var}\'"``  ``Path("/1/\\'{var}\\'")``  ``/1/\'{var}\'``         ``/1/\'{var}\'``

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -911,7 +911,7 @@ to be evaluated in Python mode using the ``@()`` syntax:
 Advanced String Literals
 ========================
 
-For fine control of envvar substitutions, brace substitutions and backslash escapes
+For the fine control of environment variables (envvar) substitutions, brace substitutions and backslash escapes
 there are extended list of literals:
 
 - ``""`` - regular string: backslash escapes. Envvar substitutions in subprocess-mode.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -914,13 +914,13 @@ Advanced String Literals
 For fine control of envvar substitutions, brace substitutions and backslash escapes
 there are extended list of literals:
 
-- ``"txt"`` - regular string: backslash escapes. Envvar substitutions in subprocess-mode.
-- ``r"txt"`` - raw string: unmodified.
-- ``f"txt"`` - formatted string: brace substitutions, backslash escapes. Envvar substitutions in subprocess-mode.
-- ``fr"txt"`` - raw formatted string: brace substitutions.
-- ``p"txt"`` - path string: backslash escapes, envvar substitutions, returns Path.
-- ``pr"txt"`` - raw Path string: envvar substitutions, returns Path.
-- ``pf"txt"`` - formatted Path string: backslash escapes, brace and envvar substitutions, returns Path.
+- ``""`` - regular string: backslash escapes. Envvar substitutions in subprocess-mode.
+- ``r""`` - raw string: unmodified.
+- ``f""`` - formatted string: brace substitutions, backslash escapes. Envvar substitutions in subprocess-mode.
+- ``fr""`` - raw formatted string: brace substitutions.
+- ``p""`` - path string: backslash escapes, envvar substitutions, returns Path.
+- ``pr""`` - raw Path string: envvar substitutions, returns Path.
+- ``pf""`` - formatted Path string: backslash escapes, brace and envvar substitutions, returns Path.
 
 To complete understanding let's set environment variable ``$EVAR`` to ``1`` and local variable ``var`` to ``2``
 and make a table that shows how literal changes the string in Python- and subprocess-mode:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -902,8 +902,42 @@ to be evaluated in Python mode using the ``@()`` syntax:
     >>> echo @("my home is $HOME")
     my home is $HOME
 
-You can also disable environment variable expansion completely by setting
-``$EXPAND_ENV_VARS`` to ``False``.
+
+.. note::
+
+    You can also disable environment variable expansion completely by setting
+    ``$EXPAND_ENV_VARS`` to ``False``.
+
+Advanced String Literals
+========================
+
+For fine control of envvar substitutions, brace substitutions and backslash escapes
+there are extended list of literals:
+
+ - ``"foo"`` - regular string: backslash escapes.
+ - ``r"foo"`` - raw string: unmodified.
+ - ``f"foo"`` - formatted string: brace substitutions, backslash escapes.
+ - ``fr"foo"`` - raw formatted string: brace substitutions.
+ - ``p"foo"`` - path string: backslash escapes, envvar substitutions, returns Path.
+ - ``pr"foo"`` - raw Path string: envvar substitutions, returns Path.
+ - ``pf"foo"`` - formatted Path string: backslash escapes, brace substitutions, envvar substitutions, returns Path.
+
+To complete understanding let's set environment variable ``$EVAR`` to ``1`` and local variable ``var`` to ``2``
+and make a table that shows how literal changes the string in Python and subprocess mode:
+
+.. table::
+
+    ========================  ==========================  =======================  =====================
+         String literal            As python object       print(<String literal>)  echo <String literal>
+    ========================  ==========================  =======================  =====================
+    ``"/$EVAR/\'{var}\'"``    ``"/$EVAR/'{var}'"``        ``/$EVAR/'{var}'``       ``/1/'{var}'``
+    ``f"/$EVAR/\'{var}\'"``   ``"/$EVAR/'2'"``            ``/$EVAR/'2'``           ``/1/'2'``
+    ``r"/$EVAR/\'{var}\'"``   ``"/$EVAR/\\'{var}\\'"``    ``/$EVAR/\'{var}\'``     ``/$EVAR/\'{var}\'``
+    ``fr"/$EVAR/\'{var}\'"``  ``"/$EVAR/\\'2\\'"``        ``/$EVAR/\'2\'``         ``/$EVAR/\'2\'``
+    ``p"/$EVAR/\'{var}\'"``   ``Path("/1/'{var}'")``      ``/1/'{var}'``           ``/1/'{var}'``
+    ``pr"/$EVAR/\'{var}\'"``  ``Path("/1/\\'{var}\\'")``  ``/1/\'{var}\'``         ``/1/\'{var}\'``
+    ``pf"/$EVAR/\'{var}\'"``  ``Path("/1/'2'")``          ``/1/'2'``               ``/1/'2'``
+    ========================  ==========================  =======================  =====================
 
 Filename Globbing with ``*``
 ===============================

--- a/news/tutorial_literal.rst
+++ b/news/tutorial_literal.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added "Advanced String Literals" to the "Tutorial".
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes #3820

The code to getting an rst table of literals: 

<details>

```python
#!/usr/bin/env xonsh
import pandas as pd
import pytablewriter

str_literal = [
    '"/$EVAR/\\\'{var}\\\'"',
    'r"/$EVAR/\\\'{var}\\\'"',
    'f"/$EVAR/\\\'{var}\\\'"',
    'fr"/$EVAR/\\\'{var}\\\'"',
    'p"/$EVAR/\\\'{var}\\\'"',
    'pr"/$EVAR/\\\'{var}\\\'"',
    'pf"/$EVAR/\\\'{var}\\\'"',
]

def code(s):
    return f"``{s}``"

$EVAR = 1
var = 2
tbl = {}
for s in str_literal:
    locs = {'var': var}
    tbl[code(s)] = {
        'As python object': code(repr(evalx(s, locs=locs))).replace('Posix', ''),
        'print(<String literal>)': code(evalx(f'str({s})', locs=locs)),
    }
    execx(f'echo {s} > 1.tmp', locs=locs)
    with open('1.tmp') as f:
        l = f.readline()
    tbl[code(s)]['echo <String literal>'] = code(l.strip())

df = pd.DataFrame.from_dict(tbl).T
df.index.name='String literal'
df = df.reset_index()

writer = pytablewriter.RstSimpleTableWriter()
writer.from_dataframe(df)
writer.write_table()
```

</details>