### PR TITLE
Short color token name support for `register_custom_style()` (#4339)

### DIFF
--- a/news/fix_short_color_names.rst
+++ b/news/fix_short_color_names.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Short color token names can be used in ``register_custom_style()`` (#4339)
+
+**Security:**
+
+* <news item>

--- a/tests/test_pyghooks.py
+++ b/tests/test_pyghooks.py
@@ -365,6 +365,11 @@ def test_colorize_file_ca(xs_LS_COLORS, monkeypatch):
             {"completion-menu.completion.current": "#00ff00"},
             {Token.PTK.CompletionMenu.Completion.Current: "#00ff00"},
         ),  # ptk style
+        (
+            "test6",
+            {"RED": "#ff0000"},
+            {Token.Color.RED: "#ff0000"},
+        ),  # short color name
     ],
 )
 def test_register_custom_pygments_style(name, styles, refrules):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -245,18 +245,21 @@ def color_token_by_name(xc: tuple, styles=None) -> _TokenType:
         try:
             styles = XSH.shell.shell.styler.styles  # type:ignore
         except AttributeError:
-            return Color
+            pass
 
     tokName = xc[0]
-    pc = color_name_to_pygments_code(xc[0], styles)
+    if styles:
+        pc = color_name_to_pygments_code(xc[0], styles)
 
-    if len(xc) > 1:
-        pc += " " + color_name_to_pygments_code(xc[1], styles)
-        tokName += "__" + xc[1]
+        if len(xc) > 1:
+            pc += " " + color_name_to_pygments_code(xc[1], styles)
+            tokName += "__" + xc[1]
 
     token = getattr(Color, norm_name(tokName))
-    if token not in styles or not styles[token]:
+
+    if styles and (token not in styles or not styles[token]):
         styles[token] = pc
+
     return token
 
 


### PR DESCRIPTION
Short color token support for `register_custom_style()`, even before shell is initialized, so they can be used in `.xonshrc`.

Fixes #4339.
