### PR TITLE
Add saving current working directory (cwd) to the history

### DIFF
--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -314,6 +314,9 @@ class BaseShell(object):
         self._styler = DefaultNotGiven
         self.prompt_formatter = PromptFormatter()
         self.accumulated_inputs = ""
+        self.precwd = (
+            None  # The current working directory just before execution of the line
+        )
 
     @property
     def styler(self):
@@ -347,6 +350,7 @@ class BaseShell(object):
 
     def precmd(self, line):
         """Called just before execution of line."""
+        self.precwd = os.getcwd()
         return line if self.need_more_lines else line.lstrip()
 
     def default(self, line, raw_line=None):
@@ -391,6 +395,7 @@ class BaseShell(object):
                 ts=[ts0, ts1],
                 spc=self.src_starts_with_space,
                 tee_out=tee_out,
+                cwd=self.precwd,
             )
             self.accumulated_inputs += src
             if (

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1050,11 +1050,6 @@ class GeneralSetting(Xettings):
         "Whether or not to store the stdin that is supplied to the "
         "``!()`` and ``![]`` operators.",
     )
-    XONSH_STORE_STDOUT = Var.with_default(
-        False,
-        "Whether or not to store the ``stdout`` and ``stderr`` streams in the "
-        "history files.",
-    )
     XONSH_STYLE_OVERRIDES = Var(
         is_str_str_dict,
         to_str_str_dict,
@@ -1188,21 +1183,6 @@ class PromptSetting(Xettings):
         "",
         "The string used to show a shortened directory in a shortened cwd, "
         "e.g. ``'…'``.",
-    )
-    HISTCONTROL = Var(
-        is_string_set,
-        csv_to_set,
-        set_to_csv,
-        set(),
-        "A set of strings (comma-separated list in string form) of options "
-        "that determine what commands are saved to the history list. By "
-        "default all commands are saved. The option ``ignoredups`` will not "
-        "save the command if it matches the previous command. The option "
-        "``ignoreerr`` will cause any commands that fail (i.e. return non-zero "
-        "exit status) to not be added to the history list. The option "
-        "``erasedups`` will remove all previous commands that matches and updates the frequency. "
-        "Note: ``erasedups`` is supported only in sqlite backend).",
-        can_store_as_str=True,
     )
     IGNOREEOF = Var.with_default(
         False,
@@ -1404,42 +1384,11 @@ class PromptSetting(Xettings):
         "* ``XONSH_GITSTATUS_BEHIND``: ``↓·``\n",
         pattern="XONSH_GITSTATUS_*",
     )
-    XONSH_HISTORY_BACKEND = Var(
-        is_history_backend,
-        to_itself,
-        ensure_string,
-        "json",
-        "Set which history backend to use. Options are: 'json', "
-        "'sqlite', and 'dummy'. The default is 'json'. "
-        "``XONSH_HISTORY_BACKEND`` also accepts a class type that inherits "
-        "from ``xonsh.history.base.History``, or its instance.",
-    )
-    XONSH_HISTORY_FILE = Var.with_default(
-        None,
-        "Location of history file set by history backend (default) or set by user in RC file.",
-        is_configurable=False,
-        doc_default="None",
-        type_str="path",
-    )
     XONSH_HISTORY_MATCH_ANYWHERE = Var.with_default(
         False,
         "When searching history from a partial string (by pressing up arrow), "
         "match command history anywhere in a given line (not just the start)",
         doc_default="False",
-    )
-    XONSH_HISTORY_SIZE = Var(
-        is_history_tuple,
-        to_history_tuple,
-        history_tuple_to_str,
-        (8128, "commands"),
-        "Value and units tuple that sets the size of history after garbage "
-        "collection. Canonical units are:\n\n"
-        "- ``commands`` for the number of past commands executed,\n"
-        "- ``files`` for the number of history files to keep,\n"
-        "- ``s`` for the number of seconds in the past that are allowed, and\n"
-        "- ``b`` for the number of bytes that history may consume.\n\n"
-        "Common abbreviations, such as '6 months' or '1 GB' are also allowed.",
-        doc_default="``(8128, 'commands')`` or ``'8128 commands'``",
     )
     XONSH_STDERR_PREFIX = Var.with_default(
         "",
@@ -1456,6 +1405,67 @@ class PromptSetting(Xettings):
         "conjunction with ``$XONSH_STDERR_PREFIX`` to start the block."
         "For example, to have stderr appear on a red background, the "
         'prefix & postfix pair would be "{BACKGROUND_RED}" & "{RESET}".',
+    )
+
+
+class PromptHistorySetting(Xettings):
+    """Interactive Prompt History"""
+
+    XONSH_HISTORY_BACKEND = Var(
+        is_history_backend,
+        to_itself,
+        ensure_string,
+        "json",
+        "Set which history backend to use. Options are: 'json', "
+        "'sqlite', and 'dummy'. The default is 'json'. "
+        "``XONSH_HISTORY_BACKEND`` also accepts a class type that inherits "
+        "from ``xonsh.history.base.History``, or its instance.",
+    )
+    XONSH_HISTORY_FILE = Var.with_default(
+        None,
+        "Location of history file set by history backend (default) or set by the user.",
+        is_configurable=False,
+        doc_default="None",
+        type_str="path",
+    )
+    HISTCONTROL = Var(
+        is_string_set,
+        csv_to_set,
+        set_to_csv,
+        set(),
+        "A set of strings (comma-separated list in string form) of options "
+        "that determine what commands are saved to the history list. By "
+        "default all commands are saved. The option ``ignoredups`` will not "
+        "save the command if it matches the previous command. The option "
+        "``ignoreerr`` will cause any commands that fail (i.e. return non-zero "
+        "exit status) to not be added to the history list. The option "
+        "``erasedups`` will remove all previous commands that matches and updates the frequency. "
+        "Note: ``erasedups`` is supported only in sqlite backend).",
+        can_store_as_str=True,
+    )
+    XONSH_HISTORY_SIZE = Var(
+        is_history_tuple,
+        to_history_tuple,
+        history_tuple_to_str,
+        (8128, "commands"),
+        "Value and units tuple that sets the size of history after garbage "
+        "collection. Canonical units are:\n\n"
+        "- ``commands`` for the number of past commands executed,\n"
+        "- ``files`` for the number of history files to keep,\n"
+        "- ``s`` for the number of seconds in the past that are allowed, and\n"
+        "- ``b`` for the number of bytes that history may consume.\n\n"
+        "Common abbreviations, such as '6 months' or '1 GB' are also allowed.",
+        doc_default="``(8128, 'commands')`` or ``'8128 commands'``",
+    )
+    XONSH_STORE_STDOUT = Var.with_default(
+        False,
+        "Whether or not to store the ``stdout`` and ``stderr`` streams in the "
+        "history files.",
+    )
+    XONSH_HISTORY_SAVE_CWD = Var.with_default(
+        True,
+        "Save current working directory to the history.",
+        doc_default="True",
     )
 
 

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -18,7 +18,8 @@ class HistoryEntry(types.SimpleNamespace):
     ts: two-tuple of floats
         The timestamps of when the command started and finished, including
         fractions.
-
+    cwd: str
+        The current working directory before execution the command.
     """
 
 
@@ -67,6 +68,7 @@ class History:
         self.rtns = None
         self.tss = None
         self.outs = None
+        self.cwds = None
         self.last_cmd_rtn = None
         self.last_cmd_out = None
         self.hist_size = None
@@ -87,15 +89,17 @@ class History:
                 out=self.outs[item],
                 rtn=self.rtns[item],
                 ts=self.tss[item],
+                cwd=self.cwds[item],
             )
         elif isinstance(item, slice):
             cmds = self.inps[item]
             outs = self.outs[item]
             rtns = self.rtns[item]
             tss = self.tss[item]
+            cwds = self.cwds[item]
             return [
-                HistoryEntry(cmd=c, out=o, rtn=r, ts=t)
-                for c, o, r, t in zip(cmds, outs, rtns, tss)
+                HistoryEntry(cmd=c, out=o, rtn=r, ts=t, cwd=cwd)
+                for c, o, r, t, cwd in zip(cmds, outs, rtns, tss, cwds)
             ]
         else:
             raise TypeError(

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -433,6 +433,8 @@ class JsonHistory(History):
         self.inps = JsonCommandField("inp", self)
         self.outs = JsonCommandField("out", self)
         self.rtns = JsonCommandField("rtn", self)
+        self.cwds = JsonCommandField("cwd", self)
+        self.save_cwd = builtins.__xonsh__.env.get("XONSH_HISTORY_SAVE_CWD", True)
 
     def __len__(self):
         return self._len - self._skipped
@@ -465,6 +467,9 @@ class JsonHistory(History):
 
         self.buffer.append(cmd)
         self._len += 1  # must come before flushing
+
+        if not self.save_cwd and "cwd" in cmd:
+            del cmd["cwd"]
 
         try:
             del cmd["spc"]
@@ -575,6 +580,7 @@ class JsonHistory(History):
         self.inps = JsonCommandField("inp", self)
         self.outs = JsonCommandField("out", self)
         self.rtns = JsonCommandField("rtn", self)
+        self.cwds = JsonCommandField("cwd", self)
         self._len = 0
         self._skipped = 0
 


### PR DESCRIPTION
Saving current working directory (cwd) to the history:
* Allows to implement the features like in [autojump](https://github.com/wting/autojump) or [zoxide](https://github.com/ajeetdsouza/zoxide) natively in xonsh.
* Allows to use cwd to get/suggest/complete the commands that were executed in the appropriate directory. For example if you have a project directory you want to use the history only from this directory.
* Allows to get the history from appropriate directory - it's more sane for human brain than searching by time.
* Allowing to make many kinds of tricks with SQLite database by counting statistics, filtering, updating, etc (see example of query below).

Testing example:
```python
bash
pip install -U git+https://github.com/anki-code/xonsh@history_save_paths

# Json history
XONSH_HISTORY_FILE=/tmp/hist.json xonsh --no-rc
echo 1
cd /tmp
echo 2
history flush
cat $XONSH_HISTORY_FILE | jq -c .data.cmds 
# [{"cwd":"/home/pc","inp":"echo 1\n","rtn":0,"ts":[1620552959.9635565,1620552959.9755843]},
# {"cwd":"/home/pc","inp":"cd /tmp\n","rtn":0,"ts":[1620552961.5285661,1620552961.537506]},
# {"cwd":"/tmp","inp":"echo 2\n","rtn":0,"ts":[1620552963.0651615,1620552963.0905378]}]
exit

# SQLite history
XONSH_HISTORY_BACKEND=sqlite XONSH_HISTORY_FILE=/tmp/hist.sqlite xonsh --no-rc
echo 1
cd /tmp
echo 2
sqlite3 /tmp/hist.sqlite  "SELECT * FROM xonsh_history;"
# echo 1|0|1620553077.97475|1620553077.99318|08cf4f7f-085b-4bd1-affa-6f349d67209c|||1|/home/pc
# cd /tmp|0|1620553079.5891|1620553079.59851|08cf4f7f-085b-4bd1-affa-6f349d67209c|||1|/home/pc
# echo 2|0|1620553080.66405|1620553080.69019|08cf4f7f-085b-4bd1-affa-6f349d67209c|||1|/tmp
exit
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
