### PR TITLE
docs: Remove duplicate Installation heading

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,9 +1,5 @@
-
 Installation
 ============
-
-Installation
-------------
 
 Xonsh can be installed and run with various package managers, by using appimage, or from a docker container:
 


### PR DESCRIPTION
There is currently an "Installation" heading with another "Installation" subheading under it (and no other subheadings).

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
