### PR TITLE
Strict permission for history file (json, sqlite)

### DIFF
--- a/news/chmod_history_file.rst
+++ b/news/chmod_history_file.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* History files (json, sqlite) now have 600 (rw only for user) permission by default.
 
 **Deprecated:**
 
@@ -20,4 +20,4 @@
 
 **Security:**
 
-* History files (json, sqlite) now have ``chmod 600`` (rw only for user) permission by default.
+* <news item>

--- a/news/chmod_history_file.rst
+++ b/news/chmod_history_file.rst
@@ -20,4 +20,4 @@
 
 **Security:**
 
-* History files (json, sqlite) now have 600 (-rw-------) permission by default.
+* History files (json, sqlite) now have ``chmod 600`` (rw only for user) permission by default.

--- a/news/chmod_history_file.rst
+++ b/news/chmod_history_file.rst
@@ -20,4 +20,4 @@
 
 **Security:**
 
-* History files (json, sqlite) now have ``600`` (``-rw-------``) permission by default.
+* History files (json, sqlite) now have 600 (-rw-------) permission by default.

--- a/news/chmod_history_file.rst
+++ b/news/chmod_history_file.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* History files (json, sqlite) now have ``600`` (``-rw-------``) permission by default.

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -391,10 +391,17 @@ class JsonHistory(History):
         self._skipped = 0
         self.last_cmd_out = None
         self.last_cmd_rtn = None
+
         meta["cmds"] = []
         meta["sessionid"] = str(self.sessionid)
         with open(self.filename, "w", newline="\n") as f:
             xlj.ljdump(meta, f, sort_keys=True)
+
+        try:
+            os.chmod(self.filename, 0o600)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
         self.gc = JsonHistoryGC() if gc else None
         # command fields that are known
         self.tss = JsonCommandField("ts", self)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -252,6 +252,14 @@ class SqliteHistory(History):
         self.outs = []
         self.tss = []
 
+        if not os.path.exists(self.filename):
+            with _xh_sqlite_get_conn(filename=self.filename) as conn:
+                pass
+            try:
+                os.chmod(self.filename, 0o600)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
         # during init rerun create command
         setattr(XH_SQLITE_CACHE, XH_SQLITE_CREATED_SQL_TBL, False)
 

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -254,7 +254,8 @@ class SqliteHistory(History):
 
         if not os.path.exists(self.filename):
             with _xh_sqlite_get_conn(filename=self.filename) as conn:
-                pass
+                if conn:
+                    pass
             try:
                 os.chmod(self.filename, 0o600)
             except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
History files (json, sqlite) now have ``600`` (``-rw-------``) permission by default.