### PR TITLE
ptk: Wrap selection with quotes/parens with $XONSH_AUTOPAIR

### DIFF
--- a/news/ptk-autopair-with-selection.rst
+++ b/news/ptk-autopair-with-selection.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Wrap selection with quote/parens when ``$XONSH_AUTOPAIR=True``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

![nice](https://user-images.githubusercontent.com/18242949/117583229-b76d8a80-b10e-11eb-8543-8cf46569fc4d.gif)

Supports `"`, `'`, `(`, `[`, `{`

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
