### PR TITLE
chore: fix generated token for docs push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,12 @@ jobs:
       - name: Build Docs
         run: cd docs && make html
       - uses: tibdex/github-app-token@v1
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' }}
         id: generate-token
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          repository: xonsh/xonsh-docs
       - name: Deploy to dev if not tagged
         if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
we need to create the token so that it lives in the appropriate target repository (in this case, xonsh-docs)