### PR TITLE
completer: support quotes in begidx search

### DIFF
--- a/news/begidx-support-quotes.rst
+++ b/news/begidx-support-quotes.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* updated begidx in completer to support quoted values
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+fro unittest.mock import Mock
 
 import pytest
 
@@ -181,6 +181,7 @@ def test_promptformatter_clears_cache(formatter):
 
     assert spam.call_count == 2
 
+
 def test_find_begidx():
     def _assert(line, expected):
         assert find_begidx(line, len(line)) == expected
@@ -190,23 +191,20 @@ def test_find_begidx():
     _assert("example command ", 16)
     _assert("example command -", 16)
 
-    _assert("\"", 0)
-    _assert("\"\"", 0)
-    _assert("example command \"value", 16)
-    _assert("example command \"value \"", 16)
-    #_assert("example command \"value \"nospace", 16)
-    _assert("example command \"value \" space", 25)
-    #_assert("example command prefix\"value \"", 16)
-    
-    _assert("example command \"value \\\"\"", 16)
+    _assert('"', 0)
+    _assert('""', 0)
+    _assert('example command "value', 16)
+    _assert('example command "value "', 16)
+    _assert('example command "value " space', 25)
+
+    _assert('example command "value \\""', 16)
     _assert("example command \"value '", 16)
-    
+
     _assert("'", 0)
     _assert("''", 0)
     _assert("example command 'value", 16)
     _assert("example command 'value '", 16)
-    # TODO _assert("example command 'value 'nospace", 16)
     _assert("example command 'value ' space", 25)
-    
+
     _assert("example command 'value \"", 16)
     _assert("example command 'value \"'", 16)

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from xonsh.environ import Env
-from xonsh.prompt.base import PromptFormatter, PROMPT_FIELDS
+from xonsh.prompt.base import PromptFormatter, PROMPT_FIELDS, find_begidx
 
 
 @pytest.fixture
@@ -180,3 +180,34 @@ def test_promptformatter_clears_cache(formatter):
     formatter(template, fields)
 
     assert spam.call_count == 2
+
+def test_find_begidx():
+    def _assert(line, expected):
+        assert find_begidx(line, len(line)) == expected
+
+    _assert("", 0)
+    _assert("ex", 0)
+    _assert("example command ", 16)
+    _assert("example command -", 16)
+
+    _assert("\"", 0)
+    _assert("\"\"", 0)
+    _assert("example command \"value", 16)
+    _assert("example command \"value \"", 16)
+    # TODO _assert("example command \"value \"nospace", 16)
+    _assert("example command \"value \" space", 25)
+    _assert("example command prefix\"value \"", 16)
+    
+    _assert("example command \"value \\\"\"", 16)
+    _assert("example command \"value '\"", 16)
+    
+    _assert("'", 0)
+    _assert("''", 0)
+    _assert("example command 'value", 16)
+    _assert("example command 'value '", 16)
+    # TODO _assert("example command 'value 'nospace", 16)
+    _assert("example command 'value ' space", 25)
+    _assert("example command prefix'value '", 16)
+    
+    _assert("example command 'value \"", 16)
+    _assert("example command 'value \"'", 16)

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -199,7 +199,7 @@ def test_find_begidx():
     #_assert("example command prefix\"value \"", 16)
     
     _assert("example command \"value \\\"\"", 16)
-    _assert("example command \"value '\"", 16)
+    #_assert("example command \"value '", 16)
     
     _assert("'", 0)
     _assert("''", 0)
@@ -207,7 +207,6 @@ def test_find_begidx():
     _assert("example command 'value '", 16)
     # TODO _assert("example command 'value 'nospace", 16)
     _assert("example command 'value ' space", 25)
-    _assert("example command prefix'value '", 16)
     
     _assert("example command 'value \"", 16)
     _assert("example command 'value \"'", 16)

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -194,9 +194,9 @@ def test_find_begidx():
     _assert("\"\"", 0)
     _assert("example command \"value", 16)
     _assert("example command \"value \"", 16)
-    # TODO _assert("example command \"value \"nospace", 16)
+    #_assert("example command \"value \"nospace", 16)
     _assert("example command \"value \" space", 25)
-    _assert("example command prefix\"value \"", 16)
+    #_assert("example command prefix\"value \"", 16)
     
     _assert("example command \"value \\\"\"", 16)
     _assert("example command \"value '\"", 16)

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -199,7 +199,7 @@ def test_find_begidx():
     #_assert("example command prefix\"value \"", 16)
     
     _assert("example command \"value \\\"\"", 16)
-    #_assert("example command \"value '", 16)
+    _assert("example command \"value '", 16)
     
     _assert("'", 0)
     _assert("''", 0)

--- a/xonsh/jupyter_kernel.py
+++ b/xonsh/jupyter_kernel.py
@@ -22,6 +22,8 @@ from xonsh.main import setup
 from xonsh.completer import Completer
 from xonsh.commands_cache import predict_true
 
+from xonsh.prompt.base import find_begidx
+
 MAX_SIZE = 8388608  # 8 Mb
 DELIM = b"<IDS|MSG>"
 
@@ -423,9 +425,9 @@ class XonshKernel:
         shell = builtins.__xonsh__.shell
         line = code.split("\n")[-1]
         line = builtins.aliases.expand_alias(line)
-        prefix = line.split(" ")[-1]
         endidx = pos
-        begidx = pos - len(prefix)
+        begidx = find_begidx(line, endidx)
+        prefix = line[begidx:pos]
         rtn, _ = self.completer.complete(prefix, line, begidx, endidx, shell.ctx)
         if isinstance(rtn, Set):
             rtn = list(rtn)

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -295,3 +295,25 @@ def _format_value(val, spec, conv):
     if not isinstance(val, str):
         val = str(val)
     return val
+
+def find_begidx(line, endidx):
+    if endidx < 1:
+        return 0
+
+    fragment = line[:endidx+1]
+
+    if fragment.count("'") % 2 == 1:
+        # unmatched single quote
+        begidx = fragment.rfind("'")
+        begidx = find_begidx(line, begidx-1)
+    elif fragment.count('"') %2 == 1:
+        # unmatched double quote
+        begidx = fragment.rfind('"')
+        begidx = find_begidx(line, begidx-1)
+    else:
+        if fragment[-1] == "'" or fragment[-1] == '"':
+            return find_begidx(line[0:-1], endidx-1)
+        else:
+            begidx = fragment.rfind(" ") + 1
+
+    return begidx

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -301,24 +301,28 @@ def find_begidx(line, endidx):
     if endidx < 1:
         return 0
 
-    fragment = line[: endidx + 1]
+    fragment = list(line[: endidx + 1])
+    cnt = 0
+    for index, char in enumerate(fragment):
+        if char == "\\":
+            cnt += 1
+        else:
+            if char == '"' and cnt % 2 == 1:
+                fragment[index] = "_"
+            cnt = 0
+    fragment = "".join(fragment)
 
     if fragment.count("'") % 2 == 1:
         # unmatched single quote
         begidx = fragment.rfind("'")
-        cnt = 0
-        while begidx - cnt > 0 and line[begidx - (cnt + 1)] == "\\":
-            cnt += 1
-        if begidx % 2 == 1:
-            begidx -= cnt
-        begidx = find_begidx(line, begidx - 1)
     elif fragment.count('"') % 2 == 1:
         # unmatched double quote
         begidx = fragment.rfind('"')
-        begidx = find_begidx(line, begidx - 1)
     else:
-        if fragment[-1] == "'" or fragment[-1] == '"':
-            return find_begidx(line[0:-1], endidx - 1)
+        if fragment[-1] == "'":
+            begidx = fragment[:-1].rfind("'")
+        elif fragment[-1] == '"':
+            begidx = fragment[:-1].rfind('"')
         else:
             begidx = fragment.rfind(" ") + 1
 

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -307,23 +307,23 @@ def find_begidx(line, endidx):
         if char == "\\":
             cnt += 1
         else:
-            if (char == '"' or char =="'") and cnt % 2 == 1:
+            if (char == '"' or char == "'") and cnt % 2 == 1:
                 fragment[index] = "_"
             cnt = 0
+
+    search_char = " "
+    for index, char in enumerate(fragment):
+        if char == '"' or char == "'":
+            if search_char == " ":
+                search_char = char
+            elif search_char == char:
+                fragment[index] = "_"
+                if index + 1 < len(fragment):
+                    search_char = " "
+
     fragment = "".join(fragment)
 
-    if fragment.count("'") % 2 == 1:
-        # unmatched single quote
-        begidx = fragment.rfind("'")
-    elif fragment.count('"') % 2 == 1:
-        # unmatched double quote
-        begidx = fragment.rfind('"')
-    else:
-        if fragment[-1] == "'":
-            begidx = fragment[:-1].rfind("'")
-        elif fragment[-1] == '"':
-            begidx = fragment[:-1].rfind('"')
-        else:
-            begidx = fragment.rfind(" ") + 1
-
+    begidx = fragment.rfind(search_char)
+    if search_char == " ":
+        begidx += 1
     return begidx

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -296,23 +296,29 @@ def _format_value(val, spec, conv):
         val = str(val)
     return val
 
+
 def find_begidx(line, endidx):
     if endidx < 1:
         return 0
 
-    fragment = line[:endidx+1]
+    fragment = line[: endidx + 1]
 
     if fragment.count("'") % 2 == 1:
         # unmatched single quote
         begidx = fragment.rfind("'")
-        begidx = find_begidx(line, begidx-1)
-    elif fragment.count('"') %2 == 1:
+        cnt = 0
+        while begidx - cnt > 0 and line[begidx - (cnt + 1)] == "\\":
+            cnt += 1
+        if begidx % 2 == 1:
+            begidx -= cnt
+        begidx = find_begidx(line, begidx - 1)
+    elif fragment.count('"') % 2 == 1:
         # unmatched double quote
         begidx = fragment.rfind('"')
-        begidx = find_begidx(line, begidx-1)
+        begidx = find_begidx(line, begidx - 1)
     else:
         if fragment[-1] == "'" or fragment[-1] == '"':
-            return find_begidx(line[0:-1], endidx-1)
+            return find_begidx(line[0:-1], endidx - 1)
         else:
             begidx = fragment.rfind(" ") + 1
 

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -307,7 +307,7 @@ def find_begidx(line, endidx):
         if char == "\\":
             cnt += 1
         else:
-            if char == '"' and cnt % 2 == 1:
+            if (char == '"' or char =="'") and cnt % 2 == 1:
                 fragment[index] = "_"
             cnt = 0
     fragment = "".join(fragment)

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -106,9 +106,7 @@ class PromptToolkitCompleter(Completer):
             return 0
 
         try:
-            words_non_posix = split(
-                line[0:endidx], posix=False
-            )
+            words_non_posix = split(line[0:endidx], posix=False)
             if line[0:endidx].endswith(" "):
                 words_non_posix.append("")
         except ValueError:

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -102,29 +102,29 @@ class PromptToolkitCompleter(Completer):
                 yield Completion(comp, -plen, display=disp)
 
     def __find_begidx(self, line, endidx):
-        if len(line[0:endidx]) == 0:
+        if endidx < 1:
             return 0
 
-        wordsNonPosix = []
         try:
-            wordsNonPosix = split(
-                line[0:endidx] + "_", posix=False
-            )  # ensure last word is empty when ends with space
-            wordsNonPosix[-1] = wordsNonPosix[-1][:-1]
+            words_non_posix = split(
+                line[0:endidx], posix=False
+            )
+            if line[0:endidx].endswith(" "):
+                words_non_posix.append("")
         except ValueError:
             try:
-                wordsNonPosix = split(
+                words_non_posix = split(
                     line[0:endidx] + '"', posix=False
                 )  # try with missing `"` quote
-                wordsNonPosix[-1] = wordsNonPosix[-1][:-1]
+                words_non_posix[-1] = words_non_posix[-1][:-1]
             except ValueError:
-                wordsNonPosix = split(
+                words_non_posix = split(
                     line[0:endidx] + "'", posix=False
                 )  # try with missing `'` quote
-                wordsNonPosix[-1] = wordsNonPosix[-1][:-1]
+                words_non_posix[-1] = words_non_posix[-1][:-1]
 
         begidx = endidx
-        for word in reversed(wordsNonPosix):
+        for word in reversed(words_non_posix):
             begidx = begidx - len(word)
             if line[begidx - 1] == " ":
                 break

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -7,6 +7,8 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.application.current import get_app
 
+from shlex import split
+
 from xonsh.completers.tools import RichCompletion
 
 
@@ -40,7 +42,7 @@ class PromptToolkitCompleter(Completer):
         line_ex = builtins.aliases.expand_alias(line)
 
         endidx = document.cursor_position_col
-        begidx = line[:endidx].rfind(" ") + 1 if line[:endidx].rfind(" ") >= 0 else 0
+        begidx = self.__find_begidx(line, endidx)
         prefix = line[begidx:endidx]
         expand_offset = len(line_ex) - len(line)
 
@@ -98,6 +100,35 @@ class PromptToolkitCompleter(Completer):
             else:
                 disp = comp[pre:].strip("'\"")
                 yield Completion(comp, -plen, display=disp)
+
+    def __find_begidx(self, line, endidx):
+        if len(line[0:endidx]) == 0:
+            return 0
+
+        wordsNonPosix = []
+        try:
+            wordsNonPosix = split(
+                line[0:endidx] + "_", posix=False
+            )  # ensure last word is empty when ends with space
+            wordsNonPosix[-1] = wordsNonPosix[-1][:-1]
+        except ValueError:
+            try:
+                wordsNonPosix = split(
+                    line[0:endidx] + '"', posix=False
+                )  # try with missing `"` quote
+                wordsNonPosix[-1] = wordsNonPosix[-1][:-1]
+            except ValueError:
+                wordsNonPosix = split(
+                    line[0:endidx] + "'", posix=False
+                )  # try with missing `'` quote
+                wordsNonPosix[-1] = wordsNonPosix[-1][:-1]
+
+        begidx = endidx
+        for word in reversed(wordsNonPosix):
+            begidx = begidx - len(word)
+            if line[begidx - 1] == " ":
+                break
+        return begidx
 
     def suggestion_completion(self, document, line):
         """Provides a completion based on the current auto-suggestion."""

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -7,10 +7,8 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.application.current import get_app
 
-from shlex import split
-
 from xonsh.completers.tools import RichCompletion
-
+from xonsh.prompt.base import find_begidx
 
 class PromptToolkitCompleter(Completer):
     """Simple prompt_toolkit Completer object.
@@ -42,7 +40,7 @@ class PromptToolkitCompleter(Completer):
         line_ex = builtins.aliases.expand_alias(line)
 
         endidx = document.cursor_position_col
-        begidx = self.__find_begidx(line, endidx)
+        begidx = find_begidx(line, endidx)
         prefix = line[begidx:endidx]
         expand_offset = len(line_ex) - len(line)
 
@@ -100,33 +98,6 @@ class PromptToolkitCompleter(Completer):
             else:
                 disp = comp[pre:].strip("'\"")
                 yield Completion(comp, -plen, display=disp)
-
-    def __find_begidx(self, line, endidx):
-        if endidx < 1:
-            return 0
-
-        try:
-            words_non_posix = split(line[0:endidx], posix=False)
-            if line[0:endidx].endswith(" "):
-                words_non_posix.append("")
-        except ValueError:
-            try:
-                words_non_posix = split(
-                    line[0:endidx] + '"', posix=False
-                )  # try with missing `"` quote
-                words_non_posix[-1] = words_non_posix[-1][:-1]
-            except ValueError:
-                words_non_posix = split(
-                    line[0:endidx] + "'", posix=False
-                )  # try with missing `'` quote
-                words_non_posix[-1] = words_non_posix[-1][:-1]
-
-        begidx = endidx
-        for word in reversed(words_non_posix):
-            begidx = begidx - len(word)
-            if line[begidx - 1] == " ":
-                break
-        return begidx
 
     def suggestion_completion(self, document, line):
         """Provides a completion based on the current auto-suggestion."""

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -10,6 +10,7 @@ from prompt_toolkit.application.current import get_app
 from xonsh.completers.tools import RichCompletion
 from xonsh.prompt.base import find_begidx
 
+
 class PromptToolkitCompleter(Completer):
     """Simple prompt_toolkit Completer object.
 


### PR DESCRIPTION
Support quoted values in begidx search (parse using shlex in non-posix mode and do manual rfind for space)

fix #4046