### PR TITLE
feat: hide select branch names in gitstatus

### DIFF
--- a/news/gitstatus-hide-branch.rst
+++ b/news/gitstatus-hide-branch.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Branch names listed in ``XONSH_GITSTATUS_BRANCHES_HIDDEN`` will be hidden from gitstatus output.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1404,6 +1404,10 @@ class PromptSetting(Xettings):
         ),
         pattern="XONSH_GITSTATUS_*",
     )
+    XONSH_GITSTATUS_BRANCHES_HIDDEN = Var.with_default(
+        (),
+        "Branch names to hide in {gitstatus} prompt.",
+    )
     XONSH_GITSTATUS_FIELDS_HIDDEN = Var.with_default(
         (),
         "Fields to hide in {gitstatus} prompt (all fields below are shown by default.) \n\n"

--- a/xonsh/prompt/gitstatus.py
+++ b/xonsh/prompt/gitstatus.py
@@ -155,6 +155,9 @@ def _get_status_fields():
                 branch = line
             else:
                 branch, rest = line.split("...")
+                hidden = XSH.env.get("XONSH_GITSTATUS_BRANCHES_HIDDEN")
+                if hidden and branch in hidden:
+                    branch = ""
                 if " " in rest:
                     divergence = rest.split(" ", 1)[-1]
                     divergence = divergence.strip("[]")
@@ -236,7 +239,7 @@ def gitstatus_prompt():
 
     ret = ""
     for fld in (_DEFS.BRANCH, _DEFS.AHEAD, _DEFS.BEHIND, _DEFS.OPERATION):
-        if not _is_hidden(fld):
+        if not _is_hidden(fld) and fld:
             val = fields[fld]
             if not val:
                 continue


### PR DESCRIPTION
I'm not particularly fond of `main` or `master` being constantly displayed when I'm working on the main branch, but I want working on a feature branch to be immediately noticeable. This is a proposal  to hide a configurable list of branch names. Pretty opinionated, I know, and I don't particularly insist on merging it, but I felt like I should share it since I've hacked it together.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
