### PR TITLE
Added history backend name to the xonfig.

### DIFF
--- a/news/xonfig_history_backend.rst
+++ b/news/xonfig_history_backend.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added history backend name to the xonfig.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -516,6 +516,7 @@ def _info(ns):
             ("have readline", is_readline_available()),
             ("prompt toolkit", ptk_version() or None),
             ("shell type", env.get("SHELL_TYPE")),
+            ("history backend", env.get("XONSH_HISTORY_BACKEND")),
             ("pygments", pygments_version()),
             ("on posix", bool(ON_POSIX)),
             ("on linux", bool(ON_LINUX)),


### PR DESCRIPTION
To review the reports around history like in #4268 we need history backend in the `xonfig` output.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
