### PR TITLE
add disown command

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -51,6 +51,22 @@ Resume execution of the currently active job in the background, or, if a
 single number is given as an argument, resume that job in the background.
 
 
+``disown``
+====================
+The behavior of this command matches the behavior of zsh's disown
+command which is as follows:
+
+Remove the specified jobs from the job table; the shell will no longer
+report their status, and will not complain if you try to exit an
+interactive shell with them running or stopped. If no job is specified,
+disown the current job.
+If the jobs are currently stopped and the $AUTO_CONTINUE option is set
+($AUTO_CONTINUE = True), a warning is printed containing information about
+how to make them running after they have been disowned. If one of the
+latter two forms is used, the jobs will automatically be made running,
+independent of the setting of the $AUTO_CONTINUE option.
+
+
 ``EOF``, ``exit``, and ``quit``
 ===================================
 The commands ``EOF``, ``exit``, and ``quit`` all alias the same action, which is to

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -52,7 +52,7 @@ single number is given as an argument, resume that job in the background.
 
 
 ``disown``
-====================
+===================
 The behavior of this command matches the behavior of zsh's disown
 command which is as follows:
 

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -52,7 +52,7 @@ single number is given as an argument, resume that job in the background.
 
 
 ``disown``
-===================
+==========
 The behavior of this command matches the behavior of zsh's disown
 command which is as follows:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -139,7 +139,7 @@ Very nice.
 
 .. note::
 
-   To update ``os.environ`` when the xonsh environment changes set 
+   To update ``os.environ`` when the xonsh environment changes set
    :ref:`$UPDATE_OS_ENVIRON <update_os_environ>` to ``True``.
 
 The Environment Itself ``${...}``
@@ -837,6 +837,11 @@ The following shows an example with ``emacs``.
 
 Note that the prompt is returned to you after emacs is started.
 
+Normally background commands end upon the shell closing. To allow a background
+command to continue running after the shell has exited, use the ``disown``
+command which accepts either no arguments (to disown the most recent job)
+or an arbitrary number of job identifiers.
+
 Job Control
 ===========
 
@@ -1079,9 +1084,9 @@ handled implicitly in subprocess mode.
 Path object allows do some tricks with paths. Globbing certain path, checking and getting info:
 
 .. code-block:: xonshcon
-   
+
     >>> mypath = p'/etc'
-    >>> sorted(mypath.glob('**/*bashrc*')) 
+    >>> sorted(mypath.glob('**/*bashrc*'))
     [Path('/etc/bash.bashrc'), Path('/etc/skel/.bashrc')]
     >>> [mypath.exists(), mypath.is_dir(), mypath.is_file(), mypath.parent, mypath.owner()]
     [True, True, False, Path('/'), 'root']

--- a/news/job-ctrl-disown.rst
+++ b/news/job-ctrl-disown.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add new internal command "disown" to remove background jobs from the shell's job list
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -12,7 +12,7 @@ from xonsh.lazyasd import lazyobject
 from xonsh.dirstack import cd, pushd, popd, dirs, _get_cwd
 from xonsh.environ import locate_binary, make_args_env
 from xonsh.foreign_shells import foreign_shell_data
-from xonsh.jobs import jobs, fg, bg, clean_jobs
+from xonsh.jobs import jobs, fg, bg, clean_jobs, disown
 from xonsh.platform import (
     ON_ANACONDA,
     ON_DARWIN,
@@ -787,6 +787,7 @@ def make_default_aliases():
         "jobs": jobs,
         "fg": fg,
         "bg": bg,
+        "disown": disown,
         "EOF": xonsh_exit,
         "exit": xonsh_exit,
         "quit": xonsh_exit,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1072,7 +1072,7 @@ class GeneralSetting(Xettings):
         False,
         "If ``True``, automatically resume stopped jobs when they are disowned. "
         "When stopped jobs are disowned and this option is ``False``, a warning "
-        "will print information about how to continue the stopped process."
+        "will print information about how to continue the stopped process.",
     )
 
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -774,6 +774,13 @@ class Xettings:
 class GeneralSetting(Xettings):
     """General"""
 
+    AUTO_CONTINUE = Var.with_default(
+        False,
+        "If ``True``, automatically resume stopped jobs when they are disowned. "
+        "When stopped jobs are disowned and this option is ``False``, a warning "
+        "will print information about how to continue the stopped process.",
+    )
+
     COMMANDS_CACHE_SIZE_WARNING = Var.with_default(
         6000,
         "Number of files on the PATH above which a warning is shown.",
@@ -1068,12 +1075,6 @@ class GeneralSetting(Xettings):
     )
     STAR_PATH = Var.no_default("env_path", pattern=re.compile(r"\w*PATH$"))
     STAR_DIRS = Var.no_default("env_path", pattern=re.compile(r"\w*DIRS$"))
-    AUTO_CONTINUE = Var.with_default(
-        False,
-        "If ``True``, automatically resume stopped jobs when they are disowned. "
-        "When stopped jobs are disowned and this option is ``False``, a warning "
-        "will print information about how to continue the stopped process.",
-    )
 
 
 class ChangeDirSetting(Xettings):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1068,6 +1068,12 @@ class GeneralSetting(Xettings):
     )
     STAR_PATH = Var.no_default("env_path", pattern=re.compile(r"\w*PATH$"))
     STAR_DIRS = Var.no_default("env_path", pattern=re.compile(r"\w*DIRS$"))
+    AUTO_CONTINUE = Var.with_default(
+        False,
+        "If ``True``, automatically resume stopped jobs when they are disowned. "
+        "When stopped jobs are disowned and this option is ``False``, a warning "
+        "will print information about how to continue the stopped process."
+    )
 
 
 class ChangeDirSetting(Xettings):

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -460,7 +460,7 @@ def disown(args, stdin=None):
     ($AUTO_CONTINUE = False), a warning is printed containing information about
     how to make them continue after they have been disowned.
 
-    Specifying the -c or --cont option for this command is equivalent to
+    Specifying the -c or --continue option for this command is equivalent to
     setting $AUTO_CONTINUE=True.
     """
 
@@ -473,7 +473,7 @@ def disown(args, stdin=None):
     )
     parser.add_argument(
         "-c",
-        "--cont",
+        "--continue",
         action="store_true",
         dest="force_auto_continue",
         help="Automatically continue stopped jobs when they are disowned",
@@ -490,22 +490,22 @@ def disown(args, stdin=None):
         try:
             current_task = get_task(tid)
         except KeyError:
-            return "", "'{}' is not a valid job ID".format(tid)
+            return "", f"'{tid}' is not a valid job ID"
 
         auto_cont = builtins.__xonsh__.env.get("AUTO_CONTINUE", False)
         if auto_cont or pargs.force_auto_continue:
             _continue(current_task)
         elif current_task["status"] == "stopped":
             messages.append(
-                "warning: job is suspended, use "
-                "'kill -CONT -{}' to resume"
-                "\n".format(current_task["pids"][-1])
+                f"warning: job is suspended, use "
+                f"'kill -CONT -{current_task['pids'][-1]}' "
+                f"to resume\n"
             )
 
         # Stop tracking this task
         tasks.remove(tid)
         del builtins.__xonsh__.all_jobs[tid]
-        messages.append("Removed job {} ({})".format(tid, current_task["status"]))
+        messages.append(f"Removed job {tid} ({current_task['status']})")
 
     if messages:
         return "".join(messages)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -466,14 +466,17 @@ def disown(args, stdin=None):
 
     parser = argparse.ArgumentParser("disown", description=disown.__doc__)
     parser.add_argument(
-        "job_ids", type=int, nargs="*",
-        help="Jobs to act on or none to use the current job"
+        "job_ids",
+        type=int,
+        nargs="*",
+        help="Jobs to act on or none to use the current job",
     )
     parser.add_argument(
-        "-c", "--cont",
+        "-c",
+        "--cont",
         action="store_true",
         dest="force_auto_continue",
-        help="Automatically continue stopped jobs when they are disowned"
+        help="Automatically continue stopped jobs when they are disowned",
     )
 
     pargs = parser.parse_args(args)
@@ -483,7 +486,7 @@ def disown(args, stdin=None):
 
     messages = []
     # if args.job_ids is empty, use the active task
-    for tid in (pargs.job_ids or [tasks[0]]):
+    for tid in pargs.job_ids or [tasks[0]]:
         try:
             current_task = get_task(tid)
         except KeyError:
@@ -493,16 +496,16 @@ def disown(args, stdin=None):
         if auto_cont or pargs.force_auto_continue:
             _continue(current_task)
         elif current_task["status"] == "stopped":
-            messages.append("warning: job is suspended, use "
-                            "'kill -CONT -{}' to resume"
-                            "\n".format(current_task["pids"][-1]))
+            messages.append(
+                "warning: job is suspended, use "
+                "'kill -CONT -{}' to resume"
+                "\n".format(current_task["pids"][-1])
+            )
 
         # Stop tracking this task
         tasks.remove(tid)
         del builtins.__xonsh__.all_jobs[tid]
-        messages.append(
-            "Removed job {} ({})".format(tid, current_task["status"])
-        )
+        messages.append("Removed job {} ({})".format(tid, current_task["status"]))
 
     if messages:
-        return ''.join(messages)
+        return "".join(messages)

--- a/xonsh/procs/posix.py
+++ b/xonsh/procs/posix.py
@@ -52,6 +52,9 @@ class PopenThread(threading.Thread):
 
     def __init__(self, *args, stdin=None, stdout=None, stderr=None, **kwargs):
         super().__init__()
+
+        self.daemon = True
+
         self.lock = threading.RLock()
         env = builtins.__xonsh__.env
         # stdin setup

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -441,12 +441,10 @@ class SubprocSpec:
         self._pre_run_event_fire(event_name)
         kwargs = {n: getattr(self, n) for n in self.kwnames}
         self.prep_env(kwargs)
-        self.prep_preexec_fn(kwargs, pipeline_group=pipeline_group)
         if callable(self.alias):
-            if "preexec_fn" in kwargs:
-                kwargs.pop("preexec_fn")
             p = self.cls(self.alias, self.cmd, **kwargs)
         else:
+            self.prep_preexec_fn(kwargs, pipeline_group=pipeline_group)
             self._fix_null_cmd_bytes()
             p = self._run_binary(kwargs)
         p.spec = self


### PR DESCRIPTION
Relevant issues: #2346 and #1246

This pr adds a "disown" command to the shell. The behavior is modeled after zsh's "disown" builtin command, with the main differentiating factor being that zsh's `disown [job] &|` syntax is super esoteric so I decided to replace it with the options `-c` or `--cont`

Example usage:
```sh
nate@spicy-tuna ~/ > nemo &
[1]+ running: nemo & & (107246)
nate@spicy-tuna ~/ > disown
Removed job 1 (running)
```
```sh
nate@spicy-tuna ~/ > $THREAD_SUBPROCS=False
nate@spicy-tuna ~/ > nemo
^Znate@spicy-tuna ~/ > jobs
[1]+ stopped: nemo (107323)
nate@spicy-tuna ~/ > disown -c 1
Removed job 1 (running)
```
```sh
nate@spicy-tuna ~/ > $THREAD_SUBPROCS=False
nate@spicy-tuna ~/ > nemo
^Znate@spicy-tuna ~/ > jobs
[1]+ stopped: nemo (107408)
nate@spicy-tuna ~/ > disown
warning: job is suspended, use 'kill -CONT -107408' to resume
Removed job 1 (stopped)
```

This was my first look at this code base so feedback welcome if I missed anything!