### PR TITLE
docs: Update robots.txt to removing old documentation from search

### DIFF
--- a/docs/_static/robots.txt
+++ b/docs/_static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /dev/
+Disallow: /docs-ahundt-sphinx


### PR DESCRIPTION
Removing old documentation from search:

https://xon.sh/docs-ahundt-sphinx-readable-theme-pypi/api/aliases.html

![image](https://user-images.githubusercontent.com/1708680/111815367-a2356600-88ec-11eb-892b-b88de5c0f97b.png)

No news

