### PR TITLE
Change !() to also capture background subprocesses

### DIFF
--- a/news/capture-object-background.rst
+++ b/news/capture-object-background.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed !() to also capture background subprocesses
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -102,6 +102,23 @@ def test_capture_always(capfd, thread_subprocs, capture_always):
     assert exp in capfd.readouterr().out
 
 
+@skip_if_on_windows
+@pytest.mark.parametrize(
+    "captured, exp_is_none",
+    [
+        ("object", False),
+        ("stdout", True),
+        ("hiddenobject", True),
+        (False, True),
+    ],
+)
+def test_run_subproc_background(captured, exp_is_none):
+
+    cmds = (["echo", "hello"], "&")
+    return_val = run_subproc(cmds, captured)
+    assert (return_val is None) == exp_is_none
+
+
 @pytest.mark.parametrize("thread_subprocs", [False, True])
 def test_callable_alias_cls(thread_subprocs, xession):
     class Cls:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -892,8 +892,8 @@ def run_subproc(cmds, captured=False, envs=None):
         # sure that the shell doesn't hang. This `pause_call_resume` invocation
         # does this
         pause_call_resume(proc, int)
-    # create command or return if backgrounding.
-    if background:
+    # create command or return if backgrounding (unless captured is "object").
+    if background and captured != "object":
         return
     # now figure out what we should return.
     if captured == "stdout":

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -892,15 +892,14 @@ def run_subproc(cmds, captured=False, envs=None):
         # sure that the shell doesn't hang. This `pause_call_resume` invocation
         # does this
         pause_call_resume(proc, int)
-    # create command or return if backgrounding (unless captured is "object").
-    if background and captured != "object":
+    # now figure out what we should return
+    if captured == "object":
+        return command  # object can be returned even if backgrounding
+    elif background:
         return
-    # now figure out what we should return.
-    if captured == "stdout":
+    elif captured == "stdout":
         command.end()
         return command.output
-    elif captured == "object":
-        return command
     elif captured == "hiddenobject":
         command.end()
         return command


### PR DESCRIPTION
Closes #4392 

This PR makes `!()` to also capture information for background subprocesses. Currently, `!()` returns `None` for background subprocesses.

In the final `if` structure of the `run_subproc()` function, the `captured == "object"` branch does not call `command.end()` before returning (unlike all the other branches), so it can be used for background subprocesses.

https://github.com/xonsh/xonsh/blob/f5acbe30d40322ecab40d4e46d0c5f4417e59aaa/xonsh/procs/specs.py#L898-L909
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
