### PR TITLE
ast: do not descend into any comprehensions

### DIFF
--- a/news/fix-list-comp-boolop.rst
+++ b/news/fix-list-comp-boolop.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed list comprehension in return statement incorrectly being parsed as a subprocess command.
+
+**Security:**
+
+* <news item>

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -104,6 +104,9 @@ for root, dirs, files in os.walk(path):
 """,
         """lambda x: x + 1
 """,
+        """def f(x):
+    return [i for i in x if i is not None and i < 10]
+    """,
     ],
 )
 def test_unmodified(inp):

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -521,6 +521,11 @@ class CtxAwareTransformer(NodeTransformer):
                 node.values[i] = self.try_subproc_toks(val, strip_expr=True)
         return node
 
+    def visit_comprehension(self, node):
+        """Handles visiting list comprehensions, set comprehensions,
+        dictionary comprehensions, and generator expressions."""
+        return node  # do not descend into any comprehensions
+
     #
     # Context aggregator visitors
     #


### PR DESCRIPTION
Fixes #4529

# Cause of the issue
The example code in #4529:
```xonsh
def f(x):
    return [i for i in x if i is not None and i < 10]

print(f([1,2,3]))
```
currently fails because of a bug in the AST `CtxAwareTransformer`. When the transformer visits the boolean operation in the list comprehension, it sees that `i` is not in scope (because list comprehensions aren't currently handled by the transformer), so it parses the entire expression as a subprocess command:
https://github.com/xonsh/xonsh/blob/35d44068d399398ec8bb3979d7f26a35a2914ad9/xonsh/ast.py#L513-L522
# Solution
This PR solves the problem by not allowing `CtxAwareTransformer` to descend into any comprehensions (list comprehensions, set comprehensions, dictionary comprehensions, and generators). This seems to be the expected behavior, because the `isdescendable` function says that UnaryOp and BoolOp are the only expressions that should be visited:
https://github.com/xonsh/xonsh/blob/35d44068d399398ec8bb3979d7f26a35a2914ad9/xonsh/ast.py#L301-L305

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
