### PR TITLE
Document variable escaping in bash_to_xonsh

### DIFF
--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -29,6 +29,9 @@ line is ``#!/usr/bin/env xonsh``.
     * - ``something/$SOME_VAR/$(some_command)``
       - ``@('something/' + $SOME_VAR + $(some_command).strip())``
       - Concatenate a variable or text with the result of running a command.
+    * - ``echo 'my home is $HOME'``
+      - ``echo @("my home is $HOME")``
+      - Escape an environment variable from expansion.
     * - ``${!VAR}``
       - ``${var or expr}``
       - Look up an environment variable via another variable name. In xonsh,

--- a/news/doc-bash-env-escape.rst
+++ b/news/doc-bash-env-escape.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add method of escaping an environment variable from expansion to the Bash to Xonsh Translation Guide.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This method was already documented in the tutorial, but it took me a while to find it there. I thought it would be a good addition to the bash to xonsh guide as well.