### PR TITLE
feat: implement $SHLVL mirroring bash's implementation

### DIFF
--- a/news/feat-shlvl.rst
+++ b/news/feat-shlvl.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added support for the $SHLVL environment variable, typed as int, using bash's semantics.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -533,6 +533,62 @@ a | a | b | b
         "1" * 2 * 4,
         0,
     ),
+    # test $SHLVL
+    (
+        """
+# test parsing of $SHLVL
+
+$SHLVL = "1"
+echo $SHLVL # == 1
+
+$SHLVL = 1
+echo $SHLVL # == 1
+
+$SHLVL = "-13"
+echo $SHLVL # == 0
+
+$SHLVL = "error"
+echo $SHLVL # == 0
+
+$SHLVL = 999
+echo $SHLVL # == 999
+
+$SHLVL = 1000
+echo $SHLVL # == 1
+
+# sourcing a script should maintain $SHLVL
+
+$SHLVL = 5
+touch temp_shlvl_test.sh
+source-bash temp_shlvl_test.sh
+rm temp_shlvl_test.sh
+echo $SHLVL # == 5
+
+# creating a subshell should increment the child's $SHLVL and maintain the parents $SHLVL
+
+$SHLVL = 5
+xonsh -c r'echo $SHLVL' # == 6
+echo $SHLVL # == 5
+
+# replacing the current process with another process should derease $SHLVL
+# (so that if the new process is a shell, $SHLVL is maintained)
+
+$SHLVL = 5
+xexec python3 -c 'import os; print(os.environ["SHLVL"])' # == 4
+""",
+        """1
+1
+0
+0
+999
+1
+5
+6
+5
+4
+""",
+        0,
+    ),
 ]
 
 if not ON_WINDOWS:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -518,7 +518,7 @@ def source_foreign_fn(
     # apply results
     denv = env.detype()
     for k, v in fsenv.items():
-        if k == "SHLVL": # ignore $SHLVL as sourcing should not change $SHLVL
+        if k == "SHLVL":  # ignore $SHLVL as sourcing should not change $SHLVL
             continue
         if k in denv and v == denv[k]:
             continue  # no change from original

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -35,6 +35,8 @@ from xonsh.tools import (
     unthreadable,
     print_color,
     to_repr_pretty_,
+    to_shlvl,
+    adjust_shlvl,
 )
 from xonsh.timings import timeit_alias
 from xonsh.xontribs import xontribs_main

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -518,6 +518,8 @@ def source_foreign_fn(
     # apply results
     denv = env.detype()
     for k, v in fsenv.items():
+        if k == "SHLVL": # ignore $SHLVL as sourcing should not change $SHLVL
+            continue
         if k in denv and v == denv[k]:
             continue  # no change from original
         env[k] = v
@@ -734,6 +736,11 @@ def xexec_fn(
     denv = {}
     if not clean:
         denv = XSH.env.detype()
+
+        # decrement $SHLVL to mirror bash's behaviour
+        if "SHLVL" in denv:
+            old_shlvl = to_shlvl(denv["SHLVL"])
+            denv["SHLVL"] = str(adjust_shlvl(old_shlvl, -1))
 
     try:
         os.execvpe(cmd, command, denv)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -89,7 +89,7 @@ from xonsh.tools import (
     to_repr_pretty_,
     to_shlvl,
     is_valid_shlvl,
-    adjust_shlvl
+    adjust_shlvl,
 )
 from xonsh.ansi_colors import (
     ansi_color_escape_code_to_name,
@@ -919,7 +919,7 @@ class GeneralSetting(Xettings):
         str,
         0,
         "Shell nesting level typed as integer, mirrors bash's $SHLVL.",
-        is_configurable=False
+        is_configurable=False,
     )
     XONSH_SUBPROC_CAPTURED_PRINT_STDERR = Var.with_default(
         False,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -87,6 +87,9 @@ from xonsh.tools import (
     to_int_or_none,
     DefaultNotGivenType,
     to_repr_pretty_,
+    to_shlvl,
+    is_valid_shlvl,
+    adjust_shlvl
 )
 from xonsh.ansi_colors import (
     ansi_color_escape_code_to_name,
@@ -909,6 +912,14 @@ class GeneralSetting(Xettings):
         "This is most useful in xonsh scripts or modules where failures "
         "should cause an end to execution. This is less useful at a terminal. "
         "The error that is raised is a ``subprocess.CalledProcessError``.",
+    )
+    SHLVL = Var(
+        is_valid_shlvl,
+        to_shlvl,
+        str,
+        0,
+        "Shell nesting level typed as integer, mirrors bash's $SHLVL.",
+        is_configurable=False
     )
     XONSH_SUBPROC_CAPTURED_PRINT_STDERR = Var.with_default(
         False,
@@ -2496,6 +2507,9 @@ def default_env(env=None):
         del ctx["PROMPT"]
     except KeyError:
         pass
+    # increment $SHLVL
+    old_shlvl = to_shlvl(ctx.get("SHLVL", None))
+    ctx["SHLVL"] = adjust_shlvl(old_shlvl, 1)
     # finalize env
     if env is not None:
         ctx.update(env)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1428,6 +1428,29 @@ def SLICE_REG():
         r"(?P<start>(?:-\d)?\d*):(?P<end>(?:-\d)?\d*):?(?P<step>(?:-\d)?\d*)"
     )
 
+def to_shlvl(x):
+    """Converts a value to an $SHLVL integer according to bash's behaviour (variables.c::adjust_shell_level)."""
+    if x is None:
+        return 0
+    else:
+        x = str(x)
+    try:
+        return adjust_shlvl(max(0, int(x)), 0)
+    except ValueError:
+        return 0
+
+def is_valid_shlvl(x):
+    """Checks whether a variable is a proper $SHLVL integer."""
+    return isinstance(x, int) and to_shlvl(x) == x
+
+def adjust_shlvl(old_lvl: int, change: int):
+    """Adjusts an $SHLVL integer according to bash's behaviour (variables.c::adjust_shell_level)."""
+    new_level = old_lvl + change
+    if new_level < 0:
+        new_level = 0
+    elif new_level >= 1000:
+        new_level = 1
+    return new_level
 
 def ensure_slice(x):
     """Try to convert an object into a slice, complain on failure"""

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1428,6 +1428,7 @@ def SLICE_REG():
         r"(?P<start>(?:-\d)?\d*):(?P<end>(?:-\d)?\d*):?(?P<step>(?:-\d)?\d*)"
     )
 
+
 def to_shlvl(x):
     """Converts a value to an $SHLVL integer according to bash's behaviour (variables.c::adjust_shell_level)."""
     if x is None:
@@ -1439,9 +1440,11 @@ def to_shlvl(x):
     except ValueError:
         return 0
 
+
 def is_valid_shlvl(x):
     """Checks whether a variable is a proper $SHLVL integer."""
     return isinstance(x, int) and to_shlvl(x) == x
+
 
 def adjust_shlvl(old_lvl: int, change: int):
     """Adjusts an $SHLVL integer according to bash's behaviour (variables.c::adjust_shell_level)."""
@@ -1451,6 +1454,7 @@ def adjust_shlvl(old_lvl: int, change: int):
     elif new_level >= 1000:
         new_level = 1
     return new_level
+
 
 def ensure_slice(x):
     """Try to convert an object into a slice, complain on failure"""


### PR DESCRIPTION
Implement `$SHLVL` as a typed (int) environment variable.

The semantics are taken directly from bash's source:


- [conversion/validity rules](https://github.com/bminor/bash/blob/f3a35a2d601a55f337f8ca02a541f8c033682247/variables.c#L817) implemented in tools.py
- [increment SHLVL](https://github.com/bminor/bash/blob/f3a35a2d601a55f337f8ca02a541f8c033682247/builtins/exec.def#L240) on starting a new shell
- [decrement SHLVL](https://github.com/bminor/bash/blob/f3a35a2d601a55f337f8ca02a541f8c033682247/builtins/exec.def#L193) on xexec

Also, never source `$SHLVL`.

Fixes https://github.com/xonsh/xonsh/issues/4579.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
