### PR TITLE
Restore _repr_pretty_ for ${...} Env class

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2057,6 +2057,15 @@ class Env(cabc.MutableMapping):
     def __repr__(self):
         return "{0}.{1}(...)".format(self.__class__.__module__, self.__class__.__name__)
 
+    def _repr_pretty_(self, p, cycle):
+        name = "{0}.{1}".format(self.__class__.__module__, self.__class__.__name__)
+        with p.group(0, name + "(", ")"):
+            if cycle:
+                p.text("...")
+            elif len(self):
+                p.break_()
+                p.pretty(dict(self))
+
     def register(
         self,
         name,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2058,8 +2058,8 @@ class Env(cabc.MutableMapping):
         return "{0}.{1}(...)".format(self.__class__.__module__, self.__class__.__name__)
 
     def _repr_pretty_(self, p, cycle):
-        name = "{0}.{1}".format(self.__class__.__module__, self.__class__.__name__)
-        with p.group(0, name + "(", ")"):
+        name = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        with p.group(1, name + "(", ")"):
             if cycle:
                 p.text("...")
             elif len(self):


### PR DESCRIPTION
Restoring pretty repr for the `Env` class, raised in #4424

Now when you type just `${...}` you see your environment printed

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
