### PR TITLE
fix: ptk completer renders new line as ^J

### DIFF
--- a/news/ptk-completion-desc-newline.rst
+++ b/news/ptk-completion-desc-newline.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Newline symbols in Prompt-toolkit's completions are replaced by <space>
+
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -98,13 +98,17 @@ class PromptToolkitCompleter(Completer):
         for comp in completions:
             # do not display quote
             if isinstance(comp, RichCompletion):
-                desc = comp.description or ""
+                desc = (
+                    comp.description.replace(os.linesep, " ")
+                    if comp.description
+                    else None
+                )
                 yield Completion(
                     comp,
                     -comp.prefix_len if comp.prefix_len is not None else -plen,
                     display=comp.display or comp[pre:].strip("'\""),
                     # ptk doesn't render newlines. This can be removed once it is supported.
-                    display_meta=desc.replace(os.linesep, " "),
+                    display_meta=desc,
                     style=comp.style or "",
                 )
             elif isinstance(comp, Completion):

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -98,6 +98,7 @@ class PromptToolkitCompleter(Completer):
         for comp in completions:
             # do not display quote
             if isinstance(comp, RichCompletion):
+                # ptk doesn't render newlines. This can be removed once it is supported.
                 desc = (
                     comp.description.replace(os.linesep, " ")
                     if comp.description
@@ -107,7 +108,6 @@ class PromptToolkitCompleter(Completer):
                     comp,
                     -comp.prefix_len if comp.prefix_len is not None else -plen,
                     display=comp.display or comp[pre:].strip("'\""),
-                    # ptk doesn't render newlines. This can be removed once it is supported.
                     display_meta=desc,
                     style=comp.style or "",
                 )

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -98,11 +98,13 @@ class PromptToolkitCompleter(Completer):
         for comp in completions:
             # do not display quote
             if isinstance(comp, RichCompletion):
+                desc = comp.description or ""
                 yield Completion(
                     comp,
                     -comp.prefix_len if comp.prefix_len is not None else -plen,
                     display=comp.display or comp[pre:].strip("'\""),
-                    display_meta=comp.description or None,
+                    # ptk doesn't render newlines. This can be removed once it is supported.
+                    display_meta=desc.replace(os.linesep, " "),
                     style=comp.style or "",
                 )
             elif isinstance(comp, Completion):


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
