### PR TITLE
Fix reset color xontrib list

### DIFF
--- a/news/xontrib_list_reset.rst
+++ b/news/xontrib_list_reset.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed reset color in ``xontrib list``.
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -173,7 +173,7 @@ def _list(ns):
             if d["loaded"]:
                 s += "{GREEN}loaded{RESET}"
             else:
-                s += "{RED}not-loaded{RESET }"
+                s += "{RED}not-loaded{RESET}"
             s += "\n"
         print_color(s[:-1])
 


### PR DESCRIPTION
It's in 0.9.23

![Screenshot_20201010_023932](https://user-images.githubusercontent.com/1708680/95639633-dedd7580-0aa1-11eb-9cb8-95c001c8cbaa.png)
