### PR TITLE
docs: fix typos

### DIFF
--- a/docs/_templates_overwrite/index.html
+++ b/docs/_templates_overwrite/index.html
@@ -109,7 +109,7 @@
                         <h6>About</h6>
                         <h1>Xonsh is a Modern<br>Approach to the Terminal</h1>
                         <p>Xonsh <i>is</i> Python with added shell syntax thrown in.
-                        This makes it an ideal, intuitve way to interact with your
+                        This makes it an ideal, intuitive way to interact with your
                         computer. You probably already know Python, and so xonsh allows
                         you to run command line applications with out needing to learn
                         a new, arcane syntax when ever you want to use a for-statement.
@@ -240,7 +240,7 @@
                                         <li>Rich history interface!</li>
                                         <li>A 3rd-party extension system (<code>xontribs</code>)!</li>
                                         <li>Powerful event system let's you extend default behavior!</li>
-                                        <li>Seamlesslu mix Python & Subprocess operations!</li>
+                                        <li>Seamlessly mix Python & Subprocess operations!</li>
                                         <li>Loads of customization options, including keybindings!</li>
                                     </ul>
                                     <a class="primary_btn" href="{{ pathto('contents') }}">Documentation</a>


### PR DESCRIPTION
Fix typos on index page. Don't think this really deserves a news item, but let me know if you want me to do one up.
