### PR TITLE
zoxide & gitinfo xontribs added to the list of xontribs

### DIFF
--- a/news/zoxide_gitinfo.rst
+++ b/news/zoxide_gitinfo.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Added ``xontrib-zoxide`` to the list of xontribs.
+* Added ``xontrib-gitinfo`` to the list of xontribs.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -148,6 +148,11 @@
   "url": "https://github.com/laloch/xontrib-fzf-widgets",
   "description": ["Adds some fzf widgets to your xonsh shell."]
  },
+ {"name": "gitinfo",
+  "package": "xontrib-gitinfo",
+  "url": "https://github.com/dyuri/xontrib-gitinfo",
+  "description": ["Displays git information on entering a repository folder. Uses ``onefetch`` if available."]
+ },
  {"name": "histcpy",
   "package": "xontrib-histcpy",
   "url": "https://github.com/con-f-use/xontrib-histcpy",
@@ -290,6 +295,11 @@
   "package": "xontrib-z",
   "url": "https://github.com/AstraLuma/xontrib-z",
   "description": ["Tracks your most used directories, based on 'frecency'."]
+ },
+ {"name": "zoxide",
+  "package": "xontrib-zoxide",
+  "url": "https://github.com/dyuri/xontrib-zoxide",
+  "description": ["Zoxide integration for xonsh."]
  }
  ],
  "packages": {
@@ -391,6 +401,13 @@
    "url": "https://github.com/laloch/xontrib-fzf-widgets",
    "install": {
     "pip": "xpip install xontrib-fzf-widgets"
+   }
+  },
+  "xontrib-gitinfo": {
+   "license": "MIT",
+   "url": "https://github.com/dyuri/xontrib-gitinfo",
+   "install": {
+    "pip": "xpip install xontrib-gitinfo"
    }
   },
   "xontrib-histcpy": {
@@ -518,6 +535,13 @@
    "url": "https://github.com/AstraLuma/xontrib-z",
    "install": {
     "pip": "xpip install xontrib-z"
+   }
+  },
+  "xontrib-z": {
+   "license": "MIT",
+   "url": "https://github.com/dyuri/xontrib-zoxide",
+   "install": {
+    "pip": "xpip install xontrib-zoxide"
    }
   }
  }


### PR DESCRIPTION
Adds `xontrib-zoxide` and `xontrib-gitinfo` to the list of xontribs.

"Fixes" #3910.