### PR TITLE
Fix: support Conda environments when running on non-conda interpreter

### DIFF
--- a/news/fix-conda-env-system.rst
+++ b/news/fix-conda-env-system.rst
@@ -8,7 +8,7 @@
 
 **Fixed:**
 
-* `$CONDA_DEFAULT_ENV` is now respected when xonsh is run outside of conda.
+* ``$CONDA_DEFAULT_ENV`` is now respected when xonsh is run outside of conda.
 
 **Security:**
 

--- a/news/fix-conda-env-system.rst
+++ b/news/fix-conda-env-system.rst
@@ -1,10 +1,18 @@
 **Added:**
 
+* <news item>
+
 **Changed:**
+
+* <news item>
 
 **Deprecated:**
 
+* <news item>
+
 **Removed:**
+
+* <news item>
 
 **Fixed:**
 
@@ -12,3 +20,4 @@
 
 **Security:**
 
+* <news item>

--- a/news/fix-conda-env-system.rst
+++ b/news/fix-conda-env-system.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+* `$CONDA_DEFAULT_ENV` is now respected when xonsh is run outside of conda.
+
+**Security:**
+

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -12,9 +12,10 @@ def find_env_name():
     $CONDA_DEFAULT_ENV if that is set.
     """
     env_path = XSH.env.get("VIRTUAL_ENV", "")
-    if len(env_path) == 0 and xp.ON_ANACONDA:
-        env_path = XSH.env.get("CONDA_DEFAULT_ENV", "")
-    env_name = os.path.basename(env_path)
+    if env_path:
+        env_name = os.path.basename(env_path)
+    else:
+        env_name = XSH.env.get("CONDA_DEFAULT_ENV", "")
     return env_name
 
 

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -4,7 +4,6 @@
 import os
 
 from xonsh.built_ins import XSH
-import xonsh.platform as xp
 
 
 def find_env_name():


### PR DESCRIPTION
Xonsh currently doesn't display the virtual environment if the user is not running xonsh under Conda:
https://github.com/xonsh/xonsh/blob/7331d8aee50e8939f8fe4d5b7133ed3907f204f4/xonsh/prompt/env.py#L15

I have xonsh running under pipx, which uses a virtualenv based on the system Python. I still use Conda to provision other virtualenvs (mainly for the ability to set the Python version; I used to use pyenv). As observed in my case, the environment that xonsh is running in should be independent from activated environments. This PR decouples the platform from the environment.

This PR changes the logic here _slightly_. `$CONDA_DEFAULT_ENV` returns the _name_ of the environment, so we don't need to invoke `os.path.basename`. I also use the `bool("") is False` idiom as I assume that only strings are ever returned here.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
