### PR TITLE
#4148 $TITLE can be set to a function

### DIFF
--- a/news/fix_prompt_like_title.rst
+++ b/news/fix_prompt_like_title.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Functions can be used for $TITLE, the same way as for $PROMPT. (#4148)
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1337,13 +1337,15 @@ class PromptSetting(Xettings):
         False,
         "Whether or not to suppress branch timeout warning messages when getting {gitstatus} PROMPT_FIELD.",
     )
-    TITLE = Var.with_default(
+    TITLE = Var(
+        is_string_or_callable,
+        ensure_string,
+        ensure_string,
         DEFAULT_TITLE,
         "The title text for the window in which xonsh is running. Formatted "
         "in the same manner as ``$PROMPT``, see 'Customizing the Prompt' "
         "http://xon.sh/tutorial.html#customizing-the-prompt.",
         doc_default="``xonsh.environ.DEFAULT_TITLE``",
-        type_str="str",
     )
     UPDATE_PROMPT_ON_KEYPRESS = Var.with_default(
         False,


### PR DESCRIPTION
According to the documentation $TITLE should work like $PROMPT but it was restricted to be `string` instead of `string_or_callable`.

Fixes #4148 .
