### PR TITLE
Revert completion auto-selection

### DIFF
--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -206,15 +206,6 @@ def load_xonsh_bindings() -> KeyBindingsBase:
         env = builtins.__xonsh__.env
         event.cli.current_buffer.insert_text(env.get("INDENT"))
 
-    @handle(Keys.Tab, filter=~tab_insert_indent)
-    def start_complete(event):
-        """If starting completions, automatically move to first option"""
-        buff = event.app.current_buffer
-        if buff.complete_state:
-            buff.complete_next()
-        else:
-            buff.start_completion(select_first=True)
-
     @handle(Keys.ControlX, Keys.ControlE, filter=~has_selection)
     def open_editor(event):
         """ Open current buffer in editor """


### PR DESCRIPTION
This reverts the changes made in #3774 and fixes #3833 

As I outlined in #3833 this makes some assumptions that impact a bunch of tab-completion features.

Another example I've come across today is if I `cd <TAB>` -- the `..` present in every directory on a *nix is automatically selected, preventing me from typing another character to narrow the completion possibilities.


