### PR TITLE
feat: Added environment variable to hide unwanted printing the stderr when using captured object.

### DIFF
--- a/news/subproc_captured_print_stderr.rst
+++ b/news/subproc_captured_print_stderr.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added XONSH_SUBPROC_CAPTURED_PRINT_STDERR environment variable to hide unwanted printing the stderr when using captured object.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -174,6 +174,22 @@ print(x.returncode)
         "hallo on err\n1\n",
         0,
     ),
+    # test captured streaming alias without stderr
+    (
+        """
+def _test_stream(args, stdin, stdout, stderr):
+    print('hallo on err', file=stderr)
+    print('hallo on out', file=stdout)
+    return 1
+
+aliases['test-stream'] = _test_stream
+with __xonsh__.env.swap(XONSH_SUBPROC_CAPTURED_PRINT_STDERR=False):
+    x = !(test-stream)
+    print(x.returncode)
+""",
+        "1\n",
+        0,
+    ),
     # test piping aliases
     (
         """

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -857,6 +857,10 @@ class GeneralSetting(Xettings):
         "should cause an end to execution. This is less useful at a terminal. "
         "The error that is raised is a ``subprocess.CalledProcessError``.",
     )
+    XONSH_SUBPROC_CAPTURED_PRINT_STDERR = Var.with_default(
+        True,
+        "If ``True`` the stderr from captured subproc will be printed automatically."
+    )
     TERM = Var.no_default(
         "str",
         "TERM is sometimes set by the terminal emulator. This is used (when "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -859,7 +859,7 @@ class GeneralSetting(Xettings):
     )
     XONSH_SUBPROC_CAPTURED_PRINT_STDERR = Var.with_default(
         True,
-        "If ``True`` the stderr from captured subproc will be printed automatically."
+        "If ``True`` the stderr from captured subproc will be printed automatically.",
     )
     TERM = Var.no_default(
         "str",

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -377,12 +377,14 @@ class CommandPipeline:
         if self.stderr_postfix:
             b += self.stderr_postfix
         stderr_has_buffer = hasattr(sys.stderr, "buffer")
-        # write bytes to std stream
-        if stderr_has_buffer:
-            sys.stderr.buffer.write(b)
-        else:
-            sys.stderr.write(b.decode(encoding=enc, errors=err))
-        sys.stderr.flush()
+        show_stderr = (self.captured != 'object' or env.get("XONSH_SUBPROC_CAPTURED_PRINT_STDERR", True))
+        if show_stderr:
+            # write bytes to std stream
+            if stderr_has_buffer:
+                sys.stderr.buffer.write(b)
+            else:
+                sys.stderr.write(b.decode(encoding=enc, errors=err))
+            sys.stderr.flush()
         # save the raw bytes
         self._raw_error = b
         # do some munging of the line before we save it to the attr

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -396,7 +396,9 @@ class CommandPipeline:
         if self.stderr_postfix:
             b += self.stderr_postfix
         stderr_has_buffer = hasattr(sys.stderr, "buffer")
-        show_stderr = (self.captured != 'object' or env.get("XONSH_SUBPROC_CAPTURED_PRINT_STDERR", True))
+        show_stderr = self.captured != "object" or env.get(
+            "XONSH_SUBPROC_CAPTURED_PRINT_STDERR", True
+        )
         if show_stderr:
             # write bytes to std stream
             if stderr_has_buffer:


### PR DESCRIPTION
Closes #4021
Related #4220

Added XONSH_SUBPROC_CAPTURED_PRINT_STDERR environment variable to hide unwanted printing the stderr when using captured object.

Example:
```python
def _test_stream(args, stdin, stdout, stderr):
    print('hallo on err', file=stderr)
    print('hallo on out', file=stdout)
    return 1

aliases['test-stream'] = _test_stream

x = !(test-stream)
print(x.returncode)
# hallo on err
# 1

# Added:
with __xonsh__.env.swap(XONSH_SUBPROC_CAPTURED_PRINT_STDERR=False):
    x = !(test-stream)
    print(x.returncode)
# 1
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
