### PR TITLE
fix: append space at the end of fish completions

### DIFF
--- a/tests/xontribs/test_fish_completer.py
+++ b/tests/xontribs/test_fish_completer.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.fixture
+def fish_completer(tmpdir, xession, load_xontrib, fake_process):
+    """vox Alias function"""
+    load_xontrib("fish_completer")
+    xession.env.update(
+        dict(
+            XONSH_DATA_DIR=str(tmpdir),
+            XONSH_SHOW_TRACEBACK=True,
+        )
+    )
+
+    fake_process.register_subprocess(
+        command=["fish", fake_process.any()],
+        # completion for "git chec"
+        stdout=b"""\
+cherry-pick	Apply the change introduced by an existing commit
+checkout	Checkout and switch to a branch""",
+    )
+
+    return fake_process
+
+
+def test_fish_completer(fish_completer, check_completer):
+    assert check_completer("git", prefix="chec") == {"checkout", "cherry-pick"}

--- a/xonsh/parsers/completion_context.py
+++ b/xonsh/parsers/completion_context.py
@@ -81,6 +81,27 @@ class CommandContext(NamedTuple):
         else:
             return f"{self.opening_quote}{self.prefix}"
 
+    @property
+    def command(self):
+        if self.args:
+            return self.args[0].raw_value
+        return None
+
+    @property
+    def words_before_cursor(self) -> str:
+        """words without current prefix"""
+        return " ".join([arg.raw_value for arg in self.args[: self.arg_index]])
+
+    @property
+    def text_before_cursor(self) -> str:
+        """full text before cursor including prefix"""
+        return self.words_before_cursor + " " + self.prefix
+
+    @property
+    def begidx(self) -> int:
+        """cursor's position"""
+        return len(self.text_before_cursor)
+
 
 class PythonContext(NamedTuple):
     """


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Not including news item, because fish-completer is not released yet.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
