### PR TITLE
Update completer cli

### DIFF
--- a/news/update-completer-cli.rst
+++ b/news/update-completer-cli.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The ``completer add`` command after the non-exclusive completers.
+  This means it will not block them from adding their completions.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/aliases/test_completer_alias.py
+++ b/tests/aliases/test_completer_alias.py
@@ -1,0 +1,35 @@
+import pytest
+
+from xonsh.built_ins import XSH
+from xonsh.completers._aliases import add_one_completer
+from xonsh.completers.tools import non_exclusive_completer
+
+SIMPLE = lambda: None
+NON_EXCLUSIVE = non_exclusive_completer(lambda: None)
+
+
+@pytest.mark.parametrize(
+    "initial, exp",
+    (
+        ({}, ["new"]),
+        ({"simp": SIMPLE}, ["new", "simp"]),
+        ({"nx": NON_EXCLUSIVE}, ["nx", "new"]),
+        ({"nx": NON_EXCLUSIVE, "simp": SIMPLE}, ["nx", "new", "simp"]),
+        (
+            {"ctx1": NON_EXCLUSIVE, "ctx2": NON_EXCLUSIVE, "simp": SIMPLE},
+            ["ctx1", "ctx2", "new", "simp"],
+        ),
+        (
+            {"ctx1": NON_EXCLUSIVE, "ctx2": NON_EXCLUSIVE, "simp": SIMPLE},
+            ["ctx1", "ctx2", "new", "simp"],
+        ),
+        (
+            {"ctx1": NON_EXCLUSIVE, "simp": SIMPLE, "ctx2": NON_EXCLUSIVE},
+            ["ctx1", "new", "simp", "ctx2"],
+        ),
+    ),
+)
+def test_add_completer_start(monkeypatch, initial, exp):
+    monkeypatch.setattr(XSH, "completers", initial)
+    add_one_completer("new", SIMPLE, "start")
+    assert list(XSH.completers.keys()) == exp

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -49,7 +49,7 @@ def _register_completer(name: str, func: str, pos="start", stack=None):
         position into the list of completers at which the new
         completer should be added.  It can be one of the following values:
         * "start" indicates that the completer should be added to the start of
-                 the list of completers (it should be run before all others)
+                 the list of completers (it should be run before all other exclusive completers)
         * "end" indicates that the completer should be added to the end of the
                list of completers (it should be run after all others)
         * ">KEY", where KEY is a pre-existing name, indicates that this should

--- a/xonsh/completers/completer.py
+++ b/xonsh/completers/completer.py
@@ -89,17 +89,22 @@ def add_one_completer(name, func, loc="end"):
 
 def list_completers():
     """List the active completers"""
-    o = "Registered Completer Functions: \n"
+    o = "Registered Completer Functions: (NX = Non Exclusive)\n\n"
+    non_exclusive = " [NX]"
     _comp = XSH.completers
     ml = max((len(i) for i in _comp), default=0)
+    exclusive_len = ml + len(non_exclusive) + 1
     _strs = []
     for c in _comp:
         if _comp[c].__doc__ is None:
             doc = "No description provided"
         else:
             doc = " ".join(_comp[c].__doc__.split())
-        doc = justify(doc, 80, ml + 3)
-        _strs.append("{: >{}} : {}".format(c, ml, doc))
+        doc = justify(doc, 80, exclusive_len + 3)
+        if is_exclusive_completer(_comp[c]):
+            _strs.append("{: <{}} : {}".format(c, exclusive_len, doc))
+        else:
+            _strs.append("{: <{}} {} : {}".format(c, ml, non_exclusive, doc))
     return o + "\n".join(_strs) + "\n"
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

1. Print which completers are non exclusive in `completer list`:
![image](https://user-images.githubusercontent.com/18242949/120085639-96cb9b80-c0e2-11eb-86e2-4661f0da37d0.png)

2. When adding a new completer via `completer add`, add it before the **exclusive** completers.
This means it won't interfere with the non-exclusive ones. (see more detailed comment in code)

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
