### PR TITLE
readline: Render completions using the entire line

### DIFF
--- a/news/readline-complete-with-space.rst
+++ b/news/readline-complete-with-space.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Completing strings with spaces in readline.
+
+**Security:**
+
+* <news item>

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -86,7 +86,7 @@ def setup_readline():
     import ctypes.util
 
     uses_libedit = readline.__doc__ and "libedit" in readline.__doc__
-    readline.set_completer_delims(" \t\n")
+    readline.set_completer_delims("\n")
     # Cygwin seems to hang indefinitely when querying the readline lib
     if (not ON_CYGWIN) and (not ON_MSYS) and (not readline.__file__.endswith(".py")):
         RL_LIB = lib = ctypes.cdll.LoadLibrary(readline.__file__)
@@ -453,7 +453,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             multiline_text=prev_text + line,
             cursor_index=len(prev_text) + endidx,
         )
-        rtn_completions = _render_completions(completions, prefix, plen)
+        rtn_completions = _render_completions(completions, line, plen)
 
         rtn = []
         prefix_begs_quote = prefix.startswith("'") or prefix.startswith('"')


### PR DESCRIPTION
Since the completions we return are completed wrt. the completion prefix,
in order to handle spaced strings we need to use the entire line as the completion prefix.
For example:
    ls 'spaced
Can now correctly result in:
    ls 'spaced file' / ls 'spaced dir/'

Closes #2865

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
