### PR TITLE
Fix the import in the branch colour override example.

### DIFF
--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -179,7 +179,7 @@ The following snippet reimplements the formatter also to include untracked files
 
 .. code-block:: xonshcon
 
-    >>> from xonsh.prompt.vc_branch import git_dirty_working_directory
+    >>> from xonsh.prompt.vc import git_dirty_working_directory
     >>> $PROMPT_FIELDS['branch_color'] = lambda: ('{BOLD_INTENSE_RED}'
                                                    if git_dirty_working_directory(include_untracked=True)
                                                    else '{BOLD_INTENSE_GREEN}')

--- a/news/vc_branch-in-docs.rst
+++ b/news/vc_branch-in-docs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The git customisation example in the .xonshrc docs uses the right module name
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
i assume this module got renamed at some point, but the docs weren't updated to reflect that