### PR TITLE
fix: ignore bad file-description error during bash completion generation

### DIFF
--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -394,7 +394,7 @@ def bash_completions(
             raise ValueError
     except (
         subprocess.CalledProcessError,
-        FileNotFoundError,
+        OSError,
         ValueError,
     ):
         return set(), 0


### PR DESCRIPTION
fixes #4414

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
