### PR TITLE
Fix output capturing for !() and @$() when $THREAD_SUBPROCS is set to False

### DIFF
--- a/news/fix-capture-object-nonthread.rst
+++ b/news/fix-capture-object-nonthread.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed output capturing for !() and @$() when $THREAD_SUBPROCS is set to False
+
+**Security:**
+
+* <news item>

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -249,6 +249,10 @@ class CommandPipeline:
                 proc.wait()
                 self._endtime()
                 if self.captured == "object":
+                    if stdout:
+                        b = stdout.read()
+                        s = self._decode_uninew(b, universal_newlines=True)
+                        self.lines = s.splitlines(keepends=True)
                     self.end(tee_output=False)
                 elif self.captured == "hiddenobject" and stdout:
                     b = stdout.read()

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -742,7 +742,7 @@ def _update_last_spec(last):
         elif not thable:
             # foreground processes should use Popen
             last.threadable = False
-            if captured == "object" or captured == "hiddenobject":
+            if captured == "hiddenobject":
                 # CommandPipeline objects should not pipe stdout, stderr
                 return
     # cannot used PTY pipes for aliases, for some dark reason,


### PR DESCRIPTION
Fixes #4056

!() and @$() both use `xonsh.procs.specs.run_subproc(cmds, captured="object", envs=envs)` to capture the command results. This PR allows them to work properly when $THREAD_SUBPROCS is set to False.

Currently, when $THREAD_SUBPROCS is set to False:
- `!(echo hi).out` is an empty string (it should be `'hi\n'`)
- Running the command `@$(echo ls)` results in the error message `xonsh: subprocess mode: command is empty`

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
