### PR TITLE
fix: make sure that tokens are strings before showing in prompt

### DIFF
--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -172,7 +172,7 @@ def norm_name(name):
 def style_as_faded(template: str) -> str:
     """Remove the colors from the template string and style as faded."""
     tokens = partial_color_tokenize(template)
-    without_color = "".join([sect for _, sect in tokens])
+    without_color = "".join([str(sect) for _, sect in tokens])
     return "{RESET}{#d3d3d3}" + without_color + "{RESET}"
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

- happens when the prompt field returns non-strings
- not including news item since it is a small change no significant change and no reported issues