### PR TITLE
Add support for rc.d drop-in configuration directories

### DIFF
--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -13,8 +13,13 @@ The system-wide ``xonshrc`` file controls options that are applied to all users 
 You can create this file in ``/etc/xonshrc`` for Linux and OSX and in ``%ALLUSERSPROFILE%\xonsh\xonshrc`` on Windows.
 
 Xonsh also allows a per-user run control file in your home directory, either
-directly in the home directory at ``~/.xonshrc`` or, for XDG compliance, at ``~/.config/rc.xsh``. 
+directly in the home directory at ``~/.xonshrc`` or, for XDG compliance, at ``~/.config/xonsh/rc.xsh``.
 The options set per user override settings in the system-wide control file.
+
+Xonsh also supports configuration directories, from which all ``.xsh`` files will be sourced in order.
+This allows for drop-in configuration where your configuration can be split across scripts and common
+and local configuration more easily separated. By default, if the directory ``~/.config/xonsh/rc.d``
+exists, any ``xsh`` files within will be sourced at startup.
 
 Xonsh provides 2 wizards to create your own "xonshrc".  ``xonfig web`` provides basic settings, and ``xonfig wizard``
 steps you through all the available options.

--- a/news/rc_dir.rst
+++ b/news/rc_dir.rst
@@ -1,0 +1,30 @@
+**Added:**
+
+* In addition to reading single rc files at startup (``/etc/xonshrc``, ``~/.config/xonsh/rc.xsh``),
+  xonsh now also supports rc.d-style config directories, from which all files are sourced. This is
+  designed to support drop-in style configuration where you could, for example, have a common config
+  file shared across multiple machines and a separate machine specific file.
+
+  This is controlled by the environment variable ``XONSHRCDIR``, which defaults to
+  ``["/etc/xonsh/rc.d", "~/.config/xonsh/rc.d"]``. If those directories exist, then any ``xsh`` files
+  contained within are sorted and then sourced.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/rc_dir.rst
+++ b/news/rc_dir.rst
@@ -5,7 +5,7 @@
   designed to support drop-in style configuration where you could, for example, have a common config
   file shared across multiple machines and a separate machine specific file.
 
-  This is controlled by the environment variable ``XONSHRCDIR``, which defaults to
+  This is controlled by the environment variable ``XONSHRC_DIR``, which defaults to
   ``["/etc/xonsh/rc.d", "~/.config/xonsh/rc.d"]``. If those directories exist, then any ``xsh`` files
   contained within are sorted and then sourced.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -109,7 +109,7 @@ def test_rcdir(shell, tmpdir, monkeypatch, capsys):
     rcdir = tmpdir.join("rc.d")
     rcdir.mkdir()
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-    monkeypatch.setitem(os.environ, "XONSHRCDIR", str(rcdir))
+    monkeypatch.setitem(os.environ, "XONSHRC_DIR", str(rcdir))
     monkeypatch.setitem(os.environ, "XONSH_CACHE_SCRIPTS", "False")
 
     rcdir.join("2.xsh").write("print('2.xsh')")
@@ -125,12 +125,12 @@ def test_rcdir(shell, tmpdir, monkeypatch, capsys):
 
 
 def test_rcdir_empty(shell, tmpdir, monkeypatch, capsys):
-    """Test that an empty XONSHRCDIR is not an error"""
+    """Test that an empty XONSHRC_DIR is not an error"""
 
     rcdir = tmpdir.join("rc.d")
     rcdir.mkdir()
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
-    monkeypatch.setitem(os.environ, "XONSHRCDIR", str(rcdir))
+    monkeypatch.setitem(os.environ, "XONSHRC_DIR", str(rcdir))
 
     xonsh.main.premain([])
     stdout, stderr = capsys.readouterr()
@@ -226,7 +226,7 @@ def test_custom_rc_with_script(shell, tmpdir):
 def test_premain_no_rc(shell, tmpdir):
     xonsh.main.premain(["--no-rc", "-i"])
     assert not builtins.__xonsh__.env.get("XONSHRC")
-    assert not builtins.__xonsh__.env.get("XONSHRCDIR")
+    assert not builtins.__xonsh__.env.get("XONSHRC_DIR")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -132,7 +132,7 @@ def test_rcdir_empty(shell, tmpdir, monkeypatch, capsys):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setitem(os.environ, "XONSHRCDIR", str(rcdir))
 
-    xonsh.main.premain()
+    xonsh.main.premain([])
     stdout, stderr = capsys.readouterr()
     assert len(stderr) == 0
 
@@ -226,6 +226,7 @@ def test_custom_rc_with_script(shell, tmpdir):
 def test_premain_no_rc(shell, tmpdir):
     xonsh.main.premain(["--no-rc", "-i"])
     assert not builtins.__xonsh__.env.get("XONSHRC")
+    assert not builtins.__xonsh__.env.get("XONSHRCDIR")
 
 
 @pytest.mark.parametrize(

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2154,7 +2154,13 @@ def locate_binary(name):
 def xonshrc_context(
     rcfiles=None, rcdirs=None, execer=None, ctx=None, env=None, login=True
 ):
-    """Attempts to read in all xonshrc files and return the context."""
+    """
+    Attempts to read in all xonshrc files and return the context.
+    The xonsh environment here is updated to reflect which RC files and
+    directory locations will have been loaded (if they existed). The updated
+    environment vars might be different (or empty) depending on CLI options
+    (--rc, --no-rc) or whether the session is interactive.
+    """
     loaded = env["LOADED_RC_FILES"] = []
     ctx = {} if ctx is None else ctx
     if rcfiles is None and rcdirs is None:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -6,6 +6,7 @@ import sys
 import pprint
 import textwrap
 import locale
+import glob
 import builtins
 import warnings
 import contextlib
@@ -611,6 +612,15 @@ def default_xonshrc(env):
 
 
 @default_value
+def default_xonshrcdir(env):
+    xdgrcd = os.path.join(xonsh_config_dir(env), "rc.d")
+    if ON_WINDOWS:
+        return (os.path.join(os_environ["ALLUSERSPROFILE"], "xonsh", "rc.d"), xdgrcd)
+    else:
+        return ("/etc/xonsh/rc.d", xdgrcd)
+
+
+@default_value
 def xonsh_append_newline(env):
     """Appends a newline if we are in interactive mode"""
     return env.get("XONSH_INTERACTIVE", False)
@@ -943,6 +953,18 @@ class GeneralSetting(Xettings):
             "On Linux & Mac OSX: ``['/etc/xonshrc', '~/.config/xonsh/rc.xsh', '~/.xonshrc']``\n"
             "\nOn Windows: "
             "``['%ALLUSERSPROFILE%\\\\xonsh\\\\xonshrc', '~/.config/xonsh/rc.xsh', '~/.xonshrc']``"
+        ),
+        type_str="env_path",
+    )
+    XONSHRCDIR = Var.with_default(
+        default_xonshrcdir,
+        "A list of directories, from which all .xsh files will be loaded "
+        "at startup, sorted in lexographic order. Files in these directories "
+        "are loaded after any files in XONSHRC.",
+        doc_default=(
+            "On Linux & Mac OSX: ``['/etc/xonsh/rc.d', '~/.config/xonsh/rc.d']``\n"
+            "On Windows: "
+            "``['%ALLUSERSPROFILE%\\\\xonsh\\\\rc.d', '~/.config/xonsh/rc.d']``"
         ),
         type_str="env_path",
     )
@@ -2129,21 +2151,34 @@ def locate_binary(name):
     return builtins.__xonsh__.commands_cache.locate_binary(name)
 
 
-def xonshrc_context(rcfiles=None, execer=None, ctx=None, env=None, login=True):
+def xonshrc_context(
+    rcfiles=None, rcdirs=None, execer=None, ctx=None, env=None, login=True
+):
     """Attempts to read in all xonshrc files and return the context."""
     loaded = env["LOADED_RC_FILES"] = []
     ctx = {} if ctx is None else ctx
-    if rcfiles is None:
+    if rcfiles is None and rcdirs is None:
         return env
     orig_thread = env.get("THREAD_SUBPROCS")
     env["THREAD_SUBPROCS"] = None
-    env["XONSHRC"] = tuple(rcfiles)
-    for rcfile in rcfiles:
-        if not os.path.isfile(rcfile):
-            loaded.append(False)
-            continue
-        status = xonsh_script_run_control(rcfile, ctx, env, execer=execer, login=login)
-        loaded.append(status)
+    if rcfiles:
+        env["XONSHRC"] = tuple(rcfiles)
+        for rcfile in rcfiles:
+            if not os.path.isfile(rcfile):
+                loaded.append(False)
+                continue
+            status = xonsh_script_run_control(
+                rcfile, ctx, env, execer=execer, login=login
+            )
+            loaded.append(status)
+    if rcdirs:
+        env["XONSHRCDIR"] = tuple(rcdirs)
+        for rcdir in rcdirs:
+            if os.path.isdir(rcdir):
+                for rcfile in sorted(glob.glob(os.path.join(rcdir, "*.xsh"))):
+                    status = xonsh_script_run_control(
+                        rcfile, ctx, env, execer=execer, login=login
+                    )
     if env["THREAD_SUBPROCS"] is None:
         env["THREAD_SUBPROCS"] = orig_thread
     return ctx

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2161,7 +2161,7 @@ def xonshrc_context(
         return env
     orig_thread = env.get("THREAD_SUBPROCS")
     env["THREAD_SUBPROCS"] = None
-    if rcfiles:
+    if rcfiles is not None:
         env["XONSHRC"] = tuple(rcfiles)
         for rcfile in rcfiles:
             if not os.path.isfile(rcfile):
@@ -2171,7 +2171,7 @@ def xonshrc_context(
                 rcfile, ctx, env, execer=execer, login=login
             )
             loaded.append(status)
-    if rcdirs:
+    if rcdirs is not None:
         env["XONSHRCDIR"] = tuple(rcdirs)
         for rcdir in rcdirs:
             if os.path.isdir(rcdir):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -956,7 +956,7 @@ class GeneralSetting(Xettings):
         ),
         type_str="env_path",
     )
-    XONSHRCDIR = Var.with_default(
+    XONSHRC_DIR = Var.with_default(
         default_xonshrcdir,
         "A list of directories, from which all .xsh files will be loaded "
         "at startup, sorted in lexographic order. Files in these directories "
@@ -2172,7 +2172,7 @@ def xonshrc_context(
             )
             loaded.append(status)
     if rcdirs is not None:
-        env["XONSHRCDIR"] = tuple(rcdirs)
+        env["XONSHRC_DIR"] = tuple(rcdirs)
         for rcdir in rcdirs:
             if os.path.isdir(rcdir):
                 for rcfile in sorted(glob.glob(os.path.join(rcdir, "*.xsh"))):

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -296,6 +296,8 @@ def start_services(shell_kwargs, args, pre_env={}):
     for k, v in pre_env.items():
         env[k] = v
 
+    # determine which RC files to load, including whether any RC directories
+    # should be scanned for such files
     if shell_kwargs.get("norc") or (
         args.mode != XonshMode.interactive
         and not args.force_interactive
@@ -305,9 +307,14 @@ def start_services(shell_kwargs, args, pre_env={}):
         # interactive mode was not forced, then disable loading RC files and dirs
         rc = ()
         rcd = ()
+    elif shell_kwargs.get("rc"):
+        # if an explicit --rc was passed, then we should load only that RC
+        # file, and nothing else (ignore both XONSHRC and XONSHRC_DIR)
+        rc = shell_kwargs.get("rc")
+        rcd = ()
     else:
-        # otherwise, get the RC files from --rc  if set, and from XONSHRC otherwise
-        rc = shell_kwargs.get("rc") or env.get("XONSHRC")
+        # otherwise, get the RC files from XONSHRC, and RC dirs from XONSHRC_DIR
+        rc = env.get("XONSHRC")
         rcd = env.get("XONSHRC_DIR")
 
     events.on_pre_rc.fire()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -308,7 +308,7 @@ def start_services(shell_kwargs, args, pre_env={}):
     else:
         # otherwise, get the RC files from --rc  if set, and from XONSHRC otherwise
         rc = shell_kwargs.get("rc") or env.get("XONSHRC")
-        rcd = env.get("XONSHRCDIR")
+        rcd = env.get("XONSHRC_DIR")
 
     events.on_pre_rc.fire()
     xonshrc_context(

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -297,6 +297,7 @@ def start_services(shell_kwargs, args, pre_env={}):
         env[k] = v
     rc = shell_kwargs.get("rc", None)
     rc = env.get("XONSHRC") if rc is None else rc
+    rcd = env.get("XONSHRCDIR")
     if (
         args.mode != XonshMode.interactive
         and not args.force_interactive
@@ -304,8 +305,11 @@ def start_services(shell_kwargs, args, pre_env={}):
     ):
         #  Don't load xonshrc if not interactive shell
         rc = None
+        rcd = None
     events.on_pre_rc.fire()
-    xonshrc_context(rcfiles=rc, execer=execer, ctx=ctx, env=env, login=login)
+    xonshrc_context(
+        rcfiles=rc, rcdirs=rcd, execer=execer, ctx=ctx, env=env, login=login
+    )
     events.on_post_rc.fire()
     # create shell
     builtins.__xonsh__.shell = Shell(execer=execer, **shell_kwargs)


### PR DESCRIPTION
This adds support for `rc.d` style configuration directories, where all contained config files are sourced in order. This technique is used by other shells (eg, `fish` supports `~/.config/fish/conf.d/*.fish`) and various unix tools (see all the `*.d` directories in `/etc`).

I find this useful as a way to split my configuration into a set of drop-in files rather than a single one, which means it's easy to share common bits of config across machines, while also having machine or account specific files.

This adds a new environment variable `XONSHRCDIR` (compare `XONSHRC`), which sets a list of directories to search. The defaults are `/etc/xonsh/rc.d` and `~/.config/xonsh/rc.d`, and from those any `*.xsh` files are sourced, after sorting to ensure predictable loading order. This happens after any "normal" rc files are loaded. Nothing happens if the directory does not exist.

(Alternative naming suggestions welcome)

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
