### PR TITLE
Fix OSError on Windows with GnuWin32

### DIFF
--- a/news/fix-windows-oserror.rst
+++ b/news/fix-windows-oserror.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed OSError on Windows when GnuWin32 is installed in the PATH.
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -482,7 +482,7 @@ class LsColors(cabc.MutableMapping):
             out = subprocess.check_output(
                 cmd, env=denv, universal_newlines=True, stderr=subprocess.DEVNULL
             )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             return cls(cls.default_settings)
         if not out:
             return cls(cls.default_settings)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -482,8 +482,13 @@ class LsColors(cabc.MutableMapping):
             out = subprocess.check_output(
                 cmd, env=denv, universal_newlines=True, stderr=subprocess.DEVNULL
             )
-        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return cls(cls.default_settings)
+        except OSError:
+            # necessary to catch OSError: [WinError 740] The requested operation requires elevation
+            if ON_WINDOWS:
+                return cls(cls.default_settings)
+            raise
         if not out:
             return cls(cls.default_settings)
         s = out.splitlines()[0]


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

On Windows, if you have [GnuWin32](http://gnuwin32.sourceforge.net/) installed in your `PATH`, when `xonsh` tries to run `dircolors`, it produces an `OSError` due to lack of elevation, which isn't caught by `xonsh`. See [the full error in this gist](https://gist.github.com/evhub/a84a986a947c821faaf0b7612fdfa9ac). This PR fixes the error by catching `OSError` arising from the `dircolors` call in addition to `CalledProcessError` and `FileNotFoundError`.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**