### PR TITLE
Decrease command cache warn limit

### DIFF
--- a/news/path_warn.rst
+++ b/news/path_warn.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added warning about huge amount of commands in CommandsCache that could affect on start speed.
+* Added warning about huge amount of commands in CommandsCache.
 
 **Changed:**
 

--- a/news/path_warn.rst
+++ b/news/path_warn.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added warning about huge amount of commands in CommandsCache.
+* Added warning about huge amount of commands in CommandsCache that could affect on start speed.
 
 **Changed:**
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1739,7 +1739,7 @@ def DEFAULT_VARS():
             is_int,
             int,
             str,
-            10000,
+            6000,
             "Number of files on the PATH above which a warning is shown.",
         ),
     }


### PR DESCRIPTION
The limit 10000 was for counter of files read but because we use count of unique keys in the check for warning the limit should be decreased to make it valuable.

Closes #3948