### PR TITLE
xonsh: requirements: Change `prompt_toolkit` minimum version to `3.0`

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 cloud_sptheme
 numpydoc
 Sphinx>=3.1
-prompt_toolkit>=2.0
+prompt_toolkit>=3.0
 pygments>=2.2
 psutil
 pyzmq


### PR DESCRIPTION
If you take a look in the file `xonsh/ptk_shell/shell.py` you will see that there's an import of `load_emacs_shift_selection_bindings` which is available only from `prompt_toolkit>=3.0`
