### PR TITLE
Perform path completion filtering based on expanded path

### DIFF
--- a/news/fix-cd-rmdir-completions.rst
+++ b/news/fix-cd-rmdir-completions.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug where "cd" and "rmdir" would return non-directory completions
+
+**Security:**
+
+* <news item>

--- a/xonsh/completers/dirs.py
+++ b/xonsh/completers/dirs.py
@@ -7,7 +7,10 @@ def complete_cd(prefix, line, start, end, ctx):
     Completion for "cd", includes only valid directory names.
     """
     if start != 0 and line.split(" ")[0] == "cd":
-        return complete_dir(prefix, line, start, end, ctx, True)
+        results, prefix = complete_dir(prefix, line, start, end, ctx, True)
+        if len(results) == 0:
+            raise StopIteration
+        return results, prefix
     return set()
 
 
@@ -22,5 +25,7 @@ def complete_rmdir(prefix, line, start, end, ctx):
             if i.startswith(prefix)
         }
         comps, lp = complete_dir(prefix, line, start, end, ctx, True)
+        if len(comps) == 0 and len(opts) == 0:
+            raise StopIteration
         return comps | opts, lp
     return set()

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -342,12 +342,12 @@ def complete_path(prefix, line, start, end, ctx, cdpath=True, filtfunc=None):
         ):
             if xt.levenshtein(prefix, s, threshold) < threshold:
                 paths.add(s)
-    if tilde in prefix:
-        home = os.path.expanduser(tilde)
-        paths = {s.replace(home, tilde) for s in paths}
     if cdpath and cd_in_command(line):
         _add_cdpaths(paths, prefix)
     paths = set(filter(filtfunc, paths))
+    if tilde in prefix:
+        home = os.path.expanduser(tilde)
+        paths = {s.replace(home, tilde) for s in paths}
     paths, _ = _quote_paths(
         {_normpath(s) for s in paths}, path_str_start, path_str_end, append_end, cdpath
     )


### PR DESCRIPTION
This fixes issues with the cd and rmdir completers not working correctly due to `os.path.isdir` returning false for paths like '\~/example'. That causes the filtering in `complete_path` to always remove all path completions when the prefix has a '~', which in turn causes the cd and rmdir completers to return nothing. That seems to trigger the general path completer to run, which returns all paths with the given prefix, including files.

This PR moves the filtering step in `complete_path` to before the 'unexpanding' step, which seems to resolve the issue. I have not added a test for this case, as it's not clear to me if the infrastructure in tests/competers can handle this case.