### PR TITLE
Enable bracketed paste mode for readline

### DIFF
--- a/news/enable-bracketed-paste.rst
+++ b/news/enable-bracketed-paste.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Enabled bracketed paste mode for readline to protect against paste jacking
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -161,6 +161,13 @@ def setup_readline():
         except Exception:
             # this seems to fail with libedit
             print_exception("xonsh: could not load readline default init file.")
+
+    # Protection against paste jacking (issue #1154)
+    # This must be set after the init file is loaded since read_init_file()
+    # automatically disables bracketed paste
+    # (https://github.com/python/cpython/pull/24108)
+    readline.parse_and_bind("set enable-bracketed-paste on")
+
     # properly reset input typed before the first prompt
     readline.set_startup_hook(carriage_return)
 


### PR DESCRIPTION
Closes #1154

This PR protects users against paste jacking when using the readline shell. When a user pastes a line containing a newline character, they now have to press Enter to execute the line.

See [dxa4481/Pastejacking](https://github.com/dxa4481/Pastejacking) for a detailed explanation on paste jacking, [https://security.love/Pastejacking/](https://security.love/Pastejacking/) for a working demo.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
