### PR TITLE
update imphooks encoding regex to match the newer version at PEP 263

### DIFF
--- a/news/PEP263upd.rst
+++ b/news/PEP263upd.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* update imphooks encoding regex to match the newer version at PEP 263
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -23,7 +23,7 @@ from xonsh.platform import ON_WINDOWS
 def ENCODING_LINE():
     # this regex comes from PEP 263
     # https://www.python.org/dev/peps/pep-0263/#defining-the-encoding
-    return re.compile(b"^[ tv]*#.*?coding[:=][ t]*([-_.a-zA-Z0-9]+)")
+    return re.compile(b"^[ tf]*#.*?coding[:=][ t]*([-_.a-zA-Z0-9]+)")
 
 
 def find_source_encoding(src):

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -23,7 +23,7 @@ from xonsh.platform import ON_WINDOWS
 def ENCODING_LINE():
     # this regex comes from PEP 263
     # https://www.python.org/dev/peps/pep-0263/#defining-the-encoding
-    return re.compile(b"^[ tf]*#.*?coding[:=][ t]*([-_.a-zA-Z0-9]+)")
+    return re.compile(b"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 
 
 def find_source_encoding(src):


### PR DESCRIPTION
Noticed the PEP 263 update while fixing a BOM bug, though not sure this has any effect