### PR TITLE
SQLite history backend now has the same logic of storing stdout to the memory like json history backend

### DIFF
--- a/news/hist_sqlite_stdout.rst
+++ b/news/hist_sqlite_stdout.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* SQLite history backend now has the same logic of storing stdout to the memory like json history backend.
+* The SQLite history backend now has the same logic of storing stdout to the memory like json history backend.
 
 **Deprecated:**
 

--- a/news/hist_sqlite_stdout.rst
+++ b/news/hist_sqlite_stdout.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* SQLite history backend now has the same logic of storing stdout to the memory like json history backend.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -245,11 +245,7 @@ class SqliteHistory(History):
         envs = builtins.__xonsh__.env
         inp = cmd["inp"].rstrip()
         self.inps.append(inp)
-        store_stdout = envs.get("XONSH_STORE_STDOUT", False)
-        if store_stdout:
-            self.outs.append(cmd.get("out"))
-        else:
-            self.outs.append(None)
+        self.outs.append(cmd.get("out"))
         self.rtns.append(cmd["rtn"])
         self.tss.append(cmd.get("ts", (None, None)))
 
@@ -264,7 +260,7 @@ class SqliteHistory(History):
         xh_sqlite_append_history(
             cmd,
             str(self.sessionid),
-            store_stdout,
+            store_stdout=envs.get("XONSH_STORE_STDOUT", False),
             filename=self.filename,
             remove_duplicates=("erasedups" in opts),
         )


### PR DESCRIPTION
Current inconsistent logic of storing stdout in memory:
```python
# In xonshrc: $XONSH_HISTORY_BACKEND = 'json'
echo 123
# 123
__xonsh__.history[-1].out
# 123

# In xonshrc: $XONSH_HISTORY_BACKEND = 'sqlite'
echo 123
# 123
__xonsh__.history[-1].out
#                       # Empty output because storing in memory is off for SQLite

# Prepared by xontrib-hist-format
```

After this PR the logic becomes consistent:
```python
# In xonshrc: $XONSH_HISTORY_BACKEND = 'json'
echo 123
# 123
__xonsh__.history[-1].out
# 123

# In xonshrc: $XONSH_HISTORY_BACKEND = 'sqlite'
echo 123
# 123
__xonsh__.history[-1].out
# 123

# Prepared by xontrib-hist-format
```