### PR TITLE
Update tutorial_ptk.rst

### DIFF
--- a/docs/tutorial_ptk.rst
+++ b/docs/tutorial_ptk.rst
@@ -30,7 +30,7 @@ Control characters
 We can't and won't stop you from doing what you want, but in the interest of a
 functioning shell, you probably shouldn't mess with the following keystrokes.
 Some of them are `ASCII control characters
-<https://en.wikipedia.org/wiki/Control_character#In_ASCII>`_ and _really_
+<https://en.wikipedia.org/wiki/Control_character#In_ASCII>`_ and *really*
 shouldn't be used. The others are used by xonsh and will result in some loss of
 functionality (in less you take the time to rebind them elsewhere).
 


### PR DESCRIPTION
Using `_` to indicate italics only works in Markdown. Use `*` to modify text in restructuredText

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
