### PR TITLE
pygments: Colorize 'and'/'or' keywords like '&&'/'||'

### DIFF
--- a/news/colorize-and-or.rst
+++ b/news/colorize-and-or.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Colorize ``and``/``or`` operators correctly like ``&&``/``||``
+
+**Security:**
+
+* <news item>

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1712,7 +1712,7 @@ class XonshLexer(Python3Lexer):
         ],
         "subproc": [
             include("mode_switch_brackets"),
-            (r"&&|\|\|", Operator, "subproc_start"),
+            (r"&&|\|\||and|or", Operator, "subproc_start"),
             (r'"(\\\\|\\[0-7]+|\\.|[^"\\])*"', String.Double),
             (r"'(\\\\|\\[0-7]+|\\.|[^'\\])*'", String.Single),
             (r"(?<=\w|\s)!", Keyword, "subproc_macro"),


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Really tiny fix that bothered me :)

Before:
![image](https://user-images.githubusercontent.com/18242949/99581369-5f6c8b80-29e9-11eb-915b-04f610e85f1f.png)

After:
![image](https://user-images.githubusercontent.com/18242949/99581325-482d9e00-29e9-11eb-917d-20a952861681.png)
