### PR TITLE
test: add convention to import typing module

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,6 +2,7 @@ py
 pytest>=6
 flake8
 flake8-docstrings
+flake8-typing-import-style
 pytest-cov
 pytest-timeout
 prompt-toolkit>=3.0


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

this is to add the convention of restricting import style. We can add other import conventions as well. Let me know if you want to add any. (using tp because it is short. also not import individual names as they collide with ast module imported names)

Not including news item, as this will affect only developers and not users.