### PR TITLE
refactor: rewrite xontribs/jedi.xsh -> xontribs/jedi.py to take advan…

### DIFF
--- a/.github/workflows/elm.yml
+++ b/.github/workflows/elm.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           activate-environment: elm-xonsh-test
           environment-file: ci/environment-elm.yml
-          update-conda: true
+          auto-update-conda: true
           python-version: 3.7
           condarc-file: ci/condarc.yml
       - shell: bash -l {0}

--- a/news/xontrib_jedi_xsh_to_py.rst
+++ b/news/xontrib_jedi_xsh_to_py.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* rewrite xontribs/jedi.xsh -> xontribs/jedi.py to take advantage of python tooling
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/xontribs/test_jedi.py
+++ b/tests/xontribs/test_jedi.py
@@ -41,6 +41,9 @@ def jedi_xontrib(monkeypatch, source_path, jedi_mock, completer_mock):
 
 def test_completer_added(jedi_xontrib):
     assert "xontrib.jedi" in sys.modules
+    assert "python" not in builtins.__xonsh__.completers
+    assert "python_mode" not in builtins.__xonsh__.completers
+    assert "jedi_python" in builtins.__xonsh__.completers
 
 
 @pytest.mark.parametrize(

--- a/tests/xontribs/test_jedi.py
+++ b/tests/xontribs/test_jedi.py
@@ -39,12 +39,8 @@ def jedi_xontrib(monkeypatch, source_path, jedi_mock, completer_mock):
     del sys.modules[spec.name]
 
 
-def test_completer_added(jedi_xontrib, completer_mock):
-    assert completer_mock.call_args_list == [
-        call(["remove", "python_mode"]),
-        call(["add", "jedi_python", "complete_jedi", "<python"]),
-        call(["remove", "python"]),
-    ]
+def test_completer_added(jedi_xontrib):
+    assert "xontrib.jedi" in sys.modules
 
 
 @pytest.mark.parametrize(

--- a/xontrib/jedi.py
+++ b/xontrib/jedi.py
@@ -8,6 +8,7 @@ from xonsh.completers.tools import (
     get_ptk_completer,
     RichCompletion,
 )
+from xonsh.completers import _aliases
 
 __all__ = ()
 
@@ -72,15 +73,14 @@ def complete_jedi(prefix, line, start, end, ctx):
 
     extra_ctx = {"__xonsh__": __xonsh__}
     try:
-        extra_ctx['_'] = _
+        extra_ctx["_"] = _
     except NameError:
         pass
 
     if JEDI_NEW_API:
         script = jedi.Interpreter(source, [ctx, extra_ctx])
     else:
-        script = jedi.Interpreter(source, [ctx, extra_ctx], line=row,
-                                  column=column)
+        script = jedi.Interpreter(source, [ctx, extra_ctx], line=row, column=column)
 
     script_comp = set()
     try:
@@ -100,16 +100,16 @@ def complete_jedi(prefix, line, start, end, ctx):
             (
                 create_completion(comp)
                 for comp in script_comp
-                if complete_underscores or
-                   not comp.name.startswith('_') or
-                   not comp.complete.startswith("_")
+                if complete_underscores
+                or not comp.name.startswith("_")
+                or not comp.complete.startswith("_")
             ),
             (t for t in XONSH_SPECIAL_TOKENS if filter_func(t, prefix)),
         )
     )
 
 
-def create_completion(comp):
+def create_completion(comp: jedi.api.classes.Completion):
     """Create a RichCompletion from a Jedi Completion object"""
     comp_type = None
     description = None
@@ -138,7 +138,6 @@ def create_completion(comp):
 xonsh.completers.base.complete_python = complete_jedi
 
 # Jedi ignores leading '@(' and friends
-completer remove python_mode
-
-completer add jedi_python complete_jedi '<python'
-completer remove python
+_aliases._remove_completer(["python_mode"])
+_aliases._add_one_completer("jedi_python", complete_jedi, "<python")
+_aliases._remove_completer(["python"])


### PR DESCRIPTION
…tage of python tooling. 

Just fiddling with completers and saw this is the only core xontrib in `.xsh`. 

Probably `completers` need an API. Maybe a subclass of OrderedDict with methods to `add/remove`. What do you think about adding such API to completers? it will help testing and will close the gap with cli. 

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
