### PR TITLE
fix: sourcing files before foreign aliases/functions

### DIFF
--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -428,7 +428,7 @@ class ForeignShellBaseAlias(object):
         args, streaming = self._is_streaming(args)
         input = self.INPUT.format(args=" ".join(args), **self._input_kwargs())
         if len(self.files) > 0:
-            input = "".join(['f{self.sourcer} "{f}"\n' for f in self.files]) + input
+            input = "".join([f'{self.sourcer} "{f}"\n' for f in self.files]) + input
         cmd = [self.shell] + list(self.extra_args) + ["-ic", input]
         env = XSH.env
         denv = env.detype()


### PR DESCRIPTION
When addressing review comments in https://github.com/xonsh/xonsh/pull/4393 I accidentally made a typo with a format string.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
