### PR TITLE
Fix libc detection and uptime functionality on FreeBSD

### DIFF
--- a/news/fix_freebsd_libc_uptime.rst
+++ b/news/fix_freebsd_libc_uptime.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix libc detection on FreeBSD
+* Fix uptime functionality on FreeBSD
+
+**Security:**
+
+* <news item>

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -550,6 +550,11 @@ def LIBC():
         libc = ctypes.CDLL("cygwin1.dll")
     elif ON_MSYS:
         libc = ctypes.CDLL("msys-2.0.dll")
+    elif ON_FREEBSD:
+        try:
+            libc = ctypes.CDLL("libc.so.7")
+        except OSError:
+            libc = None
     elif ON_BSD:
         try:
             libc = ctypes.CDLL("libc.so")

--- a/xonsh/xoreutils/uptime.py
+++ b/xonsh/xoreutils/uptime.py
@@ -100,13 +100,13 @@ def _uptime_bsd():
         return None
     # Determine how much space we need for the response.
     sz = ctypes.c_uint(0)
-    xp.LIBC.sysctlbyname("kern.boottime", None, ctypes.byref(sz), None, 0)
+    xp.LIBC.sysctlbyname(b"kern.boottime", None, ctypes.byref(sz), None, 0)
     if sz.value != struct.calcsize("@LL"):
         # Unexpected, let's give up.
         return None
     # For real now.
     buf = ctypes.create_string_buffer(sz.value)
-    xp.LIBC.sysctlbyname("kern.boottime", buf, ctypes.byref(sz), None, 0)
+    xp.LIBC.sysctlbyname(b"kern.boottime", buf, ctypes.byref(sz), None, 0)
     sec, usec = struct.unpack_from("@LL", buf.raw)
     # OS X disagrees what that second value is.
     if usec > 1000000:


### PR DESCRIPTION
This is a possible fix for the libc detection bug on Freebsd, as discussed in #4048.

- Fix libc detection on FreeBSD
- sysctlbyname needs bytes, not unicode strs
- Add news item for FreeBSD libc fix
