### PR TITLE
fix: not enough space for completions

### DIFF
--- a/news/fix-reserve-menu.rst
+++ b/news/fix-reserve-menu.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Sometimes the completion menu doesn't take space when cursor is at the bottom of the screen.
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -346,7 +346,7 @@ class PromptToolkitShell(BaseShell):
             "editing_mode": editing_mode,
             "prompt_continuation": self.continuation_tokens,
             "enable_history_search": enable_history_search,
-            "reserve_space_for_menu": 0,
+            "reserve_space_for_menu": env.get("COMPLETIONS_MENU_ROWS", None),
             "key_bindings": self.key_bindings,
             "complete_style": complete_style,
             "complete_while_typing": complete_while_typing,

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -335,6 +335,11 @@ class PromptToolkitShell(BaseShell):
         ):
             self.prompter.default_buffer._history_matches = self._history_matches_orig
 
+        menu_rows = env.get("COMPLETIONS_MENU_ROWS", None)
+        if menu_rows:
+            # https://github.com/xonsh/xonsh/pull/4477#pullrequestreview-767982976
+            menu_rows += 1
+
         prompt_args = {
             "mouse_support": mouse_support,
             "auto_suggest": auto_suggest,
@@ -346,7 +351,7 @@ class PromptToolkitShell(BaseShell):
             "editing_mode": editing_mode,
             "prompt_continuation": self.continuation_tokens,
             "enable_history_search": enable_history_search,
-            "reserve_space_for_menu": env.get("COMPLETIONS_MENU_ROWS", None),
+            "reserve_space_for_menu": menu_rows,
             "key_bindings": self.key_bindings,
             "complete_style": complete_style,
             "complete_while_typing": complete_while_typing,


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

fixes https://github.com/xonsh/xonsh/issues/3775

I think it was set to 0 because there is a `reserve_space` method in `PTKCompleter` class. Anyhow it doesn't seem to be working. This change fixes the issue with completions not having enough space

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
