### PR TITLE
More stable exception handling in the completer.

### DIFF
--- a/news/completer_exception.rst
+++ b/news/completer_exception.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* More stable exception handling in the tab completer.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -2,6 +2,7 @@
 """A (tab-)completer for xonsh."""
 import builtins
 import collections.abc as cabc
+from xonsh.tools import print_exception
 
 
 class Completer(object):
@@ -35,6 +36,13 @@ class Completer(object):
             try:
                 out = func(prefix, line, begidx, endidx, ctx)
             except StopIteration:
+                return set(), len(prefix)
+            except Exception as e:
+                print_exception(
+                    f"Completer {func.__name__} raises exception when get "
+                    f"(prefix={repr(prefix)}, line={repr(line)}, begidx={repr(begidx)}, endidx={repr(endidx)}):\n"
+                    f"{e}"
+                )
                 return set(), len(prefix)
             if isinstance(out, cabc.Sequence):
                 res, lprefix = out

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -2,6 +2,7 @@
 """A (tab-)completer for xonsh."""
 import builtins
 import collections.abc as cabc
+
 from xonsh.tools import print_exception
 
 


### PR DESCRIPTION
Closes #3844

Before - in case of exception in completer there will be crash and fallback to bash.

After:
```python
def bad_completer(pref, line, *args):
    1/0

completer add test bad_completer start

$ <Tab>
```
Result:
```
Traceback (most recent call last):
  File "/opt/miniconda/lib/python3.8/site-packages/xonsh/completer.py", line 39, in complete
    out = func(prefix, line, begidx, endidx, ctx)
  File "<xonsh-code>", line 2, in bad_completer
ZeroDivisionError: division by zero
Completer bad_completer raises exception when get (prefix='', line='', begidx=0, endidx=0):
division by zero
$ # stay in xonsh
```