### PR TITLE
ulimit: Change default to access soft limits

### DIFF
--- a/news/ulimit-default-soft.rst
+++ b/news/ulimit-default-soft.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``ulimit`` builtin now operates on "soft" limits by default.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xoreutils/ulimit.py
+++ b/xonsh/xoreutils/ulimit.py
@@ -195,8 +195,8 @@ def _ul_parse_args(args, stderr):
         long_opts[_UL_RES[k][1]] = k
 
     actions = []
-    # mimic bash and default to 'hard' limits
-    res_type = _UL_HARD
+    # mimic bash and default to 'soft' limits
+    res_type = _UL_SOFT
     for arg in args:
         if arg in long_opts:
             opt = long_opts[arg]


### PR DESCRIPTION
It makes more sense for `ulimit` builtin to manipulate "soft" limits by default, because those are the limits intended to be user-adjustable. It is also what bash does. Originally, I made `ulimit` to default to "hard" limits, because I was for some reason convinced that it's what bash does.

Relates to #3988