### PR TITLE
Extend the history command with a "transfer" subcommand

### DIFF
--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -129,7 +129,7 @@ class History:
         """Get history items of current session."""
         raise NotImplementedError
 
-    def all_items(self, newest_first=False):
+    def all_items(self, newest_first=False, full_item=False):
         """Get all history items."""
         raise NotImplementedError
 

--- a/xonsh/history/dummy.py
+++ b/xonsh/history/dummy.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh history backend."""
 import collections
+import uuid
+
 from xonsh.history.base import History
 
 

--- a/xonsh/history/dummy.py
+++ b/xonsh/history/dummy.py
@@ -11,10 +11,15 @@ class DummyHistory(History):
         pass
 
     def items(self, newest_first=False):
-        yield {"inp": "dummy in action", "ts": 1464652800, "ind": 0}
+        yield {"inp": "dummy in action", "ts": 1464652800, "ind": 0, "rtn": 0}
 
-    def all_items(self, newest_first=False):
-        return self.items(newest_first=newest_first)
+    def all_items(self, newest_first=False, full_item=False):
+        if full_item:
+            sessionid = self.sessionid or uuid.uuid4()
+            for item in self.items(newest_first=newest_first):
+                yield sessionid, item
+        else:
+            yield from self.items(newest_first=newest_first)
 
     def info(self):
         data = collections.OrderedDict()

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -132,7 +132,7 @@ def _xh_get_history(
     datetime_format=None,
     start_time=None,
     end_time=None,
-    location=None
+    location=None,
 ):
     """Get the requested portion of shell history.
 
@@ -385,13 +385,12 @@ def _xh_create_parser():
         "--source",
         choices=HISTORY_BACKENDS,
         default=backend,
-        help="source history backend"
+        help="source history backend",
     )
-    tcp.add_argument("--source-filename",help="override location of source file(s)")
+    tcp.add_argument("--source-filename", help="override location of source file(s)")
     tcp.add_argument("target", choices=HISTORY_BACKENDS, help="target history backend")
     tcp.add_argument(
-        "--target-filename",
-        help="override location of target history file(s)"
+        "--target-filename", help="override location of target history file(s)"
     )
 
     return p
@@ -445,7 +444,7 @@ def _xh_transfer(args):
     print(
         f"transferring history data from {args.source!r} -> {args.target!r}...",
         end=" ",
-        file=sys.stderr
+        file=sys.stderr,
     )
     sessions = {}
 
@@ -460,9 +459,7 @@ def _xh_transfer(args):
         target_session = sessions.get(sessionid)
         if target_session is None:
             sessions[sessionid] = target_session = HISTORY_BACKENDS[args.target](
-                filename=args.target_filename,
-                gc=False,
-                sessionid=sessionid
+                filename=args.target_filename, gc=False, sessionid=sessionid
             )
 
         # sqlite expects a "ts" list-field with [tsb, tse]

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -127,7 +127,9 @@ def _xh_sqlite_get_count(cursor, sessionid=None):
     return cursor.fetchone()[0]
 
 
-def _xh_sqlite_get_records(cursor, sessionid=None, limit=None, newest_first=False, full_item=False):
+def _xh_sqlite_get_records(
+    cursor, sessionid=None, limit=None, newest_first=False, full_item=False
+):
     if full_item:
         sql = "SELECT inp, rtn, tsb, tse, sessionid, out, info, frequency FROM xonsh_history "
     else:
@@ -180,7 +182,9 @@ def xh_sqlite_items(sessionid=None, filename=None, newest_first=False, full_item
     with _xh_sqlite_get_conn(filename=filename) as conn:
         c = conn.cursor()
         _xh_sqlite_create_history_table(c)
-        return _xh_sqlite_get_records(c, sessionid=sessionid, newest_first=newest_first, full_item=full_item)
+        return _xh_sqlite_get_records(
+            c, sessionid=sessionid, newest_first=newest_first, full_item=full_item
+        )
 
 
 def xh_sqlite_delete_items(size_to_keep, filename=None):
@@ -276,8 +280,10 @@ class SqliteHistory(History):
     def all_items(self, newest_first=False, session_id=None, full_item=False):
         """Display all history items."""
         for item in xh_sqlite_items(
-            filename=self.filename, newest_first=newest_first, sessionid=session_id,
-            full_item=full_item
+            filename=self.filename,
+            newest_first=newest_first,
+            sessionid=session_id,
+            full_item=full_item,
         ):
             if full_item:
                 inp, rtn, tsb, tse, sessionid, out, info, freq = item
@@ -287,7 +293,7 @@ class SqliteHistory(History):
                     "ts": [tsb, tse],
                     "frequency": freq,
                     "out": out,
-                    "info": info
+                    "info": info,
                 }
             else:
                 inp, tsb, rtn, freq = item

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -297,7 +297,7 @@ class SqliteHistory(History):
                 }
             else:
                 inp, tsb, rtn, freq = item
-                yield {"inp": inp, "ts": ts, "rtn": rtn, "frequency": freq}
+                yield {"inp": inp, "ts": tsb, "rtn": rtn, "frequency": freq}
 
     def items(self, newest_first=False):
         """Display history items of current session."""


### PR DESCRIPTION
Extend the history command with a "transfer" subcommand to transfer data between history backends

Extended history backend interface's `all_items()` method with a `full_item: bool` keyword-argument, that would yield a tuple of sessionid and the full "cmd"-dict.

Sample usage:

- Transfers the dummy entry into a new JSON history session: `xonsh history transfer --source dummy json`
- Transfers all JSON history entries into the dummy: `xonsh history transfer --source json dummy`
- Transfers from the configured default source (`$XONSH_HISTORY_BACKEND` or "json") to the target "sqlite": `xonsh history transfer sqlite`


`--source-filename` and `--target-filename` are available to potentially override the default value passed into the `filename` keyword-argument for the History implementation, in case the user has specified non-standard log locations.

There are no test for this currently, nor have I adjusted any of the existing tests for the `full_items()` change to the History interface yet. I would like to hear your thoughts on this first and maybe tips on what tests to touch. When and if everything looks ok, I will also add the news entry.

Original discussion here: https://gitter.im/xonsh/xonsh?at=5f79f6446e0eb8446965538b
