### PR TITLE
Remove syntax override for .xsh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,7 @@
 *.rst text
 *.sh text
 *.txt text
-*.xsh text linguist-language=Python
+*.xsh text
 *.yaml text
 *.yml text
 CONTRIBUTING text


### PR DESCRIPTION
This override was introduced in 387340d435, on Oct 1st, 2020.

However, github/linguist has since incorporated Xonsh as a language.
See https://github.com/github/linguist/pull/5274, and it automatically
matches `.xsh` files.

This change will just give nicer languages stats, because the actual
syntax highlighting is still MagicStack/MagicPython.

E.g. my dotfiles repo's stats show up like this:
<img width="340" alt="Screen Shot 2021-11-19 at 7 26 50 PM" src="https://user-images.githubusercontent.com/4542383/142707019-7b35ec0b-7777-44a2-a4e8-749dc28c015e.png">

----

I don't think this is worth a changelog entry as it only affects this repos.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
