### PR TITLE
Added env variable to ignore ./ and ../ in filepath completion

### DIFF
--- a/news/ignore_dots.rst
+++ b/news/ignore_dots.rst
@@ -1,6 +1,9 @@
 **Added:**
 
-* Added environment variable to ignore ./ and ../ in file path completions.
+* Added environment variable `$COMPLETE_DOTS` to specify how current and previous directories should be tab completed in cd  ('./', '../'):
+    - ``always`` Always complete paths with ./ and ../
+    - ``never`` Never complete paths with ./ and ../
+    - ``matching`` Complete if path starts with . or ..
 
 **Changed:**
 

--- a/news/ignore_dots.rst
+++ b/news/ignore_dots.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added environment variable to ignore ./ and ../ in file path completions.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -124,13 +124,16 @@ def _env(prefix):
 
 
 def _dots(prefix):
-    ignore_dots = bool(builtins.__xonsh__.env.get("IGNORE_DOTS"))
-    if ignore_dots:
+    complete_dots = builtins.__xonsh__.env.get("COMPLETE_DOTS").lower()
+    if complete_dots == 'never':
         return ()
     slash = xt.get_sep()
     if slash == "\\":
         slash = ""
-    if prefix in {"", "."}:
+    prefixes = {"."}
+    if complete_dots == 'always':
+        prefixes.add("")
+    if prefix in prefixes:
         return ("." + slash, ".." + slash)
     elif prefix == "..":
         return (".." + slash,)

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -124,7 +124,7 @@ def _env(prefix):
 
 
 def _dots(prefix):
-    complete_dots = builtins.__xonsh__.env.get("COMPLETE_DOTS").lower()
+    complete_dots = builtins.__xonsh__.env.get("COMPLETE_DOTS", "matching").lower()
     if complete_dots == 'never':
         return ()
     slash = xt.get_sep()

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -124,6 +124,9 @@ def _env(prefix):
 
 
 def _dots(prefix):
+    ignore_dots = bool(builtins.__xonsh__.env.get("IGNORE_DOTS"))
+    if ignore_dots:
+        return ()
     slash = xt.get_sep()
     if slash == "\\":
         slash = ""

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1107,6 +1107,14 @@ class ChangeDirSetting(Xettings):
         False,
         "Whether or not to suppress directory stack manipulation output.",
     )
+    COMPLETE_DOTS = Var.with_default(
+        "matching",
+        doc="Flag to specify how current and previous directories should be "
+        "tab completed  ('./', '../'):"
+        "    - ``always`` Always complete paths with ./ and ../\n"
+        "    - ``never`` Never complete paths with ./ and ../\n"
+        "    - ``matching`` Complete if path starts with . or ..",
+    )
 
 
 class InterpreterSetting(Xettings):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
**Added:**

* Added environment variable `$IGNORE_DOTS` to ignore ./ and ../ in file path completions.

This addresses issue  #4213 

⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
