### PR TITLE
Handle cancelled futures in AsyncPrompt

### DIFF
--- a/news/asyncprompt-handle-cancelled-future.rst
+++ b/news/asyncprompt-handle-cancelled-future.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Prevent cancelled future errors for async prompt ($ENABLE_ASYNC_PROMPT) fields from bubbling up (and destroying the prompt's formatting)
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/updator.py
+++ b/xonsh/ptk_shell/updator.py
@@ -89,7 +89,10 @@ class AsyncPrompt:
             print(f"Warn: AsyncPrompt is created without tokens - {self.name}")
             return
         for fut in concurrent.futures.as_completed(self.futures):
-            val = fut.result()
+            try:
+                val = fut.result()
+            except concurrent.futures.CancelledError:
+                continue
 
             if fut not in self.futures:
                 # rare case where the future is completed but the container is already cleared


### PR DESCRIPTION
Prevent cancelled future errors for async prompt fields from bubbling up (and destroying the prompt's formatting). This happens for example when I keep holding down my enter key: after a while I will get tracebacks about uncaught `concurrent.futures.CancelledError`. This fixes this issue and prevents them from bubbling up.