### PR TITLE
Auto suggest word alias

### DIFF
--- a/docs/keyboard_shortcuts.rst
+++ b/docs/keyboard_shortcuts.rst
@@ -31,4 +31,6 @@ Xonsh comes pre-baked with a few keyboard shortcuts. The following is only avail
       - Cut highlighted section
     * - Ctrl-V *[Beta]*
       - Paste clipboard contents
+    * - Ctrl-Right
+      - Complete a single auto-suggestion word
 

--- a/news/auto-suggest-word-alias.rst
+++ b/news/auto-suggest-word-alias.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add ``CTRL-Right`` key binding to complete a single auto-suggestion word.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -208,9 +208,14 @@ def wrap_selection(buffer, left, right=None):
     buffer.selection_state = selection_state
 
 
-def load_xonsh_bindings() -> KeyBindingsBase:
+def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
     """
     Load custom key bindings.
+
+    Parameters
+    ----------
+    ptk_bindings :
+        The default prompt toolkit bindings. We need these to add aliases to them.
     """
     key_bindings = KeyBindings()
     handle = key_bindings.add
@@ -388,5 +393,13 @@ def load_xonsh_bindings() -> KeyBindingsBase:
         if buff.selection_state:
             buff.cut_selection()
         get_by_name("yank").call(event)
+
+    def create_alias(new_keys, original_keys):
+        bindings = ptk_bindings.get_bindings_for_keys(tuple(original_keys))
+        for original_binding in bindings:
+            handle(*new_keys, filter=original_binding.filter)(original_binding.handler)
+
+    # Complete a single auto-suggestion word
+    create_alias([Keys.ControlRight], ["escape", "f"])
 
     return key_bindings

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -207,7 +207,8 @@ class PromptToolkitShell(BaseShell):
 
         self.prompt_formatter = PTKPromptFormatter(self.prompter)
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx, self)
-        self.key_bindings = load_xonsh_bindings()
+        ptk_bindings = self.prompter.app.key_bindings
+        self.key_bindings = load_xonsh_bindings(ptk_bindings)
         self._overrides_deprecation_warning_shown = False
 
         # Store original `_history_matches` in case we need to restore it


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Closes #4330 
Closes #3639

This adds a `CTRL-Right` shortcut to add a single auto-suggestion word (like in fish).
This is already implemented in ptk as in `ALT-f` which isn't very ergonomic or expected, so we add a comfortable alias!

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
