### PR TITLE
feat: add xontrib-cd

### DIFF
--- a/news/xontrib-cd.rst
+++ b/news/xontrib-cd.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* added `xontrib-cd<https://github.com/eugenesvk/xontrib-cd>`_
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs_meta.py
+++ b/xonsh/xontribs_meta.py
@@ -212,6 +212,17 @@ def define_xontribs():
                 url="https://github.com/jnoortheen/xontrib-broot",
             ),
         ),
+        "cd": Xontrib(
+            url="https://github.com/eugenesvk/xontrib-cd",
+            description="'cd' to any path without escaping in xonsh shell "
+            "('cd '→'cd! ')",
+            package=_XontribPkg(
+                name="xontrib-cd",
+                license="MIT",
+                install={"pip": "xpip install xontrib-cd"},
+                url="https://github.com/eugenesvk/xontrib-cd",
+            ),
+        ),
         "cmd_done": Xontrib(
             url="https://github.com/jnoortheen/xontrib-cmd-durations",
             description="send notification once long-running command is "


### PR DESCRIPTION
this xontrib allows a user to `cd` to any path without escaping by automatically replacing `cd ` with `cd! ` in the beginning of any command