### PR TITLE
docs: added quotes to pip install

### DIFF
--- a/docs/_templates_overwrite/index.html
+++ b/docs/_templates_overwrite/index.html
@@ -321,7 +321,7 @@
                             <div id="collapse1" class="collapse show" role="tabpanel" aria-labelledby="faq1" data-parent="#accordion">
                                 <div class="card-body">
                                     <p>Install:</p>
-                                    <pre class="code">python -m pip install xonsh[full]</pre>
+                                    <pre class="code">python -m pip install 'xonsh[full]'</pre>
                                     <a href="https://xon.sh/packages.html">Learn more →</a>
                                 </div>
                             </div>

--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -28,7 +28,7 @@ correct Python interpreter and ``pip`` module.
 
 .. code-block:: console
 
-    $ pip install xonsh[full]
+    $ pip install 'xonsh[full]'
 
 This uses the pip 'extras' syntax, and is equivalent to:
 


### PR DESCRIPTION
To avoid errors in zsh/xonsh we need to add quotes

```python
zsh
pip install xonsh[full]
# zsh: no matches found: xonsh[full]

xonsh
pip install xonsh[full]
# SyntaxError: <xonsh-code>:1:4: ('code: install',)
```

No news