### PR TITLE
Refactor: minimise globals in codebase

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ from xonsh.environ import Env, Var, Xettings
 
 if tp.TYPE_CHECKING:
     from xonsh.environ import VarKeyType
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.xontribs_meta import get_xontribs
 from xonsh.commands_cache import CommandsCache
 
@@ -37,7 +37,7 @@ import rst_helpers
 spec = importlib.util.find_spec("prompt_toolkit")
 if spec is not None:
     # hacky runaround to import PTK-specific events
-    XSH.env = Env()
+    xsh.XSH.env = Env()
     from xonsh.ptk_shell.shell import events
 else:
     from xonsh.events import events
@@ -447,9 +447,9 @@ def make_events():
 make_xontribs()
 make_events()
 
-XSH.history = None
-XSH.env = {}
-XSH.commands_cache = CommandsCache()
+xsh.XSH.history = None
+xsh.XSH.env = {}
+xsh.XSH.commands_cache = CommandsCache()
 
 
 def setup(app):

--- a/docs/xonshrc.py
+++ b/docs/xonshrc.py
@@ -1,6 +1,6 @@
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
-env = XSH.env
+env = xsh.XSH.env
 # adjust some paths
 env["PATH"].append("/home/scopatz/sandbox/bin")
 env["LD_LIBRARY_PATH"] = ["/home/scopatz/.local/lib", "/home/scopatz/miniconda3/lib"]
@@ -10,9 +10,9 @@ def _quit_awesome(args, stdin=None):
     print("awesome python code")
 
 
-XSH.aliases["qa"] = _quit_awesome
+xsh.XSH.aliases["qa"] = _quit_awesome
 # setting aliases as list are faster since they don't involve parser.
-XSH.aliases["gc"] = ["git", "commit"]
+xsh.XSH.aliases["gc"] = ["git", "commit"]
 
 # some customization options, see https://xon.sh/envvars.html for details
 env["MULTILINE_PROMPT"] = "`·.,¸,.·*¯`·.,¸,.·*¯"

--- a/tests/aliases/test_completer_alias.py
+++ b/tests/aliases/test_completer_alias.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.completers._aliases import add_one_completer
 from xonsh.completers.tools import non_exclusive_completer
 
@@ -30,6 +30,6 @@ NON_EXCLUSIVE = non_exclusive_completer(lambda: None)
     ),
 )
 def test_add_completer_start(monkeypatch, initial, exp):
-    monkeypatch.setattr(XSH, "completers", initial)
+    monkeypatch.setattr(xsh.XSH, "completers", initial)
     add_one_completer("new", SIMPLE, "start")
-    assert list(XSH.completers.keys()) == exp
+    assert list(xsh.XSH.completers.keys()) == exp

--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -16,7 +16,9 @@ from xonsh.completers.commands import complete_command, complete_skipper
 
 @pytest.fixture(autouse=True)
 def xs_orig_commands_cache(xession, monkeypatch, xonsh_execer):
-    xession.unload()
+    assert False
+    xession._unload()
+    # TODO Fixme
     xession.load(execer=xonsh_execer)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from xonsh.aliases import Aliases
-from xonsh.built_ins import XonshSession, XSH
+from xonsh.session import XonshSession, XSH
 from xonsh.completer import Completer
 from xonsh.execer import Execer
 from xonsh.jobs import tasks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,8 @@ def session_vars():
 def xonsh_builtins(monkeypatch, xonsh_events, session_vars):
     """Mock out most of the builtins xonsh attributes."""
     old_builtins = dict(vars(builtins).items())  # type: ignore
-
+    assert False
+    # TODO fixme
     XSH.load(ctx={}, **session_vars)
 
     def locate_binary(self, name):

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -6,7 +6,7 @@ from subprocess import Popen
 import pytest
 
 from xonsh.procs.specs import cmds_to_specs, run_subproc
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.procs.posix import PopenThread
 from xonsh.procs.proxies import ProcProxy, ProcProxyThread, STDOUT_DISPATCHER
 
@@ -50,7 +50,7 @@ def test_cmds_to_specs_thread_subproc(xession):
 
 @pytest.mark.parametrize("thread_subprocs", [True, False])
 def test_cmds_to_specs_capture_stdout_not_stderr(thread_subprocs):
-    env = XSH.env
+    env = xsh.XSH.env
     cmds = (["ls", "/root"],)
 
     env["THREAD_SUBPROCS"] = thread_subprocs
@@ -76,7 +76,7 @@ def test_capture_always(
         else:
             return pytest.skip("https://github.com/xonsh/xonsh/issues/4444")
 
-    env = XSH.env
+    env = xsh.XSH.env
     exp = "HELLO\nBYE\n"
     cmds = [["echo", "-n", exp]]
     if pipe:
@@ -88,15 +88,15 @@ def test_capture_always(
         # Enable capfd for function aliases:
         monkeypatch.setattr(STDOUT_DISPATCHER, "default", sys.stdout)
         if alias_type == "func":
-            XSH.aliases["tst"] = (
+            xsh.XSH.aliases["tst"] = (
                 lambda: run_subproc([first_cmd], "hiddenobject") and None
             )  # Don't return a value
         elif alias_type == "exec":
             first_cmd = " ".join(repr(arg) for arg in first_cmd)
-            XSH.aliases["tst"] = f"![{first_cmd}]"
+            xsh.XSH.aliases["tst"] = f"![{first_cmd}]"
         else:
             # alias_type == "simple"
-            XSH.aliases["tst"] = first_cmd
+            xsh.XSH.aliases["tst"] = first_cmd
 
         cmds[0] = ["tst"]
 

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -8,7 +8,7 @@ import pytest
 from xonsh import imphooks
 from xonsh.execer import Execer
 from xonsh.environ import Env
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 imphooks.install_import_hooks()
 
@@ -18,7 +18,7 @@ def imp_env(xession):
     Execer(unload=False)
     xession.env = Env({"PATH": [], "PATHEXT": []})
     yield
-    XSH.unload()
+    xsh.XSH.unload()
 
 
 def test_import():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@ import itertools
 import pytest
 
 from xonsh.ast import AST, With, Pass, Str, Call
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.parser import Parser
 from xonsh.parsers.fstring_adaptor import FStringAdaptor
 
@@ -43,7 +43,7 @@ def check_stmts(inp, run=True, mode="exec", debug_level=0):
 
 
 def check_xonsh_ast(xenv, inp, run=True, mode="eval", debug_level=0, return_obs=False):
-    XSH.env = xenv
+    xsh.XSH.env = xenv
     obs = PARSER.parse(inp, debug_level=debug_level)
     if obs is None:
         return  # comment only
@@ -167,7 +167,7 @@ def test_fstring_adaptor(inp, exp):
     assert isinstance(joined_str_node, ast.JoinedStr)
     node = ast.Expression(body=joined_str_node)
     code = compile(node, "<test_fstring_adaptor>", mode="eval")
-    XSH.env = {"HOME": "/foo/bar", "FOO": "HO", "BAR": "ME"}
+    xsh.XSH.env = {"HOME": "/foo/bar", "FOO": "HO", "BAR": "ME"}
     obs = eval(code)
     assert exp == obs
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -8,7 +8,7 @@ import pytest
 from xonsh.platform import ON_WINDOWS
 from xonsh.procs.pipelines import CommandPipeline
 from tests.tools import skip_if_on_windows, skip_if_on_unix
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 @pytest.fixture(autouse=True)
@@ -18,12 +18,12 @@ def patched_events(monkeypatch, xonsh_events, xonsh_execer):
     tasks.clear()
     # needed for ci tests
     monkeypatch.setitem(
-        XSH.env, "RAISE_SUBPROC_ERROR", False
+        xsh.XSH.env, "RAISE_SUBPROC_ERROR", False
     )  # for the failing `grep` commands
-    monkeypatch.setitem(XSH.env, "XONSH_CAPTURE_ALWAYS", True)  # capture output of ![]
+    monkeypatch.setitem(xsh.XSH.env, "XONSH_CAPTURE_ALWAYS", True)  # capture output of ![]
     if ON_WINDOWS:
         monkeypatch.setattr(
-            XSH,
+            xsh.XSH,
             "aliases",
             {
                 "echo": "cmd /c echo".split(),

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -18,7 +18,7 @@ from pygments.token import (
 from tools import skip_if_on_windows
 
 from xonsh.platform import ON_WINDOWS
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.pyghooks import XonshLexer, Color, XonshStyle, on_lscolors_change
 from xonsh.environ import LsColors
 from xonsh.events import events, EventManager
@@ -28,8 +28,8 @@ from tools import DummyShell
 @pytest.fixture(autouse=True)
 def load_command_cache(xession):
     gc.collect()
-    XSH.unload()
-    XSH.load()
+    xsh.XSH.unload()
+    xsh.XSH.load()
     if ON_WINDOWS:
         for key in ("cd", "bash"):
             xession.aliases[key] = lambda *args, **kwargs: None

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -12,7 +12,7 @@ from collections.abc import MutableMapping
 
 import pytest
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.environ import Env
 from xonsh.base_shell import BaseShell
 
@@ -169,12 +169,12 @@ class DummyEnv(MutableMapping):
 
 
 def check_exec(input, **kwargs):
-    XSH.execer.exec(input, **kwargs)
+    xsh.XSH.execer.exec(input, **kwargs)
     return True
 
 
 def check_eval(input):
-    XSH.env = Env(
+    xsh.XSH.env = Env(
         {
             "AUTO_CD": False,
             "XONSH_ENCODING": "utf-8",
@@ -183,13 +183,13 @@ def check_eval(input):
         }
     )
     if ON_WINDOWS:
-        XSH.env["PATHEXT"] = [".COM", ".EXE", ".BAT", ".CMD"]
-    XSH.execer.eval(input)
+        xsh.XSH.env["PATHEXT"] = [".COM", ".EXE", ".BAT", ".CMD"]
+    xsh.XSH.execer.eval(input)
     return True
 
 
 def check_parse(input):
-    tree = XSH.execer.parse(input, ctx=None)
+    tree = xsh.XSH.execer.parse(input, ctx=None)
     return tree
 
 

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -3,7 +3,7 @@ import re
 import sys
 import warnings
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.platform import HAS_PYGMENTS
 from xonsh.lazyasd import LazyDict, lazyobject
 from xonsh.color_tools import (
@@ -48,7 +48,7 @@ def _ensure_color_map(style="default", cmap=None):
         except Exception:
             msg = "Could not find color style {0!r}, using default."
             print(msg.format(style), file=sys.stderr)
-            XSH.env["XONSH_COLOR_STYLE"] = "default"
+            xsh.XSH.env["XONSH_COLOR_STYLE"] = "default"
             cmap = ANSI_STYLES["default"]
     return cmap
 
@@ -162,7 +162,7 @@ def ansi_partial_color_format(template, style="default", cmap=None, hide=False):
 
 def _ansi_partial_color_format_main(template, style="default", cmap=None, hide=False):
     cmap = _ensure_color_map(style=style, cmap=cmap)
-    overrides = XSH.env["XONSH_STYLE_OVERRIDES"]
+    overrides = xsh.XSH.env["XONSH_STYLE_OVERRIDES"]
     if overrides:
         cmap.update(_style_dict_to_ansi(overrides))
     esc = ("\001" if hide else "") + "\033["

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -108,7 +108,7 @@ from ast import Ellipsis as EllipsisNode
 import textwrap
 import itertools
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.tools import subproc_toks, find_next_break, get_logical_line
 
 from ast import (
@@ -314,8 +314,8 @@ def isexpression(node, ctx=None, *args, **kwargs):
     # parse string to AST
     if isinstance(node, str):
         node = node if node.endswith("\n") else node + "\n"
-        ctx = XSH.ctx if ctx is None else ctx
-        node = XSH.execer.parse(node, ctx, *args, **kwargs)
+        ctx = xsh.XSH.ctx if ctx is None else ctx
+        node = xsh.XSH.execer.parse(node, ctx, *args, **kwargs)
     # determine if expression-like enough
     if isinstance(node, (Expr, Expression)):
         isexpr = True

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -6,7 +6,7 @@ import sys
 import time
 from os.path import expanduser
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.tools import (
     XonshError,
     print_exception,
@@ -67,7 +67,7 @@ class _TeeStdBuf(io.RawIOBase):
         """
         self.stdbuf = stdbuf
         self.membuf = membuf
-        env = XSH.env
+        env = xsh.XSH.env
         self.encoding = env.get("XONSH_ENCODING") if encoding is None else encoding
         self.errors = env.get("XONSH_ENCODING_ERRORS") if errors is None else errors
         self.prestd = prestd
@@ -269,7 +269,7 @@ class Tee:
             write_through=write_through,
         )
         self.stdout = _TeeStd("stdout", self.memory)
-        env = XSH.env
+        env = xsh.XSH.env
         prestderr = format_std_prepost(env.get("XONSH_STDERR_PREFIX"))
         poststderr = format_std_prepost(env.get("XONSH_STDERR_POSTFIX"))
         self.stderr = _TeeStd(
@@ -332,7 +332,7 @@ class BaseShell:
             if HAS_PYGMENTS:
                 from xonsh.pyghooks import XonshStyle
 
-                env = XSH.env
+                env = xsh.XSH.env
                 self._styler = XonshStyle(env.get("XONSH_COLOR_STYLE"))
             else:
                 self._styler = None
@@ -378,8 +378,8 @@ class BaseShell:
 
         events.on_precommand.fire(cmd=src)
 
-        env = XSH.env
-        hist = XSH.history  # pylint: disable=no-member
+        env = xsh.XSH.env
+        hist = xsh.XSH.history  # pylint: disable=no-member
         ts1 = None
         enc = env.get("XONSH_ENCODING")
         err = env.get("XONSH_ENCODING_ERRORS")
@@ -417,7 +417,7 @@ class BaseShell:
                 print(os.linesep, end="")
             tee.close()
             self._fix_cwd()
-        if XSH.exit:  # pylint: disable=no-member
+        if xsh.XSH.exit:  # pylint: disable=no-member
             return True
 
     def _append_history(self, tee_out=None, **info):
@@ -426,7 +426,7 @@ class BaseShell:
         This also handles on_postcommand because this is the place where all the
         information is available.
         """
-        hist = XSH.history  # pylint: disable=no-member
+        hist = xsh.XSH.history  # pylint: disable=no-member
         info["rtn"] = hist.last_cmd_rtn if hist is not None else None
         tee_out = tee_out or None
         last_out = hist.last_cmd_out if hist is not None else None
@@ -447,7 +447,7 @@ class BaseShell:
 
     def _fix_cwd(self):
         """Check if the cwd changed out from under us."""
-        env = XSH.env
+        env = xsh.XSH.env
         try:
             cwd = os.getcwd()
         except OSError:
@@ -534,7 +534,7 @@ class BaseShell:
 
     def settitle(self):
         """Sets terminal title."""
-        env = XSH.env  # pylint: disable=no-member
+        env = xsh.XSH.env  # pylint: disable=no-member
         term = env.get("TERM", None)
         # Shells running in emacs sets TERM to "dumb" or "eterm-color".
         # Do not set title for these to avoid garbled prompt.
@@ -568,7 +568,7 @@ class BaseShell:
                     print_exception()
                     self.mlprompt = "<multiline prompt error> "
             return self.mlprompt
-        env = XSH.env  # pylint: disable=no-member
+        env = xsh.XSH.env  # pylint: disable=no-member
         p = env.get("PROMPT")
         try:
             p = self.prompt_formatter(p)
@@ -581,7 +581,7 @@ class BaseShell:
         """Formats the colors in a string. ``BaseShell``'s default implementation
         of this method uses colors based on ANSI color codes.
         """
-        style = XSH.env.get("XONSH_COLOR_STYLE")
+        style = xsh.XSH.env.get("XONSH_COLOR_STYLE")
         return ansi_partial_color_format(string, hide=hide, style=style)
 
     def print_color(self, string, hide=False, **kwargs):
@@ -594,7 +594,7 @@ class BaseShell:
             s = self.format_color(string, hide=hide)
         elif HAS_PYGMENTS:
             # assume this is a list of (Token, str) tuples and format it
-            env = XSH.env
+            env = xsh.XSH.env
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
             style_proxy = pyghooks.xonsh_style_proxy(self.styler)
             formatter = pyghooks.XonshTerminal256Formatter(style=style_proxy)

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -29,6 +29,7 @@ from xonsh.tools import (
     XonshCalledProcessError,
     print_color,
 )
+import xonsh.session as xsh
 
 INSPECTOR = Inspector()
 
@@ -101,9 +102,9 @@ def regexsearch(s):
 
 
 def globsearch(s):
-    csc = XSH.env.get("CASE_SENSITIVE_COMPLETIONS")
-    glob_sorted = XSH.env.get("GLOB_SORTED")
-    dotglob = XSH.env.get("DOTGLOB")
+    csc = xsh.XSH.env.get("CASE_SENSITIVE_COMPLETIONS")
+    glob_sorted = xsh.XSH.env.get("GLOB_SORTED")
+    dotglob = xsh.XSH.env.get("DOTGLOB")
     return globpath(
         s,
         ignore_case=(not csc),
@@ -152,7 +153,7 @@ def subproc_captured_inject(*cmds, envs=None):
     toks = []
     for line in o:
         line = line.rstrip(os.linesep)
-        toks.extend(XSH.execer.parser.lexer.split(line))
+        toks.extend(xsh.XSH.execer.parser.lexer.split(line))
     return toks
 
 
@@ -228,16 +229,16 @@ def list_of_list_of_strs_outer_product(x):
     for los in itertools.product(*lolos):
         s = "".join(los)
         if "*" in s:
-            rtn.extend(XSH.glob(s))
+            rtn.extend(xsh.XSH.glob(s))
         else:
-            rtn.append(XSH.expand_path(s))
+            rtn.append(xsh.XSH.expand_path(s))
     return rtn
 
 
 def eval_fstring_field(field):
     """Evaluates the argument in Xonsh context."""
-    res = XSH.execer.eval(
-        field[0].strip(), glbs=globals(), locs=XSH.ctx, filename=field[1]
+    res = xsh.XSH.execer.eval(
+        field[0].strip(), glbs=globals(), locs=xsh.XSH.ctx, filename=field[1]
     )
     return res
 
@@ -303,7 +304,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name="<arg>", macroname="<ma
     if kind is str or kind is None:
         return raw_arg  # short circuit since there is nothing else to do
     # select from kind and convert
-    execer = XSH.execer
+    execer = xsh.XSH.execer
     filename = macroname + "(" + name + ")"
     if kind is AST:
         ctx = set(dir(builtins)) | set(glbs.keys())
@@ -416,7 +417,7 @@ def _eval_regular_args(raw_args, glbs, locs):
         return [], {}
     arglist = list(itertools.takewhile(_starts_as_arg, raw_args))
     kwarglist = raw_args[len(arglist) :]
-    execer = XSH.execer
+    execer = xsh.XSH.execer
     if not arglist:
         args = arglist
         kwargstr = "dict({})".format(", ".join(kwarglist))

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -35,33 +35,6 @@ INSPECTOR = Inspector()
 warnings.filterwarnings("once", category=DeprecationWarning)
 
 
-@lazyobject
-def AT_EXIT_SIGNALS():
-    sigs = (
-        signal.SIGABRT,
-        signal.SIGFPE,
-        signal.SIGILL,
-        signal.SIGSEGV,
-        signal.SIGTERM,
-    )
-    if ON_POSIX:
-        sigs += (signal.SIGTSTP, signal.SIGQUIT, signal.SIGHUP)
-    return sigs
-
-
-def resetting_signal_handle(sig, f):
-    """Sets a new signal handle that will automatically restore the old value
-    once the new handle is finished.
-    """
-    oldh = signal.getsignal(sig)
-
-    def newh(s=None, frame=None):
-        f(s, frame)
-        signal.signal(sig, oldh)
-        if sig != 0:
-            sys.exit(sig)
-
-    signal.signal(sig, newh)
 
 
 def helper(x, name=""):
@@ -501,11 +474,6 @@ def enter_macro(obj, raw_block, glbs, locs):
     return obj
 
 
-def _lastflush(s=None, f=None):
-    if XSH.history is not None:
-        XSH.history.flush(at_exit=True)
-
-
 @contextlib.contextmanager
 def xonsh_builtins(execer=None):
     """A context manager for using the xonsh builtins only in a limited
@@ -514,161 +482,6 @@ def xonsh_builtins(execer=None):
     XSH.load(execer=execer)
     yield
     XSH.unload()
-
-
-class XonshSession:
-    """All components defining a xonsh session."""
-
-    def __init__(self, execer=None, ctx=None):
-        """
-        Parameters
-        ----------
-        execer : Execer, optional
-            Xonsh execution object, may be None to start
-        ctx : Mapping, optional
-            Context to start xonsh session with.
-        """
-        self.execer = execer
-        self.ctx = {} if ctx is None else ctx
-        self.builtins_loaded = False
-        self.history = None
-        self.shell = None
-        self.env = None
-        self.rc_files = None
-
-    def load(self, execer=None, ctx=None, **kwargs):
-        """Loads the session with default values.
-
-        Parameters
-        ----------
-        execer : Execer, optional
-            Xonsh execution object, may be None to start
-        ctx : Mapping, optional
-            Context to start xonsh session with.
-        """
-        from xonsh.environ import Env, default_env
-        from xonsh.commands_cache import CommandsCache
-        from xonsh.completers.init import default_completers
-
-        if not hasattr(builtins, "__xonsh__"):
-            builtins.__xonsh__ = self
-        if ctx is not None:
-            self.ctx = ctx
-
-        self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env())
-        self.help = kwargs.pop("help") if "help" in kwargs else helper
-        self.superhelp = superhelper
-        self.pathsearch = pathsearch
-        self.globsearch = globsearch
-        self.regexsearch = regexsearch
-        self.glob = globpath
-        self.expand_path = expand_path
-        self.exit = False
-        self.stdout_uncaptured = None
-        self.stderr_uncaptured = None
-
-        if hasattr(builtins, "exit"):
-            self.pyexit = builtins.exit
-            del builtins.exit
-
-        if hasattr(builtins, "quit"):
-            self.pyquit = builtins.quit
-            del builtins.quit
-
-        self.subproc_captured_stdout = subproc_captured_stdout
-        self.subproc_captured_inject = subproc_captured_inject
-        self.subproc_captured_object = subproc_captured_object
-        self.subproc_captured_hiddenobject = subproc_captured_hiddenobject
-        self.subproc_uncaptured = subproc_uncaptured
-        self.execer = execer
-        self.commands_cache = (
-            kwargs.pop("commands_cache")
-            if "commands_cache" in kwargs
-            else CommandsCache()
-        )
-        self.modules_cache = {}
-        self.all_jobs = {}
-        self.ensure_list_of_strs = ensure_list_of_strs
-        self.list_of_strs_or_callables = list_of_strs_or_callables
-        self.list_of_list_of_strs_outer_product = list_of_list_of_strs_outer_product
-        self.eval_fstring_field = eval_fstring_field
-
-        self.completers = default_completers()
-        self.call_macro = call_macro
-        self.enter_macro = enter_macro
-        self.path_literal = path_literal
-
-        self.builtins = _BuiltIns(execer)
-
-        aliases_given = kwargs.pop("aliases", None)
-        for attr, value in kwargs.items():
-            if hasattr(self, attr):
-                setattr(self, attr, value)
-        self.link_builtins(aliases_given)
-        self.builtins_loaded = True
-
-    def link_builtins(self, aliases=None):
-        from xonsh.aliases import Aliases, make_default_aliases
-
-        # public built-ins
-        proxy_mapping = [
-            "XonshError",
-            "XonshCalledProcessError",
-            "evalx",
-            "execx",
-            "compilex",
-            "events",
-            "print_color",
-            "printx",
-        ]
-        for refname in proxy_mapping:
-            objname = f"__xonsh__.builtins.{refname}"
-            proxy = DynamicAccessProxy(refname, objname)
-            setattr(builtins, refname, proxy)
-
-        # sneak the path search functions into the aliases
-        # Need this inline/lazy import here since we use locate_binary that
-        # relies on __xonsh__.env in default aliases
-        if aliases is None:
-            aliases = Aliases(make_default_aliases())
-        self.aliases = builtins.default_aliases = builtins.aliases = aliases
-        atexit.register(_lastflush)
-        for sig in AT_EXIT_SIGNALS:
-            resetting_signal_handle(sig, _lastflush)
-
-    def unlink_builtins(self):
-        names = [
-            "XonshError",
-            "XonshCalledProcessError",
-            "evalx",
-            "execx",
-            "compilex",
-            "default_aliases",
-            "events",
-            "print_color",
-            "printx",
-        ]
-
-        for name in names:
-            if hasattr(builtins, name):
-                delattr(builtins, name)
-
-    def unload(self):
-        if not hasattr(builtins, "__xonsh__"):
-            self.builtins_loaded = False
-            return
-        env = getattr(self, "env", None)
-        if hasattr(self.env, "undo_replace_env"):
-            env.undo_replace_env()
-        if hasattr(self, "pyexit"):
-            builtins.exit = self.pyexit
-        if hasattr(self, "pyquit"):
-            builtins.quit = self.pyquit
-        if not self.builtins_loaded:
-            return
-        self.unlink_builtins()
-        delattr(builtins, "__xonsh__")
-        self.builtins_loaded = False
 
 
 class _BuiltIns:
@@ -736,5 +549,8 @@ class DynamicAccessProxy:
         return self.obj.__dir__()
 
 
-# singleton
-XSH = XonshSession()
+# TODO: remove this in the future
+@lazyobject
+def XSH():
+    from .session import XSH
+    return XSH

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -474,32 +474,6 @@ def enter_macro(obj, raw_block, glbs, locs):
     return obj
 
 
-@contextlib.contextmanager
-def xonsh_builtins(execer=None):
-    """A context manager for using the xonsh builtins only in a limited
-    scope. Likely useful in testing.
-    """
-    XSH.load(execer=execer)
-    yield
-    XSH.unload()
-
-
-def create_builtins_namespace(execer):
-    from xonsh.events import events
-
-    return types.SimpleNamespace(
-        # public built-ins
-        XonshError=XonshError,
-        XonshCalledProcessError=XonshCalledProcessError,
-        evalx=None if execer is None else execer.eval,
-        execx=None if execer is None else execer.exec,
-        compilex=None if execer is None else execer.compile,
-        events=events,
-        print_color=print_color,
-        printx=print_color,
-    )
-
-
 class DynamicAccessProxy:
     """Proxies access dynamically."""
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -484,18 +484,20 @@ def xonsh_builtins(execer=None):
     XSH.unload()
 
 
-class _BuiltIns:
-    def __init__(self, execer=None):
-        from xonsh.events import events
+def create_builtins_namespace(execer):
+    from xonsh.events import events
 
+    return types.SimpleNamespace(
         # public built-ins
-        self.XonshError = XonshError
-        self.XonshCalledProcessError = XonshCalledProcessError
-        self.evalx = None if execer is None else execer.eval
-        self.execx = None if execer is None else execer.exec
-        self.compilex = None if execer is None else execer.compile
-        self.events = events
-        self.print_color = self.printx = print_color
+        XonshError=XonshError,
+        XonshCalledProcessError=XonshCalledProcessError,
+        evalx=None if execer is None else execer.eval,
+        execx=None if execer is None else execer.exec,
+        compilex=None if execer is None else execer.compile,
+        events=events,
+        print_color=print_color,
+        printx=print_color,
+    )
 
 
 class DynamicAccessProxy:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -523,10 +523,3 @@ class DynamicAccessProxy:
 
     def __dir__(self):
         return self.obj.__dir__()
-
-
-# TODO: remove this in the future
-@lazyobject
-def XSH():
-    from .session import XSH
-    return XSH

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -266,13 +266,13 @@ class RstHelpFormatter(ap.RawTextHelpFormatter):
 
 
 def get_argparse_formatter_class():
-    from xonsh.built_ins import XSH
+    import xonsh.session as xsh
     from xonsh.platform import HAS_PYGMENTS
 
     if (
         hasattr(sys, "stderr")
         and sys.stderr.isatty()
-        and XSH.env.get("XONSH_INTERACTIVE")
+        and xsh.XSH.env.get("XONSH_INTERACTIVE")
         and HAS_PYGMENTS
     ):
         return RstHelpFormatter

--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from xonsh import __version__ as XONSH_VERSION
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.lazyasd import lazyobject
 from xonsh.platform import PYTHON_VERSION_INFO_BYTES
 
@@ -42,10 +42,10 @@ def should_use_cache(execer, mode):
     """
     if mode == "exec":
         return (execer.scriptcache or execer.cacheall) and (
-            XSH.env["XONSH_CACHE_SCRIPTS"] or XSH.env["XONSH_CACHE_EVERYTHING"]
+            xsh.XSH.env["XONSH_CACHE_SCRIPTS"] or xsh.XSH.env["XONSH_CACHE_EVERYTHING"]
         )
     else:
-        return execer.cacheall or XSH.env["XONSH_CACHE_EVERYTHING"]
+        return execer.cacheall or xsh.XSH.env["XONSH_CACHE_EVERYTHING"]
 
 
 def run_compiled_code(code, glb, loc, mode):
@@ -71,7 +71,7 @@ def get_cache_filename(fname, code=True):
     The ``code`` switch should be true if we should use the code store rather
     than the script store.
     """
-    datadir = XSH.env["XONSH_DATA_DIR"]
+    datadir = xsh.XSH.env["XONSH_DATA_DIR"]
     cachedir = os.path.join(
         datadir, "xonsh_code_cache" if code else "xonsh_script_cache"
     )

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -30,7 +30,7 @@ class CommandsCache(cabc.Mapping):
     the command has an alias.
     """
 
-    def __init__(self, cache_path):
+    def __init__(self, cache_path=None):
         self._cmds_cache = {}
         self._path_checksum = None
         self._alias_checksum = None

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -40,11 +40,11 @@ class CommandsCache(cabc.Mapping):
         self._cache_path = cache_path
 
     def __contains__(self, key):
-        _ = self.all_commands
+        self.update_cache()
         return self.lazyin(key)
 
     def __iter__(self):
-        for cmd, (path, _) in self.all_commands.items():
+        for cmd, (path, _) in self.update_cache().items():
             if ON_WINDOWS and path is not None:
                 # All command keys are stored in uppercase on Windows.
                 # This ensures the original command name is returned.
@@ -52,10 +52,10 @@ class CommandsCache(cabc.Mapping):
             yield cmd
 
     def __len__(self):
-        return len(self.all_commands)
+        return len(self.update_cache())
 
     def __getitem__(self, key):
-        _ = self.all_commands
+        self.update_cache()
         return self.lazyget(key)
 
     def is_empty(self):
@@ -99,8 +99,7 @@ class CommandsCache(cabc.Mapping):
         yield max_mtime <= self._path_mtime
         self._path_mtime = max_mtime
 
-    @property
-    def all_commands(self):
+    def update_cache(self):
         env = xsh.XSH.env
         path = [] if env is None else xsh.XSH.env.get("PATH", [])
         path_immut = tuple(CommandsCache.remove_dups(path))
@@ -229,7 +228,7 @@ class CommandsCache(cabc.Mapping):
             (default ``False``)
         """
         # make sure the cache is up to date by accessing the property
-        _ = self.all_commands
+        self.update_cache()
         return self.lazy_locate_binary(name, ignore_alias)
 
     def lazy_locate_binary(self, name, ignore_alias=False):
@@ -267,7 +266,7 @@ class CommandsCache(cabc.Mapping):
         no underlying executable. For example, the "cd" command is only available
         as a functional alias.
         """
-        _ = self.all_commands
+        self.update_cache()
         return self.lazy_is_only_functional_alias(name)
 
     def lazy_is_only_functional_alias(self, name):

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -30,14 +30,14 @@ class CommandsCache(cabc.Mapping):
     the command has an alias.
     """
 
-    def __init__(self, cache_file):
+    def __init__(self, cache_path):
         self._cmds_cache = {}
         self._path_checksum = None
         self._alias_checksum = None
         self._path_mtime = -1
         self.threadable_predictors = default_threadable_predictors()
         self._loaded_pickled = False
-        self.cache_file = cache_file
+        self._cache_path = cache_path
 
     def __contains__(self, key):
         _ = self.all_commands
@@ -122,7 +122,7 @@ class CommandsCache(cabc.Mapping):
                 self.set_cmds_cache(self._cmds_cache)
             return self._cmds_cache
 
-        if self.cache_file and self.cache_file.exists():
+        if self._cache_path and self._cache_path.exists():
             # pickle the result only if XONSH_DATA_DIR is set
             if not self._loaded_pickled:
                 # first time load the commands from cache-file
@@ -167,18 +167,18 @@ class CommandsCache(cabc.Mapping):
         return self.set_cmds_cache(allcmds)
 
     def get_cached_commands(self) -> tp.Dict[str, str]:
-        if self.cache_file and self.cache_file.exists():
+        if self._cache_path and self._cache_path.exists():
             try:
-                return pickle.loads(self.cache_file.read_bytes()) or {}
+                return pickle.loads(self._cache_path.read_bytes()) or {}
             except Exception:
                 # the file is corrupt
-                self.cache_file.unlink(missing_ok=True)
+                self._cache_path.unlink(missing_ok=True)
         return {}
 
     def set_cmds_cache(self, allcmds: tp.Dict[str, tp.Any]) -> tp.Dict[str, tp.Any]:
         """write cmds to cache-file and instance-attribute"""
-        if self.cache_file:
-            self.cache_file.write_bytes(pickle.dumps(allcmds))
+        if self._cache_path:
+            self._cache_path.write_bytes(pickle.dumps(allcmds))
         self._cmds_cache = allcmds
         return allcmds
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -11,7 +11,7 @@ from xonsh.completers.tools import (
     apply_lprefix,
     is_exclusive_completer,
 )
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.parsers.completion_context import CompletionContext, CompletionContextParser
 from xonsh.tools import print_exception
 
@@ -127,7 +127,7 @@ class Completer(object):
     def generate_completions(
         completion_context, old_completer_args, trace: bool
     ) -> tp.Iterator[tp.Tuple[Completion, int]]:
-        for name, func in XSH.completers.items():
+        for name, func in xsh.XSH.completers.items():
             try:
                 if is_contextual_completer(func):
                     if completion_context is None:
@@ -196,13 +196,13 @@ class Completer(object):
                 break
 
     def complete_from_context(self, completion_context, old_completer_args=None):
-        trace = XSH.env.get("XONSH_TRACE_COMPLETIONS")
+        trace = xsh.XSH.env.get("XONSH_TRACE_COMPLETIONS")
         if trace:
             print("\nTRACE COMPLETIONS: Getting completions with context:")
             sys.displayhook(completion_context)
         lprefix = 0
         completions = set()
-        query_limit = XSH.env.get("COMPLETION_QUERY_LIMIT")
+        query_limit = xsh.XSH.env.get("COMPLETION_QUERY_LIMIT")
 
         for comp in self.generate_completions(
             completion_context,

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -1,5 +1,5 @@
 import xonsh.cli_utils as xcli
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.completers.completer import (
     list_completers,
     remove_completer,
@@ -76,7 +76,7 @@ def _register_completer(
     """
     err = None
     func_name = func
-    xsh = XSH
+    xsh = xsh.XSH
     if name in xsh.completers:
         err = f"The name {name} is already a registered completer function."
     else:
@@ -123,7 +123,7 @@ def complete_argparser_aliases(command: CommandContext):
         return
     cmd = command.args[0].value
 
-    alias = XSH.aliases.get(cmd)  # type: ignore
+    alias = xsh.XSH.aliases.get(cmd)  # type: ignore
     # todo: checking isinstance(alias, ArgParserAlias) fails when amalgamated.
     #  see https://github.com/xonsh/xonsh/pull/4267#discussion_r676066853
     if not hasattr(alias, "parser"):

--- a/xonsh/completers/argparser.py
+++ b/xonsh/completers/argparser.py
@@ -1,7 +1,7 @@
 import argparse as ap
 import typing as tp
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.completers.tools import RichCompletion
 from xonsh.parsers.completion_context import CommandContext
 
@@ -63,10 +63,10 @@ class ArgparseCompleter:
             yield from act.choices
         elif hasattr(act, "completer") and callable(act.completer):  # type: ignore
             # call the completer function
-            from xonsh.built_ins import XSH
+            import xonsh.session as xsh
 
             kwargs.update(self.kwargs)
-            yield from act.completer(xsh=XSH, action=act, completer=self, **kwargs)  # type: ignore
+            yield from act.completer(xsh=xsh.XSH, action=act, completer=self, **kwargs)  # type: ignore
 
     def _complete_pos(self, act):
         if isinstance(act.choices, dict):  # sub-parsers
@@ -103,7 +103,7 @@ class ArgparseCompleter:
             return
 
         # complete remaining options only if requested or enabled
-        show_opts = XSH.env.get("ALIAS_COMPLETIONS_OPTIONS_BY_DEFAULT", False)
+        show_opts = xsh.XSH.env.get("ALIAS_COMPLETIONS_OPTIONS_BY_DEFAULT", False)
         if not show_opts:
             if not (
                 self.command.prefix

--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -6,14 +6,14 @@ from xonsh.completers.path import _quote_paths
 from xonsh.completers.bash_completion import bash_completions
 from xonsh.completers.tools import contextual_command_completer, RichCompletion
 from xonsh.parsers.completion_context import CommandContext
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 @contextual_command_completer
 def complete_from_bash(context: CommandContext):
     """Completes based on results from BASH completion."""
-    env = XSH.env.detype()  # type: ignore
-    paths = XSH.env.get("BASH_COMPLETIONS", ())  # type: ignore
+    env = xsh.XSH.env.detype()  # type: ignore
+    paths = xsh.XSH.env.get("BASH_COMPLETIONS", ())  # type: ignore
     command = xp.bash_command()
     args = [arg.value for arg in context.args]
     prefix = context.prefix  # without the quotes

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -12,7 +12,7 @@ from xonsh.completers.tools import (
     non_exclusive_completer,
 )
 from xonsh.parsers.completion_context import CompletionContext, CommandContext
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 SKIP_TOKENS = {"sudo", "time", "timeit", "which", "showcmd", "man"}
@@ -27,7 +27,7 @@ def complete_command(command: CommandContext):
     cmd = command.prefix
     out: tp.Set[Completion] = {
         RichCompletion(s, append_space=True)
-        for s in XSH.commands_cache  # type: ignore
+        for s in xsh.XSH.commands_cache  # type: ignore
         if get_filter_function()(s, cmd)
     }
     if xp.ON_WINDOWS:
@@ -67,7 +67,7 @@ def complete_skipper(command_context: CommandContext):
         # completing the command after a SKIP_TOKEN
         return complete_command(skipped_command_context)
 
-    completer: Completer = XSH.shell.shell.completer  # type: ignore
+    completer: Completer = xsh.XSH.shell.shell.completer  # type: ignore
     return completer.complete_from_context(CompletionContext(skipped_command_context))
 
 

--- a/xonsh/completers/completer.py
+++ b/xonsh/completers/completer.py
@@ -1,6 +1,6 @@
 import collections
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.cli_utils import Arg, Annotated, get_doc
 from xonsh.completers.tools import (
     justify,
@@ -17,7 +17,7 @@ def add_one_completer(name, func, loc="end"):
         # because then they won't be used when this completer is successful.
         # On the other hand, if the new completer is non-exclusive,
         # we want it to be before all other exclusive completers so that is will always work.
-        items = list(XSH.completers.items())
+        items = list(xsh.XSH.completers.items())
         first_exclusive = next(
             (i for i, (_, v) in enumerate(items) if is_exclusive_completer(v)),
             len(items),
@@ -28,13 +28,13 @@ def add_one_completer(name, func, loc="end"):
         for k, v in items[first_exclusive:]:
             new[k] = v
     elif loc == "end":
-        for (k, v) in XSH.completers.items():
+        for (k, v) in xsh.XSH.completers.items():
             new[k] = v
         new[name] = func
     else:
         direction, rel = loc[0], loc[1:]
         found = False
-        for (k, v) in XSH.completers.items():
+        for (k, v) in xsh.XSH.completers.items():
             if rel == k and direction == "<":
                 new[name] = func
                 found = True
@@ -44,15 +44,15 @@ def add_one_completer(name, func, loc="end"):
                 found = True
         if not found:
             new[name] = func
-    XSH.completers.clear()
-    XSH.completers.update(new)
+    xsh.XSH.completers.clear()
+    xsh.XSH.completers.update(new)
 
 
 def list_completers():
     """List the active completers"""
     o = "Registered Completer Functions: (NX = Non Exclusive)\n\n"
     non_exclusive = " [NX]"
-    _comp = XSH.completers
+    _comp = xsh.XSH.completers
     ml = max((len(i) for i in _comp), default=0)
     exclusive_len = ml + len(non_exclusive) + 1
     _strs = []
@@ -87,10 +87,10 @@ def remove_completer(
         completers in order)
     """
     err = None
-    if name not in XSH.completers:
+    if name not in xsh.XSH.completers:
         err = f"The name {name} is not a registered completer function."
     if err is None:
-        del XSH.completers[name]
+        del xsh.XSH.completers[name]
         return
     else:
         return None, err + "\n", 1

--- a/xonsh/completers/environment.py
+++ b/xonsh/completers/environment.py
@@ -1,4 +1,4 @@
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.parsers.completion_context import CompletionContext
 from xonsh.completers.tools import (
     contextual_completer,
@@ -26,7 +26,7 @@ def complete_environment_vars(context: CompletionContext):
     key = prefix[dollar_location + 1 :]
     lprefix = len(key) + 1
     filter_func = get_filter_function()
-    env = XSH.env
+    env = xsh.XSH.env
 
     return (
         RichCompletion(

--- a/xonsh/completers/imports.py
+++ b/xonsh/completers/imports.py
@@ -16,7 +16,7 @@ from importlib.machinery import all_suffixes
 from zipimport import zipimporter
 import typing as tp
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.lazyasd import lazyobject
 from xonsh.completers.tools import (
     contextual_completer,
@@ -86,7 +86,7 @@ def get_root_modules():
     Returns a list containing the names of all the modules available in the
     folders of the pythonpath.
     """
-    rootmodules_cache = XSH.modules_cache
+    rootmodules_cache = xsh.XSH.modules_cache
     rootmodules = list(sys.builtin_module_names)
     start_time = time()
     for path in sys.path:

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -5,7 +5,7 @@ import subprocess
 import typing as tp
 
 from xonsh.parsers.completion_context import CommandContext
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 import xonsh.lazyasd as xl
 
 from xonsh.completers.tools import get_filter_function, contextual_command_completer
@@ -32,7 +32,7 @@ def complete_from_man(context: CommandContext):
     """
     global OPTIONS, OPTIONS_PATH
     if OPTIONS is None:
-        datadir: str = XSH.env["XONSH_DATA_DIR"]  # type: ignore
+        datadir: str = xsh.XSH.env["XONSH_DATA_DIR"]  # type: ignore
         OPTIONS_PATH = os.path.join(datadir, "man_completions_cache")
         try:
             with open(OPTIONS_PATH, "rb") as f:

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -3,7 +3,7 @@ import re
 import ast
 import glob
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.parsers.completion_context import CommandContext
 
 import xonsh.tools as xt
@@ -27,7 +27,7 @@ def PATTERN_NEED_QUOTES():
 
 def cd_in_command(line):
     """Returns True if "cd" is a token in the line, False otherwise."""
-    lexer = XSH.execer.parser.lexer
+    lexer = xsh.XSH.execer.parser.lexer
     lexer.reset()
     lexer.input(line)
     have_cd = False
@@ -81,7 +81,7 @@ def _path_from_partial_string(inp, pos=None):
     except (SyntaxError, ValueError):
         return None
     if isinstance(val, bytes):
-        env = XSH.env
+        env = xsh.XSH.env
         val = val.decode(
             encoding=env.get("XONSH_ENCODING"), errors=env.get("XONSH_ENCODING_ERRORS")
         )
@@ -103,7 +103,7 @@ def _normpath(p):
         p = os.path.join(os.curdir, p)
     if trailing_slash:
         p = os.path.join(p, "")
-    if xp.ON_WINDOWS and XSH.env.get("FORCE_POSIX_PATHS"):
+    if xp.ON_WINDOWS and xsh.XSH.env.get("FORCE_POSIX_PATHS"):
         p = p.replace(os.sep, os.altsep)
     return p
 
@@ -119,7 +119,7 @@ def _startswithnorm(x, start, startlow=None):
 
 
 def _dots(prefix):
-    complete_dots = XSH.env.get("COMPLETE_DOTS", "matching").lower()
+    complete_dots = xsh.XSH.env.get("COMPLETE_DOTS", "matching").lower()
     if complete_dots == "never":
         return ()
     slash = xt.get_sep()
@@ -138,7 +138,7 @@ def _dots(prefix):
 
 def _add_cdpaths(paths, prefix):
     """Completes current prefix using CDPATH"""
-    env = XSH.env
+    env = xsh.XSH.env
     csc = env.get("CASE_SENSITIVE_COMPLETIONS")
     glob_sorted = env.get("GLOB_SORTED")
     for cdp in env.get("CDPATH"):
@@ -160,7 +160,7 @@ def _quote_to_use(x):
 
 
 def _is_directory_in_cdpath(path):
-    env = XSH.env
+    env = xsh.XSH.env
     for cdp in env.get("CDPATH"):
         if os.path.isdir(os.path.join(cdp, path)):
             return True
@@ -168,7 +168,7 @@ def _is_directory_in_cdpath(path):
 
 
 def _quote_paths(paths, start, end, append_end=True, cdpath=False):
-    expand_path = XSH.expand_path
+    expand_path = xsh.XSH.expand_path
     out = set()
     space = " "
     backslash = "\\"
@@ -275,7 +275,7 @@ def _subsequence_match_iter(ref, typed):
 
 def _expand_one(sofar, nextone, csc):
     out = set()
-    glob_sorted = XSH.env.get("GLOB_SORTED")
+    glob_sorted = xsh.XSH.env.get("GLOB_SORTED")
     for i in sofar:
         _glob = os.path.join(_joinpath(i), "*") if i is not None else "*"
         for j in xt.iglobpath(_glob, sort_result=glob_sorted):
@@ -305,7 +305,7 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
             append_end = False
     tilde = "~"
     paths = set()
-    env = XSH.env
+    env = xsh.XSH.env
     csc = env.get("CASE_SENSITIVE_COMPLETIONS")
     glob_sorted = env.get("GLOB_SORTED")
     prefix = glob.escape(prefix)

--- a/xonsh/completers/pip.py
+++ b/xonsh/completers/pip.py
@@ -4,7 +4,7 @@ import shlex
 import subprocess
 
 import xonsh.lazyasd as xl
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.completers.tools import (
     contextual_command_completer,
     get_filter_function,
@@ -28,7 +28,7 @@ def complete_pip(context: CommandContext):
     filter_func = get_filter_function()
 
     args = [arg.raw_value for arg in context.args]
-    env = XSH.env.detype()
+    env = xsh.XSH.env.detype()
     env.update(
         {
             "PIP_AUTO_COMPLETE": "1",

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -8,7 +8,7 @@ from xonsh.parsers.completion_context import CompletionContext, PythonContext
 
 import xonsh.tools as xt
 import xonsh.lazyasd as xl
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 from xonsh.completers.tools import (
     CompleterResult,
@@ -144,7 +144,7 @@ def complete_python(context: CompletionContext) -> CompleterResult:
         # this can be a command (i.e. not a subexpression)
         first = context.command.args[0].value
         ctx = context.python.ctx or {}
-        if first in XSH.commands_cache and first not in ctx:  # type: ignore
+        if first in xsh.XSH.commands_cache and first not in ctx:  # type: ignore
             # this is a known command, so it won't be python code
             return None
 
@@ -205,7 +205,7 @@ def _safe_eval(expr, ctx):
     a (None, None) tuple.
     """
     _ctx = None
-    xonsh_safe_eval = XSH.execer.eval
+    xonsh_safe_eval = xsh.XSH.execer.eval
     try:
         val = xonsh_safe_eval(expr, ctx, ctx, transform=False)
         _ctx = ctx
@@ -244,7 +244,7 @@ def attr_complete(prefix, ctx, filter_func):
         if _val_ is None and _ctx_ is None:
             continue
         a = getattr(val, opt)
-        if XSH.env["COMPLETIONS_BRACKETS"]:
+        if xsh.XSH.env["COMPLETIONS_BRACKETS"]:
             if callable(a):
                 rpl = opt + "("
             elif isinstance(a, (cabc.Sequence, cabc.Mapping)):

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -4,7 +4,7 @@ import textwrap
 import typing as tp
 from functools import wraps
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.lazyasd import lazyobject
 from xonsh.parsers.completion_context import CompletionContext, CommandContext
 
@@ -22,7 +22,7 @@ def get_filter_function():
     Return an appropriate filtering function for completions, given the valid
     of $CASE_SENSITIVE_COMPLETIONS
     """
-    csc = XSH.env.get("CASE_SENSITIVE_COMPLETIONS")
+    csc = xsh.XSH.env.get("CASE_SENSITIVE_COMPLETIONS")
     if csc:
         return _filter_normal
     else:

--- a/xonsh/contexts.py
+++ b/xonsh/contexts.py
@@ -3,7 +3,7 @@ import sys
 import textwrap
 from collections.abc import Mapping
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 class Block(object):
@@ -29,7 +29,7 @@ class Block(object):
 
     def __enter__(self):
         if not hasattr(self, "macro_block"):
-            raise XSH.builtins.XonshError(
+            raise xsh.XSH.builtins.XonshError(
                 self.__class__.__name__ + " must be entered as a macro!"
             )
         self.lines = self.macro_block.splitlines()
@@ -96,7 +96,7 @@ class Functor(Block):
         fstr = fstr.format(name=name, sig=sig, body=body, rtn=rtn)
         glbs = self.glbs
         locs = self.locs
-        execer = XSH.execer
+        execer = xsh.XSH.execer
         execer.exec(fstr, glbs=glbs, locs=locs)
         if locs is not None and name in locs:
             func = locs[name]

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -9,7 +9,7 @@ import subprocess
 import typing as tp
 from contextlib import contextmanager
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.cli_utils import Annotated, Arg, ArgParserAlias
 from xonsh.events import events
 from xonsh.platform import ON_WINDOWS
@@ -148,7 +148,7 @@ def _get_cwd():
 
 
 def _change_working_directory(newdir, follow_symlinks=False):
-    env = XSH.env
+    env = xsh.XSH.env
     old = env["PWD"]
     new = os.path.join(old, newdir)
 
@@ -183,10 +183,10 @@ def _try_cdpath(apath):
     # a second $ cd xonsh has no effects, to move in the nested xonsh
     # in bash a full $ cd ./xonsh is needed.
     # In xonsh a relative folder is always preferred.
-    env = XSH.env
+    env = xsh.XSH.env
     cdpaths = env.get("CDPATH")
     for cdp in cdpaths:
-        globber = XSH.expand_path(os.path.join(cdp, apath))
+        globber = xsh.XSH.expand_path(os.path.join(cdp, apath))
         for cdpath_prefixed_path in glob.iglob(globber):
             return cdpath_prefixed_path
     return apath
@@ -198,7 +198,7 @@ def cd(args, stdin=None):
     If no directory is specified (i.e. if `args` is None) then this
     changes to the current user's home directory.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     oldpwd = env.get("OLDPWD", None)
     cwd = env["PWD"]
 
@@ -304,7 +304,7 @@ def pushd_fn(
     """
     global DIRSTACK
 
-    env = XSH.env
+    env = xsh.XSH.env
 
     pwd = env["PWD"]
 
@@ -395,7 +395,7 @@ def popd_fn(
     """
     global DIRSTACK
 
-    env = XSH.env
+    env = xsh.XSH.env
 
     if env.get("PUSHD_MINUS"):
         BACKWARD = "-"
@@ -441,7 +441,7 @@ def popd_fn(
 
     if new_pwd is not None:
         if cd:
-            env = XSH.env
+            env = xsh.XSH.env
             pwd = env["PWD"]
 
             _change_working_directory(new_pwd)
@@ -486,7 +486,7 @@ def dirs_fn(
     """
     global DIRSTACK
 
-    env = XSH.env
+    env = xsh.XSH.env
     dirstack = [os.path.expanduser(env["PWD"])] + DIRSTACK
 
     if env.get("PUSHD_MINUS"):

--- a/xonsh/dumb_shell.py
+++ b/xonsh/dumb_shell.py
@@ -1,6 +1,6 @@
 """A dumb shell for when $TERM == 'dumb', which usually happens in emacs."""
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.readline_shell import ReadlineShell
 
 
@@ -8,5 +8,5 @@ class DumbShell(ReadlineShell):
     """A dumb shell for when $TERM == 'dumb', which usually happens in emacs."""
 
     def __init__(self, *args, **kwargs):
-        XSH.env["XONSH_COLOR_STYLE"] = "emacs"
+        xsh.XSH.env["XONSH_COLOR_STYLE"] = "emacs"
         super().__init__(*args, **kwargs)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -30,7 +30,7 @@ from xonsh.platform import (
     ON_CYGWIN,
     os_environ,
 )
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.tools import (
     always_true,
     always_false,
@@ -192,8 +192,8 @@ def to_debug(x):
     execer's debug level.
     """
     val = to_bool_or_int(x)
-    if XSH.execer is not None:
-        XSH.execer.debug_level = val
+    if xsh.XSH.execer is not None:
+        xsh.XSH.execer.debug_level = val
     return val
 
 
@@ -422,7 +422,7 @@ class LsColors(cabc.MutableMapping):
     @property
     def style_name(self):
         """Current XONSH_COLOR_STYLE value"""
-        env = getattr(XSH, "env", {}) or {}
+        env = getattr(xsh.XSH, "env", {}) or {}
         env_style_name = env.get("XONSH_COLOR_STYLE", "default")
         if self._style_name is None or self._style_name != env_style_name:
             self._style_name = env_style_name
@@ -474,8 +474,8 @@ class LsColors(cabc.MutableMapping):
         if filename is not None:
             cmd.append(filename)
         # get env
-        if XSH.env:
-            denv = XSH.env.detype()
+        if xsh.XSH.env:
+            denv = xsh.XSH.env.detype()
         else:
             denv = None
         # run dircolors
@@ -516,7 +516,7 @@ def ensure_ls_colors_in_env(spec=None, **kwargs):
     environment. This fires exactly once upon the first time the
     ls command is called.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     if "LS_COLORS" not in env._d:
         # this adds it to the env too
         default_lscolors(env)
@@ -2285,7 +2285,7 @@ def _yield_executables(directory, name):
 
 def locate_binary(name):
     """Locates an executable on the file system."""
-    return XSH.commands_cache.locate_binary(name)
+    return xsh.XSH.commands_cache.locate_binary(name)
 
 
 def xonshrc_context(

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -1,7 +1,7 @@
 """
 Events for xonsh.
 
-In all likelihood, you want xonsh.built_ins.XSH.events
+In all likelihood, you want xonsh.built_ins.xsh.XSH.events
 
 The best way to "declare" an event is something like::
 
@@ -11,7 +11,7 @@ import abc
 import collections.abc
 import inspect
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.tools import print_exception
 
 
@@ -22,8 +22,9 @@ def has_kwargs(func):
 
 
 def debug_level():
-    if XSH.env:
-        return XSH.env.get("XONSH_DEBUG")
+    return 0 # TODO FIXME
+    if xsh.XSH.env:
+        return xsh.XSH.env.get("XONSH_DEBUG")
     # FIXME: Under py.test, return 1(?)
     else:
         return 0  # Optimize for speed, not guaranteed correctness

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -17,7 +17,7 @@ from xonsh.tools import (
     starting_whitespace,
     ends_with_colon_token,
 )
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 class Execer(object):
@@ -28,8 +28,6 @@ class Execer(object):
         filename="<xonsh-code>",
         debug_level=0,
         parser_args=None,
-        unload=True,
-        xonsh_ctx=None,
         scriptcache=True,
         cacheall=False,
     ):
@@ -41,10 +39,6 @@ class Execer(object):
             Debugging level to use in lexing and parsing.
         parser_args : dict, optional
             Arguments to pass down to the parser.
-        unload : bool, optional
-            Whether or not to unload xonsh builtins upon deletion.
-        xonsh_ctx : dict or None, optional
-            Xonsh xontext to load as xonsh.built_ins.XSH.ctx
         scriptcache : bool, optional
             Whether or not to use a precompiled bytecode cache when execing
             code, default: True.
@@ -57,15 +51,9 @@ class Execer(object):
         self.filename = filename
         self._default_filename = filename
         self.debug_level = debug_level
-        self.unload = unload
         self.scriptcache = scriptcache
         self.cacheall = cacheall
         self.ctxtransformer = CtxAwareTransformer(self.parser)
-        XSH.load(execer=self, ctx=xonsh_ctx)
-
-    def __del__(self):
-        if self.unload:
-            XSH.unload()
 
     def parse(self, input, ctx, mode="exec", filename=None, transform=True):
         """Parses xonsh code in a context-aware fashion. For context-free

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -11,7 +11,7 @@ import warnings
 import functools
 import collections.abc as cabc
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.lazyasd import lazyobject
 from xonsh.tools import to_bool, ensure_string
 from xonsh.platform import ON_WINDOWS, ON_CYGWIN, ON_MSYS
@@ -275,8 +275,8 @@ def foreign_shell_data(
         tmpfile.write(command.encode("utf8"))
         tmpfile.close()
         cmd.append(tmpfile.name)
-    if currenv is None and XSH.env:
-        currenv = XSH.env.detype()
+    if currenv is None and xsh.XSH.env:
+        currenv = xsh.XSH.env.detype()
     elif currenv is not None:
         currenv = dict(currenv)
     try:
@@ -472,7 +472,7 @@ class ForeignShellBaseAlias(object):
         args, streaming = self._is_streaming(args)
         input = self.INPUT.format(args=" ".join(args), **self._input_kwargs())
         cmd = [self.shell] + list(self.extra_args) + ["-c", input]
-        env = XSH.env
+        env = xsh.XSH.env
         denv = env.detype()
         if streaming:
             subprocess.check_call(cmd, env=denv)
@@ -699,15 +699,15 @@ def load_foreign_aliases(shells):
         A dictionary of the merged aliases.
     """
     aliases = {}
-    xonsh_aliases = XSH.aliases
+    xonsh_aliases = xsh.XSH.aliases
     for shell in shells:
         shell = ensure_shell(shell)
         _, shaliases = foreign_shell_data(**shell)
-        if not XSH.env.get("FOREIGN_ALIASES_OVERRIDE"):
+        if not xsh.XSH.env.get("FOREIGN_ALIASES_OVERRIDE"):
             shaliases = {} if shaliases is None else shaliases
             for alias in set(shaliases) & set(xonsh_aliases):
                 del shaliases[alias]
-                if XSH.env.get("XONSH_DEBUG") >= 1:
+                if xsh.XSH.env.get("XONSH_DEBUG") >= 1:
                     print(
                         "aliases: ignoring alias {!r} of shell {!r} "
                         "which tries to override xonsh alias."

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -7,7 +7,7 @@ import collections
 import threading
 import collections.abc as cabc
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 try:
     import ujson as json
@@ -91,7 +91,7 @@ def _xhj_gc_bytes_to_rmfiles(hsize, files):
 
 def _xhj_get_data_dir():
     dir = xt.expanduser_abs_path(
-        os.path.join(XSH.env.get("XONSH_DATA_DIR"), "history_json")
+        os.path.join(xsh.XSH.env.get("XONSH_DATA_DIR"), "history_json")
     )
     if not os.path.exists(dir):
         os.makedirs(dir)
@@ -104,7 +104,7 @@ def _xhj_get_history_files(sort=True, newest_first=False):
     """
     data_dirs = [
         _xhj_get_data_dir(),
-        XSH.env.get("XONSH_DATA_DIR"),  # backwards compatibility, remove in the future
+        xsh.XSH.env.get("XONSH_DATA_DIR"),  # backwards compatibility, remove in the future
     ]
 
     files = []
@@ -117,14 +117,14 @@ def _xhj_get_history_files(sort=True, newest_first=False):
                 if f.startswith("xonsh-") and f.endswith(".json")
             ]
         except OSError:
-            if XSH.env.get("XONSH_DEBUG"):
+            if xsh.XSH.env.get("XONSH_DEBUG"):
                 xt.print_exception(
                     f"Could not collect xonsh history json files from {data_dir}"
                 )
     if sort:
         files.sort(key=lambda x: os.path.getmtime(x), reverse=newest_first)
 
-    custom_history_file = XSH.env.get("XONSH_HISTORY_FILE", None)
+    custom_history_file = xsh.XSH.env.get("XONSH_HISTORY_FILE", None)
     if custom_history_file:
         custom_history_file = xt.expanduser_abs_path(custom_history_file)
         if custom_history_file not in files:
@@ -156,7 +156,7 @@ class JsonHistoryGC(threading.Thread):
     def run(self):
         while self.wait_for_shell:
             time.sleep(0.01)
-        env = XSH.env  # pylint: disable=no-member
+        env = xsh.XSH.env  # pylint: disable=no-member
         xonsh_debug = env.get("XONSH_DEBUG", 0)
         if self.size is None:
             hsize, units = env.get("XONSH_HISTORY_SIZE")
@@ -168,7 +168,7 @@ class JsonHistoryGC(threading.Thread):
             raise ValueError("Units type {0!r} not understood".format(units))
 
         size_over, rm_files = rmfiles_fn(hsize, files)
-        hist = getattr(XSH, "history", None)
+        hist = getattr(xsh.XSH, "history", None)
         if hist is not None:  # remember last gc pass history size
             hist.hist_size = size_over + hsize
             hist.hist_units = units
@@ -200,7 +200,7 @@ class JsonHistoryGC(threading.Thread):
         This is sorted by the last closed time. Returns a list of
         (file_size, timestamp, number of cmds, file name) tuples.
         """
-        env = XSH.env
+        env = xsh.XSH.env
         if env is None:
             return []
 
@@ -282,7 +282,7 @@ class JsonHistoryFlusher(threading.Thread):
 
     def dump(self):
         """Write the cached history to external storage."""
-        opts = XSH.env.get("HISTCONTROL", "")
+        opts = xsh.XSH.env.get("HISTCONTROL", "")
         last_inp = None
         cmds = []
         for cmd in self.buffer:
@@ -308,7 +308,7 @@ class JsonHistoryFlusher(threading.Thread):
             if "ts" in hist:
                 hist["ts"][1] = time.time()  # apply end time
             hist["locked"] = False
-        if not XSH.env.get("XONSH_STORE_STDOUT", False):
+        if not xsh.XSH.env.get("XONSH_STORE_STDOUT", False):
             [cmd.pop("out") for cmd in hist["cmds"][load_hist_len:] if "out" in cmd]
         with open(self.filename, "w", newline="\n") as f:
             xlj.ljdump(hist, f, sort_keys=True)
@@ -446,7 +446,7 @@ class JsonHistory(History):
         self.save_cwd = (
             save_cwd
             if save_cwd is not None
-            else XSH.env.get("XONSH_HISTORY_SAVE_CWD", True)
+            else xsh.XSH.env.get("XONSH_HISTORY_SAVE_CWD", True)
         )
 
     def __len__(self):
@@ -473,7 +473,7 @@ class JsonHistory(History):
         if not self.remember_history:
             return
 
-        opts = XSH.env.get("HISTCONTROL", "")
+        opts = xsh.XSH.env.get("HISTCONTROL", "")
         skipped_by_ignore_space = "ignorespace" in opts and cmd.get("spc")
         if skipped_by_ignore_space:
             return None
@@ -554,7 +554,7 @@ class JsonHistory(History):
                 commands = json_file.load()["cmds"]
             except (json.decoder.JSONDecodeError, ValueError):
                 # file is corrupted somehow
-                if XSH.env.get("XONSH_DEBUG") > 0:
+                if xsh.XSH.env.get("XONSH_DEBUG") > 0:
                     msg = "xonsh history file {0!r} is not valid JSON"
                     print(msg.format(f), file=sys.stderr)
                 continue
@@ -573,7 +573,7 @@ class JsonHistory(History):
         data["length"] = len(self)
         data["buffersize"] = self.buffersize
         data["bufferlength"] = len(self.buffer)
-        envs = XSH.env
+        envs = xsh.XSH.env
         data["gc options"] = envs.get("XONSH_HISTORY_SIZE")
         data["gc_last_size"] = f"{(self.hist_size, self.hist_units)}"
         return data

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import typing as tp
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 import xonsh.cli_utils as xcli
 from xonsh.history.base import History
 from xonsh.history.dummy import DummyHistory
@@ -21,7 +21,7 @@ HISTORY_BACKENDS = {"dummy": DummyHistory, "json": JsonHistory, "sqlite": Sqlite
 
 def construct_history(**kwargs):
     """Construct the history backend object."""
-    env = XSH.env
+    env = xsh.XSH.env
     backend = env.get("XONSH_HISTORY_BACKEND")
     if isinstance(backend, str) and backend in HISTORY_BACKENDS:
         kls_history = HISTORY_BACKENDS[backend]
@@ -41,14 +41,14 @@ def construct_history(**kwargs):
 def _xh_session_parser(hist=None, newest_first=False, **kwargs):
     """Returns history items of current session."""
     if hist is None:
-        hist = XSH.history
+        hist = xsh.XSH.history
     return hist.items()
 
 
 def _xh_all_parser(hist=None, newest_first=False, **kwargs):
     """Returns all history items."""
     if hist is None:
-        hist = XSH.history
+        hist = xsh.XSH.history
     return hist.all_items(newest_first=newest_first)
 
 
@@ -284,7 +284,7 @@ class HistoryAlias(xcli.ArgParserAlias):
     @staticmethod
     def id_cmd(_stdout):
         """Display the current session id"""
-        hist = XSH.history
+        hist = xsh.XSH.history
         if not hist.sessionid:
             return
         print(str(hist.sessionid), file=_stdout)
@@ -293,7 +293,7 @@ class HistoryAlias(xcli.ArgParserAlias):
     def flush(_stdout):
         """Flush the current history to disk"""
 
-        hist = XSH.history
+        hist = xsh.XSH.history
         hf = hist.flush()
         if isinstance(hf, threading.Thread):
             hf.join()
@@ -301,7 +301,7 @@ class HistoryAlias(xcli.ArgParserAlias):
     @staticmethod
     def off():
         """History will not be saved for this session"""
-        hist = XSH.history
+        hist = xsh.XSH.history
         if hist.remember_history:
             hist.clear()
             hist.remember_history = False
@@ -310,7 +310,7 @@ class HistoryAlias(xcli.ArgParserAlias):
     @staticmethod
     def on():
         """History will be saved for the rest of the session (default)"""
-        hist = XSH.history
+        hist = xsh.XSH.history
         if not hist.remember_history:
             hist.remember_history = True
             print("History on", file=sys.stderr)
@@ -318,14 +318,14 @@ class HistoryAlias(xcli.ArgParserAlias):
     @staticmethod
     def clear():
         """One-time wipe of session history"""
-        hist = XSH.history
+        hist = xsh.XSH.history
         hist.clear()
         print("History cleared", file=sys.stderr)
 
     @staticmethod
     def file(_stdout):
         """Display the current history filename"""
-        hist = XSH.history
+        hist = xsh.XSH.history
         if not hist.filename:
             return
         print(str(hist.filename), file=_stdout)
@@ -342,7 +342,7 @@ class HistoryAlias(xcli.ArgParserAlias):
         to_json: -j, --json
             print in JSON format
         """
-        hist = XSH.history
+        hist = xsh.XSH.history
 
         data = hist.info()
         if to_json:
@@ -367,7 +367,7 @@ class HistoryAlias(xcli.ArgParserAlias):
         force
             perform garbage collection even if history much bigger than configured limit
         """
-        hist = XSH.history
+        hist = xsh.XSH.history
         hist.run_gc(size=size, blocking=_blocking, force=force)
 
     @staticmethod
@@ -394,7 +394,7 @@ class HistoryAlias(xcli.ArgParserAlias):
             whether to print even more information
         """
 
-        hist = XSH.history
+        hist = xsh.XSH.history
         if isinstance(hist, JsonHistory):
             hd = xdh.HistoryDiffer(a, b, reopen=reopen, verbose=verbose)
             xt.print_color(hd.format(), file=_stdout)
@@ -425,7 +425,7 @@ class HistoryAlias(xcli.ArgParserAlias):
             action="store_false",
             help="makes the gc non-blocking, and thus return sooner",
         )
-        if isinstance(XSH.history, JsonHistory):
+        if isinstance(xsh.XSH.history, JsonHistory):
             # add actions belong only to JsonHistory
             parser.add_command(self.diff)
 

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.history.base import History
 import xonsh.tools as xt
 
@@ -18,7 +18,7 @@ XH_SQLITE_CREATED_SQL_TBL = "CREATED_SQL_TABLE"
 
 
 def _xh_sqlite_get_file_name():
-    envs = XSH.env
+    envs = xsh.XSH.env
     file_name = envs.get("XONSH_HISTORY_SQLITE_FILE")
     if not file_name:
         data_dir = envs.get("XONSH_DATA_DIR")
@@ -235,7 +235,7 @@ class SqliteHistoryGC(threading.Thread):
         if self.size is not None:
             hsize, units = xt.to_history_tuple(self.size)
         else:
-            envs = XSH.env
+            envs = xsh.XSH.env
             hsize, units = envs.get("XONSH_HISTORY_SIZE")
         if units != "commands":
             print(
@@ -267,7 +267,7 @@ class SqliteHistory(History):
         self.save_cwd = (
             save_cwd
             if save_cwd is not None
-            else XSH.env.get("XONSH_HISTORY_SAVE_CWD", True)
+            else xsh.XSH.env.get("XONSH_HISTORY_SAVE_CWD", True)
         )
 
         if not os.path.exists(self.filename):
@@ -285,7 +285,7 @@ class SqliteHistory(History):
     def append(self, cmd):
         if not self.remember_history:
             return
-        envs = XSH.env
+        envs = xsh.XSH.env
         inp = cmd["inp"].rstrip()
         self.inps.append(inp)
         self.outs.append(cmd.get("out"))
@@ -342,7 +342,7 @@ class SqliteHistory(History):
             sessionid=self.sessionid, filename=self.filename
         )
         data["all items"] = xh_sqlite_get_count(filename=self.filename)
-        envs = XSH.env
+        envs = xsh.XSH.env
         data["gc options"] = envs.get("XONSH_HISTORY_SIZE")
         return data
 

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -12,7 +12,7 @@ import types
 from importlib.abc import MetaPathFinder, SourceLoader, Loader
 from importlib.machinery import ModuleSpec
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.events import events
 from xonsh.execer import Execer
 from xonsh.lazyasd import lazyobject
@@ -57,12 +57,13 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
 
     @property
     def execer(self):
-        if XSH.execer is not None:
-            execer = XSH.execer
+        if xsh.XSH.execer is not None:
+            execer = xsh.XSH.execer
             if self._execer is not None:
                 self._execer = None
         elif self._execer is None:
-            self._execer = execer = Execer(unload=False)
+            self._execer = execer = Execer()
+            # TODO push session
         else:
             execer = self._execer
         return execer

--- a/xonsh/jupyter_kernel.py
+++ b/xonsh/jupyter_kernel.py
@@ -17,7 +17,7 @@ from zmq.eventloop import ioloop, zmqstream
 from zmq.error import ZMQError
 
 from xonsh import __version__ as version
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.main import setup
 from xonsh.completer import Completer
 from xonsh.commands_cache import predict_true
@@ -362,8 +362,8 @@ class XonshKernel:
                 "payload": [],
                 "user_expressions": {},
             }
-        shell = XSH.shell
-        hist = XSH.history
+        shell = xsh.XSH.shell
+        hist = xsh.XSH.history
         try:
             shell.default(code, self, parent_header)
             interrupted = False
@@ -420,7 +420,7 @@ class XonshKernel:
 
     def do_complete(self, code: str, pos: int):
         """Get completions."""
-        shell = XSH.shell  # type: ignore
+        shell = xsh.XSH.shell  # type: ignore
         line_start = code.rfind("\n", 0, pos) + 1
         line_stop = code.find("\n", pos)
         if line_stop == -1:
@@ -429,7 +429,7 @@ class XonshKernel:
             line_stop += 1
         line = code[line_start:line_stop]
         endidx = pos - line_start
-        line_ex: str = XSH.aliases.expand_alias(line, endidx)  # type: ignore
+        line_ex: str = xsh.XSH.aliases.expand_alias(line, endidx)  # type: ignore
 
         begidx = line[:endidx].rfind(" ") + 1 if line[:endidx].rfind(" ") >= 0 else 0
         prefix = line[begidx:endidx]
@@ -492,11 +492,11 @@ if __name__ == "__main__":
         xontribs=["coreutils"],
         threadable_predictors={"git": predict_true, "man": predict_true},
     )
-    if XSH.commands_cache.is_only_functional_alias("cat"):  # type:ignore
+    if xsh.XSH.commands_cache.is_only_functional_alias("cat"):  # type:ignore
         # this is needed if the underlying system doesn't have cat
         # we supply our own, because we can
-        XSH.aliases["cat"] = "xonsh-cat"  # type:ignore
-        XSH.env["PAGER"] = "xonsh-cat"  # type:ignore
-    shell = XSH.shell  # type:ignore
+        xsh.XSH.aliases["cat"] = "xonsh-cat"  # type:ignore
+        xsh.XSH.env["PAGER"] = "xonsh-cat"  # type:ignore
+    shell = xsh.XSH.shell  # type:ignore
     kernel = shell.kernel = XonshKernel()
     kernel.start()

--- a/xonsh/jupyter_shell.py
+++ b/xonsh/jupyter_shell.py
@@ -3,7 +3,7 @@ import io
 import sys
 
 from xonsh.base_shell import BaseShell
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 class StdJupyterRedirectBuf(io.RawIOBase):
@@ -61,13 +61,13 @@ class StdJupyterRedirect(io.TextIOBase):
     @property
     def encoding(self):
         """The encoding of the stream"""
-        env = XSH.env
+        env = xsh.XSH.env
         return getattr(self.std, "encoding", env.get("XONSH_ENCODING"))
 
     @property
     def errors(self):
         """The encoding errors of the stream"""
-        env = XSH.env
+        env = xsh.XSH.env
         return getattr(self.std, "errors", env.get("XONSH_ENCODING_ERRORS"))
 
     @property

--- a/xonsh/lib/__init__.py
+++ b/xonsh/lib/__init__.py
@@ -1,6 +1,8 @@
 # setup import hooks
 import xonsh.imphooks
+import xonsh.execer
 
-xonsh.imphooks.install_import_hooks()
+execer = xonsh.execer.Execer()
+xonsh.imphooks.install_import_hooks(execer)
 
 del xonsh

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -342,7 +342,6 @@ def premain(argv=None):
         "login": False,
         "scriptcache": args.scriptcache,
         "cacheall": args.cacheall,
-        "ctx": XSH.ctx,
     }
     if args.login or sys.argv[0].startswith("-"):
         args.login = True

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -273,7 +273,6 @@ def start_services(shell_kwargs, args, pre_env=None):
     """
     if pre_env is None:
         pre_env = {}
-    install_import_hooks()
     # create execer, which loads builtins
     ctx = shell_kwargs.get("ctx", {})
     debug = to_bool_or_int(os.getenv("XONSH_DEBUG", "0"))
@@ -286,6 +285,7 @@ def start_services(shell_kwargs, args, pre_env=None):
     )
     session = xonsh.session.XonshSession(execer=execer, ctx=ctx)
     xonsh.session.push_session(session)
+    install_import_hooks(execer)
 
     events.on_timingprobe.fire(name="post_execer_init")
     # load rc files
@@ -577,7 +577,7 @@ def setup(
         session = xonsh.session.XSH
 
     session.env.update(env)
-    install_import_hooks()
+    install_import_hooks(session.execer)
     session.aliases.update(aliases)
     if xontribs:
         xontribs_load(xontribs)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -571,8 +571,8 @@ def setup(
     if not hasattr(builtins, "__xonsh__"):
         execer = Execer()
         session = xonsh.session.XonshSession(execer, ctx)
-        session.shell = Shell(execer, ctx=ctx, shell_type=shell_type)
         xonsh.session.push_session(session)
+        session.shell = Shell(execer, ctx=ctx, shell_type=shell_type)
     else:
         session = xonsh.session.XSH
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -212,9 +212,9 @@ def ptk_below_max_supported():
 
 @functools.lru_cache(1)
 def best_shell_type():
-    from xonsh.built_ins import XSH
+    import xonsh.session as xsh
 
-    if XSH.env.get("TERM", "") == "dumb":
+    if xsh.XSH.env.get("TERM", "") == "dumb":
         return "dumb"
     if has_prompt_toolkit():
         return "prompt_toolkit"
@@ -371,10 +371,10 @@ def windows_bash_command():
     """Determines the command for Bash on windows."""
     # Check that bash is on path otherwise try the default directory
     # used by Git for windows
-    from xonsh.built_ins import XSH
+    import xonsh.session as xsh
 
     wbc = "bash"
-    cmd_cache = XSH.commands_cache
+    cmd_cache = xsh.XSH.commands_cache
     bash_on_path = cmd_cache.lazy_locate_binary("bash", ignore_alias=True)
     if bash_on_path:
         try:

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -12,7 +12,7 @@ import xonsh.lazyasd as xl
 import xonsh.tools as xt
 import xonsh.platform as xp
 import xonsh.jobs as xj
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 from xonsh.procs.readers import NonBlockingFDReader, ConsoleParallelReader, safe_fdclose
 
@@ -83,7 +83,7 @@ def update_fg_process_group(pipeline_group, background):
         return False
     if not xp.ON_POSIX:
         return False
-    env = XSH.env
+    env = xsh.XSH.env
     if not env.get("XONSH_INTERACTIVE"):
         return False
     return xj.give_terminal_to(pipeline_group)
@@ -224,7 +224,7 @@ class CommandPipeline:
         proc = self.proc
         if proc is None:
             return
-        timeout = XSH.env.get("XONSH_PROC_FREQUENCY")
+        timeout = xsh.XSH.env.get("XONSH_PROC_FREQUENCY")
         # get the correct stdout
         stdout = proc.stdout
         if (
@@ -347,7 +347,7 @@ class CommandPipeline:
         yields each line. This may optionally accept lines (in bytes) to iterate
         over, in which case it does not call iterraw().
         """
-        env = XSH.env
+        env = xsh.XSH.env
         enc = env.get("XONSH_ENCODING")
         err = env.get("XONSH_ENCODING_ERRORS")
         lines = self.lines
@@ -387,7 +387,7 @@ class CommandPipeline:
         """Streams lines to sys.stderr and the errors attribute."""
         if not lines:
             return
-        env = XSH.env
+        env = xsh.XSH.env
         enc = env.get("XONSH_ENCODING")
         err = env.get("XONSH_ENCODING_ERRORS")
         b = b"".join(lines)
@@ -411,7 +411,7 @@ class CommandPipeline:
         # do some munging of the line before we save it to the attr
         b = b.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
         b = RE_HIDE_ESCAPE.sub(b"", b)
-        env = XSH.env
+        env = xsh.XSH.env
         s = b.decode(
             encoding=env.get("XONSH_ENCODING"), errors=env.get("XONSH_ENCODING_ERRORS")
         )
@@ -426,7 +426,7 @@ class CommandPipeline:
         if not b:
             return ""
         if isinstance(b, (bytes, bytearray)):
-            env = XSH.env
+            env = xsh.XSH.env
             s = b.decode(
                 encoding=env.get("XONSH_ENCODING"),
                 errors=env.get("XONSH_ENCODING_ERRORS"),
@@ -478,12 +478,12 @@ class CommandPipeline:
             return
         if xj.give_terminal_to(pgid):  # if gave term succeed
             self.term_pgid = pgid
-            if XSH.shell is not None:
+            if xsh.XSH.shell is not None:
                 # restoring sanity could probably be called whenever we return
                 # control to the shell. But it only seems to matter after a
                 # ^Z event. This *has* to be called after we give the terminal
                 # back to the shell.
-                XSH.shell.shell.restore_tty_sanity()
+                xsh.XSH.shell.shell.restore_tty_sanity()
 
     def resume(self, job, tee_output=True):
         self.ended = False
@@ -580,7 +580,7 @@ class CommandPipeline:
 
     def _apply_to_history(self):
         """Applies the results to the current history object."""
-        hist = XSH.history
+        hist = xsh.XSH.history
         if hist is not None:
             hist.last_cmd_rtn = 1 if self.proc is None else self.proc.returncode
 
@@ -588,7 +588,7 @@ class CommandPipeline:
         """Raises a subprocess error, if we are supposed to."""
         spec = self.spec
         rtn = self.returncode
-        if rtn is not None and rtn != 0 and XSH.env.get("RAISE_SUBPROC_ERROR"):
+        if rtn is not None and rtn != 0 and xsh.XSH.env.get("RAISE_SUBPROC_ERROR"):
             try:
                 raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
             finally:
@@ -720,7 +720,7 @@ class CommandPipeline:
         """Prefix to print in front of stderr, as bytes."""
         p = self._stderr_prefix
         if p is None:
-            env = XSH.env
+            env = xsh.XSH.env
             t = env.get("XONSH_STDERR_PREFIX")
             s = xt.format_std_prepost(t, env=env)
             p = s.encode(
@@ -735,7 +735,7 @@ class CommandPipeline:
         """Postfix to print after stderr, as bytes."""
         p = self._stderr_postfix
         if p is None:
-            env = XSH.env
+            env = xsh.XSH.env
             t = env.get("XONSH_STDERR_POSTFIX")
             s = xt.format_std_prepost(t, env=env)
             p = s.encode(
@@ -807,7 +807,7 @@ class PrevProcCloser(threading.Thread):
             return
         proc = pipeline.proc
         prev_end_time = None
-        timeout = XSH.env.get("XONSH_PROC_FREQUENCY")
+        timeout = xsh.XSH.env.get("XONSH_PROC_FREQUENCY")
         sleeptime = min(timeout * 1000, 0.1)
         while proc.poll() is None:
             if not check_prev_done:

--- a/xonsh/procs/posix.py
+++ b/xonsh/procs/posix.py
@@ -12,7 +12,7 @@ import xonsh.lazyasd as xl
 import xonsh.platform as xp
 import xonsh.tools as xt
 import xonsh.lazyimps as xli
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 from xonsh.procs.readers import (
     BufferedFDParallelReader,
@@ -56,7 +56,7 @@ class PopenThread(threading.Thread):
         self.daemon = True
 
         self.lock = threading.RLock()
-        env = XSH.env
+        env = xsh.XSH.env
         # stdin setup
         self.orig_stdin = stdin
         if stdin is None:
@@ -119,7 +119,7 @@ class PopenThread(threading.Thread):
         self.suspended = False
         self.prevs_are_closed = False
         # This is so the thread will use the same swapped values as the origin one.
-        self.original_swapped_values = XSH.env.get_swapped_values()
+        self.original_swapped_values = xsh.XSH.env.get_swapped_values()
         self.start()
 
     def run(self):
@@ -128,7 +128,7 @@ class PopenThread(threading.Thread):
         captured_stderr to stderr.
         """
         # Set the thread-local swapped values.
-        XSH.env.set_swapped_values(self.original_swapped_values)
+        xsh.XSH.env.set_swapped_values(self.original_swapped_values)
         proc = self.proc
         spec = self._wait_and_getattr("spec")
         # get stdin and apply parallel reader if needed.

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -20,7 +20,7 @@ import collections.abc as cabc
 import xonsh.tools as xt
 import xonsh.platform as xp
 import xonsh.lazyimps as xli
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 from xonsh.procs.readers import safe_fdclose
 
@@ -452,7 +452,7 @@ class ProcProxyThread(threading.Thread):
         # start up the proc
         super().__init__()
         # This is so the thread will use the same swapped values as the origin one.
-        self.original_swapped_values = XSH.env.get_swapped_values()
+        self.original_swapped_values = xsh.XSH.env.get_swapped_values()
         self.start()
 
     def __del__(self):
@@ -466,13 +466,13 @@ class ProcProxyThread(threading.Thread):
         if self.f is None:
             return
         # Set the thread-local swapped values.
-        XSH.env.set_swapped_values(self.original_swapped_values)
+        xsh.XSH.env.set_swapped_values(self.original_swapped_values)
         spec = self._wait_and_getattr("spec")
         last_in_pipeline = spec.last_in_pipeline
         if last_in_pipeline:
             capout = spec.captured_stdout  # NOQA
             caperr = spec.captured_stderr  # NOQA
-        env = XSH.env
+        env = xsh.XSH.env
         enc = env.get("XONSH_ENCODING")
         err = env.get("XONSH_ENCODING_ERRORS")
         if xp.ON_WINDOWS:
@@ -509,7 +509,7 @@ class ProcProxyThread(threading.Thread):
             sp_stderr = sys.stderr
         # run the function itself
         try:
-            alias_stack = XSH.env.get("__ALIAS_STACK", "")
+            alias_stack = xsh.XSH.env.get("__ALIAS_STACK", "")
             if self.env and self.env.get("__ALIAS_NAME"):
                 alias_stack += ":" + self.env["__ALIAS_NAME"]
 
@@ -517,7 +517,7 @@ class ProcProxyThread(threading.Thread):
                 sp_stderr
             ), xt.redirect_stdout(STDOUT_DISPATCHER), xt.redirect_stderr(
                 STDERR_DISPATCHER
-            ), XSH.env.swap(
+            ), xsh.XSH.env.swap(
                 self.env, __ALIAS_STACK=alias_stack
             ):
                 r = self.f(self.args, sp_stdin, sp_stdout, sp_stderr, spec, spec.stack)
@@ -800,7 +800,7 @@ class ProcProxy:
         """
         if self.f is None:
             return 0
-        env = XSH.env
+        env = xsh.XSH.env
         enc = env.get("XONSH_ENCODING")
         err = env.get("XONSH_ENCODING_ERRORS")
         spec = self._wait_and_getattr("spec")
@@ -817,7 +817,7 @@ class ProcProxy:
         stderr = self._pick_buf(self.stderr, sys.stderr, enc, err)
         # run the actual function
         try:
-            with XSH.env.swap(self.env):
+            with xsh.XSH.env.swap(self.env):
                 r = self.f(self.args, stdin, stdout, stderr, spec, spec.stack)
         except Exception:
             xt.print_exception()

--- a/xonsh/procs/readers.py
+++ b/xonsh/procs/readers.py
@@ -8,7 +8,7 @@ import ctypes
 import threading
 
 import xonsh.lazyimps as xli
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 class QueueReader:
@@ -378,7 +378,7 @@ class ConsoleParallelReader(QueueReader):
         timeout : float, optional
             The queue reading timeout.
         """
-        timeout = timeout or XSH.env.get("XONSH_PROC_FREQUENCY")
+        timeout = timeout or xsh.XSH.env.get("XONSH_PROC_FREQUENCY")
         super().__init__(fd, timeout=timeout)
         self._buffer = buffer  # this cannot be public
         if buffer is None:

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -12,7 +12,7 @@ import xonsh.lazyasd as xl
 import xonsh.tools as xt
 import xonsh.platform as xp
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.prompt.cwd import (
     _collapsed_pwd,
     _replace_home_cwd,
@@ -43,7 +43,7 @@ class ParsedTokens(tp.NamedTuple):
 
     def process(self) -> str:
         """Wrapper that gets formatter-function from environment and returns final prompt."""
-        processor = XSH.env.get(  # type: ignore
+        processor = xsh.XSH.env.get(  # type: ignore
             "PROMPT_TOKENS_FORMATTER", prompt_tokens_formatter_default
         )
         return processor(self)
@@ -93,7 +93,7 @@ class PromptFormatter:
         self.cache.clear()
 
         if fields is None:
-            self.fields = XSH.env.get("PROMPT_FIELDS", PROMPT_FIELDS)  # type: ignore
+            self.fields = xsh.XSH.env.get("PROMPT_FIELDS", PROMPT_FIELDS)  # type: ignore
         else:
             self.fields = fields
         try:
@@ -124,7 +124,7 @@ class PromptFormatter:
         if field is None:
             return
         elif field.startswith("$"):
-            val = XSH.env[field[1:]]
+            val = xsh.XSH.env[field[1:]]
             return _format_value(val, spec, conv)
         elif field in self.fields:
             val = self._get_field_value(field, spec=spec, conv=conv, **kwargs)
@@ -226,7 +226,7 @@ def multiline_prompt(curr=""):
     # tail is the trailing whitespace
     tail = line if headlen == 0 else line.rsplit(head[-1], 1)[1]
     # now to construct the actual string
-    dots = XSH.env.get("MULTILINE_PROMPT")
+    dots = xsh.XSH.env.get("MULTILINE_PROMPT")
     dots = dots() if callable(dots) else dots
     if dots is None or len(dots) == 0:
         return ""
@@ -272,7 +272,7 @@ def is_template_string(template, PROMPT_FIELDS=None):
         return False
     included_names.discard(None)
     if PROMPT_FIELDS is None:
-        fmtter = XSH.env.get("PROMPT_FIELDS", PROMPT_FIELDS)
+        fmtter = xsh.XSH.env.get("PROMPT_FIELDS", PROMPT_FIELDS)
     else:
         fmtter = PROMPT_FIELDS
     known_names = set(fmtter.keys())

--- a/xonsh/prompt/cwd.py
+++ b/xonsh/prompt/cwd.py
@@ -6,28 +6,28 @@ import shutil
 
 import xonsh.tools as xt
 import xonsh.platform as xp
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 def _replace_home(x):
     if xp.ON_WINDOWS:
-        home = XSH.env["HOMEDRIVE"] + XSH.env["HOMEPATH"][0]
+        home = xsh.XSH.env["HOMEDRIVE"] + xsh.XSH.env["HOMEPATH"][0]
         if x.startswith(home):
             x = x.replace(home, "~", 1)
 
-        if XSH.env.get("FORCE_POSIX_PATHS"):
+        if xsh.XSH.env.get("FORCE_POSIX_PATHS"):
             x = x.replace(os.sep, os.altsep)
 
         return x
     else:
-        home = XSH.env["HOME"]
+        home = xsh.XSH.env["HOME"]
         if x.startswith(home):
             x = x.replace(home, "~", 1)
         return x
 
 
 def _replace_home_cwd():
-    return _replace_home(XSH.env["PWD"])
+    return _replace_home(xsh.XSH.env["PWD"])
 
 
 def _collapsed_pwd():
@@ -48,8 +48,8 @@ def _dynamically_collapsed_pwd():
     environment variable DYNAMIC_CWD_WIDTH.
     """
     original_path = _replace_home_cwd()
-    target_width, units = XSH.env["DYNAMIC_CWD_WIDTH"]
-    elision_char = XSH.env["DYNAMIC_CWD_ELISION_CHAR"]
+    target_width, units = xsh.XSH.env["DYNAMIC_CWD_WIDTH"]
+    elision_char = xsh.XSH.env["DYNAMIC_CWD_ELISION_CHAR"]
     if target_width == float("inf"):
         return original_path
     if units == "%":

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -3,7 +3,7 @@
 
 import os
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 import xonsh.platform as xp
 
 
@@ -11,9 +11,9 @@ def find_env_name():
     """Finds the current environment name from $VIRTUAL_ENV or
     $CONDA_DEFAULT_ENV if that is set.
     """
-    env_path = XSH.env.get("VIRTUAL_ENV", "")
+    env_path = xsh.XSH.env.get("VIRTUAL_ENV", "")
     if len(env_path) == 0 and xp.ON_ANACONDA:
-        env_path = XSH.env.get("CONDA_DEFAULT_ENV", "")
+        env_path = xsh.XSH.env.get("CONDA_DEFAULT_ENV", "")
     env_name = os.path.basename(env_path)
     return env_name
 
@@ -23,15 +23,15 @@ def env_name():
     ``{env_prefix}`` and ``{env_postfix}`` fields.
     """
     env_name = find_env_name()
-    if XSH.env.get("VIRTUAL_ENV_DISABLE_PROMPT") or not env_name:
+    if xsh.XSH.env.get("VIRTUAL_ENV_DISABLE_PROMPT") or not env_name:
         # env name prompt printing disabled, or no environment; just return
         return
 
-    venv_prompt = XSH.env.get("VIRTUAL_ENV_PROMPT")
+    venv_prompt = xsh.XSH.env.get("VIRTUAL_ENV_PROMPT")
     if venv_prompt is not None:
         return venv_prompt
     else:
-        pf = XSH.shell.prompt_formatter
+        pf = xsh.XSH.shell.prompt_formatter
         pre = pf._get_field_value("env_prefix")
         post = pf._get_field_value("env_postfix")
         return pre + env_name + post
@@ -44,7 +44,7 @@ def vte_new_tab_cwd():
     on startup. Note that this does not return a string, it simply prints
     and flushes the escape sequence to stdout directly.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     t = "\033]7;file://{}{}\007"
     s = t.format(env.get("HOSTNAME"), env.get("PWD"))
     print(s, end="", flush=True)

--- a/xonsh/prompt/gitstatus.py
+++ b/xonsh/prompt/gitstatus.py
@@ -3,13 +3,13 @@
 import os
 import subprocess
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.color_tools import COLORS
 from xonsh.tools import NamedConstantMeta, XAttr
 
 
 def _check_output(*args, **kwargs) -> str:
-    denv = XSH.env.detype()
+    denv = xsh.XSH.env.detype()
     denv.update({"GIT_OPTIONAL_LOCKS": "0"})
 
     kwargs.update(
@@ -20,7 +20,7 @@ def _check_output(*args, **kwargs) -> str:
             universal_newlines=True,
         )
     )
-    timeout = XSH.env["VC_BRANCH_TIMEOUT"]
+    timeout = xsh.XSH.env["VC_BRANCH_TIMEOUT"]
     # See https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate
     with subprocess.Popen(*args, **kwargs) as proc:
         try:
@@ -67,12 +67,12 @@ class _DEFS(metaclass=NamedConstantMeta):
 
 def _get_def(attr: XAttr) -> str:
     key = attr.name.upper()
-    def_ = XSH.env.get("XONSH_GITSTATUS_" + key)
+    def_ = xsh.XSH.env.get("XONSH_GITSTATUS_" + key)
     return def_ if def_ is not None else attr.value
 
 
 def _is_hidden(attr: XAttr) -> bool:
-    hidden = XSH.env.get("XONSH_GITSTATUS_FIELDS_HIDDEN") or set()
+    hidden = xsh.XSH.env.get("XONSH_GITSTATUS_FIELDS_HIDDEN") or set()
     return attr.name.upper() in hidden or attr.name.lower() in hidden
 
 

--- a/xonsh/prompt/times.py
+++ b/xonsh/prompt/times.py
@@ -2,10 +2,10 @@
 """date & time related prompt formatter"""
 import time
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 def _localtime():
-    pf = XSH.env.get("PROMPT_FIELDS", {})
+    pf = xsh.XSH.env.get("PROMPT_FIELDS", {})
     tf = pf.get("time_format", "%H:%M:%S")
     return time.strftime(tf, time.localtime())

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -11,7 +11,7 @@ import sys
 import threading
 
 import xonsh.tools as xt
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.lazyasd import LazyObject
 
 RE_REMOVE_ANSI = LazyObject(
@@ -24,7 +24,7 @@ RE_REMOVE_ANSI = LazyObject(
 def _run_git_cmd(cmd):
     # create a safe detyped env dictionary and update with the additional git environment variables
     # when running git status commands we do not want to acquire locks running command like git status
-    denv = dict(XSH.env.detype())
+    denv = dict(xsh.XSH.env.detype())
     denv.update({"GIT_OPTIONAL_LOCKS": "0"})
     return subprocess.check_output(cmd, env=denv, stderr=subprocess.DEVNULL)
 
@@ -44,7 +44,7 @@ def get_git_branch():
     be determined (timeout, not in a git repo, etc.) then this returns None.
     """
     branch = None
-    timeout = XSH.env.get("VC_BRANCH_TIMEOUT")
+    timeout = xsh.XSH.env.get("VC_BRANCH_TIMEOUT")
     q = queue.Queue()
 
     t = threading.Thread(target=_get_git_branch, args=(q,))
@@ -60,7 +60,7 @@ def get_git_branch():
 
 
 def _get_hg_root(q):
-    _curpwd = XSH.env["PWD"]
+    _curpwd = xsh.XSH.env["PWD"]
     while True:
         if not os.path.isdir(_curpwd):
             return False
@@ -82,7 +82,7 @@ def get_hg_branch(root=None):
     """Try to get the mercurial branch of the current directory,
     return None if not in a repo or subprocess.TimeoutExpired if timed out.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     timeout = env["VC_BRANCH_TIMEOUT"]
     q = queue.Queue()
     t = threading.Thread(target=_get_hg_root, args=(q,))
@@ -125,7 +125,7 @@ _FIRST_BRANCH_TIMEOUT = True
 
 def _first_branch_timeout_message():
     global _FIRST_BRANCH_TIMEOUT
-    sbtm = XSH.env["SUPPRESS_BRANCH_TIMEOUT_MESSAGE"]
+    sbtm = xsh.XSH.env["SUPPRESS_BRANCH_TIMEOUT_MESSAGE"]
     if not _FIRST_BRANCH_TIMEOUT or sbtm:
         return
     _FIRST_BRANCH_TIMEOUT = False
@@ -143,7 +143,7 @@ def _first_branch_timeout_message():
 
 def _vc_has(binary):
     """This allows us to locate binaries after git only if necessary"""
-    cmds = XSH.commands_cache
+    cmds = xsh.XSH.commands_cache
     if cmds.is_empty():
         return bool(cmds.locate_binary(binary, ignore_alias=True))
     else:
@@ -187,7 +187,7 @@ def git_dirty_working_directory():
     """Returns whether or not the git directory is dirty. If this could not
     be determined (timeout, file not found, etc.) then this returns None.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     timeout = env.get("VC_BRANCH_TIMEOUT")
     include_untracked = env.get("VC_GIT_INCLUDE_UNTRACKED")
     q = queue.Queue()
@@ -206,7 +206,7 @@ def hg_dirty_working_directory():
     """Computes whether or not the mercurial working directory is dirty or not.
     If this cannot be determined, None is returned.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     cwd = env["PWD"]
     denv = env.detype()
     vcbt = env["VC_BRANCH_TIMEOUT"]

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -7,7 +7,7 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.application.current import get_app
 
 from xonsh.completers.tools import RichCompletion
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 class PromptToolkitCompleter(Completer):
@@ -27,7 +27,7 @@ class PromptToolkitCompleter(Completer):
 
     def get_completions(self, document, complete_event):
         """Returns a generator for list of completions."""
-        env = XSH.env
+        env = xsh.XSH.env
         should_complete = complete_event.completion_requested or env.get(
             "UPDATE_COMPLETIONS_ON_KEYPRESS"
         )
@@ -38,7 +38,7 @@ class PromptToolkitCompleter(Completer):
         line = document.current_line
 
         endidx = document.cursor_position_col
-        line_ex = XSH.aliases.expand_alias(line, endidx)
+        line_ex = xsh.XSH.aliases.expand_alias(line, endidx)
 
         begidx = line[:endidx].rfind(" ") + 1 if line[:endidx].rfind(" ") >= 0 else 0
         prefix = line[begidx:endidx]
@@ -141,7 +141,7 @@ class PromptToolkitCompleter(Completer):
 
         if window and window.render_info:
             h = window.render_info.content_height
-            r = XSH.env.get("COMPLETIONS_MENU_ROWS")
+            r = xsh.XSH.env.get("COMPLETIONS_MENU_ROWS")
             size = h + r
             last_h = render._last_screen.height if render._last_screen else 0
             last_h = max(render._min_available_height, last_h)

--- a/xonsh/ptk_shell/history.py
+++ b/xonsh/ptk_shell/history.py
@@ -3,7 +3,7 @@
 
 import prompt_toolkit.history
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 class PromptToolkitHistory(prompt_toolkit.history.History):
@@ -23,7 +23,7 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
         """Loads synchronous history strings"""
         if not self.load_prev:
             return
-        hist = XSH.history
+        hist = xsh.XSH.history
         if hist is None:
             return
         for cmd in hist.all_items(newest_first=True):

--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -23,7 +23,7 @@ from xonsh.tools import (
     get_line_continuation,
     ends_with_colon_token,
 )
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.platform import ON_WINDOWS
 from xonsh.shell import transform_command
 
@@ -46,7 +46,7 @@ def carriage_return(b, cli, *, autoindent=True):
     at_end_of_line = _is_blank(doc.current_line_after_cursor)
     current_line_blank = _is_blank(doc.current_line)
 
-    env = XSH.env
+    env = xsh.XSH.env
     indent = env.get("INDENT") if autoindent else ""
 
     partial_string_info = check_for_partial_string(doc.text)
@@ -92,7 +92,7 @@ def can_compile(src):
     src = transform_command(src, show_diff=False)
     src = src.lstrip()
     try:
-        XSH.execer.compile(src, mode="single", glbs=None, locs=XSH.ctx)
+        xsh.XSH.execer.compile(src, mode="single", glbs=None, locs=xsh.XSH.ctx)
         rtn = True
     except SyntaxError:
         rtn = False
@@ -116,7 +116,7 @@ def tab_insert_indent():
 @Condition
 def tab_menu_complete():
     """Checks whether completion mode is `menu-complete`"""
-    return XSH.env.get("COMPLETION_MODE") == "menu-complete"
+    return xsh.XSH.env.get("COMPLETION_MODE") == "menu-complete"
 
 
 @Condition
@@ -148,7 +148,7 @@ def end_of_line():
 def should_confirm_completion():
     """Check if completion needs confirmation"""
     return (
-        XSH.env.get("COMPLETIONS_CONFIRM") and get_app().current_buffer.complete_state
+        xsh.XSH.env.get("COMPLETIONS_CONFIRM") and get_app().current_buffer.complete_state
     )
 
 
@@ -158,7 +158,7 @@ def ctrl_d_condition():
     """Ctrl-D binding is only active when the default buffer is selected and
     empty.
     """
-    if XSH.env.get("IGNOREEOF"):
+    if xsh.XSH.env.get("IGNOREEOF"):
         return False
     else:
         app = get_app()
@@ -170,7 +170,7 @@ def ctrl_d_condition():
 @Condition
 def autopair_condition():
     """Check if XONSH_AUTOPAIR is set"""
-    return XSH.env.get("XONSH_AUTOPAIR", False)
+    return xsh.XSH.env.get("XONSH_AUTOPAIR", False)
 
 
 @Condition
@@ -224,7 +224,7 @@ def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
     has_selection = HasSelection()
     insert_mode = ViInsertMode() | EmacsInsertMode()
 
-    if XSH.env["XONSH_CTRL_BKSP_DELETION"]:
+    if xsh.XSH.env["XONSH_CTRL_BKSP_DELETION"]:
         # Not all terminal emulators emit the same keys for backspace, therefore
         # ptk always maps backspace ("\x7f") to ^H ("\x08"), and all the backspace bindings are registered for ^H.
         # This means we can't re-map backspace and instead we register a new "real-ctrl-bksp" key.
@@ -256,7 +256,7 @@ def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
         If there are only whitespaces before current cursor position insert
         indent instead of autocompleting.
         """
-        env = XSH.env
+        env = xsh.XSH.env
         event.cli.current_buffer.insert_text(env.get("INDENT"))
 
     @handle(Keys.Tab, filter=~tab_insert_indent & tab_menu_complete)
@@ -280,7 +280,7 @@ def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
         if b.complete_state:
             b.complete_previous()
         else:
-            env = XSH.env
+            env = xsh.XSH.env
             event.cli.current_buffer.insert_text(env.get("INDENT"))
 
     def generate_parens_handlers(left, right):

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -6,7 +6,7 @@ import sys
 from functools import wraps
 from types import MethodType
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.events import events
 from xonsh.base_shell import BaseShell
 from xonsh.ptk_shell.formatter import PTKPromptFormatter
@@ -198,7 +198,7 @@ class PromptToolkitShell(BaseShell):
         self.history = ThreadedHistory(PromptToolkitHistory())
 
         ptk_args.setdefault("history", self.history)
-        if not XSH.env.get("XONSH_COPY_ON_DELETE", False):
+        if not xsh.XSH.env.get("XONSH_COPY_ON_DELETE", False):
             disable_copy_on_deletion()
         if HAVE_SYS_CLIPBOARD:
             ptk_args.setdefault("clipboard", PyperclipClipboard())
@@ -229,7 +229,7 @@ class PromptToolkitShell(BaseShell):
         """These are non-essential attributes for the PTK shell to start.
         Lazy loading these later would save some startup time.
         """
-        if not XSH.env.get("COLOR_INPUT"):
+        if not xsh.XSH.env.get("COLOR_INPUT"):
             return
 
         if HAS_PYGMENTS:
@@ -243,7 +243,7 @@ class PromptToolkitShell(BaseShell):
         events.on_timingprobe.fire(name="on_post_prompt_style")
 
     def get_prompt_style(self):
-        env = XSH.env
+        env = xsh.XSH.env
 
         style_overrides_env = env.get("PTK_STYLE_OVERRIDES", {}).copy()
         if (
@@ -291,7 +291,7 @@ class PromptToolkitShell(BaseShell):
         history.
         """
         events.on_pre_prompt_format.fire()
-        env = XSH.env
+        env = xsh.XSH.env
         mouse_support = env.get("MOUSE_SUPPORT")
         auto_suggest = auto_suggest if env.get("AUTO_SUGGEST") else None
         refresh_interval = env.get("PROMPT_REFRESH_INTERVAL")
@@ -397,7 +397,7 @@ class PromptToolkitShell(BaseShell):
             print(intro)
         auto_suggest = AutoSuggestFromHistory()
         self.push = self._push
-        while not XSH.exit:
+        while not xsh.XSH.exit:
             try:
                 line = self.singleline(auto_suggest=auto_suggest)
                 if not line:
@@ -409,13 +409,13 @@ class PromptToolkitShell(BaseShell):
             except (KeyboardInterrupt, SystemExit):
                 self.reset_buffer()
             except EOFError:
-                if XSH.env.get("IGNOREEOF"):
+                if xsh.XSH.env.get("IGNOREEOF"):
                     print('Use "exit" to leave the shell.', file=sys.stderr)
                 else:
                     break
 
     def _get_prompt_tokens(self, env_name: str, prompt_name: str, **kwargs):
-        env = XSH.env  # type:ignore
+        env = xsh.XSH.env  # type:ignore
         p = env.get(env_name)
 
         if not p and "default" in kwargs:
@@ -467,7 +467,7 @@ class PromptToolkitShell(BaseShell):
     @property
     def bottom_toolbar_tokens(self):
         """Returns self._bottom_toolbar_tokens if it would yield a result"""
-        if XSH.env.get("BOTTOM_TOOLBAR"):
+        if xsh.XSH.env.get("BOTTOM_TOOLBAR"):
             return self._bottom_toolbar_tokens
 
     def continuation_tokens(self, width, line_number, is_soft_wrap=False):
@@ -475,7 +475,7 @@ class PromptToolkitShell(BaseShell):
         if is_soft_wrap:
             return ""
         width = width - 1
-        dots = XSH.env.get("MULTILINE_PROMPT")
+        dots = xsh.XSH.env.get("MULTILINE_PROMPT")
         dots = dots() if callable(dots) else dots
         if not dots:
             return ""
@@ -508,7 +508,7 @@ class PromptToolkitShell(BaseShell):
         """
         tokens = partial_color_tokenize(string)
         if force_string and HAS_PYGMENTS:
-            env = XSH.env
+            env = xsh.XSH.env
             style_overrides_env = env.get("XONSH_STYLE_OVERRIDES", {})
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
             self.styler.override(style_overrides_env)
@@ -530,7 +530,7 @@ class PromptToolkitShell(BaseShell):
             # assume this is a list of (Token, str) tuples and just print
             tokens = string
         tokens = PygmentsTokens(tokens)
-        env = XSH.env
+        env = xsh.XSH.env
         style_overrides_env = env.get("XONSH_STYLE_OVERRIDES", {})
         if HAS_PYGMENTS:
             self.styler.style_name = env.get("XONSH_COLOR_STYLE")
@@ -563,7 +563,7 @@ class PromptToolkitShell(BaseShell):
         """Returns the current color map."""
         if not HAS_PYGMENTS:
             return DEFAULT_STYLE_DICT
-        env = XSH.env
+        env = xsh.XSH.env
         self.styler.style_name = env.get("XONSH_COLOR_STYLE")
         return self.styler.styles
 
@@ -592,7 +592,7 @@ class PromptToolkitShell(BaseShell):
         #   sys.stdout.write('\033[9999999C\n')
         if not ON_POSIX:
             return
-        stty, _ = XSH.commands_cache.lazyget("stty", (None, None))
+        stty, _ = xsh.XSH.commands_cache.lazyget("stty", (None, None))
         if stty is None:
             return
         os.system(stty + " sane")

--- a/xonsh/ptk_shell/updator.py
+++ b/xonsh/ptk_shell/updator.py
@@ -7,7 +7,7 @@ import typing as tp
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import PygmentsTokens
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.prompt.base import ParsedTokens
 from xonsh.style_tools import partial_color_tokenize, style_as_faded
 
@@ -17,7 +17,7 @@ class Executor:
 
     def __init__(self):
         self.thread_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=XSH.env["ASYNC_PROMPT_THREAD_WORKERS"]
+            max_workers=xsh.XSH.env["ASYNC_PROMPT_THREAD_WORKERS"]
         )
 
         # the attribute, .cache is cleared between calls.
@@ -132,7 +132,7 @@ class AsyncPrompt:
             setattr(self.session, self.name, formatted_tokens)
             self.session.app.invalidate()
 
-        self.timer = threading.Timer(XSH.env["ASYNC_INVALIDATE_INTERVAL"], _invalidate)
+        self.timer = threading.Timer(xsh.XSH.env["ASYNC_INVALIDATE_INTERVAL"], _invalidate)
         self.timer.start()
 
     def stop(self):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1667,7 +1667,7 @@ class XonshLexer(Python3Lexer):
         else:
             session = xonsh.session.XSH
 
-        _ = session.commands_cache.all_commands  # NOQA
+        session.commands_cache.update_cache()  # NOQA
         super().__init__(*args, **kwargs)
 
     tokens = {

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -72,7 +72,7 @@ class XonshSession:
             self.ctx = ctx
 
         self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env())
-        self.help = kwargs.pop("help") if "help" in kwargs else xonsh.built_ins.helper
+        self.help = xonsh.built_ins.helper
         self.superhelp = xonsh.built_ins.superhelper
         self.pathsearch = xonsh.built_ins.pathsearch
         self.globsearch = xonsh.built_ins.globsearch

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -44,6 +44,7 @@ class XonshSession:
     """All components defining a xonsh session."""
 
     def __init__(self):
+        # Loadable state
         self.execer = None
         self.ctx = {}
         self.builtins_loaded = False
@@ -51,6 +52,29 @@ class XonshSession:
         self.shell = None
         self.env = None
         self.rc_files = None
+
+        self.help = xonsh.built_ins.helper
+        self.superhelp = xonsh.built_ins.superhelper
+        self.pathsearch = xonsh.built_ins.pathsearch
+        self.globsearch = xonsh.built_ins.globsearch
+        self.regexsearch = xonsh.built_ins.regexsearch
+        self.glob = xonsh.built_ins.globpath
+        self.expand_path = xonsh.built_ins.expand_path
+
+        self.subproc_captured_stdout = xonsh.built_ins.subproc_captured_stdout
+        self.subproc_captured_inject = xonsh.built_ins.subproc_captured_inject
+        self.subproc_captured_object = xonsh.built_ins.subproc_captured_object
+        self.subproc_captured_hiddenobject = xonsh.built_ins.subproc_captured_hiddenobject
+        self.subproc_uncaptured = xonsh.built_ins.subproc_uncaptured
+
+        self.ensure_list_of_strs = xonsh.built_ins.ensure_list_of_strs
+        self.list_of_strs_or_callables = xonsh.built_ins.list_of_strs_or_callables
+        self.list_of_list_of_strs_outer_product = xonsh.built_ins.list_of_list_of_strs_outer_product
+        self.eval_fstring_field = xonsh.built_ins.eval_fstring_field
+
+        self.call_macro = xonsh.built_ins.call_macro
+        self.enter_macro = xonsh.built_ins.enter_macro
+        self.path_literal = xonsh.built_ins.path_literal
 
     def load(self, execer=None, ctx=None, **kwargs):
         """Loads the session with default values.
@@ -72,13 +96,7 @@ class XonshSession:
             self.ctx = ctx
 
         self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env())
-        self.help = xonsh.built_ins.helper
-        self.superhelp = xonsh.built_ins.superhelper
-        self.pathsearch = xonsh.built_ins.pathsearch
-        self.globsearch = xonsh.built_ins.globsearch
-        self.regexsearch = xonsh.built_ins.regexsearch
-        self.glob = xonsh.built_ins.globpath
-        self.expand_path = xonsh.built_ins.expand_path
+
         self.exit = False
         self.stdout_uncaptured = None
         self.stderr_uncaptured = None
@@ -91,11 +109,6 @@ class XonshSession:
             self.pyquit = builtins.quit
             del builtins.quit
 
-        self.subproc_captured_stdout = xonsh.built_ins.subproc_captured_stdout
-        self.subproc_captured_inject = xonsh.built_ins.subproc_captured_inject
-        self.subproc_captured_object = xonsh.built_ins.subproc_captured_object
-        self.subproc_captured_hiddenobject = xonsh.built_ins.subproc_captured_hiddenobject
-        self.subproc_uncaptured = xonsh.built_ins.subproc_uncaptured
         self.execer = execer
         self.commands_cache = (
             kwargs.pop("commands_cache")
@@ -104,15 +117,8 @@ class XonshSession:
         )
         self.modules_cache = {}
         self.all_jobs = {}
-        self.ensure_list_of_strs = xonsh.built_ins.ensure_list_of_strs
-        self.list_of_strs_or_callables = xonsh.built_ins.list_of_strs_or_callables
-        self.list_of_list_of_strs_outer_product = xonsh.built_ins.list_of_list_of_strs_outer_product
-        self.eval_fstring_field = xonsh.built_ins.eval_fstring_field
 
         self.completers = default_completers()
-        self.call_macro = xonsh.built_ins.call_macro
-        self.enter_macro = xonsh.built_ins.enter_macro
-        self.path_literal = xonsh.built_ins.path_literal
 
         self.builtins = xonsh.built_ins.create_builtins_namespace(execer)
         self._default_builtin_names = frozenset(vars(self.builtins))

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -134,8 +134,6 @@ class XonshSession:
         # relies on __xonsh__.env in default aliases
         from xonsh.aliases import Aliases, make_default_aliases
 
-        if not hasattr(builtins, "__xonsh__"):
-            builtins.__xonsh__ = self
         if ctx is not None:
             self.ctx = ctx
 
@@ -178,6 +176,9 @@ class XonshSession:
         for attr, value in kwargs.items():
             if hasattr(self, attr):
                 setattr(self, attr, value)
+
+        # Make sure we have __xonsh__
+        builtins.__xonsh__ = self
 
     def unload(self):
         if not hasattr(builtins, "__xonsh__"):

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -122,7 +122,7 @@ class XonshSession:
         self.enter_macro = xonsh.built_ins.enter_macro
         self.path_literal = xonsh.built_ins.path_literal
 
-        self.builtins = xonsh.built_ins._BuiltIns(execer)
+        self.builtins = xonsh.built_ins.create_builtins_namespace(execer)
         self._default_builtin_names = frozenset(vars(self.builtins))
 
         aliases_given = kwargs.pop("aliases", None)

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -43,17 +43,9 @@ def _lastflush(s=None, f=None):
 class XonshSession:
     """All components defining a xonsh session."""
 
-    def __init__(self, execer=None, ctx=None):
-        """
-        Parameters
-        ----------
-        execer : Execer, optional
-            Xonsh execution object, may be None to start
-        ctx : Mapping, optional
-            Context to start xonsh session with.
-        """
-        self.execer = execer
-        self.ctx = {} if ctx is None else ctx
+    def __init__(self):
+        self.execer = None
+        self.ctx = {}
         self.builtins_loaded = False
         self.history = None
         self.shell = None

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -81,15 +81,14 @@ class XonshSession:
         self.stderr_uncaptured = None
         self.shell = None
 
-        cache_file = (
+        cache_path = (
             (Path(env["XONSH_DATA_DIR"]).joinpath("commands-cache.pickle").resolve())
             if env is not None
             and "XONSH_DATA_DIR" in env
             and env.get("COMMANDS_CACHE_SAVE_INTERMEDIATE")
             else None
         )
-
-        self.commands_cache = CommandsCache(cache_file)
+        self.commands_cache = CommandsCache(cache_path)
         self.modules_cache = {}
         self.all_jobs = {}
 

--- a/xonsh/session.py
+++ b/xonsh/session.py
@@ -1,0 +1,178 @@
+import atexit
+import builtins
+import signal
+from xonsh.platform import ON_POSIX, ON_WINDOWS
+from xonsh.lazyasd import lazyobject
+import xonsh.built_ins
+import sys
+
+@lazyobject
+def AT_EXIT_SIGNALS():
+    sigs = (
+        signal.SIGABRT,
+        signal.SIGFPE,
+        signal.SIGILL,
+        signal.SIGSEGV,
+        signal.SIGTERM,
+    )
+    if ON_POSIX:
+        sigs += (signal.SIGTSTP, signal.SIGQUIT, signal.SIGHUP)
+    return sigs
+
+
+def resetting_signal_handle(sig, f):
+    """Sets a new signal handle that will automatically restore the old value
+    once the new handle is finished.
+    """
+    oldh = signal.getsignal(sig)
+
+    def newh(s=None, frame=None):
+        f(s, frame)
+        signal.signal(sig, oldh)
+        if sig != 0:
+            sys.exit(sig)
+
+    signal.signal(sig, newh)
+
+
+def _lastflush(s=None, f=None):
+    if XSH.history is not None:
+        XSH.history.flush(at_exit=True)
+
+
+class XonshSession:
+    """All components defining a xonsh session."""
+
+    def __init__(self, execer=None, ctx=None):
+        """
+        Parameters
+        ----------
+        execer : Execer, optional
+            Xonsh execution object, may be None to start
+        ctx : Mapping, optional
+            Context to start xonsh session with.
+        """
+        self.execer = execer
+        self.ctx = {} if ctx is None else ctx
+        self.builtins_loaded = False
+        self.history = None
+        self.shell = None
+        self.env = None
+        self.rc_files = None
+
+    def load(self, execer=None, ctx=None, **kwargs):
+        """Loads the session with default values.
+
+        Parameters
+        ----------
+        execer : Execer, optional
+            Xonsh execution object, may be None to start
+        ctx : Mapping, optional
+            Context to start xonsh session with.
+        """
+        from xonsh.environ import Env, default_env
+        from xonsh.commands_cache import CommandsCache
+        from xonsh.completers.init import default_completers
+
+        if not hasattr(builtins, "__xonsh__"):
+            builtins.__xonsh__ = self
+        if ctx is not None:
+            self.ctx = ctx
+
+        self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env())
+        self.help = kwargs.pop("help") if "help" in kwargs else xonsh.built_ins.helper
+        self.superhelp = xonsh.built_ins.superhelper
+        self.pathsearch = xonsh.built_ins.pathsearch
+        self.globsearch = xonsh.built_ins.globsearch
+        self.regexsearch = xonsh.built_ins.regexsearch
+        self.glob = xonsh.built_ins.globpath
+        self.expand_path = xonsh.built_ins.expand_path
+        self.exit = False
+        self.stdout_uncaptured = None
+        self.stderr_uncaptured = None
+
+        if hasattr(builtins, "exit"):
+            self.pyexit = builtins.exit
+            del builtins.exit
+
+        if hasattr(builtins, "quit"):
+            self.pyquit = builtins.quit
+            del builtins.quit
+
+        self.subproc_captured_stdout = xonsh.built_ins.subproc_captured_stdout
+        self.subproc_captured_inject = xonsh.built_ins.subproc_captured_inject
+        self.subproc_captured_object = xonsh.built_ins.subproc_captured_object
+        self.subproc_captured_hiddenobject = xonsh.built_ins.subproc_captured_hiddenobject
+        self.subproc_uncaptured = xonsh.built_ins.subproc_uncaptured
+        self.execer = execer
+        self.commands_cache = (
+            kwargs.pop("commands_cache")
+            if "commands_cache" in kwargs
+            else CommandsCache()
+        )
+        self.modules_cache = {}
+        self.all_jobs = {}
+        self.ensure_list_of_strs = xonsh.built_ins.ensure_list_of_strs
+        self.list_of_strs_or_callables = xonsh.built_ins.list_of_strs_or_callables
+        self.list_of_list_of_strs_outer_product = xonsh.built_ins.list_of_list_of_strs_outer_product
+        self.eval_fstring_field = xonsh.built_ins.eval_fstring_field
+
+        self.completers = default_completers()
+        self.call_macro = xonsh.built_ins.call_macro
+        self.enter_macro = xonsh.built_ins.enter_macro
+        self.path_literal = xonsh.built_ins.path_literal
+
+        self.builtins = xonsh.built_ins._BuiltIns(execer)
+        self._default_builtin_names = frozenset(vars(self.builtins))
+
+        aliases_given = kwargs.pop("aliases", None)
+        for attr, value in kwargs.items():
+            if hasattr(self, attr):
+                setattr(self, attr, value)
+        self.link_builtins(aliases_given)
+        self.builtins_loaded = True
+
+    def link_builtins(self, aliases=None):
+        from xonsh.aliases import Aliases, make_default_aliases
+
+        # public built-ins
+        for refname in self._default_builtin_names:
+            objname = f"__xonsh__.builtins.{refname}"
+            proxy = xonsh.built_ins.DynamicAccessProxy(refname, objname)
+            setattr(builtins, refname, proxy)
+
+        # sneak the path search functions into the aliases
+        # Need this inline/lazy import here since we use locate_binary that
+        # relies on __xonsh__.env in default aliases
+        if aliases is None:
+            aliases = Aliases(make_default_aliases())
+        self.aliases = builtins.default_aliases = builtins.aliases = aliases
+        atexit.register(_lastflush)
+        for sig in AT_EXIT_SIGNALS:
+            resetting_signal_handle(sig, _lastflush)
+
+    def unlink_builtins(self):
+        for name in self._default_builtin_names:
+            if hasattr(builtins, name):
+                delattr(builtins, name)
+
+    def unload(self):
+        if not hasattr(builtins, "__xonsh__"):
+            self.builtins_loaded = False
+            return
+        env = getattr(self, "env", None)
+        if hasattr(self.env, "undo_replace_env"):
+            env.undo_replace_env()
+        if hasattr(self, "pyexit"):
+            builtins.exit = self.pyexit
+        if hasattr(self, "pyquit"):
+            builtins.quit = self.pyquit
+        if not self.builtins_loaded:
+            return
+        self.unlink_builtins()
+        delattr(builtins, "__xonsh__")
+        self.builtins_loaded = False
+
+
+# singleton
+XSH = XonshSession()

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -15,7 +15,7 @@ from xonsh.tools import XonshError, print_exception, simple_random_choice
 from xonsh.events import events
 from xonsh.history.dummy import DummyHistory
 import xonsh.history.main as xhm
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 events.doc(
     "on_transform_command",
@@ -105,7 +105,7 @@ def transform_command(src, show_diff=True):
                 "the recursion limit number of iterations to "
                 "converge."
             )
-    debug_level = XSH.env.get("XONSH_DEBUG")
+    debug_level = xsh.XSH.env.get("XONSH_DEBUG")
     if show_diff and debug_level >= 1 and src != raw:
         sys.stderr.writelines(
             difflib.unified_diff(
@@ -199,11 +199,11 @@ class Shell(object):
         """
         self.execer = execer
         self.ctx = {} if ctx is None else ctx
-        env = XSH.env
+        env = xsh.XSH.env
 
         # build history backend before creating shell
         if env.get("XONSH_INTERACTIVE"):
-            XSH.history = hist = xhm.construct_history(
+            xsh.XSH.history = hist = xhm.construct_history(
                 env=env.detype(),
                 ts=[time.time(), None],
                 locked=True,
@@ -211,7 +211,7 @@ class Shell(object):
             )
             env["XONSH_HISTORY_FILE"] = hist.filename
         else:
-            XSH.history = hist = DummyHistory()
+            xsh.XSH.history = hist = DummyHistory()
             env["XONSH_HISTORY_FILE"] = None
 
         shell_type = self.choose_shell_type(shell_type, env)

--- a/xonsh/style_tools.py
+++ b/xonsh/style_tools.py
@@ -63,11 +63,11 @@ def partial_color_tokenize(template):
     of tuples mapping the token to the string which has that color.
     These sub-strings maybe templates themselves.
     """
-    from xonsh.built_ins import XSH
+    import xonsh.session as xsh
 
-    if HAS_PYGMENTS and XSH.shell is not None:
-        styles = XSH.shell.shell.styler.styles
-    elif XSH.shell is not None:
+    if HAS_PYGMENTS and xsh.XSH.shell is not None:
+        styles = xsh.XSH.shell.shell.styler.styles
+    elif xsh.XSH.shell is not None:
         styles = DEFAULT_STYLE_DICT
     else:
         styles = None

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -15,7 +15,7 @@ import time
 import timeit
 import itertools
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.lazyasd import lazyobject, lazybool
 from xonsh.events import events
 from xonsh.platform import ON_WINDOWS
@@ -188,7 +188,7 @@ def timeit_alias(args, stdin=None):
     repeat = 3
     precision = 3
     # setup
-    ctx = XSH.ctx
+    ctx = xsh.XSH.ctx
     timer = Timer(timer=clock)
     stmt = " ".join(args)
     innerstr = INNER_TEMPLATE.format(stmt=stmt)
@@ -196,13 +196,13 @@ def timeit_alias(args, stdin=None):
     # Minimum time above which compilation time will be reported
     tc_min = 0.1
     t0 = clock()
-    innercode = XSH.builtins.compilex(
+    innercode = xsh.XSH.builtins.compilex(
         innerstr, filename="<xonsh-timeit>", mode="exec", glbs=ctx
     )
     tc = clock() - t0
     # get inner func
     ns = {}
-    XSH.builtins.execx(innercode, glbs=ctx, locs=ns, mode="exec")
+    xsh.XSH.builtins.execx(innercode, glbs=ctx, locs=ns, mode="exec")
     timer.inner = ns["inner"]
     # Check if there is a huge difference between the best and worst timings.
     worst_tuning = 0

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -64,9 +64,9 @@ def is_superuser():
 
 @lazyobject
 def xsh():
-    from xonsh.built_ins import XSH
+    import xonsh.session as xsh
 
-    return XSH
+    return xsh.XSH
 
 
 class XonshError(Exception):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -900,7 +900,7 @@ def suggest_commands(cmd, env):
             if levenshtein(alias.lower(), cmd, thresh) < thresh:
                 suggested[alias] = "Alias"
 
-    for _cmd in xsh.XSH.commands_cache.all_commands:
+    for _cmd in xsh.XSH.commands_cache.update_cache():
         if _cmd not in suggested:
             if levenshtein(_cmd.lower(), cmd, thresh) < thresh:
                 suggested[_cmd] = "Command ({0})".format(_cmd)

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -11,7 +11,7 @@ import collections.abc as cabc
 import typing as tp
 
 from xonsh.tools import to_bool, to_bool_or_break, backup_file, print_color
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.jsonutils import serialize_xonsh_json
 
 
@@ -714,8 +714,8 @@ class PromptVisitor(StateVisitor):
             singleline() method. See BaseShell for mor details.
         """
         super().__init__(tree=tree, state=state)
-        self.env = XSH.env
-        self.shell = XSH.shell.shell
+        self.env = xsh.XSH.env
+        self.shell = xsh.XSH.shell.shell
         self.shell_kwargs = kwargs
 
     def visit_wizard(self, node):

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -18,7 +18,7 @@ from xonsh.ply import ply
 
 import xonsh.wizard as wiz
 from xonsh import __version__ as XONSH_VERSION
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.cli_utils import ArgParserAlias, Annotated, Arg, add_args
 from xonsh.prompt.base import is_template_string
 from xonsh.platform import (
@@ -190,7 +190,7 @@ def _dump_xonfig_foreign_shell(path, value):
 
 def _dump_xonfig_env(path, value):
     name = os.path.basename(path.rstrip("/"))
-    detyper = XSH.env.get_detyper(name)
+    detyper = xsh.XSH.env.get_detyper(name)
     dval = str(value) if detyper is None else detyper(value)
     dval = str(value) if dval is None else dval
     return "${name} = {val!r}".format(name=name, val=dval)
@@ -290,7 +290,7 @@ ENVVAR_PROMPT = "{BOLD_GREEN}>>>{RESET} "
 
 def make_exit_message():
     """Creates a message for how to exit the wizard."""
-    shell_type = XSH.shell.shell_type
+    shell_type = xsh.XSH.shell.shell_type
     keyseq = "Ctrl-D" if shell_type == "readline" else "Ctrl-C"
     msg = "To exit the wizard at any time, press {BOLD_UNDERLINE_CYAN}"
     msg += keyseq + "{RESET}.\n"
@@ -300,7 +300,7 @@ def make_exit_message():
 
 def make_envvar(name):
     """Makes a StoreNonEmpty node for an environment variable."""
-    env = XSH.env
+    env = xsh.XSH.env
     vd = env.get_docs(name)
     if not vd.is_configurable:
         return
@@ -346,7 +346,7 @@ def _make_flat_wiz(kidfunc, *args):
 
 def make_env_wiz():
     """Makes an environment variable wizard."""
-    w = _make_flat_wiz(make_envvar, sorted(XSH.env.keys()))
+    w = _make_flat_wiz(make_envvar, sorted(xsh.XSH.env.keys()))
     return w
 
 
@@ -457,8 +457,8 @@ def _wizard(
     confirm
         confirm that the wizard should be run.
     """
-    env = XSH.env
-    shell = XSH.shell.shell
+    env = xsh.XSH.env
+    shell = xsh.XSH.shell.shell
     xonshrcs = env.get("XONSHRC", [])
     fname = xonshrcs[-1] if xonshrcs and rcfile is None else rcfile
     no_wiz = os.path.join(env.get("XONSH_CONFIG_DIR"), "no-wizard")
@@ -523,7 +523,7 @@ def _info(
     to_json
         reports results as json
     """
-    env = XSH.env
+    env = xsh.XSH.env
     data: tp.List[tp.Any] = [("xonsh", XONSH_VERSION)]
     hash_, date_ = githash()
     if hash_:
@@ -570,7 +570,7 @@ def _info(
     data.extend([("on jupyter", jup_ksm is not None), ("jupyter kernel", jup_kernel)])
 
     data.extend([("xontrib", xontribs_loaded())])
-    data.extend([("RC file", XSH.rc_files)])
+    data.extend([("RC file", xsh.XSH.rc_files)])
 
     formatter = _xonfig_format_json if to_json else _xonfig_format_human
     s = formatter(data)
@@ -587,7 +587,7 @@ def _styles(
     to_json
         reports results as json
     """
-    env = XSH.env
+    env = xsh.XSH.env
     curr = env.get("XONSH_COLOR_STYLE")
     styles = sorted(color_style_names())
     if to_json:
@@ -664,13 +664,13 @@ def _colors(
     """
     columns, _ = shutil.get_terminal_size()
     columns -= int(bool(ON_WINDOWS))
-    style_stash = XSH.env["XONSH_COLOR_STYLE"]
+    style_stash = xsh.XSH.env["XONSH_COLOR_STYLE"]
 
     if style is not None:
         if style not in color_style_names():
             print("Invalid style: {}".format(style))
             return
-        XSH.env["XONSH_COLOR_STYLE"] = style
+        xsh.XSH.env["XONSH_COLOR_STYLE"] = style
 
     color_map = color_style()
     if not color_map:
@@ -682,7 +682,7 @@ def _colors(
     else:
         s = _tok_colors(color_map, columns)
     print_color(s)
-    XSH.env["XONSH_COLOR_STYLE"] = style_stash
+    xsh.XSH.env["XONSH_COLOR_STYLE"] = style_stash
 
 
 def _tutorial():
@@ -889,7 +889,7 @@ WELCOME_MSG = [
 
 
 def print_welcome_screen():
-    shell_type = XSH.env.get("SHELL_TYPE")
+    shell_type = xsh.XSH.env.get("SHELL_TYPE")
     subst = dict(tagline=random.choice(list(TAGLINES)), version=XONSH_VERSION)
     for elem in WELCOME_MSG:
         if elem == "[SHELL_TYPE_WARNING]":

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -8,7 +8,7 @@ import typing as tp
 from enum import IntEnum
 from pathlib import Path
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.cli_utils import ArgParserAlias, Arg, Annotated
 from xonsh.completers.tools import RichCompletion
 from xonsh.xontribs_meta import get_xontribs
@@ -69,7 +69,7 @@ def update_context(name, ctx=None):
     then __xonsh__.ctx is updated.
     """
     if ctx is None:
-        ctx = XSH.ctx
+        ctx = xsh.XSH.ctx
     modctx = xontrib_context(name)
     if modctx is None:
         if not hasattr(update_context, "bad_imports"):
@@ -111,7 +111,7 @@ def xontribs_load(
     verbose
         verbose output
     """
-    ctx = XSH.ctx
+    ctx = xsh.XSH.ctx
     res = ExitCode.OK
     for name in names:
         if verbose:

--- a/xonsh/xoreutils/_which.py
+++ b/xonsh/xoreutils/_which.py
@@ -30,7 +30,7 @@ import stat
 import getopt
 import collections.abc as cabc
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 r"""Find the full path to commands.
 
@@ -192,7 +192,7 @@ def whichgen(command, path=None, verbose=0, exts=None):
     # Windows has the concept of a list of extensions (PATHEXT env var).
     if sys.platform.startswith("win"):
         if exts is None:
-            exts = XSH.env["PATHEXT"]
+            exts = xsh.XSH.env["PATHEXT"]
             # If '.exe' is not in exts then obviously this is Win9x and
             # or a bogus PATHEXT, then use a reasonable default.
             for ext in exts:

--- a/xonsh/xoreutils/cat.py
+++ b/xonsh/xoreutils/cat.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 import xonsh.procs.pipelines as xpp
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.xoreutils.util import arg_handler
 
 
@@ -39,7 +39,7 @@ def _cat_line(
 
 
 def _cat_single_file(opts, fname, stdin, out, err, line_count=1):
-    env = XSH.env
+    env = xsh.XSH.env
     enc = env.get("XONSH_ENCODING")
     enc_errors = env.get("XONSH_ENCODING_ERRORS")
     read_size = 0

--- a/xonsh/xoreutils/pwd.py
+++ b/xonsh/xoreutils/pwd.py
@@ -1,11 +1,11 @@
 """A pwd implementation for xonsh."""
 import os
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 def pwd(args, stdin, stdout, stderr):
     """A pwd implementation"""
-    e = XSH.env["PWD"]
+    e = xsh.XSH.env["PWD"]
     if "-h" in args or "--help" in args:
         print(PWD_HELP, file=stdout)
         return 0

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -7,7 +7,7 @@ import xonsh
 from xonsh.xoreutils import _which
 import xonsh.platform as xp
 import xonsh.procs.pipelines as xpp
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 @functools.lru_cache()
@@ -76,7 +76,7 @@ def _which_create_parser():
 
 def print_global_object(arg, stdout):
     """Print the object."""
-    obj = XSH.ctx.get(arg)
+    obj = xsh.XSH.ctx.get(arg)
     print("global object of {}".format(type(obj)), file=stdout)
 
 
@@ -88,7 +88,7 @@ def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
         p, f = os.path.split(abs_name)
         f = next(s.name for s in os.scandir(p) if s.name.lower() == f.lower())
         abs_name = os.path.join(p, f)
-        if XSH.env.get("FORCE_POSIX_PATHS", False):
+        if xsh.XSH.env.get("FORCE_POSIX_PATHS", False):
             abs_name.replace(os.sep, os.altsep)
     if verbose:
         print(f"{abs_name} ({from_where})", file=stdout)
@@ -99,7 +99,7 @@ def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
 
 def print_alias(arg, stdout, verbose=False):
     """Print the alias."""
-    alias = XSH.aliases[arg]
+    alias = xsh.XSH.aliases[arg]
     if not verbose:
         if not callable(alias):
             print(" ".join(alias), file=stdout)
@@ -114,7 +114,7 @@ def print_alias(arg, stdout, verbose=False):
             file=stdout,
         )
         if callable(alias) and not isinstance(alias, xonsh.aliases.ExecAlias):
-            XSH.superhelp(alias)
+            xsh.XSH.superhelp(alias)
 
 
 def which(args, stdin=None, stdout=None, stderr=None, spec=None):
@@ -141,16 +141,16 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         if pargs.exts:
             exts = pargs.exts
         else:
-            exts = XSH.env["PATHEXT"]
+            exts = xsh.XSH.env["PATHEXT"]
     else:
         exts = None
     failures = []
     for arg in pargs.args:
         nmatches = 0
-        if pargs.all and arg in XSH.ctx:
+        if pargs.all and arg in xsh.XSH.ctx:
             print_global_object(arg, stdout)
             nmatches += 1
-        if arg in XSH.aliases and not pargs.skip:
+        if arg in xsh.XSH.aliases and not pargs.skip:
             print_alias(arg, stdout, verbose)
             nmatches += 1
             if not pargs.all:
@@ -159,7 +159,7 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         # from os.environ so we temporarily override it with
         # __xosnh_env__['PATH']
         original_os_path = xp.os_environ["PATH"]
-        xp.os_environ["PATH"] = XSH.env.detype()["PATH"]
+        xp.os_environ["PATH"] = xsh.XSH.env.detype()["PATH"]
         matches = _which.whichgen(arg, exts=exts, verbose=verbose)
         for abs_name, from_where in matches:
             print_path(abs_name, from_where, stdout, verbose, captured)

--- a/xontrib/autovox.py
+++ b/xontrib/autovox.py
@@ -6,20 +6,20 @@ mechanics of venv searching and chdir handling.
 
 This provides no interface for end users.
 
-Developers should look at XSH.builtins.events.autovox_policy
+Developers should look at xsh.XSH.builtins.events.autovox_policy
 """
 import itertools
 from pathlib import Path
 import xontrib.voxapi as voxapi
 import warnings
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ()
 
 
 _policies = []
 
-XSH.builtins.events.doc(
+xsh.XSH.builtins.events.doc(
     "autovox_policy",
     """
 autovox_policy(path: pathlib.Path) -> Union[str, pathlib.Path, None]
@@ -45,7 +45,7 @@ def get_venv(vox, dirpath):
     for path in itertools.chain((dirpath,), dirpath.parents):
         venvs = [
             vox[p]
-            for p in XSH.builtins.events.autovox_policy.fire(path=path)
+            for p in xsh.XSH.builtins.events.autovox_policy.fire(path=path)
             if p is not None and p in vox  # Filter out venvs that don't exist
         ]
         if len(venvs) == 0:
@@ -81,7 +81,7 @@ def check_for_new_venv(curdir, olddir):
 
 
 # Core mechanism: Check for venv when the current directory changes
-@XSH.builtins.events.on_chdir
+@xsh.XSH.builtins.events.on_chdir
 def cd_handler(newdir, olddir, **_):
     check_for_new_venv(Path(newdir), Path(olddir))
 
@@ -89,12 +89,12 @@ def cd_handler(newdir, olddir, **_):
 # Recalculate when venvs are created or destroyed
 
 
-@XSH.builtins.events.vox_on_create
+@xsh.XSH.builtins.events.vox_on_create
 def create_handler(**_):
     check_for_new_venv(Path.cwd(), ...)
 
 
-@XSH.builtins.events.vox_on_destroy
+@xsh.XSH.builtins.events.vox_on_destroy
 def destroy_handler(**_):
     check_for_new_venv(Path.cwd(), ...)
 
@@ -102,6 +102,6 @@ def destroy_handler(**_):
 # Initial activation before first prompt
 
 
-@XSH.builtins.events.on_post_init
+@xsh.XSH.builtins.events.on_post_init
 def load_handler(**_):
     check_for_new_venv(Path.cwd(), None)

--- a/xontrib/bashisms.py
+++ b/xontrib/bashisms.py
@@ -2,7 +2,7 @@
 import shlex
 import sys
 import re
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ()
 
@@ -15,7 +15,7 @@ PRs are welcome - https://github.com/xonsh/xonsh/blob/main/xontrib/bashisms.py""
     )
 
 
-@XSH.builtins.events.on_transform_command
+@xsh.XSH.builtins.events.on_transform_command
 def bash_preproc(cmd, **kw):
     bang_previous = {
         "!": lambda x: x,
@@ -26,7 +26,7 @@ def bash_preproc(cmd, **kw):
 
     def replace_bang(m):
         arg = m.group(1)
-        inputs = XSH.history.inps
+        inputs = xsh.XSH.history.inps
 
         # Dissect the previous command.
         if arg in bang_previous:
@@ -56,21 +56,21 @@ def alias(args, stdin=None):
                 # shlex.split to remove quotes, e.g. "foo='echo hey'" into
                 # "foo=echo hey"
                 name, cmd = shlex.split(arg)[0].split("=", 1)
-                XSH.aliases[name] = shlex.split(cmd)
-            elif arg in XSH.aliases:
-                print("{}={}".format(arg, XSH.aliases[arg]))
+                xsh.XSH.aliases[name] = shlex.split(cmd)
+            elif arg in xsh.XSH.aliases:
+                print("{}={}".format(arg, xsh.XSH.aliases[arg]))
             else:
                 print("alias: {}: not found".format(arg), file=sys.stderr)
                 ret = 1
     else:
-        for alias, cmd in XSH.aliases.items():
+        for alias, cmd in xsh.XSH.aliases.items():
             print("{}={}".format(alias, cmd))
 
     return ret
 
 
-XSH.aliases["alias"] = alias
-XSH.env["THREAD_SUBPROCS"] = False
+xsh.XSH.aliases["alias"] = alias
+xsh.XSH.env["THREAD_SUBPROCS"] = False
 
 
 def _unset(args):
@@ -79,12 +79,12 @@ def _unset(args):
 
     for v in args:
         try:
-            XSH.env.pop(v)
+            xsh.XSH.env.pop(v)
         except KeyError:
             print(f"{v} not found", file=sys.stderr)
 
 
-XSH.aliases["unset"] = _unset
+xsh.XSH.aliases["unset"] = _unset
 
 
 def _export(args):
@@ -94,29 +94,29 @@ def _export(args):
     for eq in args:
         if "=" in eq:
             name, val = shlex.split(eq)[0].split("=", 1)
-            XSH.env[name] = val
+            xsh.XSH.env[name] = val
         else:
             print(f"{eq} equal sign not found", file=sys.stderr)
 
 
-XSH.aliases["export"] = _export
+xsh.XSH.aliases["export"] = _export
 
 
 def _set(args):
     arg = args[0]
     if arg == "-e":
-        XSH.env["RAISE_SUBPROC_ERROR"] = True
+        xsh.XSH.env["RAISE_SUBPROC_ERROR"] = True
     elif arg == "+e":
-        XSH.env["RAISE_SUBPROC_ERROR"] = False
+        xsh.XSH.env["RAISE_SUBPROC_ERROR"] = False
     elif arg == "-x":
-        XSH.env["XONSH_TRACE_SUBPROC"] = True
+        xsh.XSH.env["XONSH_TRACE_SUBPROC"] = True
     elif arg == "+x":
-        XSH.env["XONSH_TRACE_SUBPROC"] = False
+        xsh.XSH.env["XONSH_TRACE_SUBPROC"] = False
     else:
         _warn_not_supported(f"set {arg}")
 
 
-XSH.aliases["set"] = _set
+xsh.XSH.aliases["set"] = _set
 
 
 def _shopt(args):
@@ -126,7 +126,7 @@ def _shopt(args):
     args_len = len(args)
     if args_len == 0:
         for so in supported_shopt:
-            onoff = "on" if so in XSH.env and XSH.env[so] else "off"
+            onoff = "on" if so in xsh.XSH.env and xsh.XSH.env[so] else "off"
             print(f"dotglob\t{onoff}")
         return
     elif args_len < 2 or args[0] in ["-h", "--help"]:
@@ -137,14 +137,14 @@ def _shopt(args):
     optname = args[1]
 
     if opt == "-s" and optname == "dotglob":
-        XSH.env["DOTGLOB"] = True
+        xsh.XSH.env["DOTGLOB"] = True
     elif opt == "-u" and optname == "dotglob":
-        XSH.env["DOTGLOB"] = False
+        xsh.XSH.env["DOTGLOB"] = False
     else:
         _warn_not_supported(f"shopt {args}")
 
 
-XSH.aliases["shopt"] = _shopt
+xsh.XSH.aliases["shopt"] = _shopt
 
 
-XSH.aliases["complete"] = "completer list"
+xsh.XSH.aliases["complete"] = "completer list"

--- a/xontrib/coreutils.py
+++ b/xontrib/coreutils.py
@@ -19,13 +19,13 @@ from xonsh.xoreutils.pwd import pwd
 from xonsh.xoreutils.tee import tee
 from xonsh.xoreutils.tty import tty
 from xonsh.xoreutils.yes import yes
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ()
 
-XSH.aliases["cat"] = cat
-XSH.aliases["echo"] = echo
-XSH.aliases["pwd"] = pwd
-XSH.aliases["tee"] = tee
-XSH.aliases["tty"] = tty
-XSH.aliases["yes"] = yes
+xsh.XSH.aliases["cat"] = cat
+xsh.XSH.aliases["echo"] = echo
+xsh.XSH.aliases["pwd"] = pwd
+xsh.XSH.aliases["tee"] = tee
+xsh.XSH.aliases["tty"] = tty
+xsh.XSH.aliases["yes"] = yes

--- a/xontrib/distributed.py
+++ b/xontrib/distributed.py
@@ -1,6 +1,6 @@
 """Hooks for the distributed parallel computing library."""
 from xonsh.contexts import Functor
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ["DSubmitter", "dsubmit"]
 
@@ -14,7 +14,7 @@ def dworker(args, stdin=None):
     dworker.main.main(args=args, prog_name="dworker", standalone_mode=False)
 
 
-XSH.aliases["dworker"] = dworker
+xsh.XSH.aliases["dworker"] = dworker
 
 
 class DSubmitter(Functor):

--- a/xontrib/free_cwd.py
+++ b/xontrib/free_cwd.py
@@ -12,7 +12,7 @@ import functools
 from pathlib import Path
 
 from xonsh.tools import print_exception
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.platform import ON_WINDOWS, ON_CYGWIN, ON_MSYS
 
 
@@ -35,7 +35,7 @@ def _cwd_release_wrapper(func):
     displayed. This works by temporarily setting
     the workdir to the users home directory.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
         return func if not hasattr(func, "_orgfunc") else func._orgfunc
 
@@ -57,7 +57,7 @@ def _cwd_release_wrapper(func):
                 except (FileNotFoundError, NotADirectoryError):
                     print_exception()
                     newpath = _chdir_up(pwd)
-                    XSH.env["PWD"] = newpath
+                    xsh.XSH.env["PWD"] = newpath
                     raise KeyboardInterrupt
             return out
 
@@ -70,7 +70,7 @@ def _cwd_restore_wrapper(func):
     directory. Designed to wrap completer callbacks from the
     prompt_toolkit or readline.
     """
-    env = XSH.env
+    env = xsh.XSH.env
     if env.get("UPDATE_PROMPT_ON_KEYPRESS"):
         return func if not hasattr(func, "_orgfunc") else func._orgfunc
 
@@ -91,7 +91,7 @@ def _cwd_restore_wrapper(func):
         return wrapper
 
 
-@XSH.builtins.events.on_ptk_create
+@xsh.XSH.builtins.events.on_ptk_create
 def setup_release_cwd_hook(prompter, history, completer, bindings, **kw):
     if ON_WINDOWS and not ON_CYGWIN and not ON_MSYS:
         prompter.prompt = _cwd_release_wrapper(prompter.prompt)

--- a/xontrib/jedi.py
+++ b/xontrib/jedi.py
@@ -3,7 +3,7 @@ import os
 
 import xonsh
 from xonsh.lazyasd import lazyobject, lazybool
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.completers.tools import (
     get_filter_function,
     RichCompletion,
@@ -60,7 +60,7 @@ def complete_jedi(context: CompletionContext):
     # taken from xonsh/completers/python.py
     if context.command and context.command.arg_index != 0:
         first = context.command.args[0].value
-        if first in XSH.commands_cache and first not in ctx:  # type: ignore
+        if first in xsh.XSH.commands_cache and first not in ctx:  # type: ignore
             return None
 
     # if we're completing a possible command and the prefix contains a valid path, don't complete.
@@ -70,7 +70,7 @@ def complete_jedi(context: CompletionContext):
             return None
 
     filter_func = get_filter_function()
-    jedi.settings.case_insensitive_completion = not XSH.env.get(
+    jedi.settings.case_insensitive_completion = not xsh.XSH.env.get(
         "CASE_SENSITIVE_COMPLETIONS"
     )
 
@@ -81,7 +81,7 @@ def complete_jedi(context: CompletionContext):
         index - source.rfind("\n", 0, index) - 1
     )  # will be `index - (-1) - 1` if there's no newline
 
-    extra_ctx = {"__xonsh__": XSH}
+    extra_ctx = {"__xonsh__": xsh.XSH}
     try:
         extra_ctx["_"] = _
     except NameError:

--- a/xontrib/mpl.py
+++ b/xontrib/mpl.py
@@ -4,7 +4,7 @@ is imported.
 
 from xonsh.tools import unthreadable
 from xonsh.lazyasd import lazyobject
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 __all__ = ()
@@ -18,7 +18,7 @@ def mpl(args, stdin=None):
     show()
 
 
-XSH.aliases["mpl"] = mpl
+xsh.XSH.aliases["mpl"] = mpl
 
 
 @lazyobject
@@ -30,10 +30,10 @@ def pylab_helpers():
     return m
 
 
-@XSH.builtins.events.on_import_post_exec_module
+@xsh.XSH.builtins.events.on_import_post_exec_module
 def interactive_pyplot(module=None, **kwargs):
     """This puts pyplot in interactive mode once it is imported."""
-    if module.__name__ != "matplotlib.pyplot" or not XSH.env.get("XONSH_INTERACTIVE"):
+    if module.__name__ != "matplotlib.pyplot" or not xsh.XSH.env.get("XONSH_INTERACTIVE"):
         return
     # Since we are in interactive mode, let's monkey-patch plt.show
     # to try to never block.
@@ -59,7 +59,7 @@ def interactive_pyplot(module=None, **kwargs):
     module.show = xonsh_show
 
     # register figure drawer
-    @XSH.builtins.events.on_postcommand
+    @xsh.XSH.builtins.events.on_postcommand
     def redraw_mpl_figure(**kwargs):
         """Redraws the current matplotlib figure after each command."""
         pylab_helpers.Gcf.draw_all()

--- a/xontrib/mplhooks.py
+++ b/xontrib/mplhooks.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 
 from xonsh.tools import print_color, ON_WINDOWS
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 try:
     # Use iterm2_tools as an indicator for the iterm2 terminal emulator
@@ -155,7 +155,7 @@ def display_figure_with_iterm2(fig):
 def show():
     """Run the mpl display sequence by printing the most recent figure to console"""
     try:
-        minimal = XSH.env["XONTRIB_MPL_MINIMAL"]
+        minimal = xsh.XSH.env["XONTRIB_MPL_MINIMAL"]
     except KeyError:
         minimal = XONTRIB_MPL_MINIMAL_DEFAULT
     fig = plt.gcf()

--- a/xontrib/prompt_ret_code.py
+++ b/xontrib/prompt_ret_code.py
@@ -1,10 +1,10 @@
 from xonsh.tools import ON_WINDOWS as _ON_WINDOWS
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 
 def _ret_code_color():
-    if XSH.history.rtns:
-        color = "blue" if XSH.history.rtns[-1] == 0 else "red"
+    if xsh.XSH.history.rtns:
+        color = "blue" if xsh.XSH.history.rtns[-1] == 0 else "red"
     else:
         color = "blue"
     if _ON_WINDOWS:
@@ -20,8 +20,8 @@ def _ret_code_color():
 
 
 def _ret_code():
-    if XSH.history.rtns:
-        return_code = XSH.history.rtns[-1]
+    if xsh.XSH.history.rtns:
+        return_code = xsh.XSH.history.rtns[-1]
         if return_code != 0:
             return "[{}]".format(return_code)
     return None
@@ -29,7 +29,7 @@ def _ret_code():
 
 def _update():
 
-    env = XSH.env
+    env = xsh.XSH.env
 
     env["PROMPT"] = env["PROMPT"].replace(
         "{prompt_end}{RESET}", "{ret_code_color}{ret_code}{prompt_end}{RESET}"

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -2,7 +2,7 @@
 
 import xonsh.cli_utils as xcli
 import xontrib.voxapi as voxapi
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ()
 
@@ -232,4 +232,4 @@ class VoxHandler(xcli.ArgParserAlias):
         print()
 
 
-XSH.aliases["vox"] = VoxHandler()
+xsh.XSH.aliases["vox"] = VoxHandler()

--- a/xontrib/vox.py
+++ b/xontrib/vox.py
@@ -18,7 +18,7 @@ def venv_names_completer(command, alias: "VoxHandler", **_):
 
 
 def py_interpreter_path_completer(xsh, **_):
-    for _, (path, is_alias) in xsh.commands_cache.all_commands.items():
+    for _, (path, is_alias) in xsh.commands_cache.update_cache().items():
         if not is_alias and ("/python" in path or "/pypy" in path):
             yield path
 

--- a/xontrib/voxapi.py
+++ b/xontrib/voxapi.py
@@ -15,7 +15,7 @@ import logging
 import collections.abc
 import subprocess as sp
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 from xonsh.platform import ON_POSIX, ON_WINDOWS
 
 
@@ -122,12 +122,12 @@ class Vox(collections.abc.Mapping):
     """
 
     def __init__(self):
-        if not XSH.env.get("VIRTUALENV_HOME"):
+        if not xsh.XSH.env.get("VIRTUALENV_HOME"):
             home_path = os.path.expanduser("~")
             self.venvdir = os.path.join(home_path, ".virtualenvs")
-            XSH.env["VIRTUALENV_HOME"] = self.venvdir
+            xsh.XSH.env["VIRTUALENV_HOME"] = self.venvdir
         else:
-            self.venvdir = XSH.env["VIRTUALENV_HOME"]
+            self.venvdir = xsh.XSH.env["VIRTUALENV_HOME"]
 
     def create(
         self,
@@ -273,7 +273,7 @@ class Vox(collections.abc.Mapping):
             the current one (throws a KeyError if there isn't one).
         """
         if name is ...:
-            env = XSH.env
+            env = xsh.XSH.env
             env_paths = [env["VIRTUAL_ENV"]]
         elif isinstance(name, os.PathLike):
             env_paths = [os.fspath(name)]
@@ -332,7 +332,7 @@ class Vox(collections.abc.Mapping):
 
         Returns None if no environment is active.
         """
-        env = XSH.env
+        env = xsh.XSH.env
         if "VIRTUAL_ENV" not in env:
             return
         env_path = env["VIRTUAL_ENV"]
@@ -353,7 +353,7 @@ class Vox(collections.abc.Mapping):
         name : str
             Virtual environment name or absolute path.
         """
-        env = XSH.env
+        env = xsh.XSH.env
         ve = self[name]
         if "VIRTUAL_ENV" in env:
             self.deactivate()
@@ -370,7 +370,7 @@ class Vox(collections.abc.Mapping):
         """
         Deactivate the active virtual environment. Returns its name.
         """
-        env = XSH.env
+        env = xsh.XSH.env
         if "VIRTUAL_ENV" not in env:
             raise NoEnvironmentActive("No environment currently active.")
 
@@ -411,4 +411,4 @@ class Vox(collections.abc.Mapping):
 
 def _get_vox_default_interpreter():
     """Return the interpreter set by the $VOX_DEFAULT_INTERPRETER if set else sys.executable"""
-    return XSH.env.get("VOX_DEFAULT_INTERPRETER", sys.executable)
+    return xsh.XSH.env.get("VOX_DEFAULT_INTERPRETER", sys.executable)

--- a/xontrib/whole_word_jumping.py
+++ b/xontrib/whole_word_jumping.py
@@ -4,12 +4,12 @@ Alt+Left/Right remains unmodified to jump over smaller word segments.
 """
 from prompt_toolkit.keys import Keys
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ()
 
 
-@XSH.builtins.events.on_ptk_create
+@xsh.XSH.builtins.events.on_ptk_create
 def custom_keybindings(bindings, **kw):
 
     # Key bindings for jumping over whole words (everything that's not

--- a/xontrib/xog.py
+++ b/xontrib/xog.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import tempfile
 
-from xonsh.built_ins import XSH
+import xonsh.session as xsh
 
 __all__ = ()
 
@@ -52,7 +52,7 @@ def _xog(args, stdout=None, stderr=None):
         _print_help(stdout)
         return 0
 
-    logfile = XSH.env.get("XONSH_TRACEBACK_LOGFILE", "")
+    logfile = xsh.XSH.env.get("XONSH_TRACEBACK_LOGFILE", "")
     if not (logfile and os.path.isfile(logfile)):
         print("Traceback log file doesn't exist.", file=stderr)
         return -1
@@ -65,5 +65,5 @@ def _xog(args, stdout=None, stderr=None):
     return 0 if rc else -1
 
 
-XSH.env["XONSH_TRACEBACK_LOGFILE"] = _get_log_file_name()
-XSH.aliases["xog"] = _xog
+xsh.XSH.env["XONSH_TRACEBACK_LOGFILE"] = _get_log_file_name()
+xsh.XSH.aliases["xog"] = _xog


### PR DESCRIPTION
## TLDR

This draft PR intends to drastically minimise the number of global references to the Xonsh machinery. Right now, there are several problems:
1. XSH is a god object
2. XSH is a singleton
3. Most tools reference XSH instead of the actual component (e.g. `XSH.execer.parser.lexer`)

#4280 was a good decision to make the global state explicit (for testing), and this PR takes that to the next stage. In particular, this PR has two goals:
1. Replace the mutable XSH singleton with a stack mechanism.
2. Replace references to `xonsh.session.XSH` with explicit dependency injection.

## Details
On the face of it, there are no pressing benefits for moving towards a stack mechanism. In particular, I'm not sure how often users are going to want to have multiple Xonsh sessions floating around. However, really this gives us a robust way of modifying the Xonsh session in a reversible way - e.g. for testing, just push a test session, and pop it when done. This is much safer than mutating the session in place. It might *also* be useful for _clients_ of Xonsh, rather than the Xonsh shell itself. The main design choice here is to move from mutating (`XSH.load`) into pushing onto the stack, making it clear what's going on. 

With the possibility of multiple sessions in Xonsh, there would also be the need for xontribs to re-register themselves with each session. Rather than executing at module import, as they do at present, xontribs should declare a registrar function that accepts the session similar to IPython e.g.
```python3
def load_xontrib(session):
   pass
```
This is a non-goal for this PR.

Given how Xonsh has grown organically over time, there are many places where we should be just passing in the necessary dependencies rather than using `XSH`, e.g. `CommandsCache`. We should replace those lookups with the appropriate values e.g. `cache_file` for `CommandsCache`: In my view, many of the free functions that refer to `__xonsh__` / `XSH` should instead be bound methods which refer to the context directly. Not only do these functions prevent us from shrinking the large API surface of XSH, they are also highly stateful, requiring lots of monkeypatching in the test suite to circumvent this. It is not easy when given a free function to know whether it is stateful, and what its side effects are.

This PR is a move-fast-and-break-things approach. I am familiarising myself with the code-base as I go, and my direction may change as things progress!


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
