### PR TITLE
Add an optional message to the deprecation warning

### DIFF
--- a/news/no_color_deprecation.rst
+++ b/news/no_color_deprecation.rst
@@ -2,10 +2,11 @@
 
 * Add a new color ``DEFAULT`` that is used to designate the terminal's default color.
 * Add a new special color token ``RESET`` used to reset all attributes.
+* Add a new xonsh tool 'print_warning' that prints a traceback with a warning message.
 
 **Changed:**
 
-* Moved interal uses of ``NO_COLOR`` to ``RESET``.
+* Moved internal uses of ``NO_COLOR`` to ``RESET``.
 
 **Deprecated:**
 

--- a/xonsh/color_tools.py
+++ b/xonsh/color_tools.py
@@ -7,9 +7,9 @@ WTFPL http://sam.zoy.org/wtfpl/
 """
 import re
 import math
-import sys
 
 from xonsh.lazyasd import lazyobject, LazyObject
+from xonsh.tools import print_warning
 
 _NO_COLOR_WARNING_SHOWN = False
 
@@ -487,7 +487,5 @@ def warn_deprecated_no_color():
     """Show a warning once if NO_COLOR was used instead of RESET."""
     global _NO_COLOR_WARNING_SHOWN
     if not _NO_COLOR_WARNING_SHOWN:
-        print(
-            "NO_COLOR is deprecated and should be replaced with RESET.", file=sys.stderr
-        )
+        print_warning("NO_COLOR is deprecated and should be replaced with RESET.")
         _NO_COLOR_WARNING_SHOWN = True

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from xonsh.platform import HAS_PYGMENTS
 from xonsh.lazyasd import LazyObject
-from xonsh.color_tools import RE_BACKGROUND, iscolor
+from xonsh.color_tools import RE_BACKGROUND, iscolor, warn_deprecated_no_color
 from xonsh.tools import FORMATTER
 
 
@@ -143,6 +143,8 @@ def color_by_name(name, fg=None, bg=None):
     """
     name = name.upper()
     if name in ("RESET", "NO_COLOR"):
+        if name == "NO_COLOR":
+            warn_deprecated_no_color()
         return Color.RESET, None, None
     m = RE_BACKGROUND.search(name)
     if m is None:  # must be foreground color

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -911,6 +911,51 @@ def suggest_commands(cmd, env, aliases):
     return rtn
 
 
+def print_warning(msg):
+    """Print warnings with/without traceback."""
+    env = getattr(builtins.__xonsh__, "env", None)
+    # flags indicating whether the traceback options have been manually set
+    if env is None:
+        env = os_environ
+        manually_set_trace = "XONSH_SHOW_TRACEBACK" in env
+        manually_set_logfile = "XONSH_TRACEBACK_LOGFILE" in env
+    else:
+        manually_set_trace = env.is_manually_set("XONSH_SHOW_TRACEBACK")
+        manually_set_logfile = env.is_manually_set("XONSH_TRACEBACK_LOGFILE")
+    if (not manually_set_trace) and (not manually_set_logfile):
+        # Notify about the traceback output possibility if neither of
+        # the two options have been manually set
+        sys.stderr.write(
+            "xonsh: For full traceback set: " "$XONSH_SHOW_TRACEBACK = True\n"
+        )
+    # get env option for traceback and convert it if necessary
+    show_trace = env.get("XONSH_SHOW_TRACEBACK", False)
+    if not is_bool(show_trace):
+        show_trace = to_bool(show_trace)
+    # if the trace option has been set, print all traceback info to stderr
+    if show_trace:
+        # notify user about XONSH_TRACEBACK_LOGFILE if it has
+        # not been set manually
+        if not manually_set_logfile:
+            sys.stderr.write(
+                "xonsh: To log full traceback to a file set: "
+                "$XONSH_TRACEBACK_LOGFILE = <filename>\n"
+            )
+        traceback.print_stack()
+    # additionally, check if a file for traceback logging has been
+    # specified and convert to a proper option if needed
+    log_file = env.get("XONSH_TRACEBACK_LOGFILE", None)
+    log_file = to_logfile_opt(log_file)
+    if log_file:
+        # if log_file <> '' or log_file <> None, append
+        # traceback log there as well
+        with open(os.path.abspath(log_file), "a") as f:
+            traceback.print_stack(file=f)
+
+    msg = msg if msg.endswith("\n") else msg + "\n"
+    sys.stderr.write(msg)
+
+
 def print_exception(msg=None):
     """Print exceptions with/without traceback."""
     env = getattr(builtins.__xonsh__, "env", None)
@@ -1196,8 +1241,7 @@ def str_to_env_path(x):
 
 
 def path_to_str(x):
-    """Converts a path to a string.
-    """
+    """Converts a path to a string."""
     return str(x)
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -911,25 +911,30 @@ def suggest_commands(cmd, env, aliases):
     return rtn
 
 
-def print_warning(msg):
-    """Print warnings with/without traceback."""
+def _get_env_var(name, default=None):
+    """Returns if the given variable is manually set as well as it's value."""
     env = getattr(builtins.__xonsh__, "env", None)
-    # flags indicating whether the traceback options have been manually set
     if env is None:
         env = os_environ
-        manually_set_trace = "XONSH_SHOW_TRACEBACK" in env
-        manually_set_logfile = "XONSH_TRACEBACK_LOGFILE" in env
+        manually_set = name in env
     else:
-        manually_set_trace = env.is_manually_set("XONSH_SHOW_TRACEBACK")
-        manually_set_logfile = env.is_manually_set("XONSH_TRACEBACK_LOGFILE")
+        manually_set = env.is_manually_set(name)
+
+    value = env.get(name, default)
+    return (manually_set, value)
+
+
+def print_warning(msg):
+    """Print warnings with/without traceback."""
+    manually_set_trace, show_trace = _get_env_var("XONSH_SHOW_TRACEBACK", False)
+    manually_set_logfile, log_file = _get_env_var("XONSH_TRACEBACK_LOGFILE")
     if (not manually_set_trace) and (not manually_set_logfile):
         # Notify about the traceback output possibility if neither of
         # the two options have been manually set
         sys.stderr.write(
             "xonsh: For full traceback set: " "$XONSH_SHOW_TRACEBACK = True\n"
         )
-    # get env option for traceback and convert it if necessary
-    show_trace = env.get("XONSH_SHOW_TRACEBACK", False)
+    # convert show_trace to bool if necessary
     if not is_bool(show_trace):
         show_trace = to_bool(show_trace)
     # if the trace option has been set, print all traceback info to stderr
@@ -944,7 +949,6 @@ def print_warning(msg):
         traceback.print_stack()
     # additionally, check if a file for traceback logging has been
     # specified and convert to a proper option if needed
-    log_file = env.get("XONSH_TRACEBACK_LOGFILE", None)
     log_file = to_logfile_opt(log_file)
     if log_file:
         # if log_file <> '' or log_file <> None, append
@@ -958,23 +962,15 @@ def print_warning(msg):
 
 def print_exception(msg=None):
     """Print exceptions with/without traceback."""
-    env = getattr(builtins.__xonsh__, "env", None)
-    # flags indicating whether the traceback options have been manually set
-    if env is None:
-        env = os_environ
-        manually_set_trace = "XONSH_SHOW_TRACEBACK" in env
-        manually_set_logfile = "XONSH_TRACEBACK_LOGFILE" in env
-    else:
-        manually_set_trace = env.is_manually_set("XONSH_SHOW_TRACEBACK")
-        manually_set_logfile = env.is_manually_set("XONSH_TRACEBACK_LOGFILE")
+    manually_set_trace, show_trace = _get_env_var("XONSH_SHOW_TRACEBACK", False)
+    manually_set_logfile, log_file = _get_env_var("XONSH_TRACEBACK_LOGFILE")
     if (not manually_set_trace) and (not manually_set_logfile):
         # Notify about the traceback output possibility if neither of
         # the two options have been manually set
         sys.stderr.write(
             "xonsh: For full traceback set: " "$XONSH_SHOW_TRACEBACK = True\n"
         )
-    # get env option for traceback and convert it if necessary
-    show_trace = env.get("XONSH_SHOW_TRACEBACK", False)
+    # convert show_trace to bool if necessary
     if not is_bool(show_trace):
         show_trace = to_bool(show_trace)
     # if the trace option has been set, print all traceback info to stderr
@@ -989,7 +985,6 @@ def print_exception(msg=None):
         traceback.print_exc()
     # additionally, check if a file for traceback logging has been
     # specified and convert to a proper option if needed
-    log_file = env.get("XONSH_TRACEBACK_LOGFILE", None)
     log_file = to_logfile_opt(log_file)
     if log_file:
         # if log_file <> '' or log_file <> None, append

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -911,7 +911,7 @@ def suggest_commands(cmd, env, aliases):
     return rtn
 
 
-def _get_env_var(name, default=None):
+def _get_manual_env_var(name, default=None):
     """Returns if the given variable is manually set as well as it's value."""
     env = getattr(builtins.__xonsh__, "env", None)
     if env is None:
@@ -926,8 +926,8 @@ def _get_env_var(name, default=None):
 
 def print_warning(msg):
     """Print warnings with/without traceback."""
-    manually_set_trace, show_trace = _get_env_var("XONSH_SHOW_TRACEBACK", False)
-    manually_set_logfile, log_file = _get_env_var("XONSH_TRACEBACK_LOGFILE")
+    manually_set_trace, show_trace = _get_manual_env_var("XONSH_SHOW_TRACEBACK", False)
+    manually_set_logfile, log_file = _get_manual_env_var("XONSH_TRACEBACK_LOGFILE")
     if (not manually_set_trace) and (not manually_set_logfile):
         # Notify about the traceback output possibility if neither of
         # the two options have been manually set
@@ -962,8 +962,8 @@ def print_warning(msg):
 
 def print_exception(msg=None):
     """Print exceptions with/without traceback."""
-    manually_set_trace, show_trace = _get_env_var("XONSH_SHOW_TRACEBACK", False)
-    manually_set_logfile, log_file = _get_env_var("XONSH_TRACEBACK_LOGFILE")
+    manually_set_trace, show_trace = _get_manual_env_var("XONSH_SHOW_TRACEBACK", False)
+    manually_set_logfile, log_file = _get_manual_env_var("XONSH_TRACEBACK_LOGFILE")
     if (not manually_set_trace) and (not manually_set_logfile):
         # Notify about the traceback output possibility if neither of
         # the two options have been manually set


### PR DESCRIPTION
This commit improves the current deprecation warning for NO_COLOR by allowing to show the traceback if XONSH_SHOW_TRACEBACK is set to True.
See https://github.com/xonsh/xonsh/pull/3793#issuecomment-703290727 for reasoning.

It also adds a new xonsh tool function: print_warning.

It is similar to print_exception, however it requires a message, as there is no exception.