### PR TITLE
Fix atdollar_no_output test

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -609,7 +609,7 @@ def test_atdollar_no_output():
     script = """
 def _echo(args):
     print(' '.join(args))
-    aliases['echo'] = _echo
+aliases['echo'] = _echo
 @$(echo)
 """
     out, err, rtn = run_xonsh(script, stderr=sp.PIPE)


### PR DESCRIPTION
This test was failing on Windows because of an incorrect indentation. The `echo` command was not actually getting aliased to the `_echo` function.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
