### PR TITLE
Fix WSL lazybools

### DIFF
--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -92,12 +92,12 @@ def ON_WSL():
 
 @lazybool
 def ON_WSL1():
-    return ON_WSL and not ON_WSL2
+    return bool(ON_WSL) and not bool(ON_WSL2)
 
 
 @lazybool
 def ON_WSL2():
-    return ON_WSL and "WSL2" in platform.release()
+    return bool(ON_WSL) and "WSL2" in platform.release()
 
 
 #


### PR DESCRIPTION
`lazybool`s that rely on other `lazybool`s need to explicitly call
`bool()` on those values or else a non-bool value gets returned when the
parent's `__bool__` method is called.

No news item since this is fixing up a recent change.
