### PR TITLE
feat: add completions for vox

### DIFF
--- a/news/vox-completions.rst
+++ b/news/vox-completions.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Completions for vox

--- a/xonsh/completers/vox.py
+++ b/xonsh/completers/vox.py
@@ -1,0 +1,50 @@
+"""Completers for vox."""
+# pylint: disable=invalid-name, missing-docstring, unsupported-membership-test
+# pylint: disable=unused-argument, not-an-iterable
+from xonsh.completers.tools import (
+    contextual_command_completer,
+    get_filter_function,
+    RichCompletion,
+)
+from xonsh.parsers.completion_context import CommandContext
+import xontrib.voxapi as voxapi
+
+
+VOX_LIST_COMMANDS = {"activate", "workon", "enter", "remove", "rm", "delete", "del"}
+VOX_ALL_COMMANDS = {
+    "new",
+    "create",
+    "activate",
+    "workon",
+    "enter",
+    "deactivate",
+    "exit",
+    "list",
+    "ls",
+    "remove",
+    "rm",
+    "delete",
+    "del",
+}
+
+
+@contextual_command_completer
+def complete_vox(context: CommandContext):
+    """Completes xonsh's vox command"""
+    prefix = context.prefix
+    if context.arg_index == 0 or (not context.args[0].value == "vox"):
+        return None
+    filter_func = get_filter_function()
+
+    if context.arg_index == 2 and context.args[1].value in VOX_LIST_COMMANDS:
+        return set(voxapi.Vox().keys())
+
+    if context.arg_index == 1:
+        suggestions = {
+            RichCompletion(c, append_space=True)
+            for c in VOX_ALL_COMMANDS
+            if filter_func(c, prefix)
+        }
+        return suggestions
+
+    return None

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -4,6 +4,8 @@ import sys
 import textwrap
 import xontrib.voxapi as voxapi
 import xonsh.lazyasd as lazyasd
+from xonsh.completers.completer import add_one_completer
+from xonsh.completers.vox import complete_vox
 
 __all__ = ()
 
@@ -252,4 +254,5 @@ class VoxHandler:
         return vox(args, stdin=stdin)
 
 
+add_one_completer("vox", complete_vox, loc="start")
 aliases["vox"] = VoxHandler.handle


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

This adds completion for vox. The completer is only registered when the vox xontrib is loaded.


Here it is in action:
![xonsh_vox_completions](https://user-images.githubusercontent.com/8786230/123025323-14ac5b00-d3a0-11eb-9ec2-2c943978148d.gif)


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
