### PR TITLE
Add xontrib-powerline2

### DIFF
--- a/news/add-xontrib-powerline2.rst
+++ b/news/add-xontrib-powerline2.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* added `xontrib-powerline2 <https://github.com/vaaaaanquish/xontrib-powerline2>`_
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -215,6 +215,11 @@
   "url": "https://github.com/santagada/xontrib-powerline",
   "description": ["Powerline for Xonsh shell"]
  },
+ {"name": "powerline2",
+  "package": "xontrib-powerline2",
+  "url": "https://github.com/vaaaaanquish/xontrib-powerline2",
+  "description": ["Powerline for Xonsh shell forked from santagada/xontrib-powerline"]
+ },
  {"name": "prompt_bar",
   "package": "xontrib-prompt-bar",
   "url": "https://github.com/anki-code/xontrib-prompt-bar",
@@ -475,6 +480,13 @@
    "url": "https://github.com/santagada/xontrib-powerline",
    "install": {
     "pip": "xpip install xontrib-powerline"
+   }
+  },
+  "xontrib-powerline2": {
+   "license": "MIT",
+   "url": "https://github.com/vaaaaanquish/xontrib-powerline2",
+   "install": {
+    "pip": "xpip install xontrib-powerline2"
    }
   },
   "xontrib-powerline-binding": {


### PR DESCRIPTION
Development of `xontrib-powerline` has been halted.  
- https://github.com/santagada/xontrib-powerline/issues/25
- https://github.com/vaaaaanquish/xontrib-powerline2/issues/5

`xontrib-powerline2` is a fork of `xontrib-powerline`.  I've only developed a few. I salute the @santagada :)
Add an `xontrib-powerline2` to the documentation for new xonsh users.