### PR TITLE
procs: Add CommandPipeline.raw_out for retreival of the raw stdout bytes

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -489,7 +489,7 @@ Python Evaluation with ``@()``
 
 The ``@(<expr>)`` operator form works in subprocess mode, and will evaluate
 arbitrary Python code. The result is appended to the subprocess command list.
-If the result is a string, it is appended to the argument list. If the result
+If the result is a string or bytes, it is appended to the argument list. If the result
 is a list or other non-string sequence, the contents are converted to strings
 and appended to the argument list in order. If the result in the first position
 is a function, it is treated as an alias (see the section on `Aliases`_ below),

--- a/news/command-pipeline-raw-out.rst
+++ b/news/command-pipeline-raw-out.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``CommandPipeline.raw_out`` and ``CommandPipeline.raw_err`` to get stdout/err as raw bytes.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/command-pipeline-raw-out.rst
+++ b/news/command-pipeline-raw-out.rst
@@ -1,6 +1,7 @@
 **Added:**
 
 * Added ``CommandPipeline.raw_out`` and ``CommandPipeline.raw_err`` to get stdout/err as raw bytes.
+* The ``@()`` operator now supports ``bytes`` objects.
 
 **Changed:**
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -7,8 +7,8 @@ import pytest
 import builtins
 
 from xonsh.platform import ON_WINDOWS
-from tests.tools import skip_if_on_windows, skip_if_on_unix
 from xonsh.procs.pipelines import CommandPipeline
+from tests.tools import skip_if_on_windows, skip_if_on_unix
 
 
 @pytest.fixture(autouse=True)
@@ -39,9 +39,23 @@ def patched_events(monkeypatch, xonsh_events, xonsh_execer):
         ("!(echo hi | grep h)", "hi\n", ""),
         ("!(echo hi | grep x)", "", ""),
 ))
-def test_captured(cmdline, stdout, stderr, xonsh_execer):
+def test_command_pipeline_capture(cmdline, stdout, stderr, xonsh_execer):
     pipeline: CommandPipeline = xonsh_execer.eval(cmdline)
     assert pipeline.out == stdout
     assert pipeline.err == (stderr or None)
     assert pipeline.raw_out == stdout.replace("\n", os.linesep).encode()
     assert pipeline.raw_err == stderr.replace("\n", os.linesep).encode()
+
+
+@pytest.mark.parametrize("cmdline, output", (
+        ("echo hi", "hi\n"),
+        ("echo hi | grep h", "hi\n"),
+        ("echo hi | grep x", ""),
+        pytest.param("echo -n hi", "hi", marks=skip_if_on_windows),
+))
+def test_simple_capture(cmdline, output, xonsh_execer):
+    assert xonsh_execer.eval(f"$({cmdline})") == output
+
+
+def test_raw_substitution(xonsh_execer):
+    assert xonsh_execer.eval("$(echo @(b'bytes!'))") == "bytes!\n"

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,0 +1,47 @@
+"""
+Tests for command pipelines.
+"""
+
+import os
+import pytest
+import builtins
+
+from xonsh.platform import ON_WINDOWS
+from tests.tools import skip_if_on_windows, skip_if_on_unix
+from xonsh.procs.pipelines import CommandPipeline
+
+
+@pytest.fixture(autouse=True)
+def patched_events(monkeypatch, xonsh_events, xonsh_execer):
+    # needed for ci tests
+    monkeypatch.setattr('builtins.events', xonsh_events, raising=False)
+    monkeypatch.setitem(builtins.__xonsh__.env, 'RAISE_SUBPROC_ERROR', False)  # for the failing `grep` commands
+    if ON_WINDOWS:
+        monkeypatch.setattr('builtins.aliases', {
+            "echo": "cmd /c echo".split(),
+            "grep": "cmd /c findstr".split(),
+        }, raising=False)
+
+
+@pytest.mark.parametrize("cmdline, stdout, stderr", (
+        ("!(echo hi)", "hi\n", ""),
+        ("!(echo hi o>e)", "", "hi\n"),
+
+        pytest.param("![echo hi]", "hi\n", "", marks=pytest.mark.xfail(
+            ON_WINDOWS, reason="ConsoleParallelReader doesn't work without a real console")),
+        pytest.param("![echo hi o>e]", "", "hi\n", marks=pytest.mark.xfail(
+            ON_WINDOWS, reason="stderr isn't captured in ![] on windows")),
+
+        pytest.param(r"!(echo 'hi\nho')", "hi\nho\n", "", marks=skip_if_on_windows),  # won't work with cmd
+        # for some reason cmd's echo adds an extra space:
+        pytest.param(r"!(cmd /c 'echo hi && echo ho')", "hi \nho\n", "", marks=skip_if_on_unix),
+
+        ("!(echo hi | grep h)", "hi\n", ""),
+        ("!(echo hi | grep x)", "", ""),
+))
+def test_captured(cmdline, stdout, stderr, xonsh_execer):
+    pipeline: CommandPipeline = xonsh_execer.eval(cmdline)
+    assert pipeline.out == stdout
+    assert pipeline.err == (stderr or None)
+    assert pipeline.raw_out == stdout.replace("\n", os.linesep).encode()
+    assert pipeline.raw_err == stderr.replace("\n", os.linesep).encode()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -217,14 +217,29 @@ def ensure_list_of_strs(x):
     return rtn
 
 
-def list_of_strs_or_callables(x):
-    """Ensures that x is a list of strings or functions"""
+def ensure_str_or_callable(x):
+    """Ensures that x is single string or function."""
     if isinstance(x, str) or callable(x):
-        rtn = [x]
+        return x
+    if isinstance(x, bytes):
+        # ``os.fsdecode`` decodes using "surrogateescape" on linux and "strict" on windows.
+        # This is used to decode bytes for interfacing with the os, notably for command line arguments.
+        # See https://www.python.org/dev/peps/pep-0383/#specification
+        return os.fsdecode(x)
+    return str(x)
+
+
+def list_of_strs_or_callables(x):
+    """
+    Ensures that x is a list of strings or functions.
+    This is called when using the ``@()`` operator to expand it's content.
+    """
+    if isinstance(x, (str, bytes)) or callable(x):
+        rtn = [ensure_str_or_callable(x)]
     elif isinstance(x, cabc.Iterable):
-        rtn = [i if isinstance(i, str) or callable(i) else str(i) for i in x]
+        rtn = list(map(ensure_str_or_callable, x))
     else:
-        rtn = [str(x)]
+        rtn = [ensure_str_or_callable(x)]
     return rtn
 
 

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -147,6 +147,7 @@ class CommandPipeline:
         self.input = self._output = self.errors = self.endtime = None
         self._closed_handle_cache = {}
         self.lines = []
+        self._raw_output = self._raw_error = b""
         self._stderr_prefix = self._stderr_postfix = None
         self.term_pgid = None
 
@@ -331,6 +332,7 @@ class CommandPipeline:
         enc = env.get("XONSH_ENCODING")
         err = env.get("XONSH_ENCODING_ERRORS")
         lines = self.lines
+        raw_out_lines = []
         stream = self.captured not in STDOUT_CAPTURE_KINDS
         if stream and not self.spec.stdout:
             stream = False
@@ -346,6 +348,8 @@ class CommandPipeline:
                 else:
                     sys.stdout.write(line.decode(encoding=enc, errors=err))
                 sys.stdout.flush()
+            # save the raw bytes
+            raw_out_lines.append(line)
             # do some munging of the line before we return it
             if line.endswith(crnl):
                 line = line[:-2] + nl
@@ -356,6 +360,9 @@ class CommandPipeline:
             # tee it up!
             lines.append(line)
             yield line
+
+        # using join is more efficient than concatenating in a loop
+        self._raw_output = b"".join(raw_out_lines)
 
     def stream_stderr(self, lines):
         """Streams lines to sys.stderr and the errors attribute."""
@@ -376,6 +383,8 @@ class CommandPipeline:
         else:
             sys.stderr.write(b.decode(encoding=enc, errors=err))
         sys.stderr.flush()
+        # save the raw bytes
+        self._raw_error = b
         # do some munging of the line before we save it to the attr
         b = b.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
         b = RE_HIDE_ESCAPE.sub(b"", b)
@@ -612,6 +621,18 @@ class CommandPipeline:
         """Error messages as a string."""
         self.end()
         return self.errors
+
+    @property
+    def raw_out(self):
+        """Output as raw bytes."""
+        self.end()
+        return self._raw_output
+
+    @property
+    def raw_err(self):
+        """Errors as raw bytes."""
+        self.end()
+        return self._raw_error
 
     @property
     def pid(self):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

This PR allows using a command's binary output as a python object.

For example:
```python
x = !(head -c 100 /bin/python3).raw_out
```

Also closes #3954 