### PR TITLE
feat: Ability to call the program by name from callable alias with the same name without the infinite loop error

### DIFF
--- a/news/fix_aliases_infinite_loop.rst
+++ b/news/fix_aliases_infinite_loop.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Ability to call the program by name from callable alias with the same name without the infinite loop error.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/fix_aliases_infinite_loop.rst
+++ b/news/fix_aliases_infinite_loop.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Ability to call the tool by name from callable alias with the same name without the infinite loop error.
+* Ability to call the tool by the name from callable alias with the same name without the infinite loop error.
 
 **Changed:**
 

--- a/news/fix_aliases_infinite_loop.rst
+++ b/news/fix_aliases_infinite_loop.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Ability to call the program by name from callable alias with the same name without the infinite loop error.
+* Ability to call the tool by name from callable alias with the same name without the infinite loop error.
 
 **Changed:**
 

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -14,7 +14,7 @@ from xonsh.commands_cache import (
     predict_false,
 )
 from xonsh import commands_cache
-from tools import skip_if_on_windows, skip_if_on_darwin
+from tools import skip_if_on_windows
 
 
 def test_commands_cache_lazy(xonsh_builtins):
@@ -63,7 +63,6 @@ def test_commands_cached_between_runs(commands_cache_tmp, tmp_path):
     for file in files:
         os.remove(file)
 
-@skip_if_on_darwin
 def test_commands_cache_uses_pickle_file(commands_cache_tmp, tmp_path):
     cc = commands_cache_tmp
     file = tmp_path / CommandsCache.CACHE_FILE

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -14,7 +14,7 @@ from xonsh.commands_cache import (
     predict_false,
 )
 from xonsh import commands_cache
-from tools import skip_if_on_windows
+from tools import skip_if_on_windows, skip_if_on_darwin
 
 
 def test_commands_cache_lazy(xonsh_builtins):
@@ -63,7 +63,7 @@ def test_commands_cached_between_runs(commands_cache_tmp, tmp_path):
     for file in files:
         os.remove(file)
 
-
+@skip_if_on_darwin
 def test_commands_cache_uses_pickle_file(commands_cache_tmp, tmp_path):
     cc = commands_cache_tmp
     file = tmp_path / CommandsCache.CACHE_FILE

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -128,7 +128,6 @@ echo
     # testing alias stack: callable alias (ExecAlias) + no binary location + infinite loop
     (
         """
-# skip_if_on_windows        
 aliases['first'] = "second @(1)"
 aliases['second'] = "first @(1)"
 first

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -102,40 +102,6 @@ f
         "hello\n",
         0,
     ),
-    # testing alias stack: lambda function
-    (
-        """
-# skip_if_on_windows
-def _echo():
-    echo hello
-
-aliases['echo'] = _echo
-echo
-""",
-        "hello\n",
-        0,
-    ),
-    # testing alias stack: ExecAlias
-    (
-        """
-# skip_if_on_windows        
-aliases['echo'] = "echo @('hello')"
-echo
-""",
-        "hello\n",
-        0,
-    ),
-    # testing alias stack: callable alias (ExecAlias) + no binary location + infinite loop
-    (
-        """
-# skip_if_on_windows        
-aliases['first'] = "second @(1)"
-aliases['second'] = "first @(1)"
-first
-""",
-        lambda out: 'Recursive calls to "first" alias.' in out,
-        0,
-    ),
     # test redirecting a function alias to a file
     (
         """
@@ -506,19 +472,56 @@ a
     ),
 ]
 
+UNIX_TESTS = [
+    # testing alias stack: lambda function
+    (
+        """
+def _echo():
+    echo hello
+
+aliases['echo'] = _echo
+echo
+""",
+        "hello\n",
+        0,
+    ),
+    # testing alias stack: ExecAlias
+    (
+        """
+aliases['echo'] = "echo @('hello')"
+echo
+""",
+        "hello\n",
+        0,
+    ),
+    # testing alias stack: callable alias (ExecAlias) + no binary location + infinite loop
+    (
+        """
+aliases['first'] = "second @(1)"
+aliases['second'] = "first @(1)"
+first
+""",
+        lambda out: 'Recursive calls to "first" alias.' in out,
+        0,
+    ),
+]
 
 @skip_if_no_xonsh
 @pytest.mark.parametrize("case", ALL_PLATFORMS)
 def test_script(case):
     script, exp_out, exp_rtn = case
-    if ON_WINDOWS and 'skip_if_on_windows' in script:
-        return
     out, err, rtn = run_xonsh(script)
     if callable(exp_out):
         assert exp_out(out)
     else:
         assert exp_out == out
     assert exp_rtn == rtn
+
+@skip_if_no_xonsh
+@skip_if_on_windows
+@pytest.mark.parametrize("case", UNIX_TESTS)
+def test_unix_tests(case):
+    test_script(case)
 
 
 ALL_PLATFORMS_STDERR = [

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -133,7 +133,7 @@ aliases['first'] = "second @(1)"
 aliases['second'] = "first @(1)"
 first
 """,
-        lambda out: 'Infinite loop of calls for "first" alias.' in out,
+        lambda out: 'Recursive calls to "first" alias.' in out,
         0,
     ),
     # test redirecting a function alias to a file

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -128,6 +128,7 @@ echo
     # testing alias stack: callable alias (ExecAlias) + no binary location + infinite loop
     (
         """
+# skip_if_on_windows        
 aliases['first'] = "second @(1)"
 aliases['second'] = "first @(1)"
 first

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -76,6 +76,8 @@ def check_run_xonsh(cmd, fmt, exp, exp_rtn=0):
     """The ``fmt`` parameter is a function
     that formats the output of cmd, can be None.
     """
+    if ON_WINDOWS and 'skip_if_on_windows' in cmd:
+        return
     out, err, rtn = run_xonsh(cmd, stderr=sp.PIPE)
     if callable(fmt):
         out = fmt(out)
@@ -105,6 +107,7 @@ f
     # testing alias stack: lambda function
     (
         """
+# skip_if_on_windows
 def _echo():
     echo hello
 
@@ -117,6 +120,7 @@ echo
     # testing alias stack: ExecAlias
     (
         """
+# skip_if_on_windows        
 aliases['echo'] = "echo @('hello')"
 echo
 """,
@@ -126,6 +130,7 @@ echo
     # testing alias stack: callable alias (ExecAlias) + no binary location + infinite loop
     (
         """
+# skip_if_on_windows        
 aliases['first'] = "second @(1)"
 aliases['second'] = "first @(1)"
 first

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -126,14 +126,11 @@ echo
     # testing alias stack: callable alias (ExecAlias) + no binary location + infinite loop
     (
         """
-aliases['nobinaryloc1'] = "nobinaryloc2 @(1)"
-aliases['nobinaryloc2'] = "nobinaryloc1 @(1)"
-try:
-    nobinaryloc2
-except:
-    print('qwe')
+aliases['first'] = "second @(1)"
+aliases['second'] = "first @(1)"
+first
 """,
-        lambda out: 'Infinite loop of calls for "nobinaryloc2" alias.' in out,
+        lambda out: 'Infinite loop of calls for "first" alias.' in out,
         0,
     ),
     # test redirecting a function alias to a file

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -76,8 +76,6 @@ def check_run_xonsh(cmd, fmt, exp, exp_rtn=0):
     """The ``fmt`` parameter is a function
     that formats the output of cmd, can be None.
     """
-    if ON_WINDOWS and 'skip_if_on_windows' in cmd:
-        return
     out, err, rtn = run_xonsh(cmd, stderr=sp.PIPE)
     if callable(fmt):
         out = fmt(out)
@@ -497,6 +495,8 @@ a
 @pytest.mark.parametrize("case", ALL_PLATFORMS)
 def test_script(case):
     script, exp_out, exp_rtn = case
+    if ON_WINDOWS and 'skip_if_on_windows' in script:
+        return
     out, err, rtn = run_xonsh(script)
     if callable(exp_out):
         assert exp_out(out)

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -500,16 +500,16 @@ class ProcProxyThread(threading.Thread):
             sp_stderr = sys.stderr
         # run the function itself
         try:
-            alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", "")
-            if self.get("ALIAS_NAME"):
-                alias_stack += ":" + self.env["ALIAS_NAME"]
+            alias_stack = builtins.__xonsh__.env.get("__ALIAS_STACK", "")
+            if self.env.get("__ALIAS_NAME"):
+                alias_stack += ":" + self.env["__ALIAS_NAME"]
 
             with STDOUT_DISPATCHER.register(sp_stdout), STDERR_DISPATCHER.register(
                 sp_stderr
             ), xt.redirect_stdout(STDOUT_DISPATCHER), xt.redirect_stderr(
                 STDERR_DISPATCHER
             ), builtins.__xonsh__.env.swap(
-                ALIAS_STACK=alias_stack
+                __ALIAS_STACK=alias_stack
             ):
                 r = self.f(self.args, sp_stdin, sp_stdout, sp_stderr, spec, spec.stack)
         except SystemExit as e:

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -500,11 +500,15 @@ class ProcProxyThread(threading.Thread):
             sp_stderr = sys.stderr
         # run the function itself
         try:
+            alias_stack = builtins.__xonsh__.env.get('ALIAS_STACK', '')
+            if self.env['ALIAS_NAME']:
+                alias_stack += ':' + self.env['ALIAS_NAME']
+
             with STDOUT_DISPATCHER.register(sp_stdout), STDERR_DISPATCHER.register(
                 sp_stderr
             ), xt.redirect_stdout(STDOUT_DISPATCHER), xt.redirect_stderr(
                 STDERR_DISPATCHER
-            ):
+            ), builtins.__xonsh__.env.swap(ALIAS_STACK=alias_stack):
                 r = self.f(self.args, sp_stdin, sp_stdout, sp_stderr, spec, spec.stack)
         except SystemExit as e:
             r = e.code if isinstance(e.code, int) else int(bool(e.code))

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -500,15 +500,17 @@ class ProcProxyThread(threading.Thread):
             sp_stderr = sys.stderr
         # run the function itself
         try:
-            alias_stack = builtins.__xonsh__.env.get('ALIAS_STACK', '')
-            if self.env['ALIAS_NAME']:
-                alias_stack += ':' + self.env['ALIAS_NAME']
+            alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", "")
+            if self.env["ALIAS_NAME"]:
+                alias_stack += ":" + self.env["ALIAS_NAME"]
 
             with STDOUT_DISPATCHER.register(sp_stdout), STDERR_DISPATCHER.register(
                 sp_stderr
             ), xt.redirect_stdout(STDOUT_DISPATCHER), xt.redirect_stderr(
                 STDERR_DISPATCHER
-            ), builtins.__xonsh__.env.swap(ALIAS_STACK=alias_stack):
+            ), builtins.__xonsh__.env.swap(
+                ALIAS_STACK=alias_stack
+            ):
                 r = self.f(self.args, sp_stdin, sp_stdout, sp_stderr, spec, spec.stack)
         except SystemExit as e:
             r = e.code if isinstance(e.code, int) else int(bool(e.code))

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -501,7 +501,7 @@ class ProcProxyThread(threading.Thread):
         # run the function itself
         try:
             alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", "")
-            if self.env["ALIAS_NAME"]:
+            if self.get("ALIAS_NAME"):
                 alias_stack += ":" + self.env["ALIAS_NAME"]
 
             with STDOUT_DISPATCHER.register(sp_stdout), STDERR_DISPATCHER.register(

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -355,6 +355,8 @@ class SubprocSpec:
         # pure attrs
         self.args = list(cmd)
         self.alias = None
+        self.alias_name = None
+        self.alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", '').split(':')
         self.binary_loc = None
         self.is_proxy = False
         self.background = False
@@ -442,6 +444,7 @@ class SubprocSpec:
         kwargs = {n: getattr(self, n) for n in self.kwnames}
         self.prep_env(kwargs)
         if callable(self.alias):
+            kwargs['env']['ALIAS_NAME'] = self.alias_name
             p = self.cls(self.alias, self.cmd, **kwargs)
         else:
             self.prep_preexec_fn(kwargs, pipeline_group=pipeline_group)
@@ -589,17 +592,29 @@ class SubprocSpec:
     def resolve_alias(self):
         """Sets alias in command, if applicable."""
         cmd0 = self.cmd[0]
+
+        if cmd0 in self.alias_stack:
+            # Disabling the alias resolving to prevent infinite loop in call stack
+            # and futher using binary_loc to resolve the alias name.
+            self.alias = None
+            return
+
         if callable(cmd0):
             alias = cmd0
         else:
             alias = builtins.aliases.get(cmd0, None)
+            if alias is not None:
+                self.alias_name = cmd0
         self.alias = alias
 
     def resolve_binary_loc(self):
         """Sets the binary location"""
         alias = self.alias
         if alias is None:
-            binary_loc = xenv.locate_binary(self.cmd[0])
+            cmd0 = self.cmd[0]
+            binary_loc = xenv.locate_binary(cmd0)
+            if binary_loc == cmd0 and cmd0 in self.alias_stack:
+                raise Exception(f'Infinite loop of calls for "{cmd0}" alias.')
         elif callable(alias):
             binary_loc = None
         else:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -356,7 +356,7 @@ class SubprocSpec:
         self.args = list(cmd)
         self.alias = None
         self.alias_name = None
-        self.alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", "").split(":")
+        self.alias_stack = builtins.__xonsh__.env.get("__ALIAS_STACK", "").split(":")
         self.binary_loc = None
         self.is_proxy = False
         self.background = False
@@ -444,7 +444,7 @@ class SubprocSpec:
         kwargs = {n: getattr(self, n) for n in self.kwnames}
         self.prep_env(kwargs)
         if callable(self.alias):
-            kwargs["env"]["ALIAS_NAME"] = self.alias_name
+            kwargs["env"]["__ALIAS_NAME"] = self.alias_name
             p = self.cls(self.alias, self.cmd, **kwargs)
         else:
             self.prep_preexec_fn(kwargs, pipeline_group=pipeline_group)

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -356,7 +356,7 @@ class SubprocSpec:
         self.args = list(cmd)
         self.alias = None
         self.alias_name = None
-        self.alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", '').split(':')
+        self.alias_stack = builtins.__xonsh__.env.get("ALIAS_STACK", "").split(":")
         self.binary_loc = None
         self.is_proxy = False
         self.background = False
@@ -444,7 +444,7 @@ class SubprocSpec:
         kwargs = {n: getattr(self, n) for n in self.kwnames}
         self.prep_env(kwargs)
         if callable(self.alias):
-            kwargs['env']['ALIAS_NAME'] = self.alias_name
+            kwargs["env"]["ALIAS_NAME"] = self.alias_name
             p = self.cls(self.alias, self.cmd, **kwargs)
         else:
             self.prep_preexec_fn(kwargs, pipeline_group=pipeline_group)

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -614,7 +614,7 @@ class SubprocSpec:
             cmd0 = self.cmd[0]
             binary_loc = xenv.locate_binary(cmd0)
             if binary_loc == cmd0 and cmd0 in self.alias_stack:
-                raise Exception(f'Infinite loop of calls for "{cmd0}" alias.')
+                raise Exception(f'Recursive calls to "{cmd0}" alias.')
         elif callable(alias):
             binary_loc = None
         else:


### PR DESCRIPTION
Closes #3159

Now we have transparent way to wrap commands into callable aliases.

Example 1:
```python
def _echo(args):
    echo @(args)
aliases['echo'] = _echo
echo ok
# Before: freezed on infinite loop
# After: ok
```

Example 2 - elegant ExecAlias (it will be awesome with #4201):
```python
aliases['echo'] = "echo @('ok')"  # ExecAlias
echo
# Before: freezed on infinite loop
# After: ok
```

Example 3 - show error for the user without freezing
```python
aliases['first'] = "second @(1)"  # ExecAlias just for demo
aliases['second'] = "first @(1)"  # ExecAlias just for demo
first
# Before: freezed on infinite loop
# After: Exception: Infinite loop of calls for "first" alias.
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
