### PR TITLE
Updated prompt-toolkit version requirement

### DIFF
--- a/news/fix_prompt_toolkit_version.rst
+++ b/news/fix_prompt_toolkit_version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* prompt-toolkit required version updated to >=3.0
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 cloud_sptheme
 numpydoc
 Sphinx>=3.1
-prompt_toolkit>=2.0
+prompt_toolkit>=3.0
 pygments>=2.2
 psutil
 pyzmq

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,7 @@ flake8
 flake8-docstrings
 pytest-cov
 pytest-timeout
-prompt-toolkit>=2.0
+prompt-toolkit>=3.0
 pygments>=2.2
 codecov
 coverage

--- a/setup.py
+++ b/setup.py
@@ -339,7 +339,7 @@ def main():
     }
     skw["cmdclass"]["develop"] = xdevelop
     skw["extras_require"] = {
-        "ptk": ["prompt-toolkit>=2.0"],
+        "ptk": ["prompt-toolkit>=3.0"],
         "pygments": ["pygments>=2.2"],
         "mac": ["gnureadline"],
         "linux": ["distro"],


### PR DESCRIPTION
Fixed dependency problem with prompt-toolkit. Xonsh required version >=2.0 but in code features from >=3.0 was used.
