### PR TITLE
Support `--rc DIR`

### DIFF
--- a/news/rcdir-cli.rst
+++ b/news/rcdir-cli.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The ``--rc`` argument is extended to support directories as well as files.
+  Passing a directory will result in all ``*.xsh`` files in the directory being
+  sorted and loaded at startup (equivalent to using the environment variable
+  ``XONSHRC_DIR``).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Completely dropped the deprecated ``--config-path`` argument, which no longer
+  did anything.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -115,6 +115,19 @@ def test_rcdir(shell, tmpdir, monkeypatch, capsys):
     assert len(stderr) == 0
 
 
+def test_rcdir_cli(shell, tmpdir, xession, monkeypatch):
+    """Test that --rc DIR works"""
+    rcdir = tmpdir.join("rcdir")
+    rcdir.mkdir()
+    rc = rcdir.join("test.xsh")
+    rc.write("print('test.xsh')")
+
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    xargs = xonsh.main.premain(["--rc", rcdir.strpath])
+    assert len(xargs.rc) == 1 and xargs.rc[0] == rcdir.strpath
+    assert rc.strpath in xession.rc_files
+
+
 def test_rcdir_empty(shell, tmpdir, monkeypatch, capsys):
     """Test that an empty XONSHRC_DIR is not an error"""
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -162,13 +162,6 @@ def parser():
         default=False,
     )
     p.add_argument(
-        "--config-path",
-        help=argparse.SUPPRESS,
-        dest="config_path",
-        default=None,
-        type=path_argument,
-    )
-    p.add_argument(
         "--rc",
         help="The xonshrc files to load, these may be either xonsh "
         "files or directories containing xonsh files",

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -108,14 +108,14 @@ def get_setproctitle():
 
 
 def path_argument(s):
-    """Return a path only if the path is actually legal
+    """Return a path only if the path is actually legal (file or directory)
 
     This is very similar to argparse.FileType, except that it doesn't return
     an open file handle, but rather simply validates the path."""
 
     s = os.path.abspath(os.path.expanduser(s))
-    if not os.path.isfile(s):
-        msg = "{0!r} must be a valid path to a file".format(s)
+    if not os.path.exists(s):
+        msg = "{0!r} must be a valid path to a file or directory".format(s)
         raise argparse.ArgumentTypeError(msg)
     return s
 
@@ -171,7 +171,7 @@ def parser():
     p.add_argument(
         "--rc",
         help="The xonshrc files to load, these may be either xonsh "
-        "files or JSON-based static configuration files.",
+        "files or directories containing xonsh files",
         dest="rc",
         nargs="+",
         type=path_argument,
@@ -179,7 +179,7 @@ def parser():
     )
     p.add_argument(
         "--no-rc",
-        help="Do not load the .xonshrc files.",
+        help="Do not load any xonsh RC files.",
         dest="norc",
         action="store_true",
         default=False,
@@ -294,6 +294,7 @@ def start_services(shell_kwargs, args, pre_env=None):
     events.on_timingprobe.fire(name="post_execer_init")
     # load rc files
     login = shell_kwargs.get("login", True)
+    rc_cli = shell_kwargs.get("rc")
     env = XSH.env
     for k, v in pre_env.items():
         env[k] = v
@@ -309,11 +310,11 @@ def start_services(shell_kwargs, args, pre_env=None):
         # interactive mode was not forced, then disable loading RC files and dirs
         rc = ()
         rcd = ()
-    elif shell_kwargs.get("rc"):
+    elif rc_cli:
         # if an explicit --rc was passed, then we should load only that RC
         # file, and nothing else (ignore both XONSHRC and XONSHRC_DIR)
-        rc = shell_kwargs.get("rc")
-        rcd = ()
+        rc = [r for r in rc_cli if os.path.isfile(r)]
+        rcd = [r for r in rc_cli if os.path.isdir(r)]
     else:
         # otherwise, get the RC files from XONSHRC, and RC dirs from XONSHRC_DIR
         rc = env.get("XONSHRC")


### PR DESCRIPTION
This is a followup to https://github.com/xonsh/xonsh/pull/4408#issuecomment-899629748, adding support for `--rc DIR` (which loads, in sorted order, `DIR/*.xsh` during startup).

This also completely drops `--config-path`, which still existed as an option but was no longer actually used anywhere (but was the only other user of `path_argument()`, which I redefined to accept files or directories).

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
