### PR TITLE
Add 'dict' merging operation for the aliases class

### DIFF
--- a/news/alias_merging.rst
+++ b/news/alias_merging.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Add '``|``' and '``|=``' operators to the ``Aliases`` class.
+* Add tests to the merging functionality.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -145,3 +145,37 @@ def test_subprocess_io_operators(xonsh_execer, xonsh_builtins, alias):
     ales = make_aliases()
     ales["echocat"] = alias
     assert isinstance(ales["echocat"], ExecAlias)
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        {'echocat': 'ls'},
+    ],
+)
+def test_dict_merging(xonsh_execer, xonsh_builtins, alias):
+    ales = make_aliases()
+    assert (ales | alias)['echocat'] == ['ls']
+    assert (alias | ales)['echocat'] == ['ls']
+    assert 'echocat' not in ales
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        {'echocat': 'echo Why do people still use python2.7?'},
+        {'echocat': 'echo Why?'},
+    ],
+)
+def test_dict_merging_assignment(xonsh_execer, xonsh_builtins, alias):
+    ales = make_aliases()
+    ales |= alias
+
+    assert 'echocat' in ales
+    assert ' '.join(ales['echocat']) == alias['echocat']
+
+    ales = make_aliases()
+    alias |= ales
+
+    assert 'o' in alias
+    assert alias['o'] == ales['o']

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -141,6 +141,23 @@ class Aliases(cabc.MutableMapping):
         else:
             self._raw[key] = val
 
+    def _common_or(self, other):
+        new_dict = self._raw.copy()
+        for key in dict(other):
+            new_dict[key] = other[key]
+        return Aliases(new_dict)
+
+    def __or__(self, other):
+        return self._common_or(other)
+
+    def __ror__(self, other):
+        return self._common_or(other)
+
+    def __ior__(self, other):
+        for key in dict(other):
+            self[key] = other[key]
+        return self
+
     def __delitem__(self, key):
         del self._raw[key]
 


### PR DESCRIPTION
This PR allows you to do the following:
```python
my_aliases = {
      'ip': 'ip -c',
      'gst': 'git status'
}
aliases |= my_aliases
```