### PR TITLE
linux: Quote command-not-found argument

### DIFF
--- a/news/command-not-found-quote.rst
+++ b/news/command-not-found-quote.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Crashing command-not-found output for bad file names on linux.
+
+**Security:**
+
+* <news item>

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -38,6 +38,7 @@ import operator
 import ast
 import string
 import typing as tp
+import shlex
 
 # adding imports from further xonsh modules is discouraged to avoid circular
 # dependencies
@@ -837,7 +838,7 @@ def debian_command_not_found(cmd):
 
     c = "{0} {1}; exit 0"
     s = subprocess.check_output(
-        c.format(cnf, cmd),
+        c.format(cnf, shlex.quote(cmd)),
         universal_newlines=True,
         stderr=subprocess.STDOUT,
         shell=True,


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

To reproduce:
```
$ aliases['a'] = 'bad(command'
$ a
subprocess.CalledProcessError: Command '/usr/lib/command-not-found bad(command); exit 0' returned non-zero exit status 2.
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
