### PR TITLE
Fix: EnvPath.add() not maintain uniqueness with Path objects on replace

### DIFF
--- a/news/fixduplicatepaths.rst
+++ b/news/fixduplicatepaths.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix Duplicate paths left over when add paths to Path via xonsh.tools.EnvPath
+
+**Security:** None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -928,9 +928,9 @@ def test_env_path_to_str(inp, exp):
     "left, right, exp",
     [
         (
-                EnvPath(["/home/wakka"]),
-                ["/home/jawaka"],
-                EnvPath(["/home/wakka", "/home/jawaka"]),
+            EnvPath(["/home/wakka"]),
+            ["/home/jawaka"],
+            EnvPath(["/home/wakka", "/home/jawaka"]),
         ),
         (["a"], EnvPath(["b"]), EnvPath(["a", "b"])),
         (EnvPath(["c"]), EnvPath(["d"]), EnvPath(["c", "d"])),
@@ -946,24 +946,27 @@ def test_env_path_add_replace_no_dupes_front_replace_existing():
     # Test replaces without dupes when added to front when adding existing entry
     path = EnvPath(["/home/wakka", "/home/wakka/bin"])
     path.add("/home/wakka/bin", front=True, replace=True)
-    exp = ["/home/wakka/bin", "/home/wakka"]
-    assert exp == path
+    assert path == ["/home/wakka/bin", "/home/wakka"]
 
 
 def test_env_path_add_replace_no_dupes_front_replace_multiple():
     # Test replaces without dupes when added to front when multiple existing occurrences
     path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
     path.add("/home/wakka/bin", front=True, replace=True)
-    exp = ["/home/wakka/bin", "/home/wakka"]
-    assert exp == path
+    assert path == ["/home/wakka/bin", "/home/wakka"]
 
 
 def test_env_path_add_replace_no_dupes_back_replace_multiple():
     # Test replaces without dupes when not added to front
     path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
     path.add("/home/wakka/bin", front=False, replace=True)
-    exp = ["/home/wakka", "/home/wakka/bin"]
-    assert exp == path
+    assert path == ["/home/wakka", "/home/wakka/bin"]
+
+
+def test_env_path_add_pathlib():
+    path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
+    path.add(pathlib.Path("/home/wakka/bin"), front=False, replace=True)
+    assert path == ["/home/wakka", "/home/wakka/bin"]
 
 
 # helper
@@ -996,12 +999,12 @@ def test_env_path_getitem(inp, exp, xession, env):
     "inp, exp",
     [
         (
-                os.pathsep.join(["xonsh_dir", "../", ".", "~/"]),
-                ["xonsh_dir", "../", ".", "~/"],
+            os.pathsep.join(["xonsh_dir", "../", ".", "~/"]),
+            ["xonsh_dir", "../", ".", "~/"],
         ),
         (
-                "/home/wakka" + os.pathsep + "/home/jakka" + os.pathsep + "~/",
-                ["/home/wakka", "/home/jakka", "~/"],
+            "/home/wakka" + os.pathsep + "/home/jakka" + os.pathsep + "~/",
+            ["/home/wakka", "/home/jakka", "~/"],
         ),
     ],
 )
@@ -1023,8 +1026,8 @@ def test_env_path_multipath(inp, exp, xession, env):
         (pathlib.Path("~/"), ["~"]),
         (pathlib.Path("."), ["."]),
         (
-                ["/home/wakka", pathlib.Path("/home/jakka"), "~/"],
-                ["/home/wakka", "/home/jakka".replace("/", os.sep), "~/"],
+            ["/home/wakka", pathlib.Path("/home/jakka"), "~/"],
+            ["/home/wakka", "/home/jakka".replace("/", os.sep), "~/"],
         ),
         (["/home/wakka", pathlib.Path("../"), "../"], ["/home/wakka", "..", "../"]),
         (["/home/wakka", pathlib.Path("~/"), "~/"], ["/home/wakka", "~", "~/"]),
@@ -1052,8 +1055,8 @@ def mkpath(*paths):
     "inp, exp",
     [
         (
-                [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
-                [mkpath("home", "wakka"), mkpath("home", "jakka")],
+            [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
+            [mkpath("home", "wakka"), mkpath("home", "jakka")],
         )
     ],
 )
@@ -1066,8 +1069,8 @@ def test_env_path_slice_get_all_except_last_element(inp, exp):
     "inp, exp",
     [
         (
-                [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
-                [mkpath("home", "jakka"), mkpath("home", "yakka")],
+            [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
+            [mkpath("home", "jakka"), mkpath("home", "yakka")],
         )
     ],
 )
@@ -1080,14 +1083,14 @@ def test_env_path_slice_get_all_except_first_element(inp, exp):
     "inp, exp_a, exp_b",
     [
         (
-                [
-                    mkpath("home", "wakka"),
-                    mkpath("home", "jakka"),
-                    mkpath("home", "yakka"),
-                    mkpath("home", "takka"),
-                ],
-                [mkpath("home", "wakka"), mkpath("home", "yakka")],
-                [mkpath("home", "jakka"), mkpath("home", "takka")],
+            [
+                mkpath("home", "wakka"),
+                mkpath("home", "jakka"),
+                mkpath("home", "yakka"),
+                mkpath("home", "takka"),
+            ],
+            [mkpath("home", "wakka"), mkpath("home", "yakka")],
+            [mkpath("home", "jakka"), mkpath("home", "takka")],
         )
     ],
 )
@@ -1102,14 +1105,14 @@ def test_env_path_slice_path_with_step(inp, exp_a, exp_b):
     "inp, exp",
     [
         (
-                [
-                    mkpath("home", "wakka"),
-                    mkpath("home", "xakka"),
-                    mkpath("other", "zakka"),
-                    mkpath("another", "akka"),
-                    mkpath("home", "bakka"),
-                ],
-                [mkpath("other", "zakka"), mkpath("another", "akka")],
+            [
+                mkpath("home", "wakka"),
+                mkpath("home", "xakka"),
+                mkpath("other", "zakka"),
+                mkpath("another", "akka"),
+                mkpath("home", "bakka"),
+            ],
+            [mkpath("other", "zakka"), mkpath("another", "akka")],
         )
     ],
 )
@@ -1256,8 +1259,8 @@ def test_ensure_slice(inp, exp):
     [
         ((range(50), slice(25, 40)), list(i for i in range(25, 40))),
         (
-                ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [slice(1, 4), slice(6, None)]),
-                [2, 3, 4, 7, 8, 9, 10],
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [slice(1, 4), slice(6, None)]),
+            [2, 3, 4, 7, 8, 9, 10],
         ),
         (([1, 2, 3, 4, 5], [slice(-2, None), slice(-5, -3)]), [4, 5, 1, 2]),
     ],
@@ -1453,25 +1456,25 @@ def test_escape_windows_cmd_string(st, esc):
         ("", '""', None),
         ("foo", "foo", '"foo"'),
         (
-                r'arg1 "hallo, "world""  "\some\path with\spaces")',
-                r'"arg1 \"hallo, \"world\"\"  \"\some\path with\spaces\")"',
-                None,
+            r'arg1 "hallo, "world""  "\some\path with\spaces")',
+            r'"arg1 \"hallo, \"world\"\"  \"\some\path with\spaces\")"',
+            None,
         ),
         (
-                r'"argument"2" argument3 argument4',
-                r'"\"argument\"2\" argument3 argument4"',
-                None,
+            r'"argument"2" argument3 argument4',
+            r'"\"argument\"2\" argument3 argument4"',
+            None,
         ),
         (r'"\foo\bar bar\foo\" arg', r'"\"\foo\bar bar\foo\\\" arg"', None),
         (
-                r"\\machine\dir\file.bat",
-                r"\\machine\dir\file.bat",
-                r'"\\machine\dir\file.bat"',
+            r"\\machine\dir\file.bat",
+            r"\\machine\dir\file.bat",
+            r'"\\machine\dir\file.bat"',
         ),
         (
-                r'"\\machine\dir space\file.bat"',
-                r'"\"\\machine\dir space\file.bat\""',
-                None,
+            r'"\\machine\dir space\file.bat"',
+            r'"\"\\machine\dir space\file.bat\""',
+            None,
         ),
     ],
 )
@@ -1625,15 +1628,15 @@ def test_expandvars(inp, exp, xession):
         (572392800.0, None, 572392800.0),
         ("42.1459", None, 42.1459),
         (
-                dt.datetime(2016, 8, 2, 13, 24),
-                None,
-                dt.datetime(2016, 8, 2, 13, 24).timestamp(),
+            dt.datetime(2016, 8, 2, 13, 24),
+            None,
+            dt.datetime(2016, 8, 2, 13, 24).timestamp(),
         ),
         ("2016-8-10 16:14", None, dt.datetime(2016, 8, 10, 16, 14).timestamp()),
         (
-                "2016/8/10 16:14:40",
-                "%Y/%m/%d %H:%M:%S",
-                dt.datetime(2016, 8, 10, 16, 14, 40).timestamp(),
+            "2016/8/10 16:14:40",
+            "%Y/%m/%d %H:%M:%S",
+            dt.datetime(2016, 8, 10, 16, 14, 40).timestamp(),
         ),
     ],
 )
@@ -1687,17 +1690,17 @@ def test_swap_values():
     "arguments, expected_docstring",
     [
         (
-                {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
-                "my_function has been deprecated in version 0.5.10 and will be removed "
-                "in version 0.6.0",
+            {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
+            "my_function has been deprecated in version 0.5.10 and will be removed "
+            "in version 0.6.0",
         ),
         (
-                {"deprecated_in": "0.5.10"},
-                "my_function has been deprecated in version 0.5.10",
+            {"deprecated_in": "0.5.10"},
+            "my_function has been deprecated in version 0.5.10",
         ),
         (
-                {"removed_in": "0.6.0"},
-                "my_function has been deprecated and will be removed in version 0.6.0",
+            {"removed_in": "0.6.0"},
+            "my_function has been deprecated and will be removed in version 0.6.0",
         ),
         ({}, "my_function has been deprecated"),
     ],
@@ -1714,18 +1717,18 @@ def test_deprecated_docstrings_with_empty_docstring(arguments, expected_docstrin
     "arguments, expected_docstring",
     [
         (
-                {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
-                "Does nothing.\n\nmy_function has been deprecated in version 0.5.10 and "
-                "will be removed in version 0.6.0",
+            {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
+            "Does nothing.\n\nmy_function has been deprecated in version 0.5.10 and "
+            "will be removed in version 0.6.0",
         ),
         (
-                {"deprecated_in": "0.5.10"},
-                "Does nothing.\n\nmy_function has been deprecated in version 0.5.10",
+            {"deprecated_in": "0.5.10"},
+            "Does nothing.\n\nmy_function has been deprecated in version 0.5.10",
         ),
         (
-                {"removed_in": "0.6.0"},
-                "Does nothing.\n\nmy_function has been deprecated and will be removed "
-                "in version 0.6.0",
+            {"removed_in": "0.6.0"},
+            "Does nothing.\n\nmy_function has been deprecated and will be removed "
+            "in version 0.6.0",
         ),
         ({}, "Does nothing.\n\nmy_function has been deprecated"),
     ],
@@ -1851,19 +1854,19 @@ def test_all_permutations():
     [
         ("test1", {}, {}),  # empty styles
         (
-                "test2",
-                {"Token.Literal.String.Single": "#ff0000"},
-                {"Token.Literal.String.Single": "#ff0000"},
+            "test2",
+            {"Token.Literal.String.Single": "#ff0000"},
+            {"Token.Literal.String.Single": "#ff0000"},
         ),  # str key
         (
-                "test3",
-                {"Literal.String.Single": "#ff0000"},
-                {"Token.Literal.String.Single": "#ff0000"},
+            "test3",
+            {"Literal.String.Single": "#ff0000"},
+            {"Token.Literal.String.Single": "#ff0000"},
         ),  # short str key
         (
-                "test4",
-                {"RED": "#ff0000"},
-                {"Token.Color.RED": "#ff0000"},
+            "test4",
+            {"RED": "#ff0000"},
+            {"Token.Color.RED": "#ff0000"},
         ),  # color
     ],
 )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -928,9 +928,9 @@ def test_env_path_to_str(inp, exp):
     "left, right, exp",
     [
         (
-            EnvPath(["/home/wakka"]),
-            ["/home/jawaka"],
-            EnvPath(["/home/wakka", "/home/jawaka"]),
+                EnvPath(["/home/wakka"]),
+                ["/home/jawaka"],
+                EnvPath(["/home/wakka", "/home/jawaka"]),
         ),
         (["a"], EnvPath(["b"]), EnvPath(["a", "b"])),
         (EnvPath(["c"]), EnvPath(["d"]), EnvPath(["c", "d"])),
@@ -940,6 +940,30 @@ def test_env_path_add(left, right, exp):
     obs = left + right
     assert is_env_path(obs)
     assert exp == obs
+
+
+def test_env_path_add_replace_no_dupes_front_replace_existing():
+    # Test replaces without dupes when added to front when adding existing entry
+    path = EnvPath(["/home/wakka", "/home/wakka/bin"])
+    path.add("/home/wakka/bin", front=True, replace=True)
+    exp = ["/home/wakka/bin", "/home/wakka"]
+    assert exp == path
+
+
+def test_env_path_add_replace_no_dupes_front_replace_multiple():
+    # Test replaces without dupes when added to front when multiple existing occurrences
+    path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
+    path.add("/home/wakka/bin", front=True, replace=True)
+    exp = ["/home/wakka/bin", "/home/wakka"]
+    assert exp == path
+
+
+def test_env_path_add_replace_no_dupes_back_replace_multiple():
+    # Test replaces without dupes when not added to front
+    path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
+    path.add("/home/wakka/bin", front=False, replace=True)
+    exp = ["/home/wakka", "/home/wakka/bin"]
+    assert exp == path
 
 
 # helper
@@ -972,12 +996,12 @@ def test_env_path_getitem(inp, exp, xession, env):
     "inp, exp",
     [
         (
-            os.pathsep.join(["xonsh_dir", "../", ".", "~/"]),
-            ["xonsh_dir", "../", ".", "~/"],
+                os.pathsep.join(["xonsh_dir", "../", ".", "~/"]),
+                ["xonsh_dir", "../", ".", "~/"],
         ),
         (
-            "/home/wakka" + os.pathsep + "/home/jakka" + os.pathsep + "~/",
-            ["/home/wakka", "/home/jakka", "~/"],
+                "/home/wakka" + os.pathsep + "/home/jakka" + os.pathsep + "~/",
+                ["/home/wakka", "/home/jakka", "~/"],
         ),
     ],
 )
@@ -999,8 +1023,8 @@ def test_env_path_multipath(inp, exp, xession, env):
         (pathlib.Path("~/"), ["~"]),
         (pathlib.Path("."), ["."]),
         (
-            ["/home/wakka", pathlib.Path("/home/jakka"), "~/"],
-            ["/home/wakka", "/home/jakka".replace("/", os.sep), "~/"],
+                ["/home/wakka", pathlib.Path("/home/jakka"), "~/"],
+                ["/home/wakka", "/home/jakka".replace("/", os.sep), "~/"],
         ),
         (["/home/wakka", pathlib.Path("../"), "../"], ["/home/wakka", "..", "../"]),
         (["/home/wakka", pathlib.Path("~/"), "~/"], ["/home/wakka", "~", "~/"]),
@@ -1028,8 +1052,8 @@ def mkpath(*paths):
     "inp, exp",
     [
         (
-            [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
-            [mkpath("home", "wakka"), mkpath("home", "jakka")],
+                [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
+                [mkpath("home", "wakka"), mkpath("home", "jakka")],
         )
     ],
 )
@@ -1042,8 +1066,8 @@ def test_env_path_slice_get_all_except_last_element(inp, exp):
     "inp, exp",
     [
         (
-            [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
-            [mkpath("home", "jakka"), mkpath("home", "yakka")],
+                [mkpath("home", "wakka"), mkpath("home", "jakka"), mkpath("home", "yakka")],
+                [mkpath("home", "jakka"), mkpath("home", "yakka")],
         )
     ],
 )
@@ -1056,14 +1080,14 @@ def test_env_path_slice_get_all_except_first_element(inp, exp):
     "inp, exp_a, exp_b",
     [
         (
-            [
-                mkpath("home", "wakka"),
-                mkpath("home", "jakka"),
-                mkpath("home", "yakka"),
-                mkpath("home", "takka"),
-            ],
-            [mkpath("home", "wakka"), mkpath("home", "yakka")],
-            [mkpath("home", "jakka"), mkpath("home", "takka")],
+                [
+                    mkpath("home", "wakka"),
+                    mkpath("home", "jakka"),
+                    mkpath("home", "yakka"),
+                    mkpath("home", "takka"),
+                ],
+                [mkpath("home", "wakka"), mkpath("home", "yakka")],
+                [mkpath("home", "jakka"), mkpath("home", "takka")],
         )
     ],
 )
@@ -1078,14 +1102,14 @@ def test_env_path_slice_path_with_step(inp, exp_a, exp_b):
     "inp, exp",
     [
         (
-            [
-                mkpath("home", "wakka"),
-                mkpath("home", "xakka"),
-                mkpath("other", "zakka"),
-                mkpath("another", "akka"),
-                mkpath("home", "bakka"),
-            ],
-            [mkpath("other", "zakka"), mkpath("another", "akka")],
+                [
+                    mkpath("home", "wakka"),
+                    mkpath("home", "xakka"),
+                    mkpath("other", "zakka"),
+                    mkpath("another", "akka"),
+                    mkpath("home", "bakka"),
+                ],
+                [mkpath("other", "zakka"), mkpath("another", "akka")],
         )
     ],
 )
@@ -1232,8 +1256,8 @@ def test_ensure_slice(inp, exp):
     [
         ((range(50), slice(25, 40)), list(i for i in range(25, 40))),
         (
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [slice(1, 4), slice(6, None)]),
-            [2, 3, 4, 7, 8, 9, 10],
+                ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [slice(1, 4), slice(6, None)]),
+                [2, 3, 4, 7, 8, 9, 10],
         ),
         (([1, 2, 3, 4, 5], [slice(-2, None), slice(-5, -3)]), [4, 5, 1, 2]),
     ],
@@ -1429,25 +1453,25 @@ def test_escape_windows_cmd_string(st, esc):
         ("", '""', None),
         ("foo", "foo", '"foo"'),
         (
-            r'arg1 "hallo, "world""  "\some\path with\spaces")',
-            r'"arg1 \"hallo, \"world\"\"  \"\some\path with\spaces\")"',
-            None,
+                r'arg1 "hallo, "world""  "\some\path with\spaces")',
+                r'"arg1 \"hallo, \"world\"\"  \"\some\path with\spaces\")"',
+                None,
         ),
         (
-            r'"argument"2" argument3 argument4',
-            r'"\"argument\"2\" argument3 argument4"',
-            None,
+                r'"argument"2" argument3 argument4',
+                r'"\"argument\"2\" argument3 argument4"',
+                None,
         ),
         (r'"\foo\bar bar\foo\" arg', r'"\"\foo\bar bar\foo\\\" arg"', None),
         (
-            r"\\machine\dir\file.bat",
-            r"\\machine\dir\file.bat",
-            r'"\\machine\dir\file.bat"',
+                r"\\machine\dir\file.bat",
+                r"\\machine\dir\file.bat",
+                r'"\\machine\dir\file.bat"',
         ),
         (
-            r'"\\machine\dir space\file.bat"',
-            r'"\"\\machine\dir space\file.bat\""',
-            None,
+                r'"\\machine\dir space\file.bat"',
+                r'"\"\\machine\dir space\file.bat\""',
+                None,
         ),
     ],
 )
@@ -1601,15 +1625,15 @@ def test_expandvars(inp, exp, xession):
         (572392800.0, None, 572392800.0),
         ("42.1459", None, 42.1459),
         (
-            dt.datetime(2016, 8, 2, 13, 24),
-            None,
-            dt.datetime(2016, 8, 2, 13, 24).timestamp(),
+                dt.datetime(2016, 8, 2, 13, 24),
+                None,
+                dt.datetime(2016, 8, 2, 13, 24).timestamp(),
         ),
         ("2016-8-10 16:14", None, dt.datetime(2016, 8, 10, 16, 14).timestamp()),
         (
-            "2016/8/10 16:14:40",
-            "%Y/%m/%d %H:%M:%S",
-            dt.datetime(2016, 8, 10, 16, 14, 40).timestamp(),
+                "2016/8/10 16:14:40",
+                "%Y/%m/%d %H:%M:%S",
+                dt.datetime(2016, 8, 10, 16, 14, 40).timestamp(),
         ),
     ],
 )
@@ -1663,17 +1687,17 @@ def test_swap_values():
     "arguments, expected_docstring",
     [
         (
-            {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
-            "my_function has been deprecated in version 0.5.10 and will be removed "
-            "in version 0.6.0",
+                {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
+                "my_function has been deprecated in version 0.5.10 and will be removed "
+                "in version 0.6.0",
         ),
         (
-            {"deprecated_in": "0.5.10"},
-            "my_function has been deprecated in version 0.5.10",
+                {"deprecated_in": "0.5.10"},
+                "my_function has been deprecated in version 0.5.10",
         ),
         (
-            {"removed_in": "0.6.0"},
-            "my_function has been deprecated and will be removed in version 0.6.0",
+                {"removed_in": "0.6.0"},
+                "my_function has been deprecated and will be removed in version 0.6.0",
         ),
         ({}, "my_function has been deprecated"),
     ],
@@ -1690,18 +1714,18 @@ def test_deprecated_docstrings_with_empty_docstring(arguments, expected_docstrin
     "arguments, expected_docstring",
     [
         (
-            {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
-            "Does nothing.\n\nmy_function has been deprecated in version 0.5.10 and "
-            "will be removed in version 0.6.0",
+                {"deprecated_in": "0.5.10", "removed_in": "0.6.0"},
+                "Does nothing.\n\nmy_function has been deprecated in version 0.5.10 and "
+                "will be removed in version 0.6.0",
         ),
         (
-            {"deprecated_in": "0.5.10"},
-            "Does nothing.\n\nmy_function has been deprecated in version 0.5.10",
+                {"deprecated_in": "0.5.10"},
+                "Does nothing.\n\nmy_function has been deprecated in version 0.5.10",
         ),
         (
-            {"removed_in": "0.6.0"},
-            "Does nothing.\n\nmy_function has been deprecated and will be removed "
-            "in version 0.6.0",
+                {"removed_in": "0.6.0"},
+                "Does nothing.\n\nmy_function has been deprecated and will be removed "
+                "in version 0.6.0",
         ),
         ({}, "Does nothing.\n\nmy_function has been deprecated"),
     ],
@@ -1827,19 +1851,19 @@ def test_all_permutations():
     [
         ("test1", {}, {}),  # empty styles
         (
-            "test2",
-            {"Token.Literal.String.Single": "#ff0000"},
-            {"Token.Literal.String.Single": "#ff0000"},
+                "test2",
+                {"Token.Literal.String.Single": "#ff0000"},
+                {"Token.Literal.String.Single": "#ff0000"},
         ),  # str key
         (
-            "test3",
-            {"Literal.String.Single": "#ff0000"},
-            {"Token.Literal.String.Single": "#ff0000"},
+                "test3",
+                {"Literal.String.Single": "#ff0000"},
+                {"Token.Literal.String.Single": "#ff0000"},
         ),  # short str key
         (
-            "test4",
-            {"RED": "#ff0000"},
-            {"Token.Color.RED": "#ff0000"},
+                "test4",
+                {"RED": "#ff0000"},
+                {"Token.Color.RED": "#ff0000"},
         ),  # color
     ],
 )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -944,29 +944,66 @@ def test_env_path_add(left, right, exp):
 
 def test_env_path_add_replace_no_dupes_front_replace_existing():
     # Test replaces without dupes when added to front when adding existing entry
-    path = EnvPath(["/home/wakka", "/home/wakka/bin"])
-    path.add("/home/wakka/bin", front=True, replace=True)
-    assert path == ["/home/wakka/bin", "/home/wakka"]
+    path = EnvPath(
+        [os.pathsep.join(["home", "wakka"]), os.pathsep.join(["home", "wakka", "bin"])]
+    )
+    path.add(os.pathsep.join(["home", "wakka", "bin"]), front=True, replace=True)
+    assert path == [
+        os.pathsep.join(["home", "wakka", "bin"]),
+        os.pathsep.join(["home", "wakka"]),
+    ]
 
 
 def test_env_path_add_replace_no_dupes_front_replace_multiple():
     # Test replaces without dupes when added to front when multiple existing occurrences
-    path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
-    path.add("/home/wakka/bin", front=True, replace=True)
-    assert path == ["/home/wakka/bin", "/home/wakka"]
+    path = EnvPath(
+        [
+            os.pathsep.join(["home", "wakka"]),
+            os.pathsep.join(["home", "wakka", "bin"]),
+            os.pathsep.join(["home", "wakka", "bin"]),
+        ]
+    )
+    path.add(os.pathsep.join(["home", "wakka", "bin"]), front=True, replace=True)
+    assert path == [
+        os.pathsep.join(["home", "wakka", "bin"]),
+        os.pathsep.join(["home", "wakka"]),
+    ]
 
 
 def test_env_path_add_replace_no_dupes_back_replace_multiple():
     # Test replaces without dupes when not added to front
-    path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
-    path.add("/home/wakka/bin", front=False, replace=True)
-    assert path == ["/home/wakka", "/home/wakka/bin"]
+    path = EnvPath(
+        [
+            os.pathsep.join(["home", "wakka"]),
+            os.pathsep.join(["home", "wakka", "bin"]),
+            os.pathsep.join(["home", "wakka", "bin"]),
+        ]
+    )
+    path.add(os.pathsep.join(["home", "wakka", "bin"]), front=False, replace=True)
+    assert path == [
+        os.pathsep.join(["home", "wakka"]),
+        os.pathsep.join(["home", "wakka", "bin"]),
+    ]
 
 
 def test_env_path_add_pathlib():
-    path = EnvPath(["/home/wakka", "/home/wakka/bin", "/home/wakka/bin"])
-    path.add(pathlib.Path("/home/wakka/bin"), front=False, replace=True)
-    assert path == ["/home/wakka", "/home/wakka/bin"]
+    os.pathsep.join(["home", "wakka", "bin"])
+    path = EnvPath(
+        [
+            os.pathsep.join(["home", "wakka"]),
+            os.pathsep.join(["home", "wakka", "bin"]),
+            os.pathsep.join(["home", "wakka", "bin"]),
+        ]
+    )
+    path.add(
+        pathlib.Path(os.pathsep.join(["home", "wakka", "bin"])),
+        front=False,
+        replace=True,
+    )
+    assert path == [
+        os.pathsep.join(["home", "wakka"]),
+        os.pathsep.join(["home", "wakka", "bin"]),
+    ]
 
 
 # helper

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -280,6 +280,7 @@ class EnvPath(cabc.MutableSequence):
         None
 
         """
+        data = str(expand_path(data))
         if data not in self._l:
             self._l.insert(0 if front else len(self._l), data)
         elif replace:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -283,7 +283,9 @@ class EnvPath(cabc.MutableSequence):
         if data not in self._l:
             self._l.insert(0 if front else len(self._l), data)
         elif replace:
-            self._l.remove(data)
+            # https://stackoverflow.com/a/25251306/1621381
+            self._l = list(filter(lambda x: x != data, self._l))
+            # self._l.remove(data)
             self._l.insert(0 if front else len(self._l), data)
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -285,7 +285,6 @@ class EnvPath(cabc.MutableSequence):
         elif replace:
             # https://stackoverflow.com/a/25251306/1621381
             self._l = list(filter(lambda x: x != data, self._l))
-            # self._l.remove(data)
             self._l.insert(0 if front else len(self._l), data)
 
 

--- a/xonsh/xontribs_meta.py
+++ b/xonsh/xontribs_meta.py
@@ -675,7 +675,7 @@ def define_xontribs():
         ),
         "z": Xontrib(
             url="https://github.com/AstraLuma/xontrib-z",
-            description="Tracks your most used directories, based on 'frequency'.",
+            description="Tracks your most used directories, based on 'frecency'.",
             package=_XontribPkg(
                 name="xontrib-z",
                 license="GPLv3",

--- a/xonsh/xontribs_meta.py
+++ b/xonsh/xontribs_meta.py
@@ -141,7 +141,7 @@ def define_xontribs():
             ),
         ),
         "avox_poetry": Xontrib(
-            url="github.com/jnoortheen/xontrib-avox-poetry",
+            url="https://github.com/jnoortheen/xontrib-avox-poetry",
             description="auto-activate venv as one cd into a poetry project folder. "
             "Activate ``.venv`` inside the project folder is also supported.",
             package=_XontribPkg(
@@ -193,7 +193,7 @@ def define_xontribs():
             package=core_pkg,
         ),
         "broot": Xontrib(
-            url="github.com/jnoortheen/xontrib-broot",
+            url="https://github.com/jnoortheen/xontrib-broot",
             description="supports broot with br alias",
             package=_XontribPkg(
                 name="xontrib-broot",
@@ -203,7 +203,7 @@ def define_xontribs():
             ),
         ),
         "powerline3": Xontrib(
-            url="github.com/jnoortheen/xontrib-powerline3",
+            url="https://github.com/jnoortheen/xontrib-powerline3",
             description="Powerline theme with native $PROMPT_FIELDS support.",
             package=_XontribPkg(
                 name="xontrib-powerline3",
@@ -675,7 +675,7 @@ def define_xontribs():
         ),
         "z": Xontrib(
             url="https://github.com/AstraLuma/xontrib-z",
-            description="Tracks your most used directories, based on 'frecency'.",
+            description="Tracks your most used directories, based on 'frequency'.",
             package=_XontribPkg(
                 name="xontrib-z",
                 license="GPLv3",


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
Fixes #4366

Tested via docker python.
![image](https://user-images.githubusercontent.com/1596188/132269422-df894b81-1c1d-4f80-9db7-512abd253eee.png)

Original credits for the filter out duplicates to source: https://stackoverflow.com/a/25251306/1621381  
Seems to work great when testing.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**

