### PR TITLE
Refactor: split parsing logic from Execer

### DIFF
--- a/news/refactor-execer-parser-split.rst
+++ b/news/refactor-execer-parser-split.rst
@@ -1,0 +1,17 @@
+**Added:**
+
+* New `Parser` which provides a `.parse` method for parsing Xonsh syntax
+
+**Changed:**
+
+* Split new `Parser` class from `Execer` to handle contextual parsing
+* `xonsh.parser.Parser` now returns new `Parser` class, rather than the renamed
+`StrictParser`.
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+**Security:**

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -189,7 +189,7 @@ def check_eval(input):
 
 
 def check_parse(input):
-    tree = XSH.execer.parse(input, ctx=None)
+    tree = XSH.execer.parser.parse(input, ctx=None)
     return tree
 
 

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -315,7 +315,7 @@ def isexpression(node, ctx=None, *args, **kwargs):
     if isinstance(node, str):
         node = node if node.endswith("\n") else node + "\n"
         ctx = XSH.ctx if ctx is None else ctx
-        node = XSH.execer.parse(node, ctx, *args, **kwargs)
+        node = XSH.execer.parser.parse(node, ctx, *args, **kwargs)
     # determine if expression-like enough
     if isinstance(node, (Expr, Expression)):
         isexpr = True

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -339,7 +339,7 @@ def convert_macro_arg(raw_arg, kind, glbs, locs, *, name="<arg>", macroname="<ma
         mode = mode or "eval"
         if mode != "eval" and not raw_arg.endswith("\n"):
             raw_arg += "\n"
-        arg = execer.parse(raw_arg, ctx, mode=mode, filename=filename)
+        arg = execer.parser.parse(raw_arg, ctx, mode=mode, filename=filename)
     elif kind is types.CodeType or kind is compile:  # NOQA
         mode = mode or "eval"
         arg = execer.compile(

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -1,22 +1,10 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh executer."""
-import sys
 import types
 import inspect
 import builtins
-import collections.abc as cabc
 
-from xonsh.ast import CtxAwareTransformer
 from xonsh.parser import Parser
-from xonsh.tools import (
-    subproc_toks,
-    find_next_break,
-    get_logical_line,
-    replace_logical_line,
-    balanced_parens,
-    starting_whitespace,
-    ends_with_colon_token,
-)
 from xonsh.built_ins import XSH
 
 
@@ -60,57 +48,11 @@ class Execer(object):
         self.unload = unload
         self.scriptcache = scriptcache
         self.cacheall = cacheall
-        self.ctxtransformer = CtxAwareTransformer(self.parser)
         XSH.load(execer=self, ctx=xonsh_ctx)
 
     def __del__(self):
         if self.unload:
             XSH.unload()
-
-    def parse(self, input, ctx, mode="exec", filename=None, transform=True):
-        """Parses xonsh code in a context-aware fashion. For context-free
-        parsing, please use the Parser class directly or pass in
-        transform=False.
-        """
-        if filename is None:
-            filename = self.filename
-        if not transform:
-            return self.parser.parse(
-                input, filename=filename, mode=mode, debug_level=(self.debug_level >= 2)
-            )
-
-        # Parsing actually happens in a couple of phases. The first is a
-        # shortcut for a context-free parser. Normally, all subprocess
-        # lines should be wrapped in $(), to indicate that they are a
-        # subproc. But that would be super annoying. Unfortunately, Python
-        # mode - after indentation - is whitespace agnostic while, using
-        # the Python token, subproc mode is whitespace aware. That is to say,
-        # in Python mode "ls -l", "ls-l", and "ls - l" all parse to the
-        # same AST because whitespace doesn't matter to the minus binary op.
-        # However, these phases all have very different meaning in subproc
-        # mode. The 'right' way to deal with this is to make the entire
-        # grammar whitespace aware, and then ignore all of the whitespace
-        # tokens for all of the Python rules. The lazy way implemented here
-        # is to parse a line a second time with a $() wrapper if it fails
-        # the first time. This is a context-free phase.
-        tree, input = self._parse_ctx_free(input, mode=mode, filename=filename)
-        if tree is None:
-            return None
-
-        # Now we need to perform context-aware AST transformation. This is
-        # because the "ls -l" is valid Python. The only way that we know
-        # it is not actually Python is by checking to see if the first token
-        # (ls) is part of the execution context. If it isn't, then we will
-        # assume that this line is supposed to be a subprocess line, assuming
-        # it also is valid as a subprocess line.
-        if ctx is None:
-            ctx = set()
-        elif isinstance(ctx, cabc.Mapping):
-            ctx = set(ctx.keys())
-        tree = self.ctxtransformer.ctxvisit(
-            tree, input, ctx, mode=mode, debug_level=self.debug_level
-        )
-        return tree
 
     def compile(
         self,
@@ -135,7 +77,14 @@ class Execer(object):
             glbs = frame.f_globals if glbs is None else glbs
             locs = frame.f_locals if locs is None else locs
         ctx = set(dir(builtins)) | set(glbs.keys()) | set(locs.keys())
-        tree = self.parse(input, ctx, mode=mode, filename=filename, transform=transform)
+        tree = self.parser.parse(
+            input,
+            ctx,
+            mode=mode,
+            filename=filename,
+            transform=transform,
+            debug_level=self.debug_level,
+        )
         if tree is None:
             return None  # handles comment only input
         code = compile(tree, filename, mode)
@@ -198,135 +147,3 @@ class Execer(object):
         if code is None:
             return None  # handles comment only input
         return exec(code, glbs, locs)
-
-    def _print_debug_wrapping(
-        self, line, sbpline, last_error_line, last_error_col, maxcol=None
-    ):
-        """print some debugging info if asked for."""
-        if self.debug_level >= 1:
-            msg = "{0}:{1}:{2}{3} - {4}\n" "{0}:{1}:{2}{3} + {5}"
-            mstr = "" if maxcol is None else ":" + str(maxcol)
-            msg = msg.format(
-                self.filename, last_error_line, last_error_col, mstr, line, sbpline
-            )
-            print(msg, file=sys.stderr)
-
-    def _parse_ctx_free(self, input, mode="exec", filename=None, logical_input=False):
-        last_error_line = last_error_col = -1
-        parsed = False
-        original_error = None
-        greedy = False
-        if filename is None:
-            filename = self.filename
-        if logical_input:
-            beg_spaces = starting_whitespace(input)
-            input = input[len(beg_spaces) :]
-        while not parsed:
-            try:
-                tree = self.parser.parse(
-                    input,
-                    filename=filename,
-                    mode=mode,
-                    debug_level=(self.debug_level >= 2),
-                )
-                parsed = True
-            except IndentationError as e:
-                if original_error is None:
-                    raise e
-                else:
-                    raise original_error
-            except SyntaxError as e:
-                if original_error is None:
-                    original_error = e
-                if (e.loc is None) or (
-                    last_error_line == e.loc.lineno
-                    and last_error_col in (e.loc.column + 1, e.loc.column)
-                ):
-                    raise original_error from None
-                elif last_error_line != e.loc.lineno:
-                    original_error = e
-                last_error_col = e.loc.column
-                last_error_line = e.loc.lineno
-                idx = last_error_line - 1
-                lines = input.splitlines()
-                if input.endswith("\n"):
-                    lines.append("")
-                line, nlogical, idx = get_logical_line(lines, idx)
-                if nlogical > 1 and not logical_input:
-                    _, sbpline = self._parse_ctx_free(
-                        line, mode=mode, filename=filename, logical_input=True
-                    )
-                    self._print_debug_wrapping(
-                        line, sbpline, last_error_line, last_error_col, maxcol=None
-                    )
-                    replace_logical_line(lines, sbpline, idx, nlogical)
-                    last_error_col += 3
-                    input = "\n".join(lines)
-                    continue
-                if len(line.strip()) == 0:
-                    # whitespace only lines are not valid syntax in Python's
-                    # interactive mode='single', who knew?! Just ignore them.
-                    # this might cause actual syntax errors to have bad line
-                    # numbers reported, but should only affect interactive mode
-                    del lines[idx]
-                    last_error_line = last_error_col = -1
-                    input = "\n".join(lines)
-                    continue
-
-                if last_error_line > 1 and ends_with_colon_token(lines[idx - 1]):
-                    # catch non-indented blocks and raise error.
-                    prev_indent = len(lines[idx - 1]) - len(lines[idx - 1].lstrip())
-                    curr_indent = len(lines[idx]) - len(lines[idx].lstrip())
-                    if prev_indent == curr_indent:
-                        raise original_error
-                lexer = self.parser.lexer
-                maxcol = (
-                    None
-                    if greedy
-                    else find_next_break(line, mincol=last_error_col, lexer=lexer)
-                )
-                if not greedy and maxcol in (e.loc.column + 1, e.loc.column):
-                    # go greedy the first time if the syntax error was because
-                    # we hit an end token out of place. This usually indicates
-                    # a subshell or maybe a macro.
-                    if not balanced_parens(line, maxcol=maxcol):
-                        greedy = True
-                        maxcol = None
-                sbpline = subproc_toks(
-                    line, returnline=True, greedy=greedy, maxcol=maxcol, lexer=lexer
-                )
-                if sbpline is None:
-                    # subprocess line had no valid tokens,
-                    if len(line.partition("#")[0].strip()) == 0:
-                        # likely because it only contained a comment.
-                        del lines[idx]
-                        last_error_line = last_error_col = -1
-                        input = "\n".join(lines)
-                        continue
-                    elif not greedy:
-                        greedy = True
-                        continue
-                    else:
-                        # or for some other syntax error
-                        raise original_error
-                elif sbpline[last_error_col:].startswith(
-                    "![!["
-                ) or sbpline.lstrip().startswith("![!["):
-                    # if we have already wrapped this in subproc tokens
-                    # and it still doesn't work, adding more won't help
-                    # anything
-                    if not greedy:
-                        greedy = True
-                        continue
-                    else:
-                        raise original_error
-                # replace the line
-                self._print_debug_wrapping(
-                    line, sbpline, last_error_line, last_error_col, maxcol=maxcol
-                )
-                replace_logical_line(lines, sbpline, idx, nlogical)
-                last_error_col += 3
-                input = "\n".join(lines)
-        if logical_input:
-            input = beg_spaces + input
-        return tree, input

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -8,7 +8,6 @@ import re
 
 # 'keyword' interferes with ast.keyword
 import keyword as kwmod
-import typing as tp
 
 from xonsh.ply.ply.lex import LexToken
 
@@ -413,27 +412,27 @@ def _get_token_types():
     if PYTHON_VERSION_INFO >= (3, 9, 0) and PYTHON_VERSION_INFO < (3, 10):
         kwlist.remove("__peg_parser__")
     return (
-            tuple(token_map.values())
-            + (
-                "NAME",  # name tokens
-                "BANG",  # ! tokens
-                "WS",  # whitespace in subprocess mode
-                "LPAREN",
-                "RPAREN",  # ( )
-                "LBRACKET",
-                "RBRACKET",  # [ ]
-                "LBRACE",
-                "RBRACE",  # { }
-                "AT_LPAREN",  # @(
-                "BANG_LPAREN",  # !(
-                "BANG_LBRACKET",  # ![
-                "DOLLAR_LPAREN",  # $(
-                "DOLLAR_LBRACE",  # ${
-                "DOLLAR_LBRACKET",  # $[
-                "ATDOLLAR_LPAREN",  # @$(
-                "ERRORTOKEN",  # whoops!
-            )
-            + tuple(i.upper() for i in kwlist)
+        tuple(token_map.values())
+        + (
+            "NAME",  # name tokens
+            "BANG",  # ! tokens
+            "WS",  # whitespace in subprocess mode
+            "LPAREN",
+            "RPAREN",  # ( )
+            "LBRACKET",
+            "RBRACKET",  # [ ]
+            "LBRACE",
+            "RBRACE",  # { }
+            "AT_LPAREN",  # @(
+            "BANG_LPAREN",  # !(
+            "BANG_LBRACKET",  # ![
+            "DOLLAR_LPAREN",  # $(
+            "DOLLAR_LBRACE",  # ${
+            "DOLLAR_LBRACKET",  # $[
+            "ATDOLLAR_LPAREN",  # @$(
+            "ERRORTOKEN",  # whoops!
+        )
+        + tuple(i.upper() for i in kwlist)
     )
 
 
@@ -511,4 +510,3 @@ class Lexer(object):
                 l = t.lineno + nnl
                 c = len(t.value.rpartition(nl)[-1])
         return vals
-

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -408,10 +408,39 @@ def _new_token(type, value, pos):
     return o
 
 
+def _get_token_types():
+    kwlist = kwmod.kwlist[:]
+    if PYTHON_VERSION_INFO >= (3, 9, 0) and PYTHON_VERSION_INFO < (3, 10):
+        kwlist.remove("__peg_parser__")
+    return (
+            tuple(token_map.values())
+            + (
+                "NAME",  # name tokens
+                "BANG",  # ! tokens
+                "WS",  # whitespace in subprocess mode
+                "LPAREN",
+                "RPAREN",  # ( )
+                "LBRACKET",
+                "RBRACKET",  # [ ]
+                "LBRACE",
+                "RBRACE",  # { }
+                "AT_LPAREN",  # @(
+                "BANG_LPAREN",  # !(
+                "BANG_LBRACKET",  # ![
+                "DOLLAR_LPAREN",  # $(
+                "DOLLAR_LBRACE",  # ${
+                "DOLLAR_LBRACKET",  # $[
+                "ATDOLLAR_LPAREN",  # @$(
+                "ERRORTOKEN",  # whoops!
+            )
+            + tuple(i.upper() for i in kwlist)
+    )
+
+
 class Lexer(object):
     """Implements a lexer for the xonsh language."""
 
-    _tokens: tp.Optional[tp.Tuple[str, ...]] = None
+    TOKENS = _get_token_types()
 
     def __init__(self, tolerant=False):
         """
@@ -483,37 +512,3 @@ class Lexer(object):
                 c = len(t.value.rpartition(nl)[-1])
         return vals
 
-    #
-    # All the tokens recognized by the lexer
-    #
-    @property
-    def tokens(self):
-        if self._tokens is None:
-            kwlist = kwmod.kwlist[:]
-            if PYTHON_VERSION_INFO >= (3, 9, 0) and PYTHON_VERSION_INFO < (3, 10):
-                kwlist.remove("__peg_parser__")
-            t = (
-                tuple(token_map.values())
-                + (
-                    "NAME",  # name tokens
-                    "BANG",  # ! tokens
-                    "WS",  # whitespace in subprocess mode
-                    "LPAREN",
-                    "RPAREN",  # ( )
-                    "LBRACKET",
-                    "RBRACKET",  # [ ]
-                    "LBRACE",
-                    "RBRACE",  # { }
-                    "AT_LPAREN",  # @(
-                    "BANG_LPAREN",  # !(
-                    "BANG_LBRACKET",  # ![
-                    "DOLLAR_LPAREN",  # $(
-                    "DOLLAR_LBRACE",  # ${
-                    "DOLLAR_LBRACKET",  # $[
-                    "ATDOLLAR_LPAREN",  # @$(
-                    "ERRORTOKEN",  # whoops!
-                )
-                + tuple(i.upper() for i in kwlist)
-            )
-            self._tokens = t
-        return self._tokens

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1,11 +1,24 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh parser."""
+import collections.abc as cabc
+import sys
+
+from xonsh.ast import CtxAwareTransformer
 from xonsh.lazyasd import lazyobject
 from xonsh.platform import PYTHON_VERSION_INFO
+from xonsh.tools import (
+    subproc_toks,
+    find_next_break,
+    get_logical_line,
+    replace_logical_line,
+    balanced_parens,
+    starting_whitespace,
+    ends_with_colon_token,
+)
 
 
 @lazyobject
-def Parser():
+def StrictParser():
     if PYTHON_VERSION_INFO > (3, 10):
         from xonsh.parsers.v310 import Parser as p
     elif PYTHON_VERSION_INFO > (3, 9):
@@ -15,3 +28,209 @@ def Parser():
     else:
         from xonsh.parsers.v36 import Parser as p
     return p
+
+
+class Parser:
+    def __init__(self, **strict_parser_kwargs):
+        self._strict_parser = StrictParser(**strict_parser_kwargs)
+        self._ctx_transformer = CtxAwareTransformer(self._strict_parser)
+
+    @property
+    def lexer(self):
+        # TODO refactor the usage of this attribute
+        return self._strict_parser.lexer
+
+    def parse(
+        self, input, ctx, filename="<code>", mode="exec", transform=True, debug_level=0
+    ):
+        """Parses xonsh code in a context-aware fashion. For context-free
+        parsing, please use the Parser class directly or pass in
+        transform=False.
+        """
+        if not transform:
+            return self._strict_parser.parse(
+                input, filename=filename, mode=mode, debug_level=(debug_level >= 2)
+            )
+
+        # Parsing actually happens in a couple of phases. The first is a
+        # shortcut for a context-free parser. Normally, all subprocess
+        # lines should be wrapped in $(), to indicate that they are a
+        # subproc. But that would be super annoying. Unfortunately, Python
+        # mode - after indentation - is whitespace agnostic while, using
+        # the Python token, subproc mode is whitespace aware. That is to say,
+        # in Python mode "ls -l", "ls-l", and "ls - l" all parse to the
+        # same AST because whitespace doesn't matter to the minus binary op.
+        # However, these phases all have very different meaning in subproc
+        # mode. The 'right' way to deal with this is to make the entire
+        # grammar whitespace aware, and then ignore all of the whitespace
+        # tokens for all of the Python rules. The lazy way implemented here
+        # is to parse a line a second time with a $() wrapper if it fails
+        # the first time. This is a context-free phase.
+        tree, input = self._parse_ctx_free(input, mode=mode, filename=filename)
+        if tree is None:
+            return None
+
+        # Now we need to perform context-aware AST transformation. This is
+        # because the "ls -l" is valid Python. The only way that we know
+        # it is not actually Python is by checking to see if the first token
+        # (ls) is part of the execution context. If it isn't, then we will
+        # assume that this line is supposed to be a subprocess line, assuming
+        # it also is valid as a subprocess line.
+        if ctx is None:
+            ctx = set()
+        elif isinstance(ctx, cabc.Mapping):
+            ctx = set(ctx.keys())
+        tree = self._ctx_transformer.ctxvisit(
+            tree, input, ctx, mode=mode, debug_level=debug_level
+        )
+        return tree
+
+    def _print_debug_wrapping(
+        self,
+        filename,
+        line,
+        sbpline,
+        last_error_line,
+        last_error_col,
+        maxcol=None,
+        debug_level=0,
+    ):
+        """print some debugging info if asked for."""
+        if debug_level >= 1:
+            msg = "{0}:{1}:{2}{3} - {4}\n" "{0}:{1}:{2}{3} + {5}"
+            mstr = "" if maxcol is None else ":" + str(maxcol)
+            msg = msg.format(
+                filename, last_error_line, last_error_col, mstr, line, sbpline
+            )
+            print(msg, file=sys.stderr)
+
+    def _parse_ctx_free(
+        self, input, filename="<code>", mode="exec", logical_input=False, debug_level=0
+    ):
+        last_error_line = last_error_col = -1
+        parsed = False
+        original_error = None
+        greedy = False
+        if logical_input:
+            beg_spaces = starting_whitespace(input)
+            input = input[len(beg_spaces) :]
+        while not parsed:
+            try:
+                tree = self._strict_parser.parse(
+                    input,
+                    filename=filename,
+                    mode=mode,
+                    debug_level=(debug_level >= 2),
+                )
+                parsed = True
+            except IndentationError as e:
+                if original_error is None:
+                    raise e
+                else:
+                    raise original_error
+            except SyntaxError as e:
+                if original_error is None:
+                    original_error = e
+                if (e.loc is None) or (
+                    last_error_line == e.loc.lineno
+                    and last_error_col in (e.loc.column + 1, e.loc.column)
+                ):
+                    raise original_error from None
+                elif last_error_line != e.loc.lineno:
+                    original_error = e
+                last_error_col = e.loc.column
+                last_error_line = e.loc.lineno
+                idx = last_error_line - 1
+                lines = input.splitlines()
+                if input.endswith("\n"):
+                    lines.append("")
+                line, nlogical, idx = get_logical_line(lines, idx)
+                if nlogical > 1 and not logical_input:
+                    _, sbpline = self._parse_ctx_free(
+                        line, mode=mode, filename=filename, logical_input=True
+                    )
+                    self._print_debug_wrapping(
+                        filename,
+                        line,
+                        sbpline,
+                        last_error_line,
+                        last_error_col,
+                        maxcol=None,
+                        debug_level=debug_level,
+                    )
+                    replace_logical_line(lines, sbpline, idx, nlogical)
+                    last_error_col += 3
+                    input = "\n".join(lines)
+                    continue
+                if len(line.strip()) == 0:
+                    # whitespace only lines are not valid syntax in Python's
+                    # interactive mode='single', who knew?! Just ignore them.
+                    # this might cause actual syntax errors to have bad line
+                    # numbers reported, but should only affect interactive mode
+                    del lines[idx]
+                    last_error_line = last_error_col = -1
+                    input = "\n".join(lines)
+                    continue
+
+                if last_error_line > 1 and ends_with_colon_token(lines[idx - 1]):
+                    # catch non-indented blocks and raise error.
+                    prev_indent = len(lines[idx - 1]) - len(lines[idx - 1].lstrip())
+                    curr_indent = len(lines[idx]) - len(lines[idx].lstrip())
+                    if prev_indent == curr_indent:
+                        raise original_error
+                lexer = self._strict_parser.lexer
+                maxcol = (
+                    None
+                    if greedy
+                    else find_next_break(line, mincol=last_error_col, lexer=lexer)
+                )
+                if not greedy and maxcol in (e.loc.column + 1, e.loc.column):
+                    # go greedy the first time if the syntax error was because
+                    # we hit an end token out of place. This usually indicates
+                    # a subshell or maybe a macro.
+                    if not balanced_parens(line, maxcol=maxcol):
+                        greedy = True
+                        maxcol = None
+                sbpline = subproc_toks(
+                    line, returnline=True, greedy=greedy, maxcol=maxcol, lexer=lexer
+                )
+                if sbpline is None:
+                    # subprocess line had no valid tokens,
+                    if len(line.partition("#")[0].strip()) == 0:
+                        # likely because it only contained a comment.
+                        del lines[idx]
+                        last_error_line = last_error_col = -1
+                        input = "\n".join(lines)
+                        continue
+                    elif not greedy:
+                        greedy = True
+                        continue
+                    else:
+                        # or for some other syntax error
+                        raise original_error
+                elif sbpline[last_error_col:].startswith(
+                    "![!["
+                ) or sbpline.lstrip().startswith("![!["):
+                    # if we have already wrapped this in subproc tokens
+                    # and it still doesn't work, adding more won't help
+                    # anything
+                    if not greedy:
+                        greedy = True
+                        continue
+                    else:
+                        raise original_error
+                # replace the line
+                self._print_debug_wrapping(
+                    filename,
+                    line,
+                    sbpline,
+                    last_error_line,
+                    last_error_col,
+                    maxcol=maxcol,
+                )
+                replace_logical_line(lines, sbpline, idx, nlogical)
+                last_error_col += 3
+                input = "\n".join(lines)
+        if logical_input:
+            input = beg_spaces + input
+        return tree, input

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2,7 +2,6 @@
 """Implements the base xonsh parser."""
 import os
 import re
-import time
 import textwrap
 from threading import Event, Thread
 from ast import parse as pyparse

--- a/xonsh/parsers/v36.py
+++ b/xonsh/parsers/v36.py
@@ -7,35 +7,12 @@ from xonsh.parsers.base import store_ctx, lopen_loc, BaseParser
 class Parser(BaseParser):
     """A Python v3.6 compliant parser for the xonsh language."""
 
-    def __init__(
-        self,
-        yacc_optimize=True,
-        yacc_table="xonsh.parser_table",
-        yacc_debug=False,
-        outputdir=None,
-    ):
-        """
-        Parameters
-        ----------
-        yacc_optimize : bool, optional
-            Set to false when unstable and true when parser is stable.
-        yacc_table : str, optional
-            Parser module used when optimized.
-        yacc_debug : debug, optional
-            Dumps extra debug info.
-        outputdir : str or None, optional
-            The directory to place generated tables within.
-        """
-        # Rule creation and modification *must* take place before super()
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+
         tok_rules = ["await", "async"]
         for rule in tok_rules:
-            self._tok_rule(rule)
-        super().__init__(
-            yacc_optimize=yacc_optimize,
-            yacc_table=yacc_table,
-            yacc_debug=yacc_debug,
-            outputdir=outputdir,
-        )
+            cls._tok_rule(rule)
 
     def p_classdef_or_funcdef(self, p):
         """


### PR DESCRIPTION
Currently the Execer contains parsing logic that handles the contextual resolution of Xonsh syntax. This PR separates this logic into a new `Parser` class that serves as the main parser interface.

The only backwards incompatible change is that the `xonsh.parser.Parser` object is now a different class with a different API. This can be changed if necessary.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
