### PR TITLE
Updated references to point to 'main' instead of 'master'

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ terminal application. See installation instructions for details, but it
 is recommended to do an 'editable' install via `pip'
 
         $ pip install -e .
-        
+
 Next, make a trivial change (e.g. ``print("hello!")`` in ``main.py``).
 
 Finally, run the following commands. You should see the effects of your change
@@ -111,7 +111,7 @@ is open to interpretation.
 * Simple functions should have simple docstrings.
 * Lines should be at most 80 characters long. The 72 and 79 character
   recommendations from PEP8 are not required here.
-* All Python code should be compliant with Python 3.5+.  
+* All Python code should be compliant with Python 3.5+.
 * Tests should be written with `pytest <https://docs.pytest.org/>`_ using a procedural style. Do not use
   unittest directly or write tests in an object-oriented style.
 * Test generators make more dots and the dots must flow!
@@ -365,7 +365,7 @@ developer can push their local changes directly to the website by::
 
 Branches and Releases
 =============================
-Mainline xonsh development occurs on the ``master`` branch. Other branches
+Mainline xonsh development occurs on the ``main`` branch. Other branches
 may be used for feature development (topical branches) or to represent
 past and upcoming releases.
 
@@ -381,17 +381,17 @@ getting released early.
 
 As such, the 'vX.X.X-release' branch should only exist while there are
 release candidates out.  They are akin to a temporary second level of staging,
-and so everything that is in this branch should also be part of master.
+and so everything that is in this branch should also be part of main.
 
 Every time a new release candidate comes out the vX.X.X-release should be
 tagged with the name 'X.X.X-rcX'.  There should be a 2 - 5 day period of time
 in between release candidates.  When the full and final release happens, the
-'vX.X.X-release' branch is merged into master and then deleted.
+'vX.X.X-release' branch is merged into main and then deleted.
 
 If you have a new fix that needs to be in the next release candidate, you
 should make a topical branch and then pull request it into the release branch.
 After this has been accepted, the topical branch should be merged with
-master as well.
+main as well.
 
 The release branch must be quiet and untouched for 2 - 5 days prior to the
 full release.

--- a/docs/_templates_overwrite/index-old.html
+++ b/docs/_templates_overwrite/index-old.html
@@ -452,7 +452,7 @@
                         <h3>Is xonsh open source?</h3>
                         <p>
                             Yes! Xonsh is freely usable and accessible under the
-                            <a href="https://github.com/xonsh/xonsh/blob/master/license">BSD-2-Clause license</a>.
+                            <a href="https://github.com/xonsh/xonsh/blob/main/license">BSD-2-Clause license</a>.
                         </p>
 					</div>
 				</div>
@@ -527,7 +527,7 @@
 							<h4>Legal</h4>
 						</div>
 						<ul>
-                            <li><a href="https://github.com/xonsh/xonsh/blob/master/license">License</a></li>
+                            <li><a href="https://github.com/xonsh/xonsh/blob/main/license">License</a></li>
 						</ul>
 					</aside>
 				</div>

--- a/docs/_templates_overwrite/index.html
+++ b/docs/_templates_overwrite/index.html
@@ -607,7 +607,7 @@ chmod +x xonsh-x86_64.AppImage
                             <h4>Open Source</h4>
                         </div>
                         <p>
-                            <a href="https://github.com/xonsh/xonsh/blob/master/license" target="_blank">License</a>
+                            <a href="https://github.com/xonsh/xonsh/blob/main/license" target="_blank">License</a>
                         </p>
                         <p>
                             <a href="https://github.com/xonsh/xonsh" target="_blank">Github</a>

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -3,7 +3,7 @@
 Helpful Links
 =============
 
-* `GitHub Repository <https://github.com/xonsh/xonsh>`_: `releases <https://github.com/xonsh/xonsh/releases>`_, `changelog <https://github.com/xonsh/xonsh/blob/master/CHANGELOG.rst>`_
+* `GitHub Repository <https://github.com/xonsh/xonsh>`_: `releases <https://github.com/xonsh/xonsh/releases>`_, `changelog <https://github.com/xonsh/xonsh/blob/main/CHANGELOG.rst>`_
 * GitHub topics: `xonsh <https://github.com/topics/xonsh>`_ and `xontrib <https://github.com/topics/xontrib>`_
 * `DockerHub images <https://hub.docker.com/u/xonsh>`_
 * `Cookiecutter template to creating xontribs <https://github.com/xonsh/xontrib-cookiecutter>`_

--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -43,7 +43,7 @@ The above ``pip`` commands may have to be spelled ``pip3`` or ``sudo pip3`` if y
 
 .. code-block:: console
 
-    $ pip install pygments prompt-toolkit setproctitle https://github.com/xonsh/xonsh/archive/master.zip
+    $ pip install pygments prompt-toolkit setproctitle https://github.com/xonsh/xonsh/archive/main.zip
 
 Spelling of ``pip`` command may likewise have to be amended as noted above.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -255,8 +255,8 @@ Running subprocess commands should work like in any other shell.
     >>> dir scripts
     xonsh  xonsh.bat
     >>> git status
-    On branch master
-    Your branch is up-to-date with 'origin/master'.
+    On branch main
+    Your branch is up-to-date with 'origin/main'.
     Changes not staged for commit:
       (use "git add <file>..." to update what will be committed)
       (use "git checkout -- <file>..." to discard changes in working directory)
@@ -1508,7 +1508,7 @@ By default, the following variables are available for use:
     foreground, if any.
   * ``vte_new_tab_cwd``: Issues VTE escape sequence for opening new tabs in the
     current working directory on some linux terminals. This is not usually needed.
-  * ``gitstatus``: Informative git status, like ``[master|MERGING|+1…2]``, you
+  * ``gitstatus``: Informative git status, like ``[main|MERGING|+1…2]``, you
     may use `$XONSH_GITSTATUS_* <envvars.html>`_ to customize the styling.
   * ``localtime``: The current, local time as given by ``time.localtime()``.
     This is formatted with the time format string found in ``time_format``.
@@ -1643,7 +1643,7 @@ But let's consider a problem:
 .. code-block:: console
 
     snail@home ~/xonsh $ $PROMPT = "{cwd_base} [{curr_branch}] $ "
-    xonsh [master] $ cd ..
+    xonsh [main] $ cd ..
     ~ [] $
 
 We want the branch to be displayed in square brackets, but we also don't want
@@ -1654,7 +1654,7 @@ invoked only if the value is not ``None``:
 .. code-block:: console
 
     snail@home ~/xonsh $ $PROMPT = "{cwd_base}{curr_branch: [{}]} $ "
-    xonsh [master] $ cd ..
+    xonsh [main] $ cd ..
     ~ $
 
 The curly brackets act as a placeholder, because the additional part is an

--- a/docs/tutorial_xontrib.rst
+++ b/docs/tutorial_xontrib.rst
@@ -176,7 +176,7 @@ Of course, you're under no obligation to register your xontrib.  Users will
 still be able to load your xontrib, as long as they have it installed.
 
 To register a xontrib, add an entry to
-`the xontribs_meta.py file <https://github.com/xonsh/xonsh/blob/master/xonsh/xontribs_meta.py>`_
+`the xontribs_meta.py file <https://github.com/xonsh/xonsh/blob/main/xonsh/xontribs_meta.py>`_
 in the main xonsh repository.  A pull request is probably best, but if you
 are having trouble figuring it out please contact one of the xonsh devs
 with the relevant information.


### PR DESCRIPTION
Couldn't update to `HEAD` since the link was pointing to the outdated `master.zip`, so changed that and also edited a few other outdated references

Didn't add a changelog entry as I think these edits are too minor to mention, but let me know if you think otherwise