### PR TITLE
Improve bash completions - Pass parsed command line to py-bash-commands

### DIFF
--- a/news/improve-bash-completions.rst
+++ b/news/improve-bash-completions.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Bash completions now handle quoted and space-containing arguments better.
+
+**Security:**
+
+* <news item>

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -2,12 +2,16 @@ import pytest
 
 from tests.tools import skip_if_on_windows, skip_if_on_darwin
 
+from xonsh.completers.tools import RichCompletion
 from xonsh.completers.bash import complete_from_bash
 from xonsh.parsers.completion_context import CompletionContext, CommandContext, CommandArg
 
 
 @pytest.fixture(autouse=True)
-def setup(monkeypatch, tmp_path):
+def setup(monkeypatch, tmp_path, xonsh_builtins):
+    if not xonsh_builtins.__xonsh__.env.get("BASH_COMPLETIONS"):
+        monkeypatch.setitem(xonsh_builtins.__xonsh__.env, "BASH_COMPLETIONS", ["/usr/share/bash-completion/bash_completion"])
+
     (tmp_path / "testdir").mkdir()
     (tmp_path / "spaced dir").mkdir()
     monkeypatch.chdir(str(tmp_path))
@@ -20,12 +24,50 @@ def setup(monkeypatch, tmp_path):
         (CommandContext(args=(CommandArg("bash"),), arg_index=1, prefix="--deb"), {"--debug", "--debugger"}, 5),
         (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix=""), {"'testdir/'", "'spaced dir/'"}, 0),
         (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="", opening_quote="'"), {"'testdir/'", "'spaced dir/'"}, 1),
-        pytest.param(CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="test", opening_quote="'"), {"'testdir/'"}, 1,
-            marks=pytest.mark.skip("bash completions don't consider the opening quote")),
 ))
-def test_bash_completer(command_context, completions, lprefix, xonsh_builtins, monkeypatch):
-    if not xonsh_builtins.__xonsh__.env.get("BASH_COMPLETIONS"):
-        monkeypatch.setitem(xonsh_builtins.__xonsh__.env, "BASH_COMPLETIONS", ["/usr/share/bash-completion/bash_completion"])
+def test_bash_completer(command_context, completions, lprefix):
     bash_completions, bash_lprefix = complete_from_bash(CompletionContext(command_context))
     assert bash_completions == completions and bash_lprefix == lprefix
 
+
+@skip_if_on_darwin
+@skip_if_on_windows
+@pytest.mark.parametrize("command_context, completions, lprefix", (
+        # ls /pro<TAB>  ->  ls /proc/
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="/pro"), {"/proc/"}, 4),
+
+        # ls '/pro<TAB>  ->  ls '/proc/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="/pro", opening_quote="'"), {"'/proc/'"}, 5),
+
+        # ls '/pro<TAB>'  ->  ls '/proc/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="/pro", opening_quote="'", closing_quote="'"), 
+            {"'/proc/"}, 5),
+
+        # ls '/pro'<TAB>  ->  ls '/proc/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="/pro", opening_quote="'", closing_quote="'",
+            is_after_closing_quote=True), {"'/proc/'"}, 6),
+
+        # ls """/pro"""<TAB>  ->  ls """/proc/"""
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="/pro", opening_quote='"""', closing_quote='"""',
+            is_after_closing_quote=True), {'"""/proc/"""'}, 10),
+
+        # Completions that have to be quoted:
+
+        # ls ./sp  ->  ls './spaced dir/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="./sp"), {"'./spaced dir/'"}, 4),
+
+        # ls './sp<TAB>  ->  ls './spaced dir/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="./sp", opening_quote="'"), {"'./spaced dir/'"}, 5),
+
+        # ls './sp<TAB>'  ->  ls './spaced dir/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="./sp", opening_quote="'", closing_quote="'"), 
+            {"'./spaced dir/"}, 5),
+
+        # ls './sp'<TAB>  ->  ls './spaced dir/'
+        (CommandContext(args=(CommandArg("ls"),), arg_index=1, prefix="./sp", opening_quote="'", closing_quote="'",
+            is_after_closing_quote=True), {"'./spaced dir/'"}, 6),
+))
+def test_quote_handling(command_context, completions, lprefix):
+    bash_completions, bash_lprefix = complete_from_bash(CompletionContext(command_context))
+    assert bash_completions == completions and bash_lprefix == lprefix
+    assert all(isinstance(comp, RichCompletion) and not comp.append_closing_quote for comp in bash_completions)  # make sure the completer handles the closing quote by itself

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -21,9 +21,7 @@ def complete_from_bash(context: CommandContext):
     line = " ".join(args)
 
     # lengths of all args + joining spaces
-    begidx = sum(len(a) for a in args[: context.arg_index]) + max(
-        context.arg_index - 1, 0
-    )
+    begidx = sum(len(a) for a in args[: context.arg_index]) + context.arg_index
     endidx = begidx + len(prefix)
 
     comps, lprefix = bash_completions(

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -1,6 +1,7 @@
 """Xonsh hooks into bash completions."""
 import builtins
 
+import xonsh.tools as xt
 import xonsh.platform as xp
 from xonsh.completers.path import _quote_paths
 from xonsh.completers.bash_completion import bash_completions
@@ -14,15 +15,23 @@ def complete_from_bash(context: CommandContext):
     env = builtins.__xonsh__.env.detype()  # type: ignore
     paths = builtins.__xonsh__.env.get("BASH_COMPLETIONS", ())  # type: ignore
     command = xp.bash_command()
-    # TODO: Allow passing the parsed data directly to py-bash-completion
-    args = [arg.raw_value for arg in context.args]
-    prefix = context.raw_prefix
+    args = [arg.value for arg in context.args]
+    prefix = context.prefix  # without the quotes
     args.insert(context.arg_index, prefix)
     line = " ".join(args)
 
     # lengths of all args + joining spaces
     begidx = sum(len(a) for a in args[: context.arg_index]) + context.arg_index
     endidx = begidx + len(prefix)
+
+    opening_quote = context.opening_quote
+    closing_quote = context.closing_quote
+    if closing_quote and not context.is_after_closing_quote:
+        # there already are closing quotes after our cursor, don't complete new ones (i.e. `ls "/pro<TAB>"`)
+        closing_quote = ""
+    elif opening_quote and not closing_quote:
+        # get the proper closing quote
+        closing_quote = xt.RE_STRING_START.sub("", opening_quote)
 
     comps, lprefix = bash_completions(
         prefix,
@@ -33,12 +42,28 @@ def complete_from_bash(context: CommandContext):
         paths=paths,
         command=command,
         quote_paths=_quote_paths,
+        line_args=args,
+        opening_quote=opening_quote,
+        closing_quote=closing_quote,
     )
 
-    def handle_space(comp: str):
+    def enrich_comps(comp: str):
+        append_space = False
         if comp.endswith(" "):
-            return RichCompletion(comp[:-1], append_space=True)
-        return comp
+            append_space = True
+            comp = comp.rstrip()
 
-    comps = set(map(handle_space, comps))
+        # ``bash_completions`` may have added closing quotes:
+        return RichCompletion(
+            comp, append_closing_quote=False, append_space=append_space
+        )
+
+    comps = set(map(enrich_comps, comps))
+
+    if lprefix == len(prefix):
+        lprefix += len(context.opening_quote)
+    if context.is_after_closing_quote:
+        # since bash doesn't see the closing quote, we need to add its length to lprefix
+        lprefix += len(context.closing_quote)
+
     return comps, lprefix

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -288,6 +288,9 @@ def bash_completions(
     paths=None,
     command=None,
     quote_paths=_bash_quote_paths,
+    line_args=None,
+    opening_quote="",
+    closing_quote="",
     **kwargs
 ):
     """Completes based on results from BASH completion.
@@ -320,6 +323,13 @@ def bash_completions(
         this as the default is acceptable 99+% of the time. This function should
         return a set of the new paths and a boolean for whether the paths were
         quoted.
+    line_args : list of str, optional
+        A list of the args in the current line to be used instead of ``line.split()``.
+        This is usefull with a space in an argument, e.g. ``ls 'a dir/'<TAB>``.
+    opening_quote : str, optional
+        The current argument's opening quote. This is passed to the `quote_paths` function.
+    closing_quote : str, optional
+        The closing quote that **should** be used. This is also passed to the `quote_paths` function.
 
     Returns
     -------
@@ -333,7 +343,7 @@ def bash_completions(
     if prefix.startswith("$"):  # do not complete env variables
         return set(), 0
 
-    splt = line.split()
+    splt = line_args or line.split()
     cmd = splt[0]
     cmd = os.path.basename(cmd)
     idx = n = 0
@@ -398,7 +408,7 @@ def bash_completions(
         strip_len += 1
 
     if "-o noquote" not in complete_stmt:
-        out, need_quotes = quote_paths(out, "", "")
+        out, need_quotes = quote_paths(out, opening_quote, closing_quote)
     if "-o nospace" in complete_stmt:
         out = set([x.rstrip() for x in out])
 


### PR DESCRIPTION
This PR passes the parsed command line (the real arguments and quotes to use).
Generally, the following scenarios functioned badly until now:

```
ls '/pro<TAB>
# ls /proc/

ls '/pro<TAB>'
# ls /proc/'

ls './spa<TAB>'
# ls './spaced dir''

ls './spa'<TAB>
# the bash completer won't work at all

ls './spaced d<TAB>
# the bash completer won't work
```

A matching PR is open at https://github.com/xonsh/py-bash-completion/pull/19

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
