### PR TITLE
Fix empty command error message

### DIFF
--- a/news/empty-command-handling.rst
+++ b/news/empty-command-handling.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed error message when an empty command is run
+* Fixed @$ crash when no output is sent out by the command
+* Fixed xonsh crash when launched using `xonsh -c '$("")'`
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -602,18 +602,21 @@ _bad_case = pytest.mark.skipif(
     ON_DARWIN or ON_WINDOWS or ON_TRAVIS, reason="bad platforms"
 )
 
+
 @skip_if_no_xonsh
 def test_atdollar_no_output():
     # see issue 1521
-    script="@$(echo)\n"
+    script = "@$(echo)\n"
     out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
     assert "command is empty" in err
 
+
 @skip_if_no_xonsh
 def test_empty_command():
-    script="$['']\n"
+    script = "$['']\n"
     out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
     assert "command is empty" in err
+
 
 @skip_if_no_xonsh
 @_bad_case

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -606,7 +606,12 @@ _bad_case = pytest.mark.skipif(
 @skip_if_no_xonsh
 def test_atdollar_no_output():
     # see issue 1521
-    script = "@$(echo)\n"
+    script = """
+def _echo(args):
+    print(' '.join(args))
+    aliases['echo'] = _echo
+@$(echo)
+"""
     out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
     assert "command is empty" in err
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -602,6 +602,18 @@ _bad_case = pytest.mark.skipif(
     ON_DARWIN or ON_WINDOWS or ON_TRAVIS, reason="bad platforms"
 )
 
+@skip_if_no_xonsh
+def test_atdollar_no_output():
+    # see issue 1521
+    script="@$(echo)\n"
+    out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
+    assert "command is empty" in err
+
+@skip_if_no_xonsh
+def test_empty_command():
+    script="$['']\n"
+    out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
+    assert "command is empty" in err
 
 @skip_if_no_xonsh
 @_bad_case

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -14,3 +14,6 @@ def test_githash_value_error(monkeypatch):
     sha, date_ = xp.githash()
     assert date_ is None
     assert sha is None
+
+def test_pathsplit_empty_path():
+    assert xp.pathsplit('')==('','')

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -15,5 +15,6 @@ def test_githash_value_error(monkeypatch):
     assert date_ is None
     assert sha is None
 
+
 def test_pathsplit_empty_path():
-    assert xp.pathsplit('')==('','')
+    assert xp.pathsplit("") == ("", "")

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -232,6 +232,9 @@ def pathsplit(p):
     without a drive.
     """
     n = len(p)
+    if n == 0:
+        # lazy object seps does not get initialized when n is zero
+        return "", ""
     while n and p[n - 1] not in seps:
         n -= 1
     pre = p[:n]

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -458,6 +458,8 @@ class SubprocSpec:
         return p
 
     def _run_binary(self, kwargs):
+        if not self.cmd[0]:
+            raise xt.XonshError("xonsh: subprocess mode: command is empty")
         bufsize = 1
         try:
             p = self.cls(self.cmd, bufsize=bufsize, **kwargs)
@@ -553,6 +555,8 @@ class SubprocSpec:
         modifications and adjustments based on the actual cmd that
         was received.
         """
+        if not cmd:
+            raise xt.XonshError("xonsh: subprocess mode: command is empty")
         # modifications that do not alter cmds may come before creating instance
         spec = kls(cmd, cls=cls, **kwargs)
         # modifications that alter cmds must come after creating instance


### PR DESCRIPTION
Fixes #2329
Fixes #4287 

Prints a helpful error message (`xonsh: subprocess mode: command is empty`) when an empty command is run (for example using `@$(echo)` or `$['']`).

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
