### PR TITLE
rework old pytest plugin

### DIFF
--- a/news/pytest_plugin.rst
+++ b/news/pytest_plugin.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* More generic pytest plugin that allows utilizing fixtures, parametrization and more of pytest core features
+
+**Changed:**
+
+* Existing pytest plugin
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/pytest_plugin.py
+++ b/xonsh/pytest_plugin.py
@@ -1,78 +1,42 @@
 # -*- coding: utf-8 -*-
 """Pytest plugin for testing xsh files."""
-import sys
-import importlib
-from traceback import format_list, extract_tb
-
-import pytest
+import _pytest.pathlib
 
 from xonsh.main import setup
 
 
+class XshPytestPlugin:
+    def __init__(self):
+        setup()
+
+    def pytest_collect_file(self, path, parent):
+        if path.ext.lower() == ".xsh":
+            if not parent.session.isinitpath(path):
+                all_valid_test_file_patterns = parent.config.getini("python_files") + [
+                    "__init__.py"
+                ]
+                if not any(
+                    _pytest.pathlib.fnmatch_ex(pattern, path)
+                    for pattern in all_valid_test_file_patterns
+                ):
+                    return None
+            i_hook = parent.session.gethookproxy(path)
+            return i_hook.pytest_pycollect_makemodule(
+                fspath=path, path=path, parent=parent
+            )
+        return None
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("xonsh", "Collecting and running .xsh pytest files")
+    group.addoption(
+        "--xonsh",
+        default=False,
+        action="store_true",
+        help="Enables collecting and running xonsh test files ending with .xsh",
+    )
+
+
 def pytest_configure(config):
-    setup()
-
-
-def pytest_collection_modifyitems(items):
-    """Move xsh test first to work around a bug in normal
-    pytest cleanup. The order of tests are otherwise preserved.
-    """
-    xsh_items = []
-    other_items = []
-    for item in items:
-        if isinstance(item, XshFunction):
-            xsh_items.append(item)
-        else:
-            other_items.append(item)
-    items[:] = xsh_items + other_items
-
-
-def _limited_traceback(excinfo):
-    """Return a formatted traceback with all the stack
-    from this frame (i.e __file__) up removed
-    """
-    tb = extract_tb(excinfo.tb)
-    try:
-        idx = [__file__ in e for e in tb].index(True)
-        return format_list(tb[idx + 1 :])
-    except ValueError:
-        return format_list(tb)
-
-
-def pytest_collect_file(parent, path):
-    if path.ext.lower() == ".xsh" and path.basename.startswith("test_"):
-        return XshFile.from_parent(parent, fspath=path)
-
-
-class XshFile(pytest.File):
-    def collect(self):
-        sys.path.append(self.fspath.dirname)
-        mod = importlib.import_module(self.fspath.purebasename)
-        sys.path.pop(0)
-        tests = [t for t in dir(mod) if t.startswith("test_")]
-        for test_name in tests:
-            obj = getattr(mod, test_name)
-            if hasattr(obj, "__call__"):
-                yield XshFunction.from_parent(
-                    self, name=test_name, test_func=obj, test_module=mod
-                )
-
-
-class XshFunction(pytest.Item):
-    def __init__(self, name, parent, test_func, test_module):
-        super().__init__(name, parent)
-        self._test_func = test_func
-        self._test_module = test_module
-
-    def runtest(self, *args, **kwargs):
-        self._test_func(*args, **kwargs)
-
-    def repr_failure(self, excinfo):
-        """ called when self.runtest() raises an exception. """
-        formatted_tb = _limited_traceback(excinfo)
-        formatted_tb.insert(0, "xonsh execution failed\n")
-        formatted_tb.append("{}: {}".format(excinfo.type.__name__, excinfo.value))
-        return "".join(formatted_tb)
-
-    def reportinfo(self):
-        return self.fspath, 0, "xonsh test: {}".format(self.name)
+    if config.option.xonsh:
+        config.pluginmanager.register(XshPytestPlugin())


### PR DESCRIPTION
Current pytest plugin has many limitations

1. Plugin will always collect ``test_*.xsh`` while pytest allows an ini configuration that canges the test collection prefix
2. Plugin does not support parametrization nor loading and using existing fixtures
3. Plugin is **always** activated (in some cases users using xonsh migh want to build their own collection plugin that can conflict with the base plugin shipped with xonsh)

I have re-worked the existing plugin to overcome these limitations. The new plugin now accepts ``--xonsh`` such that using this flag will allow pytest to load ``.xsh`` files. Typical use case would be having ``--xonsh`` hardcoded in user's ``pytest.ini``

I have not seen any tests for the existing pytest plugin. Not sure if such tests need to be added at the current support or not. Let me know if these are required.

Example for `pytest.ini`:

```ini
[pytest]
python_files = test_*.py test_*.xsh
```

Example for test file
```py
import pytest


@pytest.fixture(scope="function", autouse=True)
def set_env():
    with ${...}.swap(TESTVAR='foo'):
        yield



@pytest.mark.parametrize('a', [1, 2, 3, 4])
def test_echo(a):
    echo @(a)
    echo $TESTVAR
```

Examples for running this test:

```shell
$ pytest --collect-only -q
no tests collected in 0.01s

$ pytest --collect-only -q --xonsh
test_hello.xsh::test_echo[1]
test_hello.xsh::test_echo[2]
test_hello.xsh::test_echo[3]
test_hello.xsh::test_echo[4]

4 tests collected in 0.05s

$ pytest --xonsh --capture=tee-sys

=================================== test session starts ====================================
platform win32 -- Python 3.7.0, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: example, configfile: pytest.ini
plugins: cov-2.11.1, timeout-1.4.2, xonsh-0.9.24
collected 4 items

test_hello.xsh 1
foo
.2
foo
.3

foo
.4
foo
.                                                                   [100%]

==================================== 4 passed in 0.60s =====================================
```


Let me know your thoughts about this :) 