### PR TITLE
feat: Added ability to get arguments list in ExecAlias

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1230,14 +1230,14 @@ being executed.
 
 If the string is representing a block of xonsh code, the alias will be registered
 as an ``ExecAlias``, which is a callable alias. This block of code will then be
-executed whenever the alias is run. The arguments are available in ``$ALIAS_ARGS``
-and ``$ALIAS_ARG<n>`` environment variables.
+executed whenever the alias is run. The arguments are available in the list ``$args``
+or by the index in ``$arg<n>`` environment variables.
 
 .. code-block:: xonshcon
 
     >>> aliases['answer'] = 'echo @(21+21)'
-    >>> aliases['piu'] = 'pip install -U @($ALIAS_ARGS)'
-    >>> aliases['cdls'] = 'cd $ALIAS_ARG0 && ls'
+    >>> aliases['piu'] = 'pip install -U @($args)'
+    >>> aliases['cdls'] = 'cd $arg0 && ls'
 
 .. note::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1206,19 +1206,17 @@ matching only occurs for the first element of a subprocess command.
 
 The keys of ``aliases`` are strings that act as commands in subprocess-mode.
 The values are lists of strings, where the first element is the command, and
-the rest are the arguments. You can also set the value to a string, in which
-one of two things will happen:
+the rest are the arguments.
 
-1. If the string is a xonsh expression, it will be converted to a list
-   automatically with xonsh's ``Lexer.split()`` method.
-2. If the string is more complex (representing a block of xonsh code),
-   the alias will be registered as an ``ExecAlias``, which is a callable
-   alias. This block of code will then be executed whenever the alias is
-   run.
+.. code-block:: xonshcon
 
-For example, the following creates several aliases for the ``git``
-version control software.  Both styles (list of strings and single
-string) are shown:
+    >>> aliases['ls']
+    ['ls', '--color=auto', '-v']
+
+You can also set the value to a string. If the string is a xonsh expression,
+it will be converted to a list automatically with xonsh's ``Lexer.split()`` method.
+For example, the following creates several aliases for the ``git`` version
+control software. Both styles (list of strings and single string) are shown:
 
 .. code-block:: xonshcon
 
@@ -1229,6 +1227,17 @@ string) are shown:
 If you were to run ``gco feature-fabulous`` with the above aliases in effect,
 the command would reduce to ``['git', 'checkout', 'feature-fabulous']`` before
 being executed.
+
+If the string is representing a block of xonsh code, the alias will be registered
+as an ``ExecAlias``, which is a callable alias. This block of code will then be
+executed whenever the alias is run. The arguments are available in ``$ALIAS_ARGS``
+and ``$ALIAS_ARG<n>`` environment variables.
+
+.. code-block:: xonshcon
+
+    >>> aliases['answer'] = 'echo @(21+21)'
+    >>> aliases['piu'] = 'pip install -U @($ALIAS_ARGS)'
+    >>> aliases['cdls'] = 'cd $ALIAS_ARG0 && ls'
 
 
 Callable Aliases

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1239,6 +1239,10 @@ and ``$ALIAS_ARG<n>`` environment variables.
     >>> aliases['piu'] = 'pip install -U @($ALIAS_ARGS)'
     >>> aliases['cdls'] = 'cd $ALIAS_ARG0 && ls'
 
+.. note::
+
+   To add multiple aliases there is ``|=`` operator: ``aliases |= {'e': 'echo', 'g': 'git'}``.
+
 
 Callable Aliases
 ----------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1241,7 +1241,7 @@ or by the index in ``$arg<n>`` environment variables.
 
 .. note::
 
-   To add multiple aliases there is ``|=`` operator: ``aliases |= {'e': 'echo', 'g': 'git'}``.
+   To add multiple aliases there is merge operator: ``aliases |= {'e': 'echo', 'g': 'git'}``.
 
 
 Callable Aliases

--- a/news/alias_args.rst
+++ b/news/alias_args.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ability to get arguments list in ExecAlias using ALIAS_ARGS environment variable.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/alias_args.rst
+++ b/news/alias_args.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ability to get arguments list in ExecAlias using ALIAS_ARGS environment variable.
+* Added ability to get the arguments list in ExecAlias using ``$args`` and ``$arg<n>`` environment variables.
 
 **Changed:**
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, print_function
 import os
 
 import pytest
+import inspect
 
 from xonsh.aliases import Aliases, ExecAlias
 from xonsh.environ import Env
@@ -179,3 +180,13 @@ def test_dict_merging_assignment(xonsh_execer, xonsh_builtins, alias):
 
     assert 'o' in alias
     assert alias['o'] == ales['o']
+
+
+def test_exec_alias_args(xonsh_execer, xonsh_builtins):
+    stack = inspect.stack()
+    try:
+        ExecAlias('myargs = $ALIAS_ARGS')(['arg1'], stack=stack)
+    except KeyError:
+        assert False
+
+    assert stack[0][0].f_locals['myargs'] == ['arg1']

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -185,8 +185,10 @@ def test_dict_merging_assignment(xonsh_execer, xonsh_builtins, alias):
 def test_exec_alias_args(xonsh_execer, xonsh_builtins):
     stack = inspect.stack()
     try:
-        ExecAlias('myargs = $ALIAS_ARGS')(['arg1'], stack=stack)
+        ExecAlias('myargs = $args')(['arg0'], stack=stack)
+        ExecAlias('myarg0 = $arg0')(['arg0'], stack=stack)
     except KeyError:
         assert False
 
-    assert stack[0][0].f_locals['myargs'] == ['arg1']
+    assert stack[0][0].f_locals['myargs'] == ['arg0']
+    assert stack[0][0].f_locals['myarg0'] == 'arg0'

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -208,9 +208,14 @@ class ExecAlias:
     ):
         execer = builtins.__xonsh__.execer
         frame = stack[0][0]  # execute as though we are at the call site
-        execer.exec(
-            self.src, glbs=frame.f_globals, locs=frame.f_locals, filename=self.filename
-        )
+
+        with builtins.__xonsh__.env.swap(ALIAS_ARGS=args):
+            execer.exec(
+                self.src,
+                glbs=frame.f_globals,
+                locs=frame.f_locals,
+                filename=self.filename,
+            )
 
     def __repr__(self):
         return "ExecAlias({0!r}, filename={1!r})".format(self.src, self.filename)

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -213,9 +213,9 @@ class ExecAlias:
         execer = builtins.__xonsh__.execer
         frame = stack[0][0]  # execute as though we are at the call site
 
-        alias_args = {"ALIAS_ARGS": args}
+        alias_args = {"args": args}
         for i, a in enumerate(args):
-            alias_args[f"ALIAS_ARG{i}"] = a
+            alias_args[f"arg{i}"] = a
 
         with builtins.__xonsh__.env.swap(alias_args):
             execer.exec(

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -213,7 +213,11 @@ class ExecAlias:
         execer = builtins.__xonsh__.execer
         frame = stack[0][0]  # execute as though we are at the call site
 
-        with builtins.__xonsh__.env.swap(ALIAS_ARGS=args):
+        alias_args = {"ALIAS_ARGS": args}
+        for i, a in enumerate(args):
+            alias_args[f"ALIAS_ARG{i}"] = a
+
+        with builtins.__xonsh__.env.swap(alias_args):
             execer.exec(
                 self.src,
                 glbs=frame.f_globals,


### PR DESCRIPTION
This PR adds `$args` and `$arg0`..`$arg<n>` environment variables to the `ExecAlias` context. Motivation: https://github.com/xonsh/xonsh/pull/4201#issuecomment-810754606

Exampls:
```python
aliases['my'] = "echo Hello @($args)"    # ExecAlias
my 'world!'
# Hello world!
```
```python
aliases['cl'] = "cd $arg0 && ls $arg0"
cl /tmp
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**