### PR TITLE
Rever: pin AppImage python version

### DIFF
--- a/news/appimage_python.rst
+++ b/news/appimage_python.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``xonsh.AppImage`` python version pinned to 3.8.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/rever.xsh
+++ b/rever.xsh
@@ -43,3 +43,5 @@ $DOCKER_GIT_NAME = 'xonsh'
 $DOCKER_GIT_EMAIL = 'xonsh@googlegroups.com'
 
 $GHRELEASE_ASSETS = [git_archive_asset, 'xonsh-x86_64.AppImage']
+
+$APPIMAGE_PYTHON_VERSION = '3.8'


### PR DESCRIPTION
Pin AppImage python until full support of python 3.9.

Update Rever before merge: https://github.com/regro/rever/pull/235