### PR TITLE
Allow styling gitstatus separator

### DIFF
--- a/news/gitstatus-style-separator.rst
+++ b/news/gitstatus-style-separator.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Separator used by gitstatus can now be styled using ``XONSH_GITSTATUS_SEPARATOR``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/gitstatus.py
+++ b/xonsh/prompt/gitstatus.py
@@ -62,6 +62,7 @@ class _DEFS(metaclass=NamedConstantMeta):
     BEHIND = XAttr("↓·")
     LINES_ADDED = XAttr("{BLUE}+")
     LINES_REMOVED = XAttr("{RED}-")
+    SEPARATOR = XAttr("{RESET}|")
 
 
 def _get_def(attr: XAttr) -> str:
@@ -243,7 +244,7 @@ def gitstatus_prompt():
             ret += _get_def(fld) + str(val)
 
     if ret:
-        ret += COLORS.RESET + "|"
+        ret += "|"
 
     number_flds = (
         _DEFS.STAGED,
@@ -272,5 +273,7 @@ def gitstatus_prompt():
 
     if not ret.endswith(COLORS.RESET):
         ret += COLORS.RESET
+
+    ret = ret.replace("|", _get_def(_DEFS.SEPARATOR))
 
     return ret


### PR DESCRIPTION
Allows styling the separator in gitstatus. After #4229 "fixed" it, I just can't stand those bright white bars.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
