### PR TITLE
Move coloring stat calls to another thread

### DIFF
--- a/news/coloring-stat-calls.rst
+++ b/news/coloring-stat-calls.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed unresponsive prompt when coloring is enabled and the path to an unreachable network share is entered
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Fixes #2578 

Moves the `stat` calls required for coloring paths to another thread, and sets a timeout. This prevents xonsh from becoming unresponsive when coloring is enabled and the path to an unreachable network share is entered.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
