### PR TITLE
Env swap thread safety

### DIFF
--- a/news/env-swap-thread-safety.rst
+++ b/news/env-swap-thread-safety.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``${...}.swap()`` can be called from multiple threads safetly.
+* Piping multiple function aliases doesn't raise a recursion error anymore.
+
+**Security:**
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -6,7 +6,10 @@ import re
 import pathlib
 import datetime
 import itertools
+from random import shuffle
 from tempfile import TemporaryDirectory
+from threading import Thread
+from time import sleep
 
 import pytest
 
@@ -20,6 +23,7 @@ from xonsh.environ import (
     LsColors,
     default_value,
     Var,
+    InternalEnvironDict,
 )
 
 from tools import skip_if_on_unix
@@ -547,3 +551,49 @@ def test_env_get_defaults():
 def test_var_with_default_initer(val, validator):
     var = Var.with_default(val)
     assert var.validate.__name__ == validator
+
+
+def test_thread_local_dict():
+    d = InternalEnvironDict()
+    d["a"] = 1
+    assert d["a"] == 1
+    d.set_locally("a", 2)
+    assert d["a"] == 2
+    d.set_locally("a", 3)
+    assert d["a"] == 3
+    d["a"] = 4
+    assert d["a"] == 4
+    d.del_locally("a")
+    assert d["a"] == 1
+    d.set_locally("a", 5)
+    assert d.pop("a") == 5
+    assert d["a"] == 1
+    d.set_locally("a", 6)
+    assert d.popitem() == ("a", 6)
+    assert d["a"] == 1
+    assert d.pop("a", "nope") == 1
+    assert d.pop("a", "nope") == "nope"
+    assert "a" not in d
+
+
+def test_thread_local_dict_multiple():
+    d = InternalEnvironDict()
+    num_threads = 5
+    thread_values = [None] * num_threads
+
+    def thread(i):
+        d.set_locally("a", i ** 2)
+        sleep(0.1)
+        thread_values[i] = d["a"]
+        sleep(0.1)
+        d.del_locally("a")
+        sleep(0.1)
+
+    threads = [Thread(target=thread, args=(i,)) for i in range(num_threads)]
+    shuffle(threads)
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert thread_values == [i ** 2 for i in range(num_threads)]

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -154,6 +154,33 @@ def test_swap_exception_replacement():
     assert env["VAR"] == "original value"
 
 
+def test_thread_local_swap():
+    env = Env(a=1)
+    iter_count = 20
+    num_threads = 3
+    success_variables = [False] * (num_threads + 1)
+
+    def loop(index):
+        for _ in range(iter_count):
+            with env.swap(a=index):
+                sleep(0.1)
+                if env["a"] == index:
+                    success_variables[index] = True
+                else:
+                    success_variables[index] = False
+                    break
+            sleep(0.1)
+
+    threads = [Thread(target=loop, args=(i,)) for i in range(1, num_threads + 1)]
+    for t in threads:
+        t.start()
+    loop(0)
+    for t in threads:
+        t.join()
+
+    assert all(success_variables)
+
+
 @skip_if_on_unix
 def test_locate_binary_on_windows(xession):
     files = ("file1.exe", "FILE2.BAT", "file3.txt")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -518,6 +518,21 @@ first
         lambda out: 'Recursive calls to "first" alias.' in out,
         0,
     ),
+    # testing alias stack: parallel threaded callable aliases.
+    # This breaks if the __ALIAS_STACK variables leak between threads.
+    (
+        """
+from time import sleep
+aliases['a'] = lambda: print(1, end="") or sleep(0.2) or print(1, end="")
+aliases['b'] = 'a'
+a | a
+a | a
+a | b | a
+a | a | b | b
+""",
+        "1" * 2 * 4,
+        0,
+    ),
 ]
 
 if not ON_WINDOWS:

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -151,6 +151,14 @@ class DummyEnv(MutableMapping):
             else:
                 self[k] = v
 
+    @staticmethod
+    def get_swapped_values():
+        return {}
+
+    @staticmethod
+    def set_swapped_values(_):
+        pass
+
     def is_manually_set(self, key):
         return False
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1940,6 +1940,7 @@ class Env(cabc.MutableMapping):
         environment variables with other values. On exit from the context
         manager, the original values are restored.
         The changes are only applied to the current thread, so that they don't leak between threads.
+        To get the thread-local overrides use `get_swapped_values` and `set_swapped_values`.
         """
         old = {}
         # single positional argument should be a dict-like object
@@ -1966,6 +1967,12 @@ class Env(cabc.MutableMapping):
                     self._set_item(k, v, thread_local=True)
             if exception is not None:
                 raise exception from None
+
+    def get_swapped_values(self):
+        return self._d.get_local_overrides()
+
+    def set_swapped_values(self, swapped_values):
+        self._d.set_local_overrides(swapped_values)
 
     #
     # Mutable mapping interface
@@ -2234,6 +2241,14 @@ class InternalEnvironDict(ChainMap):
             del self._local[key]
         except KeyError:
             pass
+
+    def get_local_overrides(self):
+        return self._local.copy()
+
+    def set_local_overrides(self, new_local):
+        local = self._local
+        local.clear()
+        local.update(new_local)
 
 
 def _yield_executables(directory, name):

--- a/xonsh/procs/posix.py
+++ b/xonsh/procs/posix.py
@@ -118,6 +118,8 @@ class PopenThread(threading.Thread):
             self.stderr = io.BytesIO()
         self.suspended = False
         self.prevs_are_closed = False
+        # This is so the thread will use the same swapped values as the origin one.
+        self.original_swapped_values = XSH.env.get_swapped_values()
         self.start()
 
     def run(self):
@@ -125,6 +127,8 @@ class PopenThread(threading.Thread):
         and copying bytes from captured_stdout to stdout and bytes from
         captured_stderr to stderr.
         """
+        # Set the thread-local swapped values.
+        XSH.env.set_swapped_values(self.original_swapped_values)
         proc = self.proc
         spec = self._wait_and_getattr("spec")
         # get stdin and apply parallel reader if needed.

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -451,6 +451,8 @@ class ProcProxyThread(threading.Thread):
             self.old_int_handler = signal.signal(signal.SIGINT, self._signal_int)
         # start up the proc
         super().__init__()
+        # This is so the thread will use the same swapped values as the origin one.
+        self.original_swapped_values = XSH.env.get_swapped_values()
         self.start()
 
     def __del__(self):
@@ -463,6 +465,8 @@ class ProcProxyThread(threading.Thread):
         """
         if self.f is None:
             return
+        # Set the thread-local swapped values.
+        XSH.env.set_swapped_values(self.original_swapped_values)
         spec = self._wait_and_getattr("spec")
         last_in_pipeline = spec.last_in_pipeline
         if last_in_pipeline:


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

This makes `env.swap` thread safe, meaning it doesn't leak to other threads.
This is needed to swap in multiple threads in the same time, for example in the following code which used to fail before this PR:

```python
aliases['a'] = 'print 1 and sleep 1 and print 2'
a | a  # works but leaks $__ALIAS_STACK
a | a  # fails with `Exception: Recursive calls to "a" alias.`
```

This PR is needed for #4445

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
