### PR TITLE
Put history json to subdirectory

### DIFF
--- a/news/json_history_dir.rst
+++ b/news/json_history_dir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* New json history will be in XONSH_DATA_DIR/history_json directory.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -87,11 +87,15 @@ def _xhj_gc_bytes_to_rmfiles(hsize, files):
 
     return bytes_removed, files_removed
 
+
 def _xhj_get_data_dir():
-    dir = xt.expanduser_abs_path(os.path.join(builtins.__xonsh__.env.get("XONSH_DATA_DIR"), 'history_json'))
+    dir = xt.expanduser_abs_path(
+        os.path.join(builtins.__xonsh__.env.get("XONSH_DATA_DIR"), "history_json")
+    )
     if not os.path.exists(dir):
         os.makedirs(dir)
     return dir
+
 
 def _xhj_get_history_files(sort=True, newest_first=False):
     """Find and return the history files. Optionally sort files by
@@ -99,7 +103,9 @@ def _xhj_get_history_files(sort=True, newest_first=False):
     """
     data_dirs = [
         _xhj_get_data_dir(),
-        builtins.__xonsh__.env.get("XONSH_DATA_DIR")  # backwards compatibility, remove in the future
+        builtins.__xonsh__.env.get(
+            "XONSH_DATA_DIR"
+        ),  # backwards compatibility, remove in the future
     ]
 
     files = []

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -119,7 +119,9 @@ def _xhj_get_history_files(sort=True, newest_first=False):
             ]
         except OSError:
             if builtins.__xonsh__.env.get("XONSH_DEBUG"):
-                xt.print_exception("Could not collect xonsh history files.")
+                xt.print_exception(
+                    f"Could not collect xonsh history json files from {data_dir}"
+                )
     if sort:
         files.sort(key=lambda x: os.path.getmtime(x), reverse=newest_first)
 

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -86,23 +86,33 @@ def _xhj_gc_bytes_to_rmfiles(hsize, files):
 
     return bytes_removed, files_removed
 
+def _xhj_get_data_dir():
+    dir = xt.expanduser_abs_path(os.path.join(builtins.__xonsh__.env.get("XONSH_DATA_DIR"), 'history_json'))
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+    return dir
 
 def _xhj_get_history_files(sort=True, newest_first=False):
     """Find and return the history files. Optionally sort files by
     modify time.
     """
-    data_dir = builtins.__xonsh__.env.get("XONSH_DATA_DIR")
-    data_dir = xt.expanduser_abs_path(data_dir)
-    try:
-        files = [
-            os.path.join(data_dir, f)
-            for f in os.listdir(data_dir)
-            if f.startswith("xonsh-") and f.endswith(".json")
-        ]
-    except OSError:
-        files = []
-        if builtins.__xonsh__.env.get("XONSH_DEBUG"):
-            xt.print_exception("Could not collect xonsh history files.")
+    data_dirs = [
+        _xhj_get_data_dir(),
+        builtins.__xonsh__.env.get("XONSH_DATA_DIR")  # backwards compatibility, remove in the future
+    ]
+
+    files = []
+    for data_dir in data_dirs:
+        data_dir = xt.expanduser_abs_path(data_dir)
+        try:
+            files += [
+                os.path.join(data_dir, f)
+                for f in os.listdir(data_dir)
+                if f.startswith("xonsh-") and f.endswith(".json")
+            ]
+        except OSError:
+            if builtins.__xonsh__.env.get("XONSH_DEBUG"):
+                xt.print_exception("Could not collect xonsh history files.")
     if sort:
         files.sort(key=lambda x: os.path.getmtime(x), reverse=newest_first)
 
@@ -367,7 +377,7 @@ class JsonHistory(History):
         ----------
         filename : str, optional
             Location of history file, defaults to
-            ``$XONSH_DATA_DIR/xonsh-{sessionid}.json``.
+            ``$XONSH_DATA_DIR/history_json/xonsh-{sessionid}.json``.
         sessionid : int, uuid, str, optional
             Current session identifier, will generate a new sessionid if not
             set.
@@ -382,8 +392,7 @@ class JsonHistory(History):
         super().__init__(sessionid=sessionid, **meta)
         if filename is None:
             # pylint: disable=no-member
-            data_dir = builtins.__xonsh__.env.get("XONSH_DATA_DIR")
-            data_dir = os.path.expanduser(data_dir)
+            data_dir = _xhj_get_data_dir()
             self.filename = os.path.join(
                 data_dir, "xonsh-{0}.json".format(self.sessionid)
             )


### PR DESCRIPTION
Hi!
To keep `XONSH_DATA_DIR` clean the history json files now will be in `XONSH_DATA_DIR/history_json` directory.
The backwards compatibility of reading the history json from `XONSH_DATA_DIR` is on board.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
