### PR TITLE
Feat: add `Aliases.register`

### DIFF
--- a/news/feat-add-alias-decorator.rst
+++ b/news/feat-add-alias-decorator.rst
@@ -1,0 +1,17 @@
+**Added:**
+* `Aliases.register` to register an alias function.
+
+**Changed:**
+
+
+**Deprecated:**
+
+
+**Removed:**
+
+
+**Fixed:**
+
+
+**Security:**
+

--- a/news/feat-add-alias-decorator.rst
+++ b/news/feat-add-alias-decorator.rst
@@ -4,15 +4,20 @@
 
 **Changed:**
 
+* <news item>
 
 **Deprecated:**
 
+* <news item>
 
 **Removed:**
 
+* <news item>
 
 **Fixed:**
 
+* <news item>
 
 **Security:**
 
+* <news item>

--- a/news/feat-add-alias-decorator.rst
+++ b/news/feat-add-alias-decorator.rst
@@ -1,5 +1,6 @@
 **Added:**
-* `Aliases.register` to register an alias function.
+
+* ``Aliases.register`` to register an alias function.
 
 **Changed:**
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -194,21 +194,19 @@ def test_exec_alias_args(xonsh_builtins):
     assert stack[0][0].f_locals["myarg0"] == "arg0"
 
 
-class TestRegister:
-    def test_decorator(self, xession):
-        aliases = Aliases()
+def test_register_decorator(xession):
+    aliases = Aliases()
 
-        @aliases.register
-        def debug():
-            return "DEBUG"
+    @aliases.register
+    def debug():
+        ...
 
-        assert aliases["debug"] is debug
+    @aliases.register("name")
+    def with_options():
+        ...
 
-    def test_private_decorator(self, xession):
-        aliases = Aliases()
+    @aliases.register
+    def _private():
+        ...
 
-        @aliases.register
-        def _debug():
-            return "DEBUG"
-
-        assert aliases["debug"] is _debug
+    assert set(aliases) == {"debug", "name", "private"}

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -192,3 +192,21 @@ def test_exec_alias_args(xonsh_builtins):
 
     assert stack[0][0].f_locals["myargs"] == ["arg0"]
     assert stack[0][0].f_locals["myarg0"] == "arg0"
+
+
+def test_decorator(xonsh_builtins):
+    aliases = Aliases()
+    @aliases.register
+    def debug():
+        return "DEBUG"
+
+    assert aliases['debug'] is debug
+
+
+def test_private_decorator(xonsh_builtins):
+    aliases = Aliases()
+    @aliases.register
+    def _debug():
+        return "DEBUG"
+
+    assert aliases['debug'] is _debug

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -194,19 +194,21 @@ def test_exec_alias_args(xonsh_builtins):
     assert stack[0][0].f_locals["myarg0"] == "arg0"
 
 
-def test_decorator(xonsh_builtins):
-    aliases = Aliases()
-    @aliases.register
-    def debug():
-        return "DEBUG"
+class TestRegister:
+    def test_decorator(self, xession):
+        aliases = Aliases()
 
-    assert aliases['debug'] is debug
+        @aliases.register
+        def debug():
+            return "DEBUG"
 
+        assert aliases["debug"] is debug
 
-def test_private_decorator(xonsh_builtins):
-    aliases = Aliases()
-    @aliases.register
-    def _debug():
-        return "DEBUG"
+    def test_private_decorator(self, xession):
+        aliases = Aliases()
 
-    assert aliases['debug'] is _debug
+        @aliases.register
+        def _debug():
+            return "DEBUG"
+
+        assert aliases["debug"] is _debug

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -66,6 +66,7 @@ class Aliases(cabc.MutableMapping):
     def register(self, func):
         """Decorator to register the given function by name"""
         self[func.__name__] = func
+        return func
 
     def get(self, key, default=None):
         """Returns the (possibly modified) value. If the key is not present,

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -71,7 +71,7 @@ class Aliases(cabc.MutableMapping):
         if name.startswith("_"):
             name = name[1:]
             
-        self[func.__name__] = func
+        self[name] = func
         return func
 
     def get(self, key, default=None):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -63,6 +63,10 @@ class Aliases(cabc.MutableMapping):
         self._raw = {}
         self.update(*args, **kwargs)
 
+    def register(self, func):
+        """Decorator to register the given function by name"""
+        self[func.__name__] = func
+
     def get(self, key, default=None):
         """Returns the (possibly modified) value. If the key is not present,
         then `default` is returned.

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -82,17 +82,15 @@ class Aliases(cabc.MutableMapping):
         self[name] = func
         return func
 
-    if tp.TYPE_CHECKING:
+    @tp.overload
+    def register(self, func: types.FunctionType) -> types.FunctionType:
+        """simple usage"""
 
-        @tp.overload
-        def register(self, func: types.FunctionType) -> types.FunctionType:
-            """simple usage"""
-
-        @tp.overload
-        def register(
-            self, name: str, *, dash_case: bool = True
-        ) -> tp.Callable[[types.FunctionType], types.FunctionType]:
-            ...
+    @tp.overload
+    def register(
+        self, name: str, *, dash_case: bool = True
+    ) -> tp.Callable[[types.FunctionType], types.FunctionType]:
+        ...
 
     def register(self, func_or_name, name=None, dash_case=True):
         """Decorator to register the given function by name."""

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -65,6 +65,12 @@ class Aliases(cabc.MutableMapping):
 
     def register(self, func):
         """Decorator to register the given function by name"""
+        name = func.__name__
+
+        # Strip leading underscore
+        if name.startswith("_"):
+            name = name[1:]
+            
         self[func.__name__] = func
         return func
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -6,6 +6,7 @@ import sys
 import inspect
 import argparse
 import collections.abc as cabc
+import types
 import typing as tp
 
 from xonsh.built_ins import XSH
@@ -63,16 +64,46 @@ class Aliases(cabc.MutableMapping):
         self._raw = {}
         self.update(*args, **kwargs)
 
-    def register(self, func):
-        """Decorator to register the given function by name"""
+    @staticmethod
+    def _get_func_name(func):
         name = func.__name__
 
         # Strip leading underscore
         if name.startswith("_"):
             name = name[1:]
-            
+        return name
+
+    def _register(self, func, name="", dash_case=True):
+        name = name or self._get_func_name(func)
+
+        if dash_case:
+            name = name.replace("_", "-")
+
         self[name] = func
         return func
+
+    if tp.TYPE_CHECKING:
+
+        @tp.overload
+        def register(self, func: types.FunctionType) -> types.FunctionType:
+            """simple usage"""
+
+        @tp.overload
+        def register(
+            self, name: str, *, dash_case: bool = True
+        ) -> tp.Callable[[types.FunctionType], types.FunctionType]:
+            ...
+
+    def register(self, func_or_name, name=None, dash_case=True):
+        """Decorator to register the given function by name."""
+
+        if isinstance(func_or_name, types.FunctionType):
+            return self._register(func_or_name, name, dash_case)
+
+        def wrapper(func):
+            return self._register(func, func_or_name, dash_case)
+
+        return wrapper
 
     def get(self, key, default=None):
         """Returns the (possibly modified) value. If the key is not present,


### PR DESCRIPTION
This PR adds `Aliases.register` to register functional aliases. In these cases, we already have a name from the function itself, and this decorator simplifies user code (slightly).

Usage:
```python3
>>> @aliases.register
>>> def _some_cmd(args):
>>>     print(args)

>>> some_cmd 1 2
['1', '2']
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
