### PR TITLE
feat: add xontrib-linuxbrew

### DIFF
--- a/news/xontrib-linuxbrew.rst
+++ b/news/xontrib-linuxbrew.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* `xontrib-linuxbrew <https://github.com/eugenesvk/xontrib-linuxbrew>`_ to add Homebrew's shell environment to xonsh shell on Linux
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xontribs_meta.py
+++ b/xonsh/xontribs_meta.py
@@ -401,6 +401,16 @@ def define_xontribs():
                 url="https://github.com/scopatz/xontrib-kitty",
             ),
         ),
+        "linuxbrew": Xontrib(
+            url="https://github.com/eugenesvk/xontrib-linuxbrew",
+            description="Add Homebrew's shell environment to xonsh shell on Linux",
+            package=_XontribPkg(
+                name="xontrib-linuxbrew",
+                license="MIT",
+                install={"pip": "xpip install xontrib-linuxbrew"},
+                url="https://github.com/eugenesvk/xontrib-linuxbrew",
+            ),
+        ),
         "mpl": Xontrib(
             url="http://xon.sh",
             description="Matplotlib hooks for xonsh, including the new 'mpl' "


### PR DESCRIPTION
Since Homebrew on Linux doesn't support xonsh and rejected a PR to it natively, made this xontrib to automatically update shell environment on Linux to include Homebrew's vars and paths