### PR TITLE
Fix parser for subprocess command with leading whitespace

### DIFF
--- a/news/fix-subproc-leading-space.rst
+++ b/news/fix-subproc-leading-space.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* In a subprocess command, having whitespace in between the left bracket and the command no longer raises a SyntaxError.
+
+**Security:**
+
+* <news item>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2180,16 +2180,16 @@ def test_dollar_sub():
     check_xonsh_ast({}, "$(ls)", False)
 
 
-def test_dollar_sub_trailing_space():
-    check_xonsh_ast({}, "$(ls )", False)
-
-
-def test_dollar_sub_leading_space():
-    check_xonsh_ast({}, "$( ls)", False)
-
-
-def test_dollar_sub_leading_trailing_space():
-    check_xonsh_ast({}, "$( ls )", False)
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "$(ls )",
+        "$( ls)",
+        "$( ls )",
+    ],
+)
+def test_dollar_sub_space(expr):
+    check_xonsh_ast({}, expr, False)
 
 
 def test_ls_dot():
@@ -2254,16 +2254,16 @@ def test_bang_sub():
     check_xonsh_ast({}, "!(ls)", False)
 
 
-def test_bang_sub_trailing_space():
-    check_xonsh_ast({}, "!(ls )", False)
-
-
-def test_bang_sub_leading_space():
-    check_xonsh_ast({}, "!( ls)", False)
-
-
-def test_bang_sub_leading_trailing_space():
-    check_xonsh_ast({}, "!( ls )", False)
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "!(ls )",
+        "!( ls)",
+        "!( ls )",
+    ],
+)
+def test_bang_sub_space(expr):
+    check_xonsh_ast({}, expr, False)
 
 
 def test_bang_ls_dot():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2180,8 +2180,16 @@ def test_dollar_sub():
     check_xonsh_ast({}, "$(ls)", False)
 
 
-def test_dollar_sub_space():
+def test_dollar_sub_trailing_space():
     check_xonsh_ast({}, "$(ls )", False)
+
+
+def test_dollar_sub_leading_space():
+    check_xonsh_ast({}, "$( ls)", False)
+
+
+def test_dollar_sub_leading_trailing_space():
+    check_xonsh_ast({}, "$( ls )", False)
 
 
 def test_ls_dot():
@@ -2246,8 +2254,16 @@ def test_bang_sub():
     check_xonsh_ast({}, "!(ls)", False)
 
 
-def test_bang_sub_space():
+def test_bang_sub_trailing_space():
     check_xonsh_ast({}, "!(ls )", False)
+
+
+def test_bang_sub_leading_space():
+    check_xonsh_ast({}, "!( ls)", False)
+
+
+def test_bang_sub_leading_trailing_space():
+    check_xonsh_ast({}, "!( ls )", False)
 
 
 def test_bang_ls_dot():

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -3104,6 +3104,10 @@ class BaseParser(object):
         p1 = p[1]
         p[0] = [self._subproc_cliargs(p1, lineno=self.lineno, col=self.col)]
 
+    def p_subproc_s1(self, p):
+        """subproc : WS subproc"""
+        p[0] = p[2]
+
     def p_subproc_amper(self, p):
         """subproc : subproc amper"""
         p1 = p[1]


### PR DESCRIPTION
Fixes #4082

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
