### PR TITLE
Fallback for `print_color` if shell is not yet initialized

### DIFF
--- a/news/print_color_3840.rst
+++ b/news/print_color_3840.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Added ANSI fallback for `xonsh.tools.print_color` if shell is not yet initialized. Fixes #3840.
+* Added ANSI fallback for ``xonsh.tools.print_color`` if shell is not yet initialized. Fixes #3840.
 
 **Security:**
 

--- a/news/print_color_3840.rst
+++ b/news/print_color_3840.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Added ANSI fallback for `xonsh.tools.print_color` if shell is not yet initialized. Fixes #3840.
+
+**Security:**
+
+* <news item>

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1837,7 +1837,14 @@ def format_color(string, **kwargs):
     shell instances method of the same name. The results of this function should
     be directly usable by print_color().
     """
-    return builtins.__xonsh__.shell.shell.format_color(string, **kwargs)
+    try:
+        return builtins.__xonsh__.shell.shell.format_color(string, **kwargs)
+    except AttributeError:
+        # fallback for ANSI if shell is not yet initialized
+        from xonsh.ansi_colors import ansi_partial_color_format
+
+        style = builtins.__xonsh__.env.get("XONSH_COLOR_STYLE")
+        return ansi_partial_color_format(string, style=style)
 
 
 def print_color(string, **kwargs):
@@ -1845,7 +1852,11 @@ def print_color(string, **kwargs):
     method of the same name. Colors will be formatted if they have not already
     been.
     """
-    builtins.__xonsh__.shell.shell.print_color(string, **kwargs)
+    try:
+        builtins.__xonsh__.shell.shell.print_color(string, **kwargs)
+    except AttributeError:
+        # fallback for ANSI if shell is not yet initialized
+        print(format_color(string, **kwargs))
 
 
 def color_style_names():

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1837,9 +1837,9 @@ def format_color(string, **kwargs):
     shell instances method of the same name. The results of this function should
     be directly usable by print_color().
     """
-    try:
+    if hasattr(builtins.__xonsh__.shell, "shell"):
         return builtins.__xonsh__.shell.shell.format_color(string, **kwargs)
-    except AttributeError:
+    else:
         # fallback for ANSI if shell is not yet initialized
         from xonsh.ansi_colors import ansi_partial_color_format
 
@@ -1852,9 +1852,9 @@ def print_color(string, **kwargs):
     method of the same name. Colors will be formatted if they have not already
     been.
     """
-    try:
+    if hasattr(builtins.__xonsh__.shell, "shell"):
         builtins.__xonsh__.shell.shell.print_color(string, **kwargs)
-    except AttributeError:
+    else:
         # fallback for ANSI if shell is not yet initialized
         print(format_color(string, **kwargs))
 


### PR DESCRIPTION
Added a fallback for `xonsh.tools.print_color` (and `xonsh.tools.format_color`) if shell is not yet initialized, thus enabling their use in `.xonshrc`.

Fixes #3840 .
