### PR TITLE
COMPLETIONS_CONFIRM is True by default

### DIFF
--- a/news/COMPLETIONS_CONFIRM.rst
+++ b/news/COMPLETIONS_CONFIRM.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Now `COMPLETIONS_CONFIRM` is `True` by default.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/COMPLETIONS_CONFIRM.rst
+++ b/news/COMPLETIONS_CONFIRM.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Now `COMPLETIONS_CONFIRM` is `True` by default.
+* Now ``COMPLETIONS_CONFIRM`` is ``True`` by default.
 
 **Deprecated:**
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -812,7 +812,7 @@ def DEFAULT_VARS():
             is_bool,
             to_bool,
             bool_to_str,
-            False,
+            True,
             "While tab-completions menu is displayed, press <Enter> to confirm "
             "completion instead of running command. This only affects the "
             "prompt-toolkit shell.",


### PR DESCRIPTION
Closes #2364

1. _Originally posted by **gforsyth** in https://github.com/xonsh/xonsh/issues/2364#issuecomment-433938037_

    > Hey @ahundt -- I'm definitely game for setting `$COMPLETIONS_CONFIRM=True` as the default -- if we get a quorum of @xonsh/xore to agree to that we can change the default.

2. _Originally posted by **scopatz** in https://github.com/xonsh/xonsh/issues/2364#issuecomment-440098857_:

    > I am in favor of `$COMEPLETIONS_CONFIRM = True` if someone wants to put in a PR

3. _Originally posted by **anki-code** in https://github.com/xonsh/xonsh/issues/2364#issuecomment-706241263_

    > I also use COMPLETIONS_CONFIRM as True value because when you choose the item from list you want to choose next but you can't (in case of `False` setting) because Enter key will execute the command. BUT if the list contains one item it should appear in the line without pressing Enter.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
