### PR TITLE
run-tests.xsh without arguments now prints help

### DIFF
--- a/news/run-tests-xsh.rst
+++ b/news/run-tests-xsh.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``./run-tests.xsh`` without arguments previously gave an esoteric error. It
+  now prints help on how to run the tests.
+
+**Security:**
+
+* <news item>

--- a/run-tests.xsh
+++ b/run-tests.xsh
@@ -55,6 +55,8 @@ def qa(ns: argparse.Namespace):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
+    parser.set_defaults(func=lambda *args: parser.print_help())
+
     commands = parser.add_subparsers()
 
     test_parser = commands.add_parser('test', help=test.__doc__)


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Adding this because I tried running `./run-tests.xsh` a few times and didn't understand what was going on :)