### PR TITLE
Using ujson (if installed) in LazyJSON to loading json history 15% faster

### DIFF
--- a/news/history_json_faster.rst
+++ b/news/history_json_faster.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Using ``ujson`` in LazyJSON to loading json history 15% faster.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/history_json_faster.rst
+++ b/news/history_json_faster.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Using ``ujson`` in LazyJSON to loading json history 15% faster.
+* Using ``ujson`` (if installed) in LazyJSON to loading json history 15% faster.
 
 **Deprecated:**
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -11,7 +11,7 @@ import collections.abc as cabc
 try:
     import ujson as json
 except ImportError:
-    import json
+    import json  # type: ignore
 
 from xonsh.history.base import History
 import xonsh.tools as xt

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 """Implements a lazy JSON file class that wraps around json data."""
 import io
-import json
 import weakref
 import contextlib
 import collections.abc as cabc
+
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 
 def _to_json_with_size(obj, offset=0, sort_keys=False):

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -8,7 +8,7 @@ import collections.abc as cabc
 try:
     import ujson as json
 except ImportError:
-    import json
+    import json  # type: ignore
 
 
 def _to_json_with_size(obj, offset=0, sort_keys=False):


### PR DESCRIPTION
Closes #4000

Test:
```python
pip uninstall ujson
XONSH_DEBUG=1 xonsh
# [history.json] Enumerated 2,852 history files for 0.7310s
# [history.json] Enumerated 2,852 history files for 0.7258s
# [history.json] Enumerated 2,852 history files for 0.6990s
# [history.json] Enumerated 2,852 history files for 0.7035s

pip install ujson
XONSH_DEBUG=1 xonsh
# [history.ujson] Enumerated 2,852 history files for 0.5832s
# [history.ujson] Enumerated 2,852 history files for 0.6084s
# [history.ujson] Enumerated 2,852 history files for 0.6103s
# [history.ujson] Enumerated 2,852 history files for 0.5903s
```