### PR TITLE
Always capture aliases

### DIFF
--- a/news/always-capture-aliases.rst
+++ b/news/always-capture-aliases.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Make sure aliases are always captured regardless of ``$XONSH_CAPTURE_ALWAYS``
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def session_vars():
 @pytest.fixture
 def xonsh_builtins(monkeypatch, xonsh_events, session_vars):
     """Mock out most of the builtins xonsh attributes."""
-    old_builtins = set(dir(builtins))
+    old_builtins = dict(vars(builtins).items())  # type: ignore
 
     XSH.load(ctx={}, **session_vars)
     if ON_WINDOWS:
@@ -130,9 +130,12 @@ def xonsh_builtins(monkeypatch, xonsh_events, session_vars):
     # todo: remove using builtins for tests at all
     yield builtins
     XSH.unload()
-    for attr in set(dir(builtins)) - old_builtins:
+    for attr in set(dir(builtins)) - set(old_builtins):
         if hasattr(builtins, attr):
             delattr(builtins, attr)
+    for attr, old_value in old_builtins.items():
+        setattr(builtins, attr, old_value)
+
     tasks.clear()  # must to this to enable resetting all_jobs
 
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -60,13 +60,17 @@ def test_cmds_to_specs_capture_stdout_not_stderr(thread_subprocs):
 
 
 @skip_if_on_windows
+@pytest.mark.parametrize("pipe", (True, False))
 @pytest.mark.parametrize(
     "thread_subprocs, capture_always", list(itertools.product((True, False), repeat=2))
 )
-def test_capture_always(capfd, thread_subprocs, capture_always):
+def test_capture_always(capfd, thread_subprocs, capture_always, pipe):
     env = XSH.env
-    exp = "HELLO"
+    exp = "HELLO\nBYE\n"
     cmds = [["echo", "-n", exp]]
+    if pipe:
+        exp = exp.splitlines()[1] + "\n"  # second line
+        cmds += ["|", ["grep", "--color=never", exp.strip()]]
 
     env["THREAD_SUBPROCS"] = thread_subprocs
     env["XONSH_CAPTURE_ALWAYS"] = capture_always

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -1,5 +1,6 @@
 """Tests the xonsh.procs.specs"""
 import itertools
+import sys
 from subprocess import Popen
 
 import pytest
@@ -7,7 +8,7 @@ import pytest
 from xonsh.procs.specs import cmds_to_specs, run_subproc
 from xonsh.built_ins import XSH
 from xonsh.procs.posix import PopenThread
-from xonsh.procs.proxies import ProcProxy, ProcProxyThread
+from xonsh.procs.proxies import ProcProxy, ProcProxyThread, STDOUT_DISPATCHER
 
 from .tools import skip_if_on_windows
 
@@ -61,16 +62,36 @@ def test_cmds_to_specs_capture_stdout_not_stderr(thread_subprocs):
 
 @skip_if_on_windows
 @pytest.mark.parametrize("pipe", (True, False))
+@pytest.mark.parametrize("alias_type", (None, "func", "exec", "simple"))
 @pytest.mark.parametrize(
     "thread_subprocs, capture_always", list(itertools.product((True, False), repeat=2))
 )
-def test_capture_always(capfd, thread_subprocs, capture_always, pipe):
+def test_capture_always(
+    capfd, thread_subprocs, capture_always, alias_type, pipe, monkeypatch
+):
     env = XSH.env
     exp = "HELLO\nBYE\n"
     cmds = [["echo", "-n", exp]]
     if pipe:
         exp = exp.splitlines()[1] + "\n"  # second line
         cmds += ["|", ["grep", "--color=never", exp.strip()]]
+
+    if alias_type:
+        first_cmd = cmds[0]
+        # Enable capfd for function aliases:
+        monkeypatch.setattr(STDOUT_DISPATCHER, "default", sys.stdout)
+        if alias_type == "func":
+            XSH.aliases["tst"] = (
+                lambda: run_subproc([first_cmd], "hiddenobject") and None
+            )  # Don't return a value
+        elif alias_type == "exec":
+            first_cmd = " ".join(repr(arg) for arg in first_cmd)
+            XSH.aliases["tst"] = f"![{first_cmd}]"
+        else:
+            # alias_type == "simple"
+            XSH.aliases["tst"] = first_cmd
+
+        cmds[0] = ["tst"]
 
     env["THREAD_SUBPROCS"] = thread_subprocs
     env["XONSH_CAPTURE_ALWAYS"] = capture_always
@@ -90,7 +111,7 @@ def test_capture_always(capfd, thread_subprocs, capture_always, pipe):
     hidden = run_subproc(cmds, "object")  # !()
     hidden.end()
     if thread_subprocs:
-        assert not capfd.readouterr().out
+        assert exp not in capfd.readouterr().out
         assert hidden.out == exp
     else:
         # for some reason THREAD_SUBPROCS=False fails to capture in `!()` but still succeeds in `$()`
@@ -98,7 +119,7 @@ def test_capture_always(capfd, thread_subprocs, capture_always, pipe):
         assert not hidden.out
 
     output = run_subproc(cmds, "stdout")  # $()
-    assert not capfd.readouterr().out
+    assert exp not in capfd.readouterr().out
     assert output == exp
 
     # Explicitly non-captured commands are never captured (/always printed)

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -69,6 +69,12 @@ def test_cmds_to_specs_capture_stdout_not_stderr(thread_subprocs):
 def test_capture_always(
     capfd, thread_subprocs, capture_always, alias_type, pipe, monkeypatch
 ):
+    if not thread_subprocs and alias_type in ["func", "exec"]:
+        if pipe:
+            return pytest.skip("https://github.com/xonsh/xonsh/issues/4443")
+        else:
+            return pytest.skip("https://github.com/xonsh/xonsh/issues/4444")
+
     env = XSH.env
     exp = "HELLO\nBYE\n"
     cmds = [["echo", "-n", exp]]

--- a/tests/prompt/test_vc.py
+++ b/tests/prompt/test_vc.py
@@ -91,22 +91,23 @@ current = yellow reverse
         assert not branch.startswith(u"\u001b[")
 
 
-def test_current_branch_calls_locate_binary_for_empty_cmds_cache(xession):
+def test_current_branch_calls_locate_binary_for_empty_cmds_cache(xession, monkeypatch):
     cache = xession.commands_cache
-    cache.is_empty = Mock(return_value=True)
-    cache.locate_binary = Mock(return_value="")
+    monkeypatch.setattr(cache, "is_empty", Mock(return_value=True))
+    monkeypatch.setattr(cache, "locate_binary", Mock(return_value=""))
     vc.current_branch()
     assert cache.locate_binary.called
 
 
 def test_current_branch_does_not_call_locate_binary_for_non_empty_cmds_cache(
     xession,
+    monkeypatch,
 ):
     cache = xession.commands_cache
-    cache.is_empty = Mock(return_value=False)
-    cache.locate_binary = Mock(return_value="")
+    monkeypatch.setattr(cache, "is_empty", Mock(return_value=False))
+    monkeypatch.setattr(cache, "locate_binary", Mock(return_value=""))
     # make lazy locate return nothing to avoid running vc binaries
-    cache.lazy_locate_binary = Mock(return_value="")
+    monkeypatch.setattr(cache, "lazy_locate_binary", Mock(return_value=""))
     vc.current_branch()
     assert not cache.locate_binary.called
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,13 @@ def shell(xession, monkeypatch):
     monkeypatch.setattr(xonsh.main, "Shell", Shell)
 
 
+@pytest.fixture(autouse=True)
+def empty_xonshrc(monkeypatch):
+    # Don't use the local machine's xonshrc
+    empty_file_path = "NUL" if ON_WINDOWS else "/dev/null"
+    monkeypatch.setitem(os.environ, "XONSHRC", empty_file_path)
+
+
 def test_premain_no_arg(shell, monkeypatch, xession):
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     xonsh.main.premain([])

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -845,7 +845,18 @@ def cmds_to_specs(cmds, captured=False, envs=None):
             specs[i].background = True
         else:
             raise xt.XonshError(f"unrecognized redirect {redirect!r}")
+
     # Apply boundary conditions
+    if not XSH.env.get("XONSH_CAPTURE_ALWAYS"):
+        # Make sure sub-specs are always captured.
+        # I.e. ![some_alias | grep x] $(some_alias)
+        specs_to_capture = specs if captured in STDOUT_CAPTURE_KINDS else specs[:-1]
+        for spec in specs_to_capture:
+            if spec.env is None:
+                spec.env = {"XONSH_CAPTURE_ALWAYS": True}
+            else:
+                spec.env.setdefault("XONSH_CAPTURE_ALWAYS", True)
+
     _update_last_spec(specs[-1])
     return specs
 

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -449,11 +449,12 @@ class SubprocSpec:
         event_name = self._cmd_event_name()
         self._pre_run_event_fire(event_name)
         kwargs = {n: getattr(self, n) for n in self.kwnames}
-        self.prep_env(kwargs)
         if callable(self.alias):
+            kwargs["env"] = self.env or {}
             kwargs["env"]["__ALIAS_NAME"] = self.alias_name or ""
             p = self.cls(self.alias, self.cmd, **kwargs)
         else:
+            self.prep_env_subproc(kwargs)
             self.prep_preexec_fn(kwargs, pipeline_group=pipeline_group)
             self._fix_null_cmd_bytes()
             p = self._run_binary(kwargs)
@@ -493,7 +494,7 @@ class SubprocSpec:
             raise xt.XonshError(e)
         return p
 
-    def prep_env(self, kwargs):
+    def prep_env_subproc(self, kwargs):
         """Prepares the environment to use in the subprocess."""
         with XSH.env.swap(self.env) as env:
             denv = env.detype()


### PR DESCRIPTION
Since `$XONSH_CAPTURE_ALWAYS` was introduced aliases containing `![]` notation weren't being captured properly, for instance:

```bash
aliases['a'] = '![echo hi]'
print($(a))  # ''
```

Depends and rebased on #4465

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
