### PR TITLE
Completion menu rows - clean up completion menu display

### DIFF
--- a/news/completion_menu_rows.rst
+++ b/news/completion_menu_rows.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Environment variable $COMPLETIONS_MENU_ROWS sets maximum height of completion menus and now works reliably.  
+  Requires changes in prompt-toolkit which haven't been released yet.  See https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1271
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -847,7 +847,7 @@ def DEFAULT_VARS():
             int,
             str,
             5,
-            "Number of rows to reserve for tab-completions menu if "
+            "Maximum number of rows to display for tab-completions menu if "
             "``$COMPLETIONS_DISPLAY`` is ``single`` or ``multi``. This only affects the "
             "prompt-toolkit shell.",
         ),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -851,6 +851,14 @@ def DEFAULT_VARS():
             "``$COMPLETIONS_DISPLAY`` is ``single`` or ``multi``. This only affects the "
             "prompt-toolkit shell.",
         ),
+        "RESERVE_SPACE_FOR_MENU": Var(
+            is_int,
+            int,
+            str,
+            DefaultNotGiven,
+            "Additional space to reserve at bottom of screen for tab-completions menu. "
+            "Only affects prompt-toolkit shell.  Deprecated.  See ``$COMPLETIONS_MENU_ROWS``.",
+        ),
         "COMPLETION_QUERY_LIMIT": Var(
             is_int,
             int,

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -190,7 +190,7 @@ class PromptToolkitShell(BaseShell):
             "editing_mode": editing_mode,
             "prompt_continuation": self.continuation_tokens,
             "enable_history_search": enable_history_search,
-            "reserve_space_for_menu": 0,
+            "completion_menu_rows": env.get("COMPLETIONS_MENU_ROWS"),
             "key_bindings": self.key_bindings,
             "complete_style": complete_style,
             "complete_while_typing": complete_while_typing,


### PR DESCRIPTION
Supercedes #3815, but doesn't include all the fixes yet.  When done, intended to address #3775 and #3384 
Also requires an as-yet-unreleased PR, prompt-toolkit/python-prompt-toolkit#1271.

@anki-code, @ju-kreber, this should address the height-of-the-completion-menu issue as is.  You'll need to install the above version of prompt-toolkit, but can then set $COMPLETION_MENU_ROWS to a reasonable positive number and get no more than that number of completion rows wherever the prompt is in the screen.  There are some other display fixes that should look better, as well..  But no changes yet for anything to do with completions when file name contains spaces, I wanted to get this out of the way first.

And if it's working for you, we can jointly lobby @jonathanslenders  to accept the ptk PR.

