### PR TITLE
Fix f-string parsing in Python 3.9

### DIFF
--- a/news/fix-v39-fstrings.rst
+++ b/news/fix-v39-fstrings.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed f-strings parsing in Python 3.9
+
+**Security:**
+
+* <news item>

--- a/xonsh/parsers/fstring_adaptor.py
+++ b/xonsh/parsers/fstring_adaptor.py
@@ -67,7 +67,7 @@ class FStringAdaptor:
                 # expression, e.g. "($HOME)" for f"{$HOME}" string.
                 if e.text is None or e.text[0] != "(":
                     raise
-                error_expr = e.text[1:-1]
+                error_expr = e.text.strip()[1:-1]
                 epos = template.find(error_expr)
                 if epos < 0:
                     raise


### PR DESCRIPTION
The f-strings parser is very sensitive to changes in the textual representation of the exceptions raised by the Python parser. There seems to be a bug introduced in Python 3.9 causing the exception text to be terminated by an extra newline character.

Fixes #3865