### PR TITLE
Fix for crash if $XONSH_COLOR_STYLE is set to something invalid

### DIFF
--- a/news/fix_invalid_style.rst
+++ b/news/fix_invalid_style.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed crash on statup if XONSH_COLOR_STYLE is set to something invalid.
+
+**Security:**
+
+* <news item>

--- a/tests/test_ansi_colors.py
+++ b/tests/test_ansi_colors.py
@@ -143,6 +143,20 @@ def test_ansi_color_name_to_escape_code_for_all_styles(color, style):
 
 
 @pytest.mark.parametrize(
+    "style_name",
+    [
+        ("default"),
+        ("monokai"),  # defined in `ansi_colors.py`
+        ("rainbow_dash"),  # not in `ansi_colors.py`, but in pygments
+        ("foobar"),  # invalid, should not fail
+    ]
+)
+def test_ansi_style_by_name(style_name):
+    style = ansi_style_by_name(style_name)
+    assert style is not None
+
+
+@pytest.mark.parametrize(
     "name, styles, refrules",
     [
         ("test1", {}, {}),

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -1160,8 +1160,12 @@ def ansi_style_by_name(name):
     elif not HAS_PYGMENTS:
         raise KeyError("could not find style {0!r}".format(name))
     from xonsh.pygments_cache import get_style_by_name
+    from pygments.util import ClassNotFound
 
-    pstyle = get_style_by_name(name)
+    try:
+        pstyle = get_style_by_name(name)
+    except (ModuleNotFoundError, ClassNotFound):
+        pstyle = get_style_by_name("default")
     palette = make_palette(pstyle.styles.values())
     astyle = make_ansi_style(palette)
     ANSI_STYLES[name] = astyle


### PR DESCRIPTION
Fixes the following issue:
```bash
bash> export XONSH_COLOR_STYLE="foobar"
bash> xonsh --no-rc
  File "/usr/lib/python3.9/site-packages/pygments/styles/__init__.py", line 72, in get_style_by_name
    mod = __import__('pygments.styles.' + mod, None, None, [cls])
ModuleNotFoundError: No module named 'pygments.styles.foobar'
...
pygments.util.ClassNotFound: Could not find style module 'foobar'.
Xonsh encountered an issue during launch
Failback to /bin/sh
sh-5.1$
```