### PR TITLE
feat: support var-args signature for aliases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import builtins
-import glob
 import os
 import sys
 import types
@@ -8,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from xonsh.aliases import Aliases
 from xonsh.built_ins import XonshSession, XSH
 from xonsh.execer import Execer
 from xonsh.jobs import tasks
@@ -84,7 +84,7 @@ def xonsh_builtins(monkeypatch, xonsh_events):
         ("env", DummyEnv()),
         ("shell", DummyShell()),
         ("help", lambda x: x),
-        ("aliases", {}),
+        ("aliases", Aliases()),
         ("exit", False),
         ("history", DummyHistory()),
         # ("subproc_captured", sp),

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -100,3 +100,22 @@ def test_capture_always(capfd, thread_subprocs, capture_always):
     # Explicitly non-captured commands are never captured (/always printed)
     run_subproc(cmds, captured=False)  # $[]
     assert exp in capfd.readouterr().out
+
+
+@pytest.mark.parametrize("thread_subprocs", [False, True])
+def test_callable_alias_cls(thread_subprocs, xession):
+    class Cls:
+        def __call__(self, *args, **kwargs):
+            print(args, kwargs)
+
+    obj = Cls()
+    xession.aliases["tst"] = obj
+
+    env = xession.env
+    cmds = (["tst", "/root"],)
+
+    env["THREAD_SUBPROCS"] = thread_subprocs
+
+    spec = cmds_to_specs(cmds, captured="stdout")[0]
+    proc = spec.run()
+    assert proc.f == obj

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -325,7 +325,12 @@ PROXIES = (proxy_zero, proxy_one, proxy_two, proxy_three, proxy_four, proxy_five
 def partial_proxy(f):
     """Dispatches the appropriate proxy function based on the number of args."""
     numargs = 0
+
     for name, param in inspect.signature(f).parameters.items():
+        # handle *args/**kwargs signature
+        if param.kind in {param.VAR_KEYWORD, param.VAR_POSITIONAL}:
+            numargs = 6
+            break
         if (
             param.kind == param.POSITIONAL_ONLY
             or param.kind == param.POSITIONAL_OR_KEYWORD


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

it fixes following scenarios

![problem-signature](https://user-images.githubusercontent.com/6702219/126127160-9041deca-2b52-46b1-9edb-53a3ebbb26b7.png)

even though they are the same objects, different signature returned when referenced from aliases dict.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
