### PR TITLE
DOC: Autoreformat most of the docs.

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -661,7 +661,6 @@ def xexec(args, stdin=None):
     If '-a' is supplied, the shell passes name as the zeroth argument
     to the executed command.
 
-
     Notes
     -----
     This command **is not** the same as the Python builtin function
@@ -755,8 +754,8 @@ def showcmd(args, stdin=None):
     optional arguments:
       -h, --help            show this help message and exit
 
-    Example:
-    -------
+    Examples
+    --------
       >>> showcmd echo $USER "can't" hear "the sea"
       ['echo', 'I', "can't", 'hear', 'the sea']
     """

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -1099,8 +1099,8 @@ def make_ansi_style(palette):
 def _pygments_to_ansi_style(style):
     """Tries to convert the given pygments style to ANSI style.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     style : pygments style value
 
     Returns

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -354,7 +354,7 @@ class CtxAwareTransformer(NodeTransformer):
         ----------
         node : ast.AST
             A syntax tree to transform.
-        input : str
+        inp : str
             The input code in string format.
         ctx : dict
             The root context to use.

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -460,7 +460,6 @@ def enter_macro(obj, raw_block, glbs, locs):
     of the macro block, globals, and locals to the object. These modifications
     are made in-place and the original object is returned.
 
-
     Parameters
     ----------
     obj : context manager

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -173,10 +173,10 @@ class CommandsCache(cabc.Mapping):
         Parameters
         ----------
         name : str
-                name of binary to search for
+            name of binary to search for
         ignore_alias : bool, optional
-                Force return of binary path even if alias of ``name`` exists
-                (default ``False``)
+            Force return of binary path even if alias of ``name`` exists
+            (default ``False``)
         """
         # make sure the cache is up to date by accessing the property
         _ = self.all_commands
@@ -188,10 +188,10 @@ class CommandsCache(cabc.Mapping):
         Parameters
         ----------
         name : str
-                name of binary to search for
+            name of binary to search for
         ignore_alias : bool, optional
-                Force return of binary path even if alias of ``name`` exists
-                (default ``False``)
+            Force return of binary path even if alias of ``name`` exists
+            (default ``False``)
         """
         possibilities = self.get_possible_names(name)
         if ON_WINDOWS:

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -105,7 +105,7 @@ class AbstractEvent(collections.abc.MutableSet, abc.ABC):
 
         Parameters
         ----------
-        **kwargs :
+        **kwargs
             Keyword arguments to pass to each handler
         """
 
@@ -166,7 +166,7 @@ class Event(AbstractEvent):
 
         Parameters
         ----------
-        **kwargs :
+        **kwargs
             Keyword arguments to pass to each handler
 
         Returns

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -226,7 +226,6 @@ def foreign_shell_data(
     dryrun : bool, optional
         Whether or not to actually run and process the command.
 
-
     Returns
     -------
     env : dict

--- a/xonsh/inspectors.py
+++ b/xonsh/inspectors.py
@@ -208,23 +208,21 @@ def call_tip(oinfo, format_call=True):
     Parameters
     ----------
     oinfo : dict
-
     format_call : bool, optional
-      If True, the call line is formatted and returned as a string.  If not, a
-      tuple of (name, argspec) is returned.
+        If True, the call line is formatted and returned as a string.  If not, a
+        tuple of (name, argspec) is returned.
 
     Returns
     -------
     call_info : None, str or (str, dict) tuple.
-      When format_call is True, the whole call information is formatted as a
-      single string.  Otherwise, the object's name and its argspec dict are
-      returned.  If no call information is available, None is returned.
-
+        When format_call is True, the whole call information is formatted as a
+        single string.  Otherwise, the object's name and its argspec dict are
+        returned.  If no call information is available, None is returned.
     docstring : str or None
-      The most relevant docstring for calling purposes is returned, if
-      available.  The priority is: call docstring for callable instances, then
-      constructor docstring for classes, then main object's docstring otherwise
-      (regular functions).
+        The most relevant docstring for calling purposes is returned, if
+        available.  The priority is: call docstring for callable instances, then
+        constructor docstring for classes, then main object's docstring otherwise
+        (regular functions).
     """
     # Get call definition
     argspec = oinfo.get("argspec")
@@ -269,7 +267,7 @@ def find_file(obj):
     Returns
     -------
     fname : str
-      The absolute path to the file where the object was defined.
+        The absolute path to the file where the object was defined.
     """
     # get source if obj was decorated with @decorator
     if safe_hasattr(obj, "__wrapped__"):
@@ -306,7 +304,7 @@ def find_source_lines(obj):
     Returns
     -------
     lineno : int
-      The line number where the object definition starts.
+        The line number where the object definition starts.
     """
     # get source if obj was decorated with @decorator
     if safe_hasattr(obj, "__wrapped__"):
@@ -445,9 +443,9 @@ class Inspector(object):
         Parameters
         ----------
         fields : list
-          A list of 2-tuples: (field_title, field_content)
+            A list of 2-tuples: (field_title, field_content)
         title_width : int
-          How many characters to pad titles to. Default to longest title.
+            How many characters to pad titles to. Default to longest title.
         """
         out = []
         if title_width == 0:
@@ -469,9 +467,9 @@ class Inspector(object):
         Parameters
         ----------
         fields : list
-          A list of 2-tuples: (field_title, field_content)
+            A list of 2-tuples: (field_title, field_content)
         title_width : int
-          How many characters to pad titles to. Default to longest title.
+            How many characters to pad titles to. Default to longest title.
         """
         out = []
         if title_width == 0:
@@ -499,9 +497,9 @@ class Inspector(object):
         Parameters
         ----------
         fields : list
-          A list of 2-tuples: (field_title, field_content)
+            A list of 2-tuples: (field_title, field_content)
         title_width : int
-          How many characters to pad titles to. Default to longest title.
+            How many characters to pad titles to. Default to longest title.
         """
         if HAS_PYGMENTS:
             rtn = self._format_fields_tokens(fields, title_width=title_width)

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -334,11 +334,11 @@ def handle_token(state, token):
 
     Parameters
     ----------
-    state :
+    state
         The current state of the lexer, including information about whether
         we are in Python mode or subprocess mode, which changes the lexer's
         behavior.  Also includes the stream of tokens yet to be considered.
-    token :
+    token
         The token (from ``tokenize``) currently under consideration
     """
     typ = token.type

--- a/xonsh/openpy.py
+++ b/xonsh/openpy.py
@@ -77,11 +77,11 @@ def read_py_file(filename, skip_encoding_cookie=True):
     Parameters
     ----------
     filename : str
-      The path to the file to read.
+        The path to the file to read.
     skip_encoding_cookie : bool
-      If True (the default), and the encoding declaration is found in the first
-      two lines, that line will be excluded from the output - compiling a
-      unicode string with an encoding declaration is a SyntaxError in Python 2.
+        If True (the default), and the encoding declaration is found in the first
+        two lines, that line will be excluded from the output - compiling a
+        unicode string with an encoding declaration is a SyntaxError in Python 2.
 
     Returns
     -------
@@ -100,14 +100,14 @@ def read_py_url(url, errors="replace", skip_encoding_cookie=True):
     Parameters
     ----------
     url : str
-      The URL from which to fetch the file.
+        The URL from which to fetch the file.
     errors : str
-      How to handle decoding errors in the file. Options are the same as for
-      bytes.decode(), but here 'replace' is the default.
+        How to handle decoding errors in the file. Options are the same as for
+        bytes.decode(), but here 'replace' is the default.
     skip_encoding_cookie : bool
-      If True (the default), and the encoding declaration is found in the first
-      two lines, that line will be excluded from the output - compiling a
-      unicode string with an encoding declaration is a SyntaxError in Python 2.
+        If True (the default), and the encoding declaration is found in the first
+        two lines, that line will be excluded from the output - compiling a
+        unicode string with an encoding declaration is a SyntaxError in Python 2.
 
     Returns
     -------

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1500,9 +1500,9 @@ def color_file(file_path: str, path_stat: os.stat_result) -> tp.Tuple[_TokenType
 
     Parameters
     ----------
-    file_path:
+    file_path
         relative path of file (as user typed it).
-    path_stat:
+    path_stat
         lstat() results for file_path.
 
     Returns

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1451,8 +1451,8 @@ def get_portions(it, slices):
 
     Parameters
     ----------
-    it: iterable
-    slices: a slice or a list of slice objects
+    it : iterable
+    slices : a slice or a list of slice objects
     """
     if is_slice(slices):
         slices = [slices]

--- a/xonsh/winutils.py
+++ b/xonsh/winutils.py
@@ -135,7 +135,7 @@ def sudo(executable, args=None):
 
     Parameters
     ----------
-    param executable : str
+    executable : str
         The path/name of the executable
     args : list of str
         The arguments to be passed to the executable

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -709,7 +709,7 @@ class PromptVisitor(StateVisitor):
             Tree of nodes to start visitor with.
         state : dict, optional
             Initial state to begin with.
-        kwargs : optional
+        **kwargs : optional
             Options that are passed through to the prompt via the shell's
             singleline() method. See BaseShell for mor details.
         """


### PR DESCRIPTION
this uses https://github.com/Carreau/velin to try to autoreformat all
docstrings in xonsh/*.py

In particular in Parameters section the space before the colon is
necessary for numpydoc to properly find the name and the type.

When no type is there numpydoc says that colon should be removed.

This also try to find if there are typo in parameter names and fix them
when possible.

As a sideeffect of parsing with numpydoc and reconstructing the
docstring from the parsed data some whitespace information is lost; but
that has the advantage of making the whitespace rules uniform
everywhere.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
