### PR TITLE
fix: abbrevs with callback alters buffer text before expansion

### DIFF
--- a/tests/xontribs/test_abbrevs.py
+++ b/tests/xontribs/test_abbrevs.py
@@ -27,11 +27,17 @@ def abbrevs_xontrib(monkeypatch, source_path):
     del sys.modules[spec.name]
 
 
+ps_special_expand = (
+    lambda buffer, word: "procs" if buffer.text.startswith(word) else word
+)
+
+
 @mark.parametrize(
     "abbr,val,expanded,cur",
     [
         ("ps", "procs", "procs", None),
-        ("ps", lambda **kw: "callback", "callback", None),
+        ("ps", ps_special_expand, "procs", None),
+        ("docker ps", ps_special_expand, "docker ps", None),
         ("kill", "kill <edit> -9", "kill  -9", 5),
         ("pt", "poe<edit>try", "poetry", 3),
     ],

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -28,6 +28,7 @@ It is also possible to set the cursor position after expansion with,
 import builtins
 import typing as tp
 
+from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.filters import completion_is_selected, IsMultiline
 from prompt_toolkit.keys import Keys
 from xonsh.built_ins import DynamicAccessProxy
@@ -60,7 +61,7 @@ def get_abbreviated(key: str, buffer) -> str:
     return text
 
 
-def expand_abbrev(buffer) -> bool:
+def expand_abbrev(buffer: Buffer) -> bool:
     """expand the given abbr text. Return true if cursor position changed."""
     global last_expanded
     last_expanded = None
@@ -74,9 +75,11 @@ def expand_abbrev(buffer) -> bool:
         startix, endix, quote = check_for_partial_string(partial)
         if startix is not None and endix is None:
             return False
-        buffer.delete_before_cursor(count=len(word))
         text = get_abbreviated(word, buffer)
+
+        buffer.delete_before_cursor(count=len(word))
         buffer.insert_text(text)
+
         last_expanded = _LastExpanded(word, text)
         if EDIT_SYMBOL in text:
             set_cursor_position(buffer, text)


### PR DESCRIPTION
fixes #3642 bug specified in the comment https://github.com/xonsh/xonsh/issues/3642#issuecomment-793789741

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
