### PR TITLE
Prevent loging git when building prompt

### DIFF
--- a/news/prevent-git-locking-when-getting-status.rst
+++ b/news/prevent-git-locking-when-getting-status.rst
@@ -6,9 +6,8 @@
 
 * When retrieving the git status or other fields for building the prompt xonsh will run
   the git commands with ``$GIT_OPTIONAL_LOCKS=0``.  For details on what this entails see
-  the git documentation for GIT_OPTIONAL_LOCKS_.
-
-.. _GIT_OPTIONAL_LOCKS:   https://git-scm.com/docs/git#Documentation/git.txt-codeGITOPTIONALLOCKScode
+  the git documentation for
+  `GIT_OPTIONAL_LOCKS <https://git-scm.com/docs/git#Documentation/git.txt-codeGITOPTIONALLOCKScode/>`_.
 
 **Deprecated:**
 

--- a/news/prevent-git-locking-when-getting-status.rst
+++ b/news/prevent-git-locking-when-getting-status.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* When retrieving the git status or other fields for building the prompt xonsh will run
+  the git commands with ``$GIT_OPTIONAL_LOCKS=0``.  For details on what this entails see
+  the git documentation for GIT_OPTIONAL_LOCKS_.
+
+.. _GIT_OPTIONAL_LOCKS:   https://git-scm.com/docs/git#Documentation/git.txt-codeGITOPTIONALLOCKScode
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -20,14 +20,12 @@ RE_REMOVE_ANSI = LazyObject(
     "RE_REMOVE_ANSI",
 )
 
-# when running git status commands we do not want to acquire locks running command like git status
-_GIT_OPTIONAL_LOCKS = {"GIT_OPTIONAL_LOCKS": "0"}
-
 
 def _get_git_branch(q):
     # create a safge detyped env dictionary and update with the additional git environment variables
+    # when running git status commands we do not want to acquire locks running command like git status
     denv = dict(builtins.__xonsh__.env.detype())
-    denv.update(_GIT_OPTIONAL_LOCKS)
+    denv.update({"GIT_OPTIONAL_LOCKS": "0"})
     try:
         cmd = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
         branch = xt.decode_bytes(
@@ -168,11 +166,10 @@ def current_branch():
     return branch or None
 
 
-def _get_exit_code(cmd, additional_env=None):
+def _get_exit_code(cmd):
     """ Run a command and return its exit code """
     denv = dict(builtins.__xonsh__.env.detype())
-    if additional_env:
-        denv.update(additional_env)
+    denv.update({"GIT_OPTIONAL_LOCKS": "0"})
     child = subprocess.run(cmd, stderr=subprocess.DEVNULL, env=denv)
     return child.returncode
 
@@ -189,15 +186,15 @@ def _git_dirty_working_directory(q, include_untracked):
                 "--quiet",
                 "--untracked-files=normal",
             ]
-            exitcode = _get_exit_code(cmd, _GIT_OPTIONAL_LOCKS)
+            exitcode = _get_exit_code(cmd)
         else:
             # checking unindexed files is faster, so try that first
             unindexed = ["git", "diff-files", "--quiet"]
-            exitcode = _get_exit_code(unindexed, _GIT_OPTIONAL_LOCKS)
+            exitcode = _get_exit_code(unindexed)
             if exitcode == 0:
                 # then, check indexed files
                 indexed = ["git", "diff-index", "--quiet", "--cached", "HEAD"]
-                exitcode = _get_exit_code(indexed, _GIT_OPTIONAL_LOCKS)
+                exitcode = _get_exit_code(indexed)
         # "--quiet" git commands imply "--exit-code", which returns:
         # 1 if there are differences
         # 0 if there are no differences

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -25,7 +25,8 @@ _GIT_OPTIONAL_LOCKS = {"GIT_OPTIONAL_LOCKS": "0"}
 
 
 def _get_git_branch(q):
-    denv = builtins.__xonsh__.env.detype()
+    # create a safge detyped env dictionary and update with the additional git environment variables
+    denv = dict(builtins.__xonsh__.env.detype())
     denv.update(_GIT_OPTIONAL_LOCKS)
     try:
         cmd = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
@@ -169,7 +170,7 @@ def current_branch():
 
 def _get_exit_code(cmd, additional_env=None):
     """ Run a command and return its exit code """
-    denv = builtins.__xonsh__.env.detype()
+    denv = dict(builtins.__xonsh__.env.detype())
     if additional_env:
         denv.update(additional_env)
     child = subprocess.run(cmd, stderr=subprocess.DEVNULL, env=denv)


### PR DESCRIPTION
Set GIT_OPTIONAL_LOCKS=0 to prevent locking a git repo when updating the prompt.


<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->