### PR TITLE
Improve `which` output

### DIFF
--- a/news/improve-which-output.rst
+++ b/news/improve-which-output.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Improved ``which`` output for non-simple aliases
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -199,7 +199,7 @@ class ExecAlias:
         src : str
             Source code that will be
         """
-        self.src = src if src.endswith("\n") else src + "\n"
+        self.src = src
         self.filename = filename
 
     def __call__(

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -4,6 +4,7 @@ import argparse
 import builtins
 import functools
 
+import xonsh
 from xonsh.xoreutils import _which
 import xonsh.platform as xp
 import xonsh.procs.pipelines as xpp
@@ -98,19 +99,22 @@ def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
 
 def print_alias(arg, stdout, verbose=False):
     """Print the alias."""
+    alias = builtins.aliases[arg]
     if not verbose:
-        if not callable(builtins.aliases[arg]):
-            print(" ".join(builtins.aliases[arg]), file=stdout)
+        if not callable(alias):
+            print(" ".join(alias), file=stdout)
+        elif isinstance(alias, xonsh.aliases.ExecAlias):
+            print(alias.src, file=stdout)
         else:
-            print(arg, file=stdout)
+            print(alias, file=stdout)
     else:
         print(
-            "aliases['{}'] = {}".format(arg, builtins.aliases[arg]),
+            "aliases['{}'] = {}".format(arg, alias),
             flush=True,
             file=stdout,
         )
-        if callable(builtins.aliases[arg]):
-            builtins.__xonsh__.superhelp(builtins.aliases[arg])
+        if callable(alias) and not isinstance(alias, xonsh.aliases.ExecAlias):
+            builtins.__xonsh__.superhelp(alias)
 
 
 def which(args, stdin=None, stdout=None, stderr=None, spec=None):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

```python
aliases['a'] = 'ls'
aliases['b'] = 'ls | grep b'  # ExecAlias
aliases['c'] = lambda args: print(args)

# Prepared by xontrib-hist-format
```

Before:
```python
which a b c
# ls
# b
# c

# Prepared by xontrib-hist-format
```

After:
```python
which a b c
# ls
# ls | grep b
# <function <lambda> at 0x7f4d42bdc1f0>

# Prepared by xontrib-hist-format
```