### PR TITLE
Make CTRL-Backspace configurable via $XONSH_CTRL_BKSP_DELETION

### DIFF
--- a/news/ctrl-backspace-delete-word.rst
+++ b/news/ctrl-backspace-delete-word.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Add ``CTRL-Backspace`` key binding to delete a single word.
+* Add ``CTRL-Backspace`` key binding to delete a single word via ``$XONSH_CTRL_BKSPC_DELETION``.
 
 **Changed:**
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1553,6 +1553,12 @@ class PTKSetting(PromptSetting):  # sub-classing -> sub-group
         "Whether to copy words/lines to clipboard on deletion (must be set in .xonshrc file)."
         "Only available under the prompt-toolkit shell.",
     )
+    XONSH_CTRL_BKSP_DELETION = Var.with_default(
+        False,
+        "Delete a word on CTRL-Backspace (like ALT-Backspace). "
+        r"This will only work when your terminal emulator sends ``\x7f`` on backspace and "
+        r"``\x08`` on CTRL-Backspace (which is configurable on most terminal emulators).",
+    )
 
 
 class AsyncPromptSetting(PTKSetting):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1557,7 +1557,8 @@ class PTKSetting(PromptSetting):  # sub-classing -> sub-group
         False,
         "Delete a word on CTRL-Backspace (like ALT-Backspace). "
         r"This will only work when your terminal emulator sends ``\x7f`` on backspace and "
-        r"``\x08`` on CTRL-Backspace (which is configurable on most terminal emulators).",
+        r"``\x08`` on CTRL-Backspace (which is configurable on most terminal emulators). "
+        r"On windows, the keys are reversed.",
     )
 
 


### PR DESCRIPTION
Closes #4407 

@yaxollum I've fixed the way I do this thanks to @paul-ollis 's comment (https://github.com/xonsh/xonsh/issues/4407#issuecomment-893680405).
I missed that pkt remaps the normal backspace to `^H`, but now I'm treating it correctly.

This still needs to be configurable and off by default as stated by paul.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

No need for added news item

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
