### PR TITLE
Environ improvements: DIRS, tutorial, converter

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -238,6 +238,21 @@ They can be seen on the `Environment Variables page <envvars.html>`_.
           ``KeyError`` will be raised if the variable does not exist in the
           environment.
 
+Register typed environment variables
+------------------------------------
+
+Before using environment variable you can register it. Xonsh will automatically
+convert the value to appropriate format or set default value if variable
+does not exist:
+
+.. code-block:: xonshcon
+
+    ${...}.register('MY_HOSTS_FILE', type='path', default=p'/etc/hosts')
+    if $MY_HOSTS_FILE.exists():
+        wc -l $MY_HOSTS_FILE
+
+Learn more about `register function <environ.html#xonsh.environ.Env.register>`_.
+
 Running Commands
 ==============================
 As a shell, xonsh is meant to make running commands easy and fun.

--- a/news/env_path_imp.rst
+++ b/news/env_path_imp.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added section "Register typed environment variables" to the Tutorial.
+* Added the section "Register typed environment variables" to the Tutorial.
 
 **Changed:**
 

--- a/news/env_path_imp.rst
+++ b/news/env_path_imp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added section "Register typed environment variables" to the Tutorial.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed type registration for ``*DIRS`` environment variables.
+
+**Security:**
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -32,9 +32,10 @@ def test_env_contains():
 
 
 @pytest.mark.parametrize("path", [["/home/wakka"], ["wakka"]])
-def test_env_path_list(path):
-    env = Env(MYPATH=path)
+def test_env_path_dirs_list(path):
+    env = Env(MYPATH=path, MYDIRS=path)
     assert path == env["MYPATH"].paths
+    assert path == env["MYDIRS"].paths
 
 
 @pytest.mark.parametrize(

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1143,6 +1143,7 @@ def DEFAULT_VARS():
             "'/usr/bin', '/sbin', '/bin', '/usr/games', '/usr/local/games')``",
         ),
         re.compile(r"\w*PATH$"): Var(is_env_path, str_to_env_path, env_path_to_str),
+        re.compile(r"\w*DIRS$"): Var(is_env_path, str_to_env_path, env_path_to_str),
         "PATHEXT": Var(
             is_nonstring_seq_of_strings,
             pathsep_to_upper_seq,

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1183,8 +1183,19 @@ def is_env_path(x):
 
 def str_to_path(x):
     """Converts a string to a path."""
-    # checking x is needed to avoid uncontrolled converting empty string to Path('.')
-    return pathlib.Path(x) if x else None
+    if isinstance(x, str):
+        # checking x is needed to avoid uncontrolled converting empty string to Path('.')
+        return pathlib.Path(x) if x else None
+    elif isinstance(x, pathlib.Path):
+        return x
+    elif isinstance(x, EnvPath) and len(x) == 1:
+        return pathlib.Path(x[0]) if x[0] else None
+    elif x is None:
+        return None
+    else:
+        raise TypeError(
+            f"Variable should be a pathlib.Path, str or single EnvPath type. {type(x)} given."
+        )
 
 
 def str_to_env_path(x):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1183,15 +1183,15 @@ def is_env_path(x):
 
 def str_to_path(x):
     """Converts a string to a path."""
-    if isinstance(x, str):
+    if x is None:
+        return None
+    elif isinstance(x, str):
         # checking x is needed to avoid uncontrolled converting empty string to Path('.')
         return pathlib.Path(x) if x else None
     elif isinstance(x, pathlib.Path):
         return x
     elif isinstance(x, EnvPath) and len(x) == 1:
         return pathlib.Path(x[0]) if x[0] else None
-    elif x is None:
-        return None
     else:
         raise TypeError(
             f"Variable should be a pathlib.Path, str or single EnvPath type. {type(x)} given."


### PR DESCRIPTION
1. Fixed missing `*DIRS` (mention was in the doc but missing in the code) + test
2. Added section "Register typed environment variables" to the Tutorial.
3. Improved `str_to_path` converter.

After many closed PRs around environ register this should be in the near release.