### PR TITLE
Add brackets to ambiguous data type

### DIFF
--- a/xontrib/distributed.py
+++ b/xontrib/distributed.py
@@ -1,7 +1,7 @@
 """Hooks for the distributed parallel computing library."""
 from xonsh.contexts import Functor
 
-__all__ = "DSubmitter", "dsubmit"
+__all__ = ["DSubmitter", "dsubmit"]
 
 
 def dworker(args, stdin=None):


### PR DESCRIPTION
Without the brackets python defaults to assuming that the iterable is a tuple. In the reference guide `__all__` is explicitly stated to be of type `list`.

Functionally I'll admit this doesn't change anything but to observe the correct usage pattern of `__all__`, simply add the brackets.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
