### PR TITLE
Stop $() from silently capturing stderr

### DIFF
--- a/news/capture-stdout-without-stderr.rst
+++ b/news/capture-stdout-without-stderr.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* $() no longer silently captures stderr
+
+**Security:**
+
+* <news item>

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -47,6 +47,18 @@ def test_cmds_to_specs_thread_subproc(xession):
     assert specs[0].cls is ProcProxy
 
 
+@pytest.mark.parametrize("thread_subprocs", [True, False])
+def test_cmds_to_specs_capture_stdout_not_stderr(thread_subprocs):
+    env = XSH.env
+    cmds = (["ls", "/root"],)
+
+    env["THREAD_SUBPROCS"] = thread_subprocs
+
+    specs = cmds_to_specs(cmds, captured="stdout")
+    assert specs[0].stdout is not None
+    assert specs[0].stderr is None
+
+
 @skip_if_on_windows
 @pytest.mark.parametrize(
     "thread_subprocs, capture_always", list(itertools.product((True, False), repeat=2))

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -776,6 +776,8 @@ def _update_last_spec(last):
     # set standard error
     if last.stderr is not None:
         pass
+    elif captured == "stdout":
+        pass
     elif captured == "object":
         r, w = os.pipe()
         last.stderr = safe_open(w, "w")


### PR DESCRIPTION
Fixes #3786 

Currently, doing something like:
```xonsh
result=$(ls /root)
```
silently fails. This is because `$()` captures both stdout and stderr, but does not do anything with the stderr.

This PR makes `$()` only capture stdout, so that the stderr is printed to the console. This way, running `result=$(ls /root)` prints the error message:
```
ls: cannot open directory '/root': Permission denied
```

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
