### PR TITLE
procs: Add $XONSH_CAPTURE_ALWAYS variable for opt-in interactive capt…

### DIFF
--- a/news/optional-interractive-capture.rst
+++ b/news/optional-interractive-capture.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* New ``$XONSH_CAPTURE_ALWAYS`` variable for opt-in interactive capturing.
+  Since this capturing breaks background jobs and some interactive programs (like ``git`` invoking an editor),
+  This behavior is now opt-in using this variable.
+  See https://github.com/xonsh/xonsh/pull/4283 and linked issues.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -16,6 +16,16 @@ from .tools import skip_if_on_windows
 def test_cmds_to_specs_thread_subproc(xession):
     env = xession.env
     cmds = [["pwd"]]
+
+    # XONSH_CAPTURE_ALWAYS=False should disable interactive threaded subprocs
+    env["XONSH_CAPTURE_ALWAYS"] = False
+    env["THREAD_SUBPROCS"] = True
+    specs = cmds_to_specs(cmds, captured="hiddenobject")
+    assert specs[0].cls is Popen
+
+    # Now for the other situations
+    env["XONSH_CAPTURE_ALWAYS"] = True
+
     # First check that threadable subprocs become threadable
     env["THREAD_SUBPROCS"] = True
     specs = cmds_to_specs(cmds, captured="hiddenobject")

--- a/tests/test_lib/test_os.xsh
+++ b/tests/test_lib/test_os.xsh
@@ -12,15 +12,15 @@ def test_indir():
     if ON_WINDOWS:
         pytest.skip("On Windows")
     with tempfile.TemporaryDirectory() as tmpdir:
-        assert ![pwd].output.strip() != tmpdir
+        assert $(pwd).strip() != tmpdir
         with indir(tmpdir):
-            assert ![pwd].output.strip() == tmpdir
-        assert ![pwd].output.strip() != tmpdir
+            assert $(pwd).strip() == tmpdir
+        assert $(pwd).strip() != tmpdir
         try:
             with indir(tmpdir):
                 raise Exception
         except Exception:
-            assert ![pwd].output.strip() != tmpdir
+            assert $(pwd).strip() != tmpdir
 
 
 def test_rmtree():

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -20,6 +20,7 @@ def patched_events(monkeypatch, xonsh_events, xonsh_execer):
     monkeypatch.setitem(
         XSH.env, "RAISE_SUBPROC_ERROR", False
     )  # for the failing `grep` commands
+    monkeypatch.setitem(XSH.env, "XONSH_CAPTURE_ALWAYS", True)  # capture output of ![]
     if ON_WINDOWS:
         monkeypatch.setattr(
             XSH,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -883,28 +883,33 @@ class GeneralSetting(Xettings):
         "not always happen.",
         is_configurable=False,
     )
+    XONSH_CAPTURE_ALWAYS = Var.with_default(
+        False,
+        "Try to capture output of commands run without explicit capturing.\n"
+        "If True, xonsh will capture the output of commands run directly or in ``![]``.\n"
+        "Setting to True has the following disadvantages:\n"
+        "* Some interactive commands won't work properly (like when ``git`` invokes an interactive editor).\n"
+        "  For more information see discussion at https://github.com/xonsh/xonsh/issues/3672.\n"
+        "* Stopping these commands with ^Z (i.e. ``SIGTSTP``)\n"
+        "  is disabled as it causes deadlocked terminals.\n"
+        "  ``SIGTSTP`` may still be issued and only the physical pressing\n"
+        "  of ``Ctrl+Z`` is ignored.\n\n"
+        "Regardless of this value, commands run in ``$()``, ``!()`` or with an IO redirection (``>`` or ``|``) "
+        "will always be captured.\n"
+        "Setting this to True depends on ``$THREAD_SUBPROCS`` being True.",
+    )
     THREAD_SUBPROCS = Var(
         is_bool_or_none,
         to_bool_or_none,
         bool_or_none_to_str,
         not ON_CYGWIN,
+        "Note: The ``$XONSH_CAPTURE_ALWAYS`` variable introduces finer control "
+        "and you should probably use that instead.\n\n"
         "Whether or not to try to run subrocess mode in a Python thread, "
-        "when applicable. There are various trade-offs, which normally "
-        "affects only interactive sessions.\n\nWhen True:\n\n"
-        "* Xonsh is able capture & store the stdin, stdout, and stderr \n"
+        "when trying to capture its output. There are various trade-offs.\n\n"
+        "If True, xonsh is able capture & store the stdin, stdout, and stderr \n"
         "  of threadable subprocesses.\n"
-        "* However, stopping threaded subprocs with ^Z (i.e. ``SIGTSTP``)\n"
-        "  is disabled as it causes deadlocked terminals.\n"
-        "  ``SIGTSTP`` may still be issued and only the physical pressing\n"
-        "  of ``Ctrl+Z`` is ignored.\n"
-        "* Threadable commands are run with ``PopenThread`` and threadable \n"
-        "  aliases are run with ``ProcProxyThread``.\n\n"
-        "When False:\n\n"
-        "* Xonsh may not be able to capture stdin, stdout, and stderr streams \n"
-        "  unless explicitly asked to do so.\n"
-        "* Stopping the thread with ``Ctrl+Z`` yields to job control.\n"
-        "* Threadable commands are run with ``Popen`` and threadable \n"
-        "  alias are run with ``ProcProxy``.\n\n"
+        "The disadvantages are listed in ``$XONSH_CAPTURE_ALWAYS``.\n"
         "The desired effect is often up to the command, user, or use case.\n\n"
         "None values are for internal use only and are used to turn off "
         "threading when loading xonshrc files. This is done because Bash "

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -734,6 +734,7 @@ def _update_last_spec(last):
         cmds_cache = XSH.commands_cache
         thable = (
             env.get("THREAD_SUBPROCS")
+            and (captured != "hiddenobject" or env.get("XONSH_CAPTURE_ALWAYS"))
             and cmds_cache.predict_threadable(last.args)
             and cmds_cache.predict_threadable(last.cmd)
         )


### PR DESCRIPTION
…uring

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Closes #4249
Closes #4304
Closes #4024
Closes #3672
Closes #3311
Closes #4318
Closes #3584
Closes #3672

Explanation from one of the issues:

> All these issues are indeed because xonsh tries to capture the output of interactive processes. 
> Turning `THREAD_SUBPROCS` off kinda fixes it but it isn't good either, since it means `$(...)` doesn't always work.
> We've decided to add a new `XONSH_CAPTURE_INTERACTIVE` variable that will give us better control and will be False by default


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
