### PR TITLE
Welcome message: fix color, add ptk warning

### DIFF
--- a/news/welcome_message.rst
+++ b/news/welcome_message.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added warning about prompt-toolkit in the welcome message.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix colors and text in the welcome message.
+
+**Security:**
+
+* <news item>

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -877,7 +877,6 @@ WELCOME_MSG = [
 
 def print_welcome_screen():
     shell_type = builtins.__xonsh__.env.get('SHELL_TYPE')
-    print(shell_type)
     subst = dict(tagline=random.choice(list(TAGLINES)), version=XONSH_VERSION)
     for elem in WELCOME_MSG:
         if elem == '[SHELL_TYPE_WARNING]':

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -827,7 +827,6 @@ def TAGLINES():
         "Piggy glanced nervously into hell and cradled the xonsh",
         "The xonsh is a symbol",
         "It is pronounced conch",
-        "The shell, bourne again",
         "Snailed it",
         "Starfish loves you",
         "Come snail away",
@@ -848,21 +847,20 @@ def TAGLINES():
         "Python-powered, cross-platform, Unix-gazing shell",
         "Tab completion in Alderaan places",
         "This fix was trickier than expected",
-        "The unholy cross of Bash/Python",
     ]
 
 
 # list of strings or tuples (string, align, fill)
 WELCOME_MSG = [
     "",
-    ("{{INTENSE_WHITE}}Welcome to the xonsh shell ({version}){{RESET}}", "^", " "),
+    ("Welcome to the xonsh shell {version}", "^", " "),
     "",
     ("{{INTENSE_RED}}~{{RESET}} {tagline} {{INTENSE_RED}}~{{RESET}}", "^", " "),
     "",
     ("{{INTENSE_BLACK}}", "<", "-"),
     "",
     (
-        "{{INTENSE_BLACK}}Create ~/.xonshrc file manually or use xonfig to suppress the welcome screen",
+        "{{INTENSE_BLACK}}Create ~/.xonshrc file manually or use xonfig to suppress the welcome message",
         "^",
         " ",
     ),
@@ -870,6 +868,7 @@ WELCOME_MSG = [
     "{{INTENSE_BLACK}}Start from commands:",
     "  {{GREEN}}xonfig{{RESET}} web         {{INTENSE_BLACK}}# Run the configuration tool in the browser to create ~/.xonshrc {{RESET}}",
     "  {{GREEN}}xonfig{{RESET}} tutorial    {{INTENSE_BLACK}}# Open the xonsh tutorial in the browser{{RESET}}",
+    "[SHELL_TYPE_WARNING]",
     "",
     ("{{INTENSE_BLACK}}", "<", "-"),
     "",
@@ -877,8 +876,14 @@ WELCOME_MSG = [
 
 
 def print_welcome_screen():
+    shell_type = builtins.__xonsh__.env.get('SHELL_TYPE')
+    print(shell_type)
     subst = dict(tagline=random.choice(list(TAGLINES)), version=XONSH_VERSION)
     for elem in WELCOME_MSG:
+        if elem == '[SHELL_TYPE_WARNING]':
+            if shell_type != 'prompt_toolkit':
+                print_color("\n{INTENSE_BLACK}Install {RESET}prompt-toolkit{INTENSE_BLACK} to get best prompt experience.{RESET}")
+            continue
         if isinstance(elem, str):
             elem = (elem, "", "")
         line = elem[0].format(**subst)

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -882,7 +882,9 @@ def print_welcome_screen():
         if elem == "[SHELL_TYPE_WARNING]":
             if shell_type != "prompt_toolkit":
                 print_color(
-                    f"\n{{INTENSE_BLACK}}You are currently using the {shell_type} backend. For interactive tab-completion, on-the-fly syntax highlighting, and more, install prompt_toolkit by running:\n\n  {{GREEN}}xpip{{RESET}} install -U 'xonsh[full]'"
+                    f"\n{{INTENSE_BLACK}}You are currently using the {shell_type} backend. "
+                    f"For interactive tab-completion, on-the-fly syntax highlighting, and more, install prompt_toolkit by running:\n\n"
+                    f"  {{GREEN}}xpip{{RESET}} install -U 'xonsh[full]'"
                 )
             continue
         if isinstance(elem, str):

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -876,12 +876,14 @@ WELCOME_MSG = [
 
 
 def print_welcome_screen():
-    shell_type = builtins.__xonsh__.env.get('SHELL_TYPE')
+    shell_type = builtins.__xonsh__.env.get("SHELL_TYPE")
     subst = dict(tagline=random.choice(list(TAGLINES)), version=XONSH_VERSION)
     for elem in WELCOME_MSG:
-        if elem == '[SHELL_TYPE_WARNING]':
-            if shell_type != 'prompt_toolkit':
-                print_color("\n{INTENSE_BLACK}Install {RESET}prompt-toolkit{INTENSE_BLACK} to get the best prompt experience.{RESET}")
+        if elem == "[SHELL_TYPE_WARNING]":
+            if shell_type != "prompt_toolkit":
+                print_color(
+                    "\n{INTENSE_BLACK}Install {RESET}prompt-toolkit{INTENSE_BLACK} to get the best prompt experience.{RESET}"
+                )
             continue
         if isinstance(elem, str):
             elem = (elem, "", "")

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -881,7 +881,7 @@ def print_welcome_screen():
     for elem in WELCOME_MSG:
         if elem == '[SHELL_TYPE_WARNING]':
             if shell_type != 'prompt_toolkit':
-                print_color("\n{INTENSE_BLACK}Install {RESET}prompt-toolkit{INTENSE_BLACK} to get best prompt experience.{RESET}")
+                print_color("\n{INTENSE_BLACK}Install {RESET}prompt-toolkit{INTENSE_BLACK} to get the best prompt experience.{RESET}")
             continue
         if isinstance(elem, str):
             elem = (elem, "", "")

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -882,7 +882,7 @@ def print_welcome_screen():
         if elem == "[SHELL_TYPE_WARNING]":
             if shell_type != "prompt_toolkit":
                 print_color(
-                    "\n{INTENSE_BLACK}Install {RESET}prompt-toolkit{INTENSE_BLACK} to get the best prompt experience.{RESET}"
+                    f"\n{{INTENSE_BLACK}}You are currently using the {shell_type} backend. For interactive tab-completion, on-the-fly syntax highlighting, and more, install prompt_toolkit by running:\n\n  {{GREEN}}xpip{{RESET}} install -U 'xonsh[full]'"
                 )
             continue
         if isinstance(elem, str):

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -891,3 +891,4 @@ def print_welcome_screen():
         termwidth = os.get_terminal_size().columns
         line = _align_string(line, elem[1], elem[2], width=termwidth)
         print_color(line)
+    print_color("{RESET}", end="")


### PR DESCRIPTION
Closes #4141
Closes #2401

* Added warning about shell type.
* A bit fix of colors.
* Removed two phrases about bash because xonsh is not sh-compatible in fact.

Appearance:

<details>

![image](https://user-images.githubusercontent.com/1708680/110145233-421dca80-7dea-11eb-9385-8dfca826ecea.png)

</details>