### PR TITLE
Address ON_WSL() bug #4310

### DIFF
--- a/news/fix_wsl_detection.rst
+++ b/news/fix_wsl_detection.rst
@@ -1,5 +1,6 @@
 **Added:**
-* 'on wsl' field when running xonfig (when linux is detected)
+
+* ``on wsl`` field when running xonfig (when linux is detected)
 
 **Changed:**
 

--- a/news/fix_wsl_detection.rst
+++ b/news/fix_wsl_detection.rst
@@ -9,6 +9,7 @@
 **Removed:**
 
 **Fixed:**
+
 * wsl detection works on archlinux wsl2 now (and hopefully everywhere)
 
 **Security:**

--- a/news/fix_wsl_detection.rst
+++ b/news/fix_wsl_detection.rst
@@ -4,12 +4,21 @@
 
 **Changed:**
 
+* <news item>
+
 **Deprecated:**
 
+* <news item>
+
 **Removed:**
+
+* <news item>
 
 **Fixed:**
 
 * wsl detection works on archlinux wsl2 now (and hopefully everywhere)
 
 **Security:**
+
+* <news item>
+

--- a/news/fix_wsl_detection.rst
+++ b/news/fix_wsl_detection.rst
@@ -1,5 +1,5 @@
 **Added:**
-* 'on wsl' field when running xonfig
+* 'on wsl' field when running xonfig (when linux is detected)
 
 **Changed:**
 

--- a/news/fix_wsl_detection.rst
+++ b/news/fix_wsl_detection.rst
@@ -1,0 +1,13 @@
+**Added:**
+* 'on wsl' field when running xonfig
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+* wsl detection works on archlinux wsl2 now (and hopefully everywhere)
+
+**Security:**

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -87,7 +87,7 @@ def ON_BEOS():
 @lazybool
 def ON_WSL():
     """True if we are on Windows Subsystem for Linux (WSL)"""
-    return "Microsoft" in platform.release()
+    return "microsoft" in platform.release()
 
 
 #

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -528,6 +528,7 @@ def _info(ns):
         [
             ("on darwin", bool(ON_DARWIN)),
             ("on windows", bool(ON_WINDOWS)),
+            ("on wsl", bool(ON_WSL)),
             ("on cygwin", bool(ON_CYGWIN)),
             ("on msys2", bool(ON_MSYS)),
             ("is superuser", is_superuser()),

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -524,11 +524,11 @@ def _info(ns):
     )
     if ON_LINUX:
         data.append(("distro", linux_distro()))
+        data.append(("on wsl", bool(ON_WSL))),
     data.extend(
         [
             ("on darwin", bool(ON_DARWIN)),
             ("on windows", bool(ON_WINDOWS)),
-            ("on wsl", bool(ON_WSL)),
             ("on cygwin", bool(ON_CYGWIN)),
             ("on msys2", bool(ON_MSYS)),
             ("is superuser", is_superuser()),

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -30,6 +30,7 @@ from xonsh.platform import (
     ON_POSIX,
     ON_LINUX,
     linux_distro,
+    ON_WSL,
     ON_DARWIN,
     ON_WINDOWS,
     ON_CYGWIN,


### PR DESCRIPTION
Solution for #4310
```python
return "microsoft" in platform.release().lower()
return "wsl" in platform.release().lower()
```
one of these may be a better solution depending on if the result of `platform.release()` varies by distro/wsl version

Output for ArchLinux WSL2:
`5.4.72-microsoft-standard-WSL2`

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
