### PR TITLE
xonsh arguments improvement

### DIFF
--- a/news/args.rst
+++ b/news/args.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Disabled welcome screen if ``--no-rc`` argument was passed.
+* Improved printing of xonsh ``--shell-type`` argument in help message.
 
 **Deprecated:**
 

--- a/news/norc_no_welcome.rst
+++ b/news/norc_no_welcome.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Disable welcome screen if ``--no-rc`` argument was passed.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/norc_no_welcome.rst
+++ b/news/norc_no_welcome.rst
@@ -12,7 +12,7 @@
 
 **Removed:**
 
-* <news item>
+* Deprecated `--config-path` argument suppressed from help.
 
 **Fixed:**
 

--- a/news/norc_no_welcome.rst
+++ b/news/norc_no_welcome.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Disable welcome screen if ``--no-rc`` argument was passed.
+* Disabled welcome screen if ``--no-rc`` argument was passed.
 
 **Deprecated:**
 

--- a/news/norc_no_welcome.rst
+++ b/news/norc_no_welcome.rst
@@ -12,7 +12,7 @@
 
 **Removed:**
 
-* Deprecated `--config-path` argument suppressed from help.
+* Deprecated ``--config-path`` argument suppressed from help.
 
 **Fixed:**
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -210,10 +210,11 @@ def parser():
     p.add_argument(
         "--shell-type",
         help="What kind of shell should be used. "
-        "Possible options: readline, prompt_toolkit, random. "
-        "Warning! If set this overrides $SHELL_TYPE variable.",
+        "Possible options: "
+        + ", ".join(Shell.shell_type_aliases.keys())
+        + ". Warning! If set this overrides $SHELL_TYPE variable.",
         dest="shell_type",
-        choices=tuple(Shell.shell_type_aliases.keys()),
+        # choices=tuple(Shell.shell_type_aliases.keys()),
         default=None,
     )
     p.add_argument(

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -133,10 +133,9 @@ def parser():
     p.add_argument(
         "-V",
         "--version",
-        dest="version",
-        action="store_true",
-        default=False,
+        action="version",
         help="Show version information and exit.",
+        version="/".join(("xonsh", __version__))
     )
     p.add_argument(
         "-c",
@@ -323,10 +322,6 @@ def premain(argv=None):
     args = parser.parse_args(argv)
     if args.help:
         parser.print_help()
-        parser.exit()
-    if args.version:
-        version = "/".join(("xonsh", __version__))
-        print(version)
         parser.exit()
     shell_kwargs = {
         "shell_type": args.shell_type,

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -446,8 +446,10 @@ def main_xonsh(args):
             # enter the shell
             env["XONSH_INTERACTIVE"] = True
             ignore_sigtstp()
-            if env["XONSH_INTERACTIVE"] and not any(
-                os.path.isfile(i) for i in env["XONSHRC"]
+            if (
+                env["XONSH_INTERACTIVE"]
+                and not args.norc
+                and not any(os.path.isfile(i) for i in env["XONSHRC"])
             ):
                 print_welcome_screen()
             events.on_pre_cmdloop.fire()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -135,7 +135,7 @@ def parser():
         "--version",
         action="version",
         help="Show version information and exit.",
-        version="/".join(("xonsh", __version__)),
+        version=f"xonsh/{__version__}",
     )
     p.add_argument(
         "-c",

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -213,8 +213,9 @@ def parser():
         "Possible options: "
         + ", ".join(Shell.shell_type_aliases.keys())
         + ". Warning! If set this overrides $SHELL_TYPE variable.",
+        metavar="SHELL_TYPE",
         dest="shell_type",
-        # choices=tuple(Shell.shell_type_aliases.keys()),
+        choices=tuple(Shell.shell_type_aliases.keys()),
         default=None,
     )
     p.add_argument(

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -442,10 +442,8 @@ def main_xonsh(args):
             # enter the shell
             env["XONSH_INTERACTIVE"] = True
             ignore_sigtstp()
-            if (
-                env["XONSH_INTERACTIVE"]
-                and not args.norc
-                and not any(os.path.isfile(i) for i in env["XONSHRC"])
+            if env["XONSH_INTERACTIVE"] and not any(
+                os.path.isfile(i) for i in env["XONSHRC"]
             ):
                 print_welcome_screen()
             events.on_pre_cmdloop.fire()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -135,7 +135,7 @@ def parser():
         "--version",
         action="version",
         help="Show version information and exit.",
-        version="/".join(("xonsh", __version__))
+        version="/".join(("xonsh", __version__)),
     )
     p.add_argument(
         "-c",


### PR DESCRIPTION
Hello! xonsh is the most interesting thing in world ocean! Thanks!

In this PR xonsh arguments improved with love:

1. Capitalized first letter in args help text.
2. Used [argparse "version" action](https://docs.python.org/3.5/library/argparse.html#action) to show version.
3. Suppressed old deprecated `--config-path` (deprecated since 2018).
4. ~Disabled the welcome screen if `--no-rc` was passed.~ (reverted)
5. Improved formatting of help for `--shell-type`:

    Before - ugly "usage" lines and description:
    ```
    $ xonsh --help
    usage: xonsh [-h] [-V] [-c COMMAND] [-i] [-l] [--rc RC [RC ...]] [--no-rc] [--no-script-cache]
                [--cache-everything] [-D ITEM]
                [--shell-type {b,best,d,dumb,ptk,ptk1,ptk2,prompt-toolkit,prompt_toolkit,prompt-toolkit1,prompt-toolkit2,prompt-toolkit3,prompt_toolkit3,ptk3,rand,random,rl,readline}]
                [--timings]
    ...
    -D ITEM               Define an environment variable, in the form of -DNAME=VAL. May be used many times.
    --shell-type {b,best,d,dumb,ptk,ptk1,ptk2,prompt-toolkit,prompt_toolkit,prompt-toolkit1,prompt-toolkit2,prompt-toolkit3,prompt_toolkit3,ptk3,rand,random,rl,readline}
                            What kind of shell should be used. Possible options: readline, prompt_toolkit, random.
                            Warning! If set this overrides $SHELL_TYPE variable.
    ...
    ```

    After - cute usage line and good formatted description:
    ```
    $ xonsh --help
    usage: xonsh [-h] [-V] [-c COMMAND] [-i] [-l] [--rc RC [RC ...]] [--no-rc] [--no-script-cache]
                [--cache-everything] [-D ITEM] [--shell-type SHELL_TYPE] [--timings]
                [script-file] 
    ...
    -D ITEM               Define an environment variable, in the form of -DNAME=VAL. May be used many times.
    --shell-type SHELL_TYPE
                            What kind of shell should be used. Possible options: b, best, d, dumb, ptk, ptk1, ptk2,
                            prompt-toolkit, prompt_toolkit, prompt-toolkit1, prompt-toolkit2, prompt-toolkit3,
                            prompt_toolkit3, ptk3, rand, random, rl, readline. Warning! If set this overrides
                            $SHELL_TYPE variable.
    ...
    ```