### PR TITLE
fix: implement `__hash__` method for `Env`

### DIFF
--- a/news/4510.rst
+++ b/news/4510.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Implemented `__hash__` method to Env, so that it can be used in `lru_cache` without crashing.
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2098,6 +2098,9 @@ class Env(cabc.MutableMapping):
     def __repr__(self):
         return "{0}.{1}(...)".format(self.__class__.__module__, self.__class__.__name__)
 
+    def __hash__(self) -> int:
+        return hash(str(self._d))
+
     def _repr_pretty_(self, p, cycle):
         name = f"{self.__class__.__module__}.{self.__class__.__name__}"
         with p.group(1, name + "(", ")"):


### PR DESCRIPTION
Allows caching in `lru_cache` for `tools.suggest_commands()`

Closes #4510

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
