### PR TITLE
Refactor: reduce API surface of lexer

### DIFF
--- a/news/refactor-lexer-parser.rst
+++ b/news/refactor-lexer-parser.rst
@@ -1,0 +1,12 @@
+**Added:**
+
+**Changed:**
+* Privatise certain attributes of lexer/parser to minimise API surface
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+**Security:**

--- a/news/refactor-lexer-parser.rst
+++ b/news/refactor-lexer-parser.rst
@@ -1,12 +1,23 @@
 **Added:**
 
+* <news item>
+
 **Changed:**
+
 * Privatise certain attributes of lexer/parser to minimise API surface
 
 **Deprecated:**
 
+* <news item>
+
 **Removed:**
+
+* <news item>
 
 **Fixed:**
 
+* <news item>
+
 **Security:**
+
+* <news item>

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -162,8 +162,8 @@ class Execer(object):
                 filename=filename,
                 transform=transform,
             )
-        if code is None:
-            return None  # handles comment only input
+            if code is None:
+                return None  # handles comment only input
         return eval(code, glbs, locs)
 
     def exec(
@@ -195,8 +195,8 @@ class Execer(object):
                 filename=filename,
                 transform=transform,
             )
-        if code is None:
-            return None  # handles comment only input
+            if code is None:
+                return None  # handles comment only input
         return exec(code, glbs, locs)
 
     def _print_debug_wrapping(

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -466,28 +466,28 @@ class Lexer(object):
         """Splits a string into a list of strings which are whitespace-separated
         tokens.
         """
-        vals = []
         self.input(s)
+        elements = []
         l = c = -1
         ws = "WS"
         nl = "\n"
-        for t in self:
-            if t.type == ws:
+        for token in self:
+            if token.type == ws:
                 continue
-            elif l < t.lineno:
-                vals.append(t.value)
-            elif len(vals) > 0 and c == t.lexpos:
-                vals[-1] = vals[-1] + t.value
+            elif l < token.lineno:
+                elements.append(token.value)
+            elif len(elements) > 0 and c == token.lexpos:
+                elements[-1] = elements[-1] + token.value
             else:
-                vals.append(t.value)
-            nnl = t.value.count(nl)
+                elements.append(token.value)
+            nnl = token.value.count(nl)
             if nnl == 0:
-                l = t.lineno
-                c = t.lexpos + len(t.value)
+                l = token.lineno
+                c = token.lexpos + len(token.value)
             else:
-                l = t.lineno + nnl
-                c = len(t.value.rpartition(nl)[-1])
-        return vals
+                l = token.lineno + nnl
+                c = len(token.value.rpartition(nl)[-1])
+        return elements
 
     #
     # All the tokens recognized by the lexer

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -431,7 +431,11 @@ class Lexer(object):
         self.fname = ""
         self.last = None
         self.beforelast = None
-        self.tolerant = tolerant
+        self._tolerant = tolerant
+
+    @property
+    def tolerant(self):
+        return self._tolerant
 
     def build(self, **kwargs):
         """Part of the PLY lexer API."""
@@ -442,7 +446,7 @@ class Lexer(object):
 
     def input(self, s):
         """Calls the lexer on the string s."""
-        self._token_stream = get_tokens(s, self.tolerant)
+        self._token_stream = get_tokens(s, self._tolerant)
 
     def token(self):
         """Retrieves the next token."""

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -496,7 +496,7 @@ class Lexer(object):
     def tokens(self):
         if self._tokens is None:
             kwlist = kwmod.kwlist[:]
-            if PYTHON_VERSION_INFO >= (3, 9, 0) and PYTHON_VERSION_INFO < (3, 10):
+            if (3, 9, 0) <= PYTHON_VERSION_INFO < (3, 10):
                 kwlist.remove("__peg_parser__")
             t = (
                 tuple(token_map.values())

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -432,6 +432,7 @@ class Lexer(object):
         self.last = None
         self.beforelast = None
         self._tolerant = tolerant
+        self._token_stream = iter(())
 
     @property
     def tolerant(self):
@@ -450,8 +451,7 @@ class Lexer(object):
 
     def token(self):
         """Retrieves the next token."""
-        self.beforelast = self.last
-        self.last = next(self._token_stream, None)
+        self.beforelast, self.last = self.last, next(self._token_stream, None)
         return self.last
 
     def __iter__(self):

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -442,12 +442,12 @@ class Lexer(object):
 
     def input(self, s):
         """Calls the lexer on the string s."""
-        self.token_stream = get_tokens(s, self.tolerant)
+        self._token_stream = get_tokens(s, self.tolerant)
 
     def token(self):
         """Retrieves the next token."""
         self.beforelast = self.last
-        self.last = next(self.token_stream, None)
+        self.last = next(self._token_stream, None)
         return self.last
 
     def __iter__(self):

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -443,7 +443,9 @@ class Lexer(object):
         pass
 
     def reset(self):
-        pass
+        self._token_stream = iter(())
+        self.last = None
+        self.beforelast = None
 
     def input(self, s):
         """Calls the lexer on the string s."""

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -278,7 +278,7 @@ class BaseParser(object):
         self.tokens = lexer.tokens
 
         self._lines = None
-        self.xonsh_code = None
+        self._source = None
         self._attach_nocomma_tok_rules()
         self._attach_nocloser_base_rules()
         self._attach_nodedent_base_rules()
@@ -494,7 +494,7 @@ class BaseParser(object):
         self.lexer.reset()
         self._last_yielded_token = None
         self._lines = None
-        self.xonsh_code = None
+        self._source = None
         self._error = None
 
     def parse(self, s, filename="<code>", mode="exec", debug_level=0):
@@ -516,7 +516,7 @@ class BaseParser(object):
         tree : AST
         """
         self.reset()
-        self.xonsh_code = s
+        self._source = s
         self.lexer.fname = filename
         while self.parser is None:
             time.sleep(0.01)  # block until the parser is ready
@@ -618,8 +618,8 @@ class BaseParser(object):
 
     @property
     def lines(self):
-        if self._lines is None and self.xonsh_code is not None:
-            self._lines = self.xonsh_code.splitlines(keepends=True)
+        if self._lines is None and self._source is not None:
+            self._lines = self._source.splitlines(keepends=True)
         return self._lines
 
     def source_slice(self, start, stop):
@@ -647,7 +647,7 @@ class BaseParser(object):
         raise SyntaxError()
 
     def _parse_error(self, msg, loc):
-        raise_parse_error(msg, loc, self.xonsh_code, self.lines)
+        raise_parse_error(msg, loc, self._source, self.lines)
 
     #
     # Precedence of operators

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -622,7 +622,7 @@ class BaseParser(object):
             self._lines = self._source.splitlines(keepends=True)
         return self._lines
 
-    def source_slice(self, start, stop):
+    def _source_slice(self, start, stop):
         """Gets the original source code from two (line, col) tuples in
         source-space (i.e. lineno start at 1).
         """
@@ -1759,7 +1759,7 @@ class BaseParser(object):
         p3, p5 = p[3], p[5]
         beg = (p3.lineno, p3.lexpos)
         end = (p5.lineno, p5.lexpos)
-        s = self.source_slice(beg, end)
+        s = self._source_slice(beg, end)
         s = textwrap.dedent(s)
         p[0] = ast.Str(s=s, lineno=beg[0], col_offset=beg[1])
 
@@ -1768,7 +1768,7 @@ class BaseParser(object):
         p1, p3 = p[1], p[3]
         beg = (p1.lineno, p1.lexpos + 1)
         end = (p3.lineno, p3.lexpos)
-        s = self.source_slice(beg, end).strip()
+        s = self._source_slice(beg, end).strip()
         p[0] = ast.Str(s=s, lineno=beg[0], col_offset=beg[1])
 
     def _attach_nodedent_base_rules(self):
@@ -2573,7 +2573,7 @@ class BaseParser(object):
             ends = p2 + ends
         elts = []
         for beg, end in zip(begins, ends):
-            s = self.source_slice(beg, end).strip()
+            s = self._source_slice(beg, end).strip()
             if not s:
                 if len(begins) == 1:
                     break
@@ -3137,7 +3137,7 @@ class BaseParser(object):
         p3 = p[3]
         l = p1.lineno
         c = p1.lexpos + 1
-        subcmd = self.source_slice((l, c), (p3.lineno, p3.lexpos))
+        subcmd = self._source_slice((l, c), (p3.lineno, p3.lexpos))
         subcmd = subcmd.strip() + "\n"
         p0 = [
             ast.Str(s="xonsh", lineno=l, col_offset=c),
@@ -3177,7 +3177,7 @@ class BaseParser(object):
         p3, p5 = p[3], p[5]
         beg = (p3.lineno, p3.lexpos + 1)
         end = (p5.lineno, p5.lexpos)
-        s = self.source_slice(beg, end).strip()
+        s = self._source_slice(beg, end).strip()
         node = ast.Str(s=s, lineno=beg[0], col_offset=beg[1])
         p[2][-1].elts.append(node)
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

This is a small PR to clean up the lex/parse logic of xonsh. Right now, we have a lot of global state through `XSH.execer.parser.lexer`, and a large API surface. This PR will reduce the size of public API, whilst also simplifying / cleaning up the code. 

I'm not very familiar with the xonsh codebase, so the direction might change as I learn more. 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
