### PR TITLE
[RFC] pip: remove pyinotify

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,3 @@
 -r tests.txt
 sniffer
-pyinotify
 jinja2 >= 2


### PR DESCRIPTION
This dependency isn't used anywhere in the codebase and is linux-only,
making development on a mac immediately error out.

I'm unsure how to test this (or if it is worth testing) so I'm making this PR as a RFC.