### PR TITLE
fix: failing ci checks with black and mypy

### DIFF
--- a/.github/workflows/genbuilds.py
+++ b/.github/workflows/genbuilds.py
@@ -65,21 +65,26 @@ def write_to_file(
     (CURR_DIR / fname).write_text(result)
 
 
-# pytest workflows
-for os_name, python_version in product(OS_NAMES, PYTHON_VERSIONS):
-    report_coverage = python_version == PY_MAIN_VERSION
-    if report_coverage:
-        test_cmd = "test --report-coverage --no-amalgam -- --timeout=240"
-    else:
-        test_cmd = "test -- --timeout=240"
+def main():
+    # pytest workflows
+    for os_name, python_version in product(OS_NAMES, PYTHON_VERSIONS):
+        report_coverage = python_version == PY_MAIN_VERSION
+        if report_coverage:
+            test_cmd = "test --report-coverage --no-amalgam -- --timeout=240"
+        else:
+            test_cmd = "test -- --timeout=240"
 
-    write_to_file(
-        "pytest",
-        os_name,
-        python_version,
-        report_coverage=report_coverage,
-        test_cmd=test_cmd,
-    )
+        write_to_file(
+            "pytest",
+            os_name,
+            python_version,
+            report_coverage=report_coverage,
+            test_cmd=test_cmd,
+        )
 
-# qa workflow
-write_to_file("qa", "linux", PY_MAIN_VERSION, test_cmd="qa")
+    # qa workflow
+    write_to_file("qa", "linux", PY_MAIN_VERSION, test_cmd="qa")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pytest.tmpl
+++ b/.github/workflows/pytest.tmpl
@@ -68,7 +68,7 @@ jobs:
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt
-          python -m pip install{% if report_coverage %} -e{% endif %} . --no-deps
+          python -m pip install{% if report_coverage or (test_cmd == "qa")  %} -e{% endif %} . --no-deps
       - name: Run tests
         run: python -m xonsh run-tests.xsh {{ test_cmd }}
         {% if allow_failure %}

--- a/.github/workflows/qa-linux-3.9.yml
+++ b/.github/workflows/qa-linux-3.9.yml
@@ -55,6 +55,6 @@ jobs:
         run: |
           python -m pip --version
           python -m pip install -r requirements/tests.txt
-          python -m pip install . --no-deps
+          python -m pip install -e . --no-deps
       - name: Run tests
         run: python -m xonsh run-tests.xsh qa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ exclude = '''
 
 )
 |
-(
-    # and these additional random rules
+(   # and these additional random rules
     /(  __pycache__
      |  \.circleci
      |  \.github
@@ -36,3 +35,5 @@ exclude = '''
 extend_exclude = '''
 ((xonsh/parser_table.py)|(xonsh/completion_parser_table.py))
 '''
+
+force_exclude = '''.*/__amalgam__.py'''

--- a/run-tests.xsh
+++ b/run-tests.xsh
@@ -70,9 +70,8 @@ def qa():
 
     python -m flake8
 
-    mypy --version
     # todo: add xontrib folder here
-    mypy xonsh --exclude xonsh/ply
+    mypy xonsh
 
     pytest -m news
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@
 max-line-length = 180
 exclude =
     __amalgam__.py,
+    **/__amalgam__.py,
+    **/*/__amalgam__.py,
     docs/,
     */ply/,
     parser*_table.py,
@@ -95,7 +97,7 @@ cache_dir = .cache/mypy/
 warn_unused_configs = True
 warn_no_return = False
 ; a regex to exclude certain directories
-exclude = xonsh/ply
+exclude = ((xonsh/ply)|(__amalgam__.py))
 
 # report
 show_error_context = True


### PR DESCRIPTION
pip21.3 has changed the behaviour of build - https://pip.pypa.io/en/stable/news/#v21-3 to use in-tree-build by default. this creates amalgamated files.

this will install as editable dependency during qa checks

for some reason mypy exclude for __amalgam__.py is not working

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
