### PR TITLE
Add xog xontrib

### DIFF
--- a/news/xog.rst
+++ b/news/xog.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* ``xog`` xontrib - a simple command to establish and print temporary traceback
+  log file.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -268,6 +268,11 @@
                   "bit of the startup time when running your favorite, minimal ",
                   "text editor."]
   },
+ {"name": "xog",
+  "package": "xonsh",
+  "url": "http://xon.sh",
+  "description": ["Adds a simple command to establish and print temporary traceback log file."]
+ },
   {"name": "xpg",
   "package": "xontrib-xpg",
   "url": "https://github.com/fengttt/xsh/tree/master/py",

--- a/xontrib/xog.py
+++ b/xontrib/xog.py
@@ -1,0 +1,68 @@
+"""
+This adds `xog` - a simple command to establish and print temporary traceback log file.
+"""
+
+import builtins
+import os
+import pathlib
+import tempfile
+
+__all__ = ()
+
+
+def _get_log_file_name():
+    return pathlib.Path(f"{tempfile.gettempdir()}/xonsh-{os.getpid()}.log")
+
+
+def _clear_log(logfile, stderr):
+    try:
+        os.remove(logfile)
+    except OSError as e:
+        print(f"xog: {e}", file=stderr)
+        return False
+    return True
+
+
+def _print_log(logfile, stdout, stderr):
+    try:
+        with open(logfile) as log:
+            for l in log:
+                print(l, end="", file=stdout)
+    except OSError as e:
+        print(f"xog: {e}", file=stderr)
+        return False
+    return True
+
+
+def _print_help(stdout):
+    print(
+        """Usage: xog [OPTIONS]
+Prints contents of the shell's traceback log file.
+
+Options:
+  -c, --clear\t\tclear the log file contents
+  -?, --help\t\tprint this help text
+"""
+    )
+
+
+def _xog(args, stdout=None, stderr=None):
+    if "-?" in args or "--help" in args:
+        _print_help(stdout)
+        return 0
+
+    logfile = builtins.__xonsh__.env.get("XONSH_TRACEBACK_LOGFILE", "")
+    if not (logfile and os.path.isfile(logfile)):
+        print("Traceback log file doesn't exist.", file=stderr)
+        return -1
+
+    if "-c" in args or "--clear" in args:
+        rc = _clear_log(logfile, stderr=stderr)
+        return 0 if rc else -1
+
+    rc = _print_log(logfile, stdout, stderr)
+    return 0 if rc else -1
+
+
+builtins.__xonsh__.env["XONSH_TRACEBACK_LOGFILE"] = _get_log_file_name()
+aliases["xog"] = _xog


### PR DESCRIPTION
This adds `xog` internal xontrib - a simple command to establish and print temporary traceback log file.

Feel free to reject this as being more suitable for external xontrib.