### PR TITLE
fix: 'Window' object has no attribute 'children'

### DIFF
--- a/news/fix-ptk-completion-window-reserve_space.rst
+++ b/news/fix-ptk-completion-window-reserve_space.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* PTK shell: ``window has no childres`` error while completion is triggered - https://github.com/xonsh/xonsh/issues/3963
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -110,7 +110,7 @@ class PromptToolkitCompleter(Completer):
         """Adjust the height for showing autocompletion menu."""
         app = get_app()
         render = app.renderer
-        window = app.layout.container.children[0].content.children[1].content
+        window = app.layout.current_window
 
         if window and window.render_info:
             h = window.render_info.content_height


### PR DESCRIPTION
closes #3963

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
