### PR TITLE
feat: option to show only longest/descriptive arg-completions

### DIFF
--- a/news/ap-long-opts.rst
+++ b/news/ap-long-opts.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* added ``$ALIAS_COMPLETIONS_OPTIONS_LONGEST`` to control showing options in completions
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -394,6 +394,7 @@ class ArgparseCompleter:
 
         self.parser, self.remaining_args = self.get_parser(parser, args[1:])
 
+        self.long_opts_only = XSH.env.get("ALIAS_COMPLETIONS_OPTIONS_LONGEST", False)
         self.command = command
         kwargs["command"] = command
         # will be sent to completer function
@@ -498,7 +499,7 @@ class ArgparseCompleter:
 
         # in the end after positionals show remaining unfilled options
         for act in options:
-            for flag in act.option_strings:
+            for flag in sorted(act.option_strings, key=len, reverse=True):
                 desc = ""
                 if act.help:
                     formatter = self.parser._get_formatter()
@@ -507,6 +508,8 @@ class ArgparseCompleter:
                     except KeyError:
                         desc = act.help
                 yield RichCompletion(flag, description=desc)
+                if self.long_opts_only:
+                    break
 
     def _complete_options(self, options):
         while self.remaining_args:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1595,10 +1595,19 @@ class AutoCompletionSetting(Xettings):
     """Tab-completion behavior."""
 
     ALIAS_COMPLETIONS_OPTIONS_BY_DEFAULT = Var.with_default(
-        doc="If True, Argparser based alias completions will show options (e.g. -h, ...) without "
-        "requesting explicitly with option prefix (-).",
+        doc="""\
+If True, :py:class:`xonsh.completers.argparser.ArgparseCompleter` based completions
+will show options (e.g. -h, ...) without requesting explicitly with option prefix (e.g. '-').""",
         default=False,
-        type_str="bool",
+    )
+    ALIAS_COMPLETIONS_OPTIONS_LONGEST = Var.with_default(
+        doc="""\
+Whether to show all options or just the longest for
+the :py:class:`xonsh.completers.argparser.ArgparseCompleter` based completions.
+For example, with ``-h``, ``--help`` both denoting ``help`` action.
+If True, then only ``--help`` is shown.
+This is to reduce the noise in generated completions.""",
+        default=False,
     )
     BASH_COMPLETIONS = Var.with_default(
         doc="This is a list (or tuple) of strings that specifies where the "


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
