### PR TITLE
fix: async prompt workers update cache at the end

### DIFF
--- a/news/fix-async-prompt-invalid-cache-hit.rst
+++ b/news/fix-async-prompt-invalid-cache-hit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* async prompt field's returns from earlier data
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -39,6 +39,10 @@ class PromptFormatter:
 
     def __call__(self, template=DEFAULT_PROMPT, fields=None, **kwargs):
         """Formats a xonsh prompt template string."""
+
+        # keep cache only during building prompt
+        self.cache.clear()
+
         if fields is None:
             self.fields = builtins.__xonsh__.env.get("PROMPT_FIELDS", PROMPT_FIELDS)
         else:
@@ -47,8 +51,6 @@ class PromptFormatter:
             prompt = self._format_prompt(template=template, **kwargs)
         except Exception:
             return _failover_template_format(template)
-        # keep cache only during building prompt
-        self.cache.clear()
         return prompt
 
     def _format_prompt(self, template=DEFAULT_PROMPT, **kwargs):


### PR DESCRIPTION
this causes the getter to return every one in two times.
run 1-> the prompt is built the cache is cleared , but the async worker
updates the cache
run 2 -> the value is get from cache and no async worker created for
that field. cache is cleared after the prompt is built

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
