### PR TITLE
Fix readme and rever test call for release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,34 +1,44 @@
 xonsh
 =====
 
-.. raw:: html
+.. class:: center
 
-    <p align="center">
-    <b>xonsh</b> is a Python-powered, cross-platform, Unix-gazing shell language and command prompt.
-    </p>
+    **xonsh** is a Python-powered, cross-platform, Unix-gazing shell language and command prompt.
 
-    <p align="center">
-    The language is a superset of Python 3.5+ with additional shell primitives. <br>
-    xonsh (pronounced <i>conch</i>) is meant for the daily use of experts and novices alike.
-    </p>
+    The language is a superset of Python 3.6+ with additional shell primitives.
+    xonsh (pronounced *conch*) is meant for the daily use of experts and novices alike.
 
-    <p align="center">
-    <a href="https://xon.sh/contents.html#installation"><img src="https://raw.githubusercontent.com/xonsh/xonsh/master/docs/_static/xonsh4.png" alt="What is xonsh?"></a>
-    </p>
+    .. image:: https://raw.githubusercontent.com/xonsh/xonsh/master/docs/_static/xonsh4.png
+            :alt: What is xonsh?
+            :align: center
 
-    <p align="center">
-    If you like xonsh, :star: the repo, <a href="https://twitter.com/intent/tweet?text=xonsh%20is%20a%20Python-powered,%20cross-platform,%20Unix-gazing%20shell%20language%20and%20command%20prompt.&url=https://github.com/xonsh/xonsh" target="_blank">write a tweet</a> and stay tuned by watching releases.
-    </p>
+.. class:: center
 
-    <p align="center">
-    <a href="https://gitter.im/xonsh/xonsh?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge" target="_blank"><img src="https://badges.gitter.im/xonsh/xonsh.svg" alt="Join the chat at https://gitter.im/xonsh/xonsh"></a>
-    <a href="https://matrix.to/#/#xonsh:feneas.org" target="_blank"><img src="https://img.shields.io/badge/%23xonsh%3Afeneas.org-Matrix-green" alt="Matrix room: #xonsh:feneas.org"></a>
-    <a href="https://travis-ci.org/xonsh/xonsh" target="_blank"><img src="https://travis-ci.org/xonsh/xonsh.svg?branch=master" alt="Travis"></a>
-    <a href="https://ci.appveyor.com/project/xonsh/xonsh" target="_blank"><img src="https://ci.appveyor.com/api/projects/status/github/xonsh/xonsh?svg=true" alt="Appveyor"></a>
-    <a href="https://circleci.com/gh/xonsh/xonsh" target="_blank"><img src="https://circleci.com/gh/xonsh/xonsh.svg?style=shield" alt="circleci"></a>
-    <a href="https://codecov.io/gh/xonsh/xonsh" target="_blank"><img src="https://codecov.io/gh/xonsh/xonsh/branch/master/graph/badge.svg" alt="codecov"></a>
-    <br><a align="center" href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/xonsh/xonsh.git"><img alt="Open in Cloud Shell" src ="https://gstatic.com/cloudssh/images/open-btn.svg"></a></br>
-    </p>
+    If you like xonsh, :star: the repo, `write a tweet`_ and stay tuned by watching releases.
+
+    .. image:: https://badges.gitter.im/xonsh/xonsh.svg
+            :target: https://gitter.im/xonsh/xonsh?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+            :alt: Join the chat at https://gitter.im/xonsh/xonsh
+
+    .. image:: https://img.shields.io/badge/%23xonsh%3Afeneas.org-Matrix-green
+            :target: https://matrix.to/#/#xonsh:feneas.org
+            :alt: Matrix room: #xonsh:feneas.org
+
+    .. image:: https://travis-ci.org/xonsh/xonsh.svg?branch=master
+            :target: https://travis-ci.org/xonsh/xonsh
+            :alt: Travis
+
+    .. image:: https://ci.appveyor.com/api/projects/status/github/xonsh/xonsh?svg=true
+            :target: https://ci.appveyor.com/project/xonsh/xonsh
+            :alt: Appveyor
+
+    .. image:: https://codecov.io/gh/xonsh/xonsh/branch/master/graph/badge.svg
+            :target: https://codecov.io/gh/xonsh/xonsh
+            :alt: codecov
+
+    .. image:: https://gstatic.com/cloudssh/images/open-btn.svg
+            :target: https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/xonsh/xonsh.git
+            :alt: Open in Cloud Shell
 
 First steps
 ***********
@@ -46,3 +56,5 @@ Projects that use xonsh
 - `rever <https://regro.github.io/rever-docs/>`_: Cross-platform software release tool.
 - `Regro autotick bot <https://github.com/regro/cf-scripts>`_: Regro Conda-Forge autoticker.
 - `xxh <https://github.com/xxh/xxh>`_: Using xonsh wherever you go through the ssh.
+
+.. _write a tweet: https://twitter.com/intent/tweet?text=xonsh%20is%20a%20Python-powered,%20cross-platform,%20Unix-gazing%20shell%20language%20and%20command%20prompt.&url=https://github.com/xonsh/xonsh

--- a/rever.xsh
+++ b/rever.xsh
@@ -20,7 +20,7 @@ $VERSION_BUMP_PATTERNS = [
 $CHANGELOG_FILENAME = 'CHANGELOG.rst'
 $CHANGELOG_TEMPLATE = 'TEMPLATE.rst'
 
-$PYTEST_COMMAND = "./run-tests.xsh test -- "
+$PYTEST_COMMAND = "./run-tests.xsh"
 
 $TAG_REMOTE = 'git@github.com:xonsh/xonsh.git'
 $TAG_TARGET = 'master'


### PR DESCRIPTION
The rever command hasn't been tested with the new parameters to
`run-tests.xsh` (spoiler alert, it breaks).

Also converted the `raw` block to regular RST since PyPI doesn't allow
`raw` directives in the `long_description` on upload to PyPI

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
