### PR TITLE
Improve import completions

### DIFF
--- a/news/improve-import-completions.rst
+++ b/news/improve-import-completions.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Complete 'import' statements with modules that aren't loaded.
+* Complete multiple modules/objects in 'import' statements.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_python_completers.py
+++ b/tests/test_python_completers.py
@@ -3,9 +3,9 @@ import pytest
 from tests.tools import skip_if_pre_3_8
 from xonsh.completers.python import (
     python_signature_complete,
-    complete_import,
     complete_python,
 )
+from xonsh.completers.imports import complete_import
 from xonsh.parsers.completion_context import (
     CommandArg,
     CommandContext,
@@ -108,7 +108,7 @@ def test_complete_python_ctx():
         ),
         (
             CommandContext(args=(CommandArg("from"),), arg_index=1, prefix="pathli"),
-            {"pathlib "},
+            {"pathlib"},
         ),
         (
             CommandContext(args=(CommandArg("import"),), arg_index=1, prefix="os.pa"),
@@ -155,4 +155,7 @@ def test_complete_import(command, exp):
             command, python=PythonContext("", 0)  # `complete_import` needs this
         )
     )
+    if isinstance(result, tuple):
+        result, _ = result
+    result = set(result)
     assert result == exp

--- a/tests/test_python_completers.py
+++ b/tests/test_python_completers.py
@@ -116,6 +116,12 @@ def test_complete_python_ctx():
         ),
         (
             CommandContext(
+                args=(CommandArg("import"),), arg_index=1, prefix="sys,os.pa"
+            ),
+            {"os.path"},
+        ),
+        (
+            CommandContext(
                 args=(
                     CommandArg("from"),
                     CommandArg("x"),
@@ -143,6 +149,31 @@ def test_complete_python_ctx():
                     CommandArg("import"),
                 ),
                 arg_index=3,
+                prefix="PurePa",
+            ),
+            {"PurePath"},
+        ),
+        (
+            CommandContext(
+                args=(
+                    CommandArg("from"),
+                    CommandArg("pathlib"),
+                    CommandArg("import"),
+                ),
+                arg_index=3,
+                prefix="PosixPath,PurePa",
+            ),
+            {"PurePath"},
+        ),
+        (
+            CommandContext(
+                args=(
+                    CommandArg("from"),
+                    CommandArg("pathlib"),
+                    CommandArg("import"),
+                    CommandArg("PosixPath"),
+                ),
+                arg_index=4,
                 prefix="PurePa",
             ),
             {"PurePath"},

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -585,6 +585,7 @@ class XonshSession:
             if "commands_cache" in kwargs
             else CommandsCache()
         )
+        self.modules_cache = {}
         self.all_jobs = {}
         self.ensure_list_of_strs = ensure_list_of_strs
         self.list_of_strs_or_callables = list_of_strs_or_callables

--- a/xonsh/completers/imports.py
+++ b/xonsh/completers/imports.py
@@ -182,13 +182,10 @@ def complete_import(context: CompletionContext):
     if arg_index == 2 and args[0].value == "from":
         return {RichCompletion("import", append_space=True)}
     if arg_index > 2 and args[0].value == "from" and args[2].value == "import":
-        # complete thing inside a module
-        try:
-            mod = importlib.import_module(args[1].value)
-        except ImportError:
-            return set()
-        out = {i[0] for i in inspect.getmembers(mod) if i[0].startswith(prefix)}
-        return out
+        # complete thing inside a module, might be multiple objects
+        module = args[1].value
+        prefix = prefix.rsplit(",", 1)[-1]
+        return filter_completions(prefix, try_import(module)), len(prefix)
     return set()
 
 

--- a/xonsh/completers/imports.py
+++ b/xonsh/completers/imports.py
@@ -1,0 +1,141 @@
+"""
+Import statement completions.
+Contains modified code from the IPython project (at core/completerlib.py).
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""
+
+import os
+import re
+import sys
+import glob
+import inspect
+from time import time
+from importlib import import_module
+from importlib.machinery import all_suffixes
+from zipimport import zipimporter
+import typing as tp
+
+from xonsh.lazyasd import lazyobject
+from xonsh.completers.tools import (
+    CompleterResult,
+    contextual_completer,
+    get_filter_function,
+    RichCompletion,
+)
+from xonsh.parsers.completion_context import CompletionContext
+
+_suffixes = all_suffixes()
+
+# Time in seconds after which we give up
+TIMEOUT_GIVEUP = 2
+
+
+@lazyobject
+def IMPORT_RE():
+    # Regular expression for the python import statement
+    return re.compile(r'(?P<name>[^\W\d]\w*?)'
+                      r'(?P<package>[/\\]__init__)?'
+                      r'(?P<suffix>%s)$' %
+                      r'|'.join(re.escape(s) for s in _suffixes))
+
+
+def module_list(path):
+    """
+    Return the list containing the names of the modules available in the given
+    folder.
+    """
+    # sys.path has the cwd as an empty string, but isdir/listdir need it as '.'
+    if path == '':
+        path = '.'
+
+    # A few local constants to be used in loops below
+    pjoin = os.path.join
+
+    if os.path.isdir(path):
+        # Build a list of all files in the directory and all files
+        # in its subdirectories. For performance reasons, do not
+        # recurse more than one level into subdirectories.
+        files = []
+        for root, dirs, nondirs in os.walk(path, followlinks=True):
+            subdir = root[len(path)+1:]
+            if subdir:
+                files.extend(pjoin(subdir, f) for f in nondirs)
+                dirs[:] = [] # Do not recurse into additional subdirectories.
+            else:
+                files.extend(nondirs)
+
+    else:
+        try:
+            files = list(zipimporter(path)._files.keys())
+        except:
+            files = []
+
+    # Build a list of modules which match the import_re regex.
+    modules = []
+    for f in files:
+        m = IMPORT_RE.match(f)
+        if m:
+            modules.append(m.group('name'))
+    return list(set(modules))
+
+
+def get_root_modules():
+    """
+    Returns a list containing the names of all the modules available in the
+    folders of the pythonpath.
+    """
+    rootmodules_cache = {}
+    rootmodules = list(sys.builtin_module_names)
+    start_time = time()
+    store = False
+    for path in sys.path:
+        try:
+            modules = rootmodules_cache[path]
+        except KeyError:
+            modules = module_list(path)
+            try:
+                modules.remove('__init__')
+            except ValueError:
+                pass
+            if path not in ('', '.'): # cwd modules should not be cached
+                rootmodules_cache[path] = modules
+            if time() - start_time > TIMEOUT_GIVEUP:
+                print("\nwarning: Getting root modules is taking too long, we give up")
+                return []
+        rootmodules.extend(modules)
+    rootmodules = list(set(rootmodules))
+    return rootmodules
+
+
+def is_importable(module, attr, only_modules):
+    if only_modules:
+        return inspect.ismodule(getattr(module, attr))
+    else:
+        return not(attr[:2] == '__' and attr[-2:] == '__')
+
+
+def try_import(mod: str, only_modules=False) -> tp.List[str]:
+    """
+    Try to import given module and return list of potential completions.
+    """
+    mod = mod.rstrip('.')
+    try:
+        m = import_module(mod)
+    except:
+        return []
+
+    m_is_init = '__init__' in (getattr(m, '__file__', '') or '')
+
+    completions = []
+    if (not hasattr(m, '__file__')) or (not only_modules) or m_is_init:
+        completions.extend( [attr for attr in dir(m) if
+                             is_importable(m, attr, only_modules)])
+
+    completions.extend(getattr(m, '__all__', []))
+    if m_is_init:
+        completions.extend(module_list(os.path.dirname(m.__file__)))
+    completions_set = {c for c in completions if isinstance(c, str)}
+    completions_set.discard('__init__')
+    return list(completions_set)

--- a/xonsh/completers/imports.py
+++ b/xonsh/completers/imports.py
@@ -17,6 +17,7 @@ from importlib.machinery import all_suffixes
 from zipimport import zipimporter
 import typing as tp
 
+from xonsh.built_ins import XSH
 from xonsh.lazyasd import lazyobject
 from xonsh.completers.tools import (
     CompleterResult,
@@ -86,7 +87,7 @@ def get_root_modules():
     Returns a list containing the names of all the modules available in the
     folders of the pythonpath.
     """
-    rootmodules_cache = {}
+    rootmodules_cache = XSH.modules_cache
     rootmodules = list(sys.builtin_module_names)
     start_time = time()
     store = False

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -9,8 +9,8 @@ from xonsh.completers.path import complete_path
 from xonsh.completers.dirs import complete_cd, complete_rmdir
 from xonsh.completers.python import (
     complete_python,
-    complete_import,
 )
+from xonsh.completers.imports import complete_import
 from xonsh.completers.commands import (
     complete_skipper,
     complete_end_proc_tokens,

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -278,4 +278,3 @@ def python_signature_complete(prefix, line, end, ctx, filter_func):
         return set()
     args = {p + "=" for p in sig.parameters if filter_func(p, prefix)}
     return args
-


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Previously the 'import' completions only completed loaded modules (from `sys.modules`).
Now it uses ipython's logic which involves finding modules in the `sys.path` and finds modules that weren't imported yet!
Also completing `import A,B` and `from A import a,b` statements has been added.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
