### PR TITLE
Fix: don't display welcome if $XONSHRC_DIR member is found

### DIFF
--- a/news/fix-xonshrc-dir-welcome.rst
+++ b/news/fix-xonshrc-dir-welcome.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+*  Do not show welcome message when any `$XONSHRC_DIR` directory entry exists.
+
+**Security:**
+

--- a/news/fix-xonshrc-dir-welcome.rst
+++ b/news/fix-xonshrc-dir-welcome.rst
@@ -8,7 +8,7 @@
 
 **Fixed:**
 
-*  Do not show welcome message when any `$XONSHRC_DIR` directory entry exists.
+*  Do not show welcome message when any ``$XONSHRC_DIR`` directory entry exists.
 
 **Security:**
 

--- a/news/fix-xonshrc-dir-welcome.rst
+++ b/news/fix-xonshrc-dir-welcome.rst
@@ -1,14 +1,23 @@
 **Added:**
 
+* <news item>
+
 **Changed:**
+
+* <news item>
 
 **Deprecated:**
 
+* <news item>
+
 **Removed:**
+
+* <news item>
 
 **Fixed:**
 
-*  Do not show welcome message when any ``$XONSHRC_DIR`` directory entry exists.
+* Do not show welcome message when any ``$XONSHRC_DIR`` directory entry exists.
 
 **Security:**
 
+* <news item>

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -466,6 +466,8 @@ def main_xonsh(args):
             ignore_sigtstp()
             if env["XONSH_INTERACTIVE"] and not any(
                 os.path.isfile(i) for i in env["XONSHRC"]
+            ) and not any(
+                os.path.isdir(i) for i in env["XONSHRC_DIR"]
             ):
                 print_welcome_screen()
             events.on_pre_cmdloop.fire()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -464,10 +464,10 @@ def main_xonsh(args):
             env["XONSH_INTERACTIVE"] = True
 
             ignore_sigtstp()
-            if env["XONSH_INTERACTIVE"] and not any(
-                os.path.isfile(i) for i in env["XONSHRC"]
-            ) and not any(
-                os.path.isdir(i) for i in env["XONSHRC_DIR"]
+            if (
+                env["XONSH_INTERACTIVE"]
+                and not any(os.path.isfile(i) for i in env["XONSHRC"])
+                and not any(os.path.isdir(i) for i in env["XONSHRC_DIR"])
             ):
                 print_welcome_screen()
             events.on_pre_cmdloop.fire()


### PR DESCRIPTION
Currently, even if there is an `$XONSHRC_DIR` in use, xonsh shows the welcome banner. I prefer to use an `rc.d` approach for configuring my system, so I'd rather not create an empty `.xonshrc` just to disable the banner!

I don't know whether we also want to check that these directories are non-empty. I think probably not - simply creating this special directory is enough to suggest that the user knows what they're doing.