### PR TITLE
Fix for `fromdircolors` crash on Windows

### DIFF
--- a/news/dircolors-fallback.rst
+++ b/news/dircolors-fallback.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``fromdircolors`` doesn't crash if output from subprocess call to ``dircolors`` returns
+  nothing (usually due to permission errors)
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -485,6 +485,8 @@ class LsColors(cabc.MutableMapping):
             )
         except (subprocess.CalledProcessError, FileNotFoundError):
             return cls(cls.default_settings)
+        if not out:
+            return cls(cls.default_settings)
         s = out.splitlines()[0]
         _, _, s = s.partition("'")
         s, _, _ = s.rpartition("'")


### PR DESCRIPTION
Fix for #4491 

It would be good to also understand the permissions errors on the windows side, but this should resolve the startup errors.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
