### PR TITLE
Fix garbage collection of JSON history specified in seconds.

### DIFF
--- a/news/fix-json-hist-gc-seconds.rst
+++ b/news/fix-json-hist-gc-seconds.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed JSON history garbage collection for XONSH_HISTORY_SIZE in seconds.
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -59,7 +59,6 @@ def _xhj_gc_files_to_rmfiles(hsize, files):
 def _xhj_gc_seconds_to_rmfiles(hsize, files):
     """Return duration removed and list of history files to remove to get under the age limit."""
     now = time.time()
-    oldest_ts = files[0][0]
     n = 0
 
     for ts, _, f, _ in files:
@@ -67,8 +66,9 @@ def _xhj_gc_seconds_to_rmfiles(hsize, files):
             break
         n += 1
 
-    size_over = files[n][0] - oldest_ts
-    return size_over, files[:n]
+    rmfiles = files[:n]
+    size_over = rmfiles[-1][0] - rmfiles[0][0] if n > 0 else 0
+    return size_over, rmfiles
 
 
 def _xhj_gc_bytes_to_rmfiles(hsize, files):

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -57,7 +57,7 @@ def _xhj_gc_files_to_rmfiles(hsize, files):
 
 
 def _xhj_gc_seconds_to_rmfiles(hsize, files):
-    """Return duration removed and list of history files to remove to get under the age limit."""
+    """Return excess duration and list of history files to remove to get under the age limit."""
     now = time.time()
     n = 0
 
@@ -67,7 +67,7 @@ def _xhj_gc_seconds_to_rmfiles(hsize, files):
         n += 1
 
     rmfiles = files[:n]
-    size_over = rmfiles[-1][0] - rmfiles[0][0] if n > 0 else 0
+    size_over = now - hsize - rmfiles[0][0] if n > 0 else 0
     return size_over, rmfiles
 
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -57,7 +57,7 @@ def _xhj_gc_files_to_rmfiles(hsize, files):
 
 
 def _xhj_gc_seconds_to_rmfiles(hsize, files):
-    """Return age removed (the age of the *oldest* file) and list of history files to remove to get under the age limit."""
+    """Return duration removed and list of history files to remove to get under the age limit."""
     now = time.time()
     oldest_ts = files[0][0]
     n = 0
@@ -67,7 +67,8 @@ def _xhj_gc_seconds_to_rmfiles(hsize, files):
             break
         n += 1
 
-    return (now - oldest_ts) if n > 0 else 0, files[:n]
+    size_over = files[n][0] - oldest_ts
+    return size_over, files[:n]
 
 
 def _xhj_gc_bytes_to_rmfiles(hsize, files):


### PR DESCRIPTION
I was getting the warning "History garbage collection would discard more history than it would keep" every time I opened a shell. I use JSON history with XONSH_HISTORY_SIZE specified in seconds. As of #3600, the history filter was returning the timestamp of the oldest history file, but this value was being interpreted as the amount of history that would be removed. (That value should be oldest_kept - oldest_removed.) Thus whenever the gc was supposed to trigger, instead it issued a warning and did nothing. 