### PR TITLE
fix: RST link typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ v0.9.27
 
 * Add new internal command "disown" to remove background jobs from the shell's job list
 * Python3.9 issues with subscriptor forms fixed.
-* added `xontrib-cd<https://github.com/eugenesvk/xontrib-cd>`_
+* added `xontrib-cd <https://github.com/eugenesvk/xontrib-cd>`_
 * Added **xontrib-history-encrypt** - new history backend that encrypt the xonsh shell commands history to prevent leaking sensitive data. If you like the idea give a star to the repository https://github.com/anki-code/xontrib-history-encrypt
 
 **Changed:**


### PR DESCRIPTION
Noticed a typo in the RST text that prevents parsing a link as such.
Not sure this is the proper way to fix this typo, but the [devguide](https://xon.sh/devguide.html#changelog) only mentions adding news to the new releases, not fixing typos in the already released changelog