### PR TITLE
Add Python 3.9 to GitHub workflows

### DIFF
--- a/.github/workflows/genbuilds.xsh
+++ b/.github/workflows/genbuilds.xsh
@@ -15,6 +15,8 @@ OS_IMAGES = {
 }
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 
+ALLOWED_FAILURES = ["3.9"]
+
 CURR_DIR = os.path.dirname(__file__)
 template_path = os.path.join(CURR_DIR, "pytest.tmpl")
 
@@ -23,8 +25,7 @@ for os_name, python_version in product(OS_NAMES, PYTHON_VERSIONS):
     s = template.replace("OS_NAME", os_name)
     s = s.replace("OS_IMAGE", OS_IMAGES[os_name])
     s = s.replace("PYTHON_VERSION", python_version)
-    # Allow Python 3.9 to fail.
-    if python_version in ["3.9"]:
+    if python_version in ALLOWED_FAILURES:
         s = "\n".join((s, "        continue-on-error: true\n"))
     fname = os.path.join(CURR_DIR, f"pytest-{os_name}-{python_version}.yml")
     ![echo @(s) > @(fname)]

--- a/.github/workflows/genbuilds.xsh
+++ b/.github/workflows/genbuilds.xsh
@@ -13,7 +13,7 @@ OS_IMAGES = {
     "macos": "macOS-latest",
     "windows": "windows-latest",
 }
-PYTHON_VERSIONS = ["3.6", "3.7", "3.8"]
+PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 
 CURR_DIR = os.path.dirname(__file__)
 template_path = os.path.join(CURR_DIR, "pytest.tmpl")
@@ -23,5 +23,8 @@ for os_name, python_version in product(OS_NAMES, PYTHON_VERSIONS):
     s = template.replace("OS_NAME", os_name)
     s = s.replace("OS_IMAGE", OS_IMAGES[os_name])
     s = s.replace("PYTHON_VERSION", python_version)
+    # Allow Python 3.9 to fail.
+    if python_version in ["3.9"]:
+        s = "\n".join((s, "        continue-on-error: true\n"))
     fname = os.path.join(CURR_DIR, f"pytest-{os_name}-{python_version}.yml")
     ![echo @(s) > @(fname)]

--- a/.github/workflows/pytest-linux-3.6.yml
+++ b/.github/workflows/pytest-linux-3.6.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-linux-3.7.yml
+++ b/.github/workflows/pytest-linux-3.7.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-linux-3.8.yml
+++ b/.github/workflows/pytest-linux-3.8.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-linux-3.9.yml
+++ b/.github/workflows/pytest-linux-3.9.yml
@@ -40,3 +40,4 @@ jobs:
           python -m pip install . --no-deps
           python -m xonsh run-tests.xsh test -- --timeout=240
 
+        continue-on-error: true

--- a/.github/workflows/pytest-linux-3.9.yml
+++ b/.github/workflows/pytest-linux-3.9.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt
@@ -41,3 +42,4 @@ jobs:
           python -m xonsh run-tests.xsh test -- --timeout=240
 
         continue-on-error: true
+

--- a/.github/workflows/pytest-linux-3.9.yml
+++ b/.github/workflows/pytest-linux-3.9.yml
@@ -1,0 +1,42 @@
+name: pytest linux 3.9
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9]
+    name: Python ${{ matrix.python-version }} ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/miniconda*/envs/
+          key: ${{ runner.os }}-${{ matrix.python-version }}-env-${{ hashFiles('requirements/tests.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-env-
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v1
+        with:
+          activate-environment: xonsh-test
+          update-conda: true
+          python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
+          condarc-file: ci/condarc.yml
+      - shell: bash -l {0}
+        run: |
+          python -m pip --version
+          python -m pip install -r requirements/tests.txt
+          python -m pip install . --no-deps
+          python -m xonsh run-tests.xsh test -- --timeout=240
+

--- a/.github/workflows/pytest-macos-3.6.yml
+++ b/.github/workflows/pytest-macos-3.6.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-macos-3.7.yml
+++ b/.github/workflows/pytest-macos-3.7.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-macos-3.8.yml
+++ b/.github/workflows/pytest-macos-3.8.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-macos-3.9.yml
+++ b/.github/workflows/pytest-macos-3.9.yml
@@ -40,3 +40,4 @@ jobs:
           python -m pip install . --no-deps
           python -m xonsh run-tests.xsh test -- --timeout=240
 
+        continue-on-error: true

--- a/.github/workflows/pytest-macos-3.9.yml
+++ b/.github/workflows/pytest-macos-3.9.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt
@@ -41,3 +42,4 @@ jobs:
           python -m xonsh run-tests.xsh test -- --timeout=240
 
         continue-on-error: true
+

--- a/.github/workflows/pytest-macos-3.9.yml
+++ b/.github/workflows/pytest-macos-3.9.yml
@@ -1,0 +1,42 @@
+name: pytest macos 3.9
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest]
+        python-version: [3.9]
+    name: Python ${{ matrix.python-version }} ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/miniconda*/envs/
+          key: ${{ runner.os }}-${{ matrix.python-version }}-env-${{ hashFiles('requirements/tests.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-env-
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v1
+        with:
+          activate-environment: xonsh-test
+          update-conda: true
+          python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
+          condarc-file: ci/condarc.yml
+      - shell: bash -l {0}
+        run: |
+          python -m pip --version
+          python -m pip install -r requirements/tests.txt
+          python -m pip install . --no-deps
+          python -m xonsh run-tests.xsh test -- --timeout=240
+

--- a/.github/workflows/pytest-windows-3.6.yml
+++ b/.github/workflows/pytest-windows-3.6.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-windows-3.7.yml
+++ b/.github/workflows/pytest-windows-3.7.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-windows-3.8.yml
+++ b/.github/workflows/pytest-windows-3.8.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/.github/workflows/pytest-windows-3.9.yml
+++ b/.github/workflows/pytest-windows-3.9.yml
@@ -40,3 +40,4 @@ jobs:
           python -m pip install . --no-deps
           python -m xonsh run-tests.xsh test -- --timeout=240
 
+        continue-on-error: true

--- a/.github/workflows/pytest-windows-3.9.yml
+++ b/.github/workflows/pytest-windows-3.9.yml
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt
@@ -41,3 +42,4 @@ jobs:
           python -m xonsh run-tests.xsh test -- --timeout=240
 
         continue-on-error: true
+

--- a/.github/workflows/pytest-windows-3.9.yml
+++ b/.github/workflows/pytest-windows-3.9.yml
@@ -1,0 +1,42 @@
+name: pytest windows 3.9
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        python-version: [3.9]
+    name: Python ${{ matrix.python-version }} ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/miniconda*/envs/
+          key: ${{ runner.os }}-${{ matrix.python-version }}-env-${{ hashFiles('requirements/tests.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-env-
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v1
+        with:
+          activate-environment: xonsh-test
+          update-conda: true
+          python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
+          condarc-file: ci/condarc.yml
+      - shell: bash -l {0}
+        run: |
+          python -m pip --version
+          python -m pip install -r requirements/tests.txt
+          python -m pip install . --no-deps
+          python -m xonsh run-tests.xsh test -- --timeout=240
+

--- a/.github/workflows/pytest.tmpl
+++ b/.github/workflows/pytest.tmpl
@@ -33,7 +33,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}  # this itself makes sure that Python version is installed
           condarc-file: ci/condarc.yml
-      - shell: bash -l {0}
+      - name: Install Xonsh and run tests
+        shell: bash -l {0}
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt

--- a/news/github_workflow.rst
+++ b/news/github_workflow.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added Python 3.9 to continuous integration.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Xonsh currently has a good number of broken tests when run under Python 3.9, but they are invisible when no tests are run for them. This PR adds Python 3.9 to the CI.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
