### PR TITLE
Edit sys.path while loading RC files

### DIFF
--- a/news/edit-pythonpath-while-loading-rcs.rst
+++ b/news/edit-pythonpath-while-loading-rcs.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Now when loading RC files, xonsh will not fail to import modules located on
+  the same folder.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This PR makes it so that xonsh changes the `sys.path` while loading RC files, to make sure that it can load modules located in the same folder. This closes #3936.
