### PR TITLE
Added timing probes

### DIFF
--- a/news/timing_lexer.rst
+++ b/news/timing_lexer.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added timing probes for pygments lexer.
+* Added timing probes for prompt tokens and lexer.
 
 **Changed:**
 

--- a/news/timing_lexer.rst
+++ b/news/timing_lexer.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added timing probes for pygments lexer.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/timing_lexer.rst
+++ b/news/timing_lexer.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added timing probes for prompt tokens and lexer.
+* Added timing probes for prompt tokens, lexer and before prompt.
 
 **Changed:**
 

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -180,8 +180,6 @@ class PromptToolkitShell(BaseShell):
         ):
             self.prompter.default_buffer._history_matches = self._history_matches_orig
 
-
-
         prompt_args = {
             "mouse_support": mouse_support,
             "auto_suggest": auto_suggest,

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -153,8 +153,8 @@ class PromptToolkitShell(BaseShell):
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
         completer = None if completions_display == "none" else self.pt_completer
 
+        events.on_timingprobe.fire(name="on_pre_prompt_tokens")
         get_bottom_toolbar_tokens = self.bottom_toolbar_tokens
-
         if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
             get_prompt_tokens = self.prompt_tokens
             get_rprompt_tokens = self.rprompt_tokens
@@ -163,6 +163,7 @@ class PromptToolkitShell(BaseShell):
             get_rprompt_tokens = self.rprompt_tokens()
             if get_bottom_toolbar_tokens:
                 get_bottom_toolbar_tokens = get_bottom_toolbar_tokens()
+        events.on_timingprobe.fire(name="on_post_prompt_tokens")
 
         if env.get("VI_MODE"):
             editing_mode = EditingMode.VI
@@ -178,6 +179,8 @@ class PromptToolkitShell(BaseShell):
             is not self._history_matches_orig
         ):
             self.prompter.default_buffer._history_matches = self._history_matches_orig
+
+
 
         prompt_args = {
             "mouse_support": mouse_support,

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -135,7 +135,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
-        events.on_pre_prompt.fire()
+        events.on_timingprobe.fire(name="on_prompt_singleline_create")
         env = builtins.__xonsh__.env
         mouse_support = env.get("MOUSE_SUPPORT")
         auto_suggest = auto_suggest if env.get("AUTO_SUGGEST") else None
@@ -198,10 +198,13 @@ class PromptToolkitShell(BaseShell):
             "refresh_interval": refresh_interval,
             "complete_in_thread": complete_in_thread,
         }
+
         if env.get("COLOR_INPUT"):
             if HAS_PYGMENTS:
+                events.on_timingprobe.fire(name="on_pre_prompt_pygments_lexer")
                 prompt_args["lexer"] = PygmentsLexer(pyghooks.XonshLexer)
                 style = style_from_pygments_cls(pyghooks.xonsh_style_proxy(self.styler))
+                events.on_timingprobe.fire(name="on_post_prompt_pygments_lexer")
             else:
                 style = style_from_pygments_dict(DEFAULT_STYLE_DICT)
 
@@ -219,8 +222,8 @@ class PromptToolkitShell(BaseShell):
             # once the prompt is done, update it in background as each future is completed
             prompt_args["pre_run"] = self.prompt_formatter.start_update
 
+        events.on_pre_prompt.fire()
         line = self.prompter.prompt(**prompt_args)
-
         events.on_post_prompt.fire()
         return line
 

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -135,7 +135,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
-        events.on_pre_prompt.fire()
+        events.on_pre_prompt_format.fire()
         env = builtins.__xonsh__.env
         mouse_support = env.get("MOUSE_SUPPORT")
         auto_suggest = auto_suggest if env.get("AUTO_SUGGEST") else None
@@ -153,7 +153,7 @@ class PromptToolkitShell(BaseShell):
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
         completer = None if completions_display == "none" else self.pt_completer
 
-        events.on_timingprobe.fire(name="on_pre_prompt_tokens")
+        events.on_timingprobe.fire(name="on_pre_prompt_tokenize")
         get_bottom_toolbar_tokens = self.bottom_toolbar_tokens
         if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
             get_prompt_tokens = self.prompt_tokens
@@ -163,7 +163,7 @@ class PromptToolkitShell(BaseShell):
             get_rprompt_tokens = self.rprompt_tokens()
             if get_bottom_toolbar_tokens:
                 get_bottom_toolbar_tokens = get_bottom_toolbar_tokens()
-        events.on_timingprobe.fire(name="on_post_prompt_tokens")
+        events.on_timingprobe.fire(name="on_post_prompt_tokenize")
 
         if env.get("VI_MODE"):
             editing_mode = EditingMode.VI
@@ -201,15 +201,14 @@ class PromptToolkitShell(BaseShell):
         }
 
         if env.get("COLOR_INPUT"):
+            events.on_timingprobe.fire(name="on_pre_prompt_style")
             if HAS_PYGMENTS:
-                events.on_timingprobe.fire(name="on_pre_prompt_pygments_lexer")
                 prompt_args["lexer"] = PygmentsLexer(pyghooks.XonshLexer)
                 style = style_from_pygments_cls(pyghooks.xonsh_style_proxy(self.styler))
-                events.on_timingprobe.fire(name="on_post_prompt_pygments_lexer")
             else:
                 style = style_from_pygments_dict(DEFAULT_STYLE_DICT)
-
             prompt_args["style"] = style
+            events.on_timingprobe.fire(name="on_post_prompt_style")
 
             style_overrides_env = env.get("PTK_STYLE_OVERRIDES")
             if style_overrides_env:
@@ -223,7 +222,7 @@ class PromptToolkitShell(BaseShell):
             # once the prompt is done, update it in background as each future is completed
             prompt_args["pre_run"] = self.prompt_formatter.start_update
 
-        events.on_pre_prompter_prompt.fire()
+        events.on_pre_prompt.fire()
         line = self.prompter.prompt(**prompt_args)
         events.on_post_prompt.fire()
         return line

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -135,7 +135,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
-        events.on_timingprobe.fire(name="on_prompt_singleline_create")
+        events.on_pre_prompt.fire()
         env = builtins.__xonsh__.env
         mouse_support = env.get("MOUSE_SUPPORT")
         auto_suggest = auto_suggest if env.get("AUTO_SUGGEST") else None
@@ -223,7 +223,7 @@ class PromptToolkitShell(BaseShell):
             # once the prompt is done, update it in background as each future is completed
             prompt_args["pre_run"] = self.prompt_formatter.start_update
 
-        events.on_pre_prompt.fire()
+        events.on_before_prompter_prompt.fire()
         line = self.prompter.prompt(**prompt_args)
         events.on_post_prompt.fire()
         return line

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -223,7 +223,7 @@ class PromptToolkitShell(BaseShell):
             # once the prompt is done, update it in background as each future is completed
             prompt_args["pre_run"] = self.prompt_formatter.start_update
 
-        events.on_before_prompter_prompt.fire()
+        events.on_pre_prompter_prompt.fire()
         line = self.prompter.prompt(**prompt_args)
         events.on_post_prompt.fire()
         return line

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -365,9 +365,9 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             except ImportError:
                 store_in_history = True
             pos = readline.get_current_history_length() - 1
-        events.on_pre_prompt.fire()
+        events.on_pre_prompt_format.fire()
         prompt = self.prompt
-        events.on_pre_prompter_prompt.fire()
+        events.on_pre_prompt.fire()
         rtn = input(prompt)
         events.on_post_prompt.fire()
         if not store_in_history and pos >= 0:

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -366,7 +366,9 @@ class ReadlineShell(BaseShell, cmd.Cmd):
                 store_in_history = True
             pos = readline.get_current_history_length() - 1
         events.on_pre_prompt.fire()
-        rtn = input(self.prompt)
+        prompt = self.prompt
+        events.on_pre_prompter_prompt.fire()
+        rtn = input(prompt)
         events.on_post_prompt.fire()
         if not store_in_history and pos >= 0:
             readline.remove_history_item(pos)

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -76,9 +76,9 @@ Fires just after the prompt returns
 )
 
 events.doc(
-    "on_before_prompter_prompt",
+    "on_pre_prompter_prompt",
     """
-on_before_prompter_prompt() -> None
+on_pre_prompter_prompt() -> None
 
 Fires just before showing the prompt
 """,

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -58,9 +58,9 @@ Parameters:
 )
 
 events.doc(
-    "on_pre_prompt",
+    "on_pre_prompt_format",
     """
-on_pre_prompt() -> None
+on_pre_prompt_format() -> None
 
 Fires just before the prompt is shown
 """,
@@ -76,9 +76,9 @@ Fires just after the prompt returns
 )
 
 events.doc(
-    "on_pre_prompter_prompt",
+    "on_pre_prompt",
     """
-on_pre_prompter_prompt() -> None
+on_pre_prompt() -> None
 
 Fires just before showing the prompt
 """,

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -62,16 +62,7 @@ events.doc(
     """
 on_pre_prompt_format() -> None
 
-Fires just before the prompt is shown
-""",
-)
-
-events.doc(
-    "on_post_prompt",
-    """
-on_post_prompt() -> None
-
-Fires just after the prompt returns
+Fires before the prompt will be formatted
 """,
 )
 
@@ -81,6 +72,16 @@ events.doc(
 on_pre_prompt() -> None
 
 Fires just before showing the prompt
+""",
+)
+
+
+events.doc(
+    "on_post_prompt",
+    """
+on_post_prompt() -> None
+
+Fires just after the prompt returns
 """,
 )
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -75,6 +75,15 @@ Fires just after the prompt returns
 """,
 )
 
+events.doc(
+    "on_before_prompter_prompt",
+    """
+on_before_prompter_prompt() -> None
+
+Fires just before showing the prompt
+""",
+)
+
 
 def transform_command(src, show_diff=True):
     """Returns the results of firing the precommand handles."""

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -310,20 +310,20 @@ def setup_timings(argv):
             global _timings
             _timings["on_chdir"] = clock()
 
-        @events.on_pre_prompt
-        def timing_on_pre_prompt(**kw):
+        @events.on_pre_prompt_format
+        def timing_on_pre_prompt_format(**kw):
             global _timings
-            _timings["on_pre_prompt"] = clock()
+            _timings["on_pre_prompt_format"] = clock()
 
         @events.on_post_prompt
         def timing_on_post_prompt(**kw):
             global _timings
             _timings = {"on_post_prompt": clock()}
 
-        @events.on_pre_prompter_prompt
-        def timing_on_pre_prompter_prompt(**kw):
+        @events.on_pre_prompt
+        def timing_on_pre_prompt(**kw):
             global _timings
-            _timings["on_pre_prompter_prompt"] = clock()
+            _timings["on_pre_prompt"] = clock()
             times = list(_timings.items())
             times = sorted(times, key=lambda x: x[1])
             width = max(len(s) for s, _ in times) + 2

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -315,10 +315,10 @@ def setup_timings(argv):
             global _timings
             _timings = {"on_post_prompt": clock()}
 
-        @events.on_pre_prompt
-        def timing_on_pre_prompt(**kw):
+        @events.on_before_prompter_prompt
+        def timing_on_before_prompter_prompt(**kw):
             global _timings
-            _timings["on_pre_prompt"] = clock()
+            _timings["on_before_prompter_prompt"] = clock()
             times = list(_timings.items())
             times = sorted(times, key=lambda x: x[1])
             width = max(len(s) for s, _ in times) + 2

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -320,10 +320,10 @@ def setup_timings(argv):
             global _timings
             _timings = {"on_post_prompt": clock()}
 
-        @events.on_before_prompter_prompt
-        def timing_on_before_prompter_prompt(**kw):
+        @events.on_pre_prompter_prompt
+        def timing_on_pre_prompter_prompt(**kw):
             global _timings
-            _timings["on_before_prompter_prompt"] = clock()
+            _timings["on_pre_prompter_prompt"] = clock()
             times = list(_timings.items())
             times = sorted(times, key=lambda x: x[1])
             width = max(len(s) for s, _ in times) + 2

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -310,6 +310,11 @@ def setup_timings(argv):
             global _timings
             _timings["on_chdir"] = clock()
 
+        @events.on_pre_prompt
+        def timing_on_pre_prompt(**kw):
+            global _timings
+            _timings["on_pre_prompt"] = clock()
+
         @events.on_post_prompt
         def timing_on_post_prompt(**kw):
             global _timings


### PR DESCRIPTION
Hi! 

1. I've found that PygmentsLexer takes much time on first start and I add timing probe to show it.
2. I've found that `prompt_tokens` takes much time and I add timing probe to show it.
3. Added `on_before_prompter_prompt` event to show timings in the right place.

Example of no-rc start:
```
xonsh --timings --no-rc
|-------------------------------|-----------|-----------|
|Event name                     | Time (s)  | Delta (s) |
|-------------------------------|-----------|-----------|
|start                          |   0.000   |   0.000   |
|pre_execer_init                |   0.016   |   0.016   |
|post_execer_init               |   0.064   |   0.048   |
|on_pre_rc                      |   0.064   |   0.000   |
|on_post_rc                     |   0.064   |   0.000   |
|on_ptk_create                  |   0.145   |   0.081   |
|on_post_init                   |   0.145   |   0.000   |
|on_pre_cmdloop                 |   0.213   |   0.068   |
|on_prompt_singleline_create    |   0.213   |   0.000   |
|on_pre_prompt_tokens           |   0.213   |   0.000   |
|on_post_prompt_tokens          |   0.543   |   0.330   | <===========================
|on_pre_prompt_pygments_lexer   |   0.543   |   0.000   |
|on_post_prompt_pygments_lexer  |   0.585   |   0.041   |
|on_before_prompter_prompt      |   0.585   |   0.000   |
|-------------------------------|-----------|-----------|
```

Example of my rc start:
```
$ xonsh --timings 
|-------------------------------|-----------|-----------|
|Event name                     | Time (s)  | Delta (s) |
|-------------------------------|-----------|-----------|
|start                          |   0.000   |   0.000   |
|pre_execer_init                |   0.015   |   0.015   |
|post_execer_init               |   0.061   |   0.046   |
|on_pre_rc                      |   0.061   |   0.000   |
|on_post_rc                     |   0.486   |   0.425   |
|on_ptk_create                  |   0.505   |   0.019   |
|on_post_init                   |   0.506   |   0.000   |
|on_pre_cmdloop                 |   0.506   |   0.000   |
|on_prompt_singleline_create    |   0.506   |   0.000   |
|on_pre_prompt_tokens           |   0.534   |   0.028   |
|on_post_prompt_tokens          |   0.544   |   0.010   |
|on_pre_prompt_pygments_lexer   |   0.544   |   0.000   |
|on_post_prompt_pygments_lexer  |   0.879   |   0.335   | <==========================
|on_before_prompter_prompt      |   0.879   |   0.000   |
|-------------------------------|-----------|-----------|
```