### PR TITLE
Do not repeat commands when searching them in history (using up arrow)

### DIFF
--- a/xonsh/ptk_shell/history.py
+++ b/xonsh/ptk_shell/history.py
@@ -25,8 +25,12 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
         hist = builtins.__xonsh__.history
         if hist is None:
             return
+        # Do not repeat commands when searching them in history (using up arrow)
+        lines = set()
         for cmd in hist.all_items(newest_first=True):
             line = cmd["inp"].rstrip()
+            lines.add(line)
+        for line in lines:
             strs = self.get_strings()
             if len(strs) == 0 or line != strs[-1]:
                 yield line


### PR DESCRIPTION
If you execute the same command N times, it appears also N times when using up arrow to search previous commands. It is more convenient for commands not to be repeated during this type of search (as, for example, in fish shell).
I have used a python set to solve this issue, although there may be a better solution.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
