### PR TITLE
fix: escape curly braces for the prompt cwd

### DIFF
--- a/news/pwd-curly-escape.rst
+++ b/news/pwd-curly-escape.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Curly braces { } in directory names are now escaped in the prompt
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/prompt/test_cwd.py
+++ b/tests/prompt/test_cwd.py
@@ -1,0 +1,16 @@
+from xonsh.prompt.cwd import _replace_home_cwd
+from xonsh.built_ins import XSH
+
+
+def test_cwd_escapes_curly_brackets_with_more_curly_brackets():
+    XSH.env["PWD"] = "{foo}"
+    assert _replace_home_cwd() == "{{foo}}"
+
+    XSH.env["PWD"] = "{{foo}}"
+    assert _replace_home_cwd() == "{{{{foo}}}}"
+
+    XSH.env["PWD"] = "{"
+    assert _replace_home_cwd() == "{{"
+
+    XSH.env["PWD"] = "}}"
+    assert _replace_home_cwd() == "}}}}"

--- a/xonsh/prompt/cwd.py
+++ b/xonsh/prompt/cwd.py
@@ -27,7 +27,8 @@ def _replace_home(x):
 
 
 def _replace_home_cwd():
-    return _replace_home(XSH.env["PWD"])
+    pwd = XSH.env["PWD"].replace("{", "{{").replace("}", "}}")
+    return _replace_home(pwd)
 
 
 def _collapsed_pwd():


### PR DESCRIPTION
If a directory was named for example '{RED}', that would get
interpreted as a color string and the prompt would not show the
direcotry name and would color it instead. Using dir names like
'{{foo}}' or simply '{' would break the prompt outright.

There was not much documentation on the prompt formating, but it seems
that escaping a curly by doubling it makes the prompt display all
curlies correctly.

fixes #4381

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
