### PR TITLE
add default SIGPIPE signal handler (#4655)

### DIFF
--- a/news/fix_sigpipe.rst
+++ b/news/fix_sigpipe.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added a default signal handler for SIGPIPE that tells the kernel to not propagate SIGPIPE to xonsh.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Piping long output to other commands that prematurely close the pipe now works as expected. (#4655)
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -589,6 +589,24 @@ xexec python3 -c 'import os; print(os.environ["SHLVL"])' # == 4
 """,
         0,
     ),
+    # test piping long output to command that prematurely closes the end of its pipe. (#4655)
+    (
+        """
+echo @(\"\"\"
+for i in range(1, 1000001):
+  print(i)
+\"\"\") > /tmp/tst.py
+
+xonsh /tmp/tst.py | head -n 5 # raises BrokenPipeError if run with python
+""",
+        """1
+2
+3
+4
+5
+""",
+        0,
+    ),
 ]
 
 if not ON_WINDOWS:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -448,6 +448,9 @@ def main_xonsh(args):
         signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
         signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
 
+        # setup a default signal handler that tells the kernel to not propagate SIGPIPE to xonsh (#4655)
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
     events.on_post_init.fire()
     env = XSH.env
     shell = XSH.shell


### PR DESCRIPTION
Add a default signal handler for SIGPIPE that tells the kernel to not propagate SIGPIPE to xonsh.

This will fix #4655 if run with xonsh, i.e.
```
echo @("""
for i in range(1, 1000001):
  print(i)
""") > /tmp/tst.py

xonsh /tmp/tst.py | head -n 5
```

will work, whereas the following will not, as this is a problem with python itself and will also occur in other shells:

```
echo @("""
for i in range(1, 1000001):
  print(i)
""") > /tmp/tst.py

python /tmp/tst.py | head -n 5
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
