### PR TITLE
Virtualenv activator plugin

### DIFF
--- a/news/virtualenv-activator-plugin.rst
+++ b/news/virtualenv-activator-plugin.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for the virtualenv ``activate.xsh`` script is back! Ensure you create the virtualenv from the same python where xonsh is installed.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/virtualenv-activator-plugin.rst
+++ b/news/virtualenv-activator-plugin.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Support for the virtualenv ``activate.xsh`` script is back! Ensure you create the virtualenv from the same python where xonsh is installed.
+* Support for the `virtualenv <https://virtualenv.pypa.io/en/20.0.1/extend.html#activation-scripts>`_ ``activate.xsh`` script is back! Ensure you create the virtualenv from the same python where xonsh is installed.
 
 **Changed:**
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -16,6 +16,7 @@ black==22.1.0
 isort >= 5.10
 pre-commit
 pyte>=0.8.0
+virtualenv>=20.7.2
 
 # types related
 mypy==0.941

--- a/setup.py
+++ b/setup.py
@@ -324,6 +324,7 @@ def main():
             "xonsh.pytest",
             "xonsh.lib",
             "xonsh.webconfig",
+            "xonsh.virtualenv",
             "xompletions",
         ],
         package_dir={
@@ -337,6 +338,7 @@ def main():
             "xonsh": ["*.json", "*.githash"],
             "xontrib": ["*.xsh"],
             "xonsh.lib": ["*.xsh"],
+            "xonsh.virtualenv": ["*.xsh"],
             "xonsh.webconfig": [
                 "*.html",
                 "js/app.min.js",
@@ -356,6 +358,7 @@ def main():
             "xonshcon = xonsh.pyghooks:XonshConsoleLexer",
         ],
         "pytest11": ["xonsh = xonsh.pytest.plugin"],
+        "virtualenv.activate": ["xonsh = xonsh.virtualenv:XonshActivator"],
         "console_scripts": [
             "xonsh = xonsh.main:main",
             "xonsh-cat = xonsh.xoreutils.cat:main",

--- a/tests/test_virtualenv_activator.py
+++ b/tests/test_virtualenv_activator.py
@@ -1,8 +1,8 @@
 import sys
 from pathlib import Path
-from subprocess import check_call, check_output
+from subprocess import check_output
 
-from tests.tools import ON_WINDOWS
+from xonsh.pytest.tools import ON_WINDOWS
 
 
 def test_xonsh_activator(tmp_path):

--- a/tests/test_virtualenv_activator.py
+++ b/tests/test_virtualenv_activator.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+from subprocess import check_call, check_output
+
+from tests.tools import ON_WINDOWS
+
+
+def test_xonsh_activator(tmp_path):
+    # Create virtualenv
+    venv_dir = tmp_path / "venv"
+    assert b"XonshActivator" in check_output(
+        [sys.executable, "-m", "virtualenv", str(venv_dir)]
+    )
+    assert venv_dir.is_dir()
+
+    # Check activation script created
+    if ON_WINDOWS:
+        bin_path = venv_dir / "Scripts"
+    else:
+        bin_path = venv_dir / "bin"
+    activate_path = bin_path / "activate.xsh"
+    assert activate_path.is_file()
+
+    # Sanity
+    original_python = check_output(
+        [sys.executable, "-m", "xonsh", "-c", "which python"]
+    ).decode()
+    assert Path(original_python).parent != bin_path
+
+    # Activate
+    venv_python = check_output(
+        [sys.executable, "-m", "xonsh", "-c", f"source {activate_path}; which python"]
+    ).decode()
+    assert Path(venv_python).parent == bin_path
+
+    # Deactivate
+    deactivated_python = check_output(
+        [
+            sys.executable,
+            "-m",
+            "xonsh",
+            "-c",
+            f"source {activate_path}; deactivate; which python",
+        ]
+    ).decode()
+    assert deactivated_python == original_python

--- a/xonsh/virtualenv/__init__.py
+++ b/xonsh/virtualenv/__init__.py
@@ -1,5 +1,5 @@
-from virtualenv.util.path import Path
-from virtualenv.activation.via_template import ViaTemplateActivator
+from virtualenv.activation.via_template import ViaTemplateActivator  # type: ignore
+from virtualenv.util.path import Path  # type: ignore
 
 
 class XonshActivator(ViaTemplateActivator):

--- a/xonsh/virtualenv/__init__.py
+++ b/xonsh/virtualenv/__init__.py
@@ -1,0 +1,11 @@
+from virtualenv.util.path import Path
+from virtualenv.activation.via_template import ViaTemplateActivator
+
+
+class XonshActivator(ViaTemplateActivator):
+    def templates(self):
+        yield Path("activate.xsh")
+
+    @classmethod
+    def supports(cls, interpreter):
+        return interpreter.version_info >= (3, 5)

--- a/xonsh/virtualenv/activate.xsh
+++ b/xonsh/virtualenv/activate.xsh
@@ -1,0 +1,46 @@
+"""Xonsh activate script for virtualenv"""
+from xonsh.tools import get_sep as _get_sep
+
+def _deactivate(args):
+    if "pydoc" in aliases:
+        del aliases["pydoc"]
+
+    if ${...}.get("_OLD_VIRTUAL_PATH", ""):
+        $PATH = $_OLD_VIRTUAL_PATH
+        del $_OLD_VIRTUAL_PATH
+
+    if ${...}.get("_OLD_VIRTUAL_PYTHONHOME", ""):
+        $PYTHONHOME = $_OLD_VIRTUAL_PYTHONHOME
+        del $_OLD_VIRTUAL_PYTHONHOME
+
+    if "VIRTUAL_ENV" in ${...}:
+        del $VIRTUAL_ENV
+
+    if "VIRTUAL_ENV_PROMPT" in ${...}:
+        del $VIRTUAL_ENV_PROMPT
+
+    if "nondestructive" not in args:
+        # Self destruct!
+        del aliases["deactivate"]
+
+
+# unset irrelevant variables
+_deactivate(["nondestructive"])
+aliases["deactivate"] = _deactivate
+
+$VIRTUAL_ENV = r"__VIRTUAL_ENV__"
+
+$_OLD_VIRTUAL_PATH = $PATH
+$PATH = $PATH[:]
+$PATH.add($VIRTUAL_ENV + _get_sep() + "__BIN_NAME__", front=True, replace=True)
+
+if ${...}.get("PYTHONHOME", ""):
+    # unset PYTHONHOME if set
+    $_OLD_VIRTUAL_PYTHONHOME = $PYTHONHOME
+    del $PYTHONHOME
+
+$VIRTUAL_ENV_PROMPT = "__VIRTUAL_PROMPT__"
+if not $VIRTUAL_ENV_PROMPT:
+    del $VIRTUAL_ENV_PROMPT
+
+aliases["pydoc"] = ["python", "-m", "pydoc"]


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Closes #3689

Unfortunately virtualenv removed support for the xonsh activator since we gave them too much trouble :(
So now as recommended we can implement a virtualenv plugin so that new environments will contain the `activate.xsh` script as long as xonsh is installed where `virtualenv` is invoked from.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
