### PR TITLE
feat: make stracktraces behave like in python

### DIFF
--- a/news/fix_tracebacks.rst
+++ b/news/fix_tracebacks.rst
@@ -6,7 +6,8 @@
 
 * Made stacktraces behave like in python, i.e. when something in user-provided code fails (both interactively and non-interactively), only that part is shown, and the (static) part of the stacktrace showing the location where the user code was called in xonsh remains hidden. When an unexpected exception occurs inside xonsh, everything is shown like before.
 * run_compiled_code, run_script_with_cache, run_code_with_cache now return sys.exc_info() triples instead of throwing errors
-* SyntaxError tracebacks now by default hide the internal parser state (like in python); set XONSH_DEBUG >= 1 to enable it again in interactive mode.
+* SyntaxError tracebacks now by default hide the internal parser state (like in python); set XONSH_DEBUG >= 1 to enable it again.
+* XonshError tracebacks now by default hide xonshs internal state; set XONSH_DEBUG >= 1 to enable it again.
 * run_code_with_cache takes a new parameter display_filename to override the filename shown in exceptions (this is independent of caching)
 
 **Deprecated:**

--- a/news/fix_tracebacks.rst
+++ b/news/fix_tracebacks.rst
@@ -1,0 +1,29 @@
+**Added:**
+
+* Support for pythons sys.last_type, sys.last_value, sys.last_traceback.
+
+**Changed:**
+
+* Made stacktraces behave like in python, i.e. when something in user-provided code fails (both interactively and non-interactively), only that part is shown, and the (static) part of the stacktrace showing the location where the user code was called in xonsh remains hidden. When an unexpected exception occurs inside xonsh, everything is shown like before.
+* run_compiled_code, run_script_with_cache, run_code_with_cache now return sys.exc_info() triples instead of throwing errors
+* SyntaxError tracebacks now by default hide the internal parser state (like in python); set XONSH_DEBUG >= 1 to enable it again in interactive mode.
+* run_code_with_cache takes a new parameter display_filename to override the filename shown in exceptions (this is independent of caching)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* SyntaxErrors now get initialized with all available fields so that the error message can be formatted properly.
+* Raising BaseException no longer causes Xonsh to crash (fix #4567)
+* Exceptions in user code when using xonsh non-interactively no longer simply crash xonsh, rather a proper stacktrace is printed and also postmain() is called.
+* Tracebacks will now show the correct filename (i.e. as in python) for interactive use "<stdin>", scripts read by stdin "<stdin>" and -c commands "<string>". (Instead of MD5 hashes as filenames or "<xonsh-code>")
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -655,8 +655,8 @@ def test_eof_syntax_error():
     """Ensures syntax errors for EOF appear on last line."""
     script = "x = 1\na = (1, 0\n"
     out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
-    assert ":0:0: EOF in multi-line statement" not in err
-    assert ":2:0: EOF in multi-line statement" in err
+    assert "line 0" not in err
+    assert "EOF in multi-line statement" in err and "line 2" in err
 
 
 @skip_if_no_xonsh
@@ -669,8 +669,8 @@ def test_open_quote_syntax_error():
         'echo "This is line 6"\n'
     )
     out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
-    assert """:3:5: ('code: "This is line 3"',)""" not in err
-    assert ':5:4: "' in err
+    assert """('code: "This is line 3"',)""" not in err
+    assert "line 5" in err
     assert "SyntaxError:" in err
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -487,8 +487,10 @@ def test_xonsh_failback_script_from_file(shell, monkeypatch, monkeypatch_stderr)
 
     script = os.path.join(TEST_DIR, "scripts", "raise.xsh")
     monkeypatch.setattr(sys, "argv", ["xonsh", script])
-    with pytest.raises(Exception):
-        xonsh.main.main()
+
+    # changed in #4662: User-Code exceptions are now caught in main and handled there
+    # => we expect that no exception is thrown
+
     assert len(checker) == 0
 
 

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -395,6 +395,8 @@ class BaseShell:
             print(e.args[0], file=sys.stderr)
             if hist is not None and hist.last_cmd_rtn is None:
                 hist.last_cmd_rtn = 1  # return code for failure
+        except (SystemExit, KeyboardInterrupt) as err:
+            raise err
         except BaseException:
             print_exception(exc_info=exc_info)
             if hist is not None and hist.last_cmd_rtn is None:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -515,8 +515,12 @@ def main_xonsh(args):
         exit_code = 1
     finally:
         if exc_info != (None, None, None):
-            traceback.print_exception(*exc_info)
-            exit_code = 1
+            err_type, err, _ = exc_info
+            if err_type is SystemExit:
+                raise err
+            else:
+                traceback.print_exception(*exc_info)
+                exit_code = 1
         events.on_exit.fire()
         postmain(args)
         return exit_code

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -511,8 +511,14 @@ def main_xonsh(args):
                 code, "<stdin>", shell.execer, glb=shell.ctx, loc=None, mode="exec"
             )
     except SyntaxError:
-        display_error_message(sys.exc_info())
         exit_code = 1
+        debug_level = env.get("XONSH_DEBUG", 0)
+        if debug_level == 0:
+            # print error without tracktrace
+            display_error_message(sys.exc_info())
+        else:
+            # pass error to finally clause
+            exc_info = sys.exc_info()
     finally:
         if exc_info != (None, None, None):
             err_type, err, _ = exc_info

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -523,7 +523,7 @@ def main_xonsh(args):
                 exit_code = 1
         events.on_exit.fire()
         postmain(args)
-        return exit_code
+    return exit_code
 
 
 def postmain(args=None):

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -235,7 +235,7 @@ def raise_parse_error(
 
     # if loc is available, construct a proper SyntaxError with all fields
     if loc:
-        err.msg = msg
+        err.msg = str(msg) if msg else None
         err.filename = loc.fname
         err.lineno = loc.lineno
         err.offset = loc.column

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -232,6 +232,15 @@ def raise_parse_error(
             err_line_pointer = ""
     err = SyntaxError(f"{loc}: {msg}{err_line_pointer}")
     err.loc = loc  # type: ignore
+
+    # if loc is available, construct a proper SyntaxError with all fields
+    if loc:
+        err.msg = msg
+        err.filename = loc.fname
+        err.lineno = loc.lineno
+        err.offset = loc.column
+        err.text = err_line
+
     raise err
 
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -235,7 +235,7 @@ def raise_parse_error(
 
     # if loc is available, construct a proper SyntaxError with all fields
     if loc:
-        err.msg = str(msg) if msg else None
+        err.msg = str(msg) if msg else ""
         err.filename = loc.fname
         err.lineno = loc.lineno
         err.offset = loc.column

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -979,8 +979,27 @@ def print_warning(msg):
     sys.stderr.write(msg)
 
 
-def print_exception(msg=None):
-    """Print exceptions with/without traceback."""
+def print_exception(msg=None, exc_info=None):
+    """Print given exception (or current if None) with/without traceback and set sys.last_type, sys.last_value, sys.last_traceback accordingly."""
+
+    # is no exec_info() triple is given, use the exception beeing handled at the moment
+    if exc_info is None:
+        exc_info = sys.exc_info()
+
+    # these values (initialized with their default for traceback.print_exception) control how an exception is printed
+    limit = None
+    chain = True
+
+    # remove traceback noise for syntax errors as the internal state
+    # of the parser is not helpful in normal operation (XONSH_DEBUG == 0)
+    # and to be consistent with python
+    _, debug_level = _get_manual_env_var("XONSH_DEBUG", 0)
+    if debug_level == 0 and issubclass(exc_info[0], SyntaxError):
+        limit = 0
+        chain = False
+
+    sys.last_type, sys.last_value, sys.last_traceback = exc_info
+
     manually_set_trace, show_trace = _get_manual_env_var("XONSH_SHOW_TRACEBACK", False)
     manually_set_logfile, log_file = _get_manual_env_var("XONSH_TRACEBACK_LOGFILE")
     if (not manually_set_trace) and (not manually_set_logfile):
@@ -1001,7 +1020,7 @@ def print_exception(msg=None):
                 "xonsh: To log full traceback to a file set: "
                 "$XONSH_TRACEBACK_LOGFILE = <filename>\n"
             )
-        traceback.print_exc()
+        traceback.print_exception(*exc_info, limit=limit, chain=chain)
     # additionally, check if a file for traceback logging has been
     # specified and convert to a proper option if needed
     log_file = to_logfile_opt(log_file)
@@ -1009,22 +1028,22 @@ def print_exception(msg=None):
         # if log_file <> '' or log_file <> None, append
         # traceback log there as well
         with open(os.path.abspath(log_file), "a") as f:
-            traceback.print_exc(file=f)
+            traceback.print_exception(*exc_info, limit=limit, chain=chain, file=f)
 
     if not show_trace:
         # if traceback output is disabled, print the exception's
         # error message on stderr.
-        display_error_message()
+        display_error_message(exc_info)
     if msg:
         msg = msg if msg.endswith("\n") else msg + "\n"
         sys.stderr.write(msg)
 
 
-def display_error_message(strip_xonsh_error_types=True):
+def display_error_message(exc_info, strip_xonsh_error_types=True):
     """
-    Prints the error message of the current exception on stderr.
+    Prints the error message of the given sys.exc_info() triple on stderr.
     """
-    exc_type, exc_value, exc_traceback = sys.exc_info()
+    exc_type, exc_value, exc_traceback = exc_info
     exception_only = traceback.format_exception_only(exc_type, exc_value)
     if exc_type is XonshError and strip_xonsh_error_types:
         exception_only[0] = exception_only[0].partition(": ")[-1]


### PR DESCRIPTION
When reporting errors, one should differentiate between:
* Expected errors, like a syntax error in the users input, or an exception thrown in the users code
In this case, only the part of the stacktrace pertaining to the users code is relevant, since the xonsh part only called the users code and did nothing wrong.
* Unexpected errors, where something unforseeable inside xonsh fails.
In this case, the whole stackstrace should be shown.

I studied how CPython does this and ported it over.

See examples below.

# Before & After Examples

## Syntax error in non-interactive use

### New Behavior
```shell
<user>@96f01cccfc63 /xonsh fix_tracebacks # xonsh -c "syntaxerror())"
  File "<string>", line 1
    syntaxerror())
                ^
SyntaxError: Unmatched ")" at line 1, column 13
```

### Old Behavior
```shell
<user>@4bf7f9865baf /xonsh main # xonsh -c "syntaxerror())"
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 14729, in _parse_ctx_free
    debug_level=(self.debug_level >= 2),
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 522, in parse
    tree = self.parser.parse(input=s, lexer=self.lexer, debug=debug_level)
  File "/usr/local/lib/python3.6/site-packages/xonsh/ply/ply/yacc.py", line 335, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
  File "/usr/local/lib/python3.6/site-packages/xonsh/ply/ply/yacc.py", line 1203, in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
  File "/usr/local/lib/python3.6/site-packages/xonsh/ply/ply/yacc.py", line 194, in call_errorfunc
    r = errorfunc(token)
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 3468, in p_error
    self._parse_error(msg, self.currloc(lineno=p.lineno, column=p.lexpos))
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 649, in _parse_error
    raise_parse_error(msg, loc, self._source, self.lines)
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 237, in raise_parse_error
    raise err
SyntaxError: d22bed98e1af1653c86aceefad5eacea:1:13: ('code: (',)
![syntaxerror())]
             ^

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/xonsh", line 33, in <module>
    sys.exit(load_entry_point('xonsh==0.11.0', 'console_scripts', 'xonsh')())
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 22219, in main
    _failback_to_other_shells(args, err)
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 22166, in _failback_to_other_sh
ells
    raise err
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 22217, in main
    sys.exit(main_xonsh(args))
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 22263, in main_xonsh
    args.command.lstrip(), shell.execer, glb=shell.ctx, mode="single"
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 3956, in run_code_with_cache
    ccode = compile_code(filename, code, execer, glb, loc, mode)
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 3870, in compile_code
    ccode = execer.compile(code, glbs=glb, locs=loc, mode=mode, filename=filename)
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 14637, in compile
    tree = self.parse(input, ctx, mode=mode, filename=filename, transform=transform)
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 14594, in parse
    tree, input = self._parse_ctx_free(input, mode=mode, filename=filename)
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 14810, in _parse_ctx_free
    raise original_error
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 14729, in _parse_ctx_free
    debug_level=(self.debug_level >= 2),
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 522, in parse
    tree = self.parser.parse(input=s, lexer=self.lexer, debug=debug_level)
  File "/usr/local/lib/python3.6/site-packages/xonsh/ply/ply/yacc.py", line 335, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
  File "/usr/local/lib/python3.6/site-packages/xonsh/ply/ply/yacc.py", line 1203, in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
  File "/usr/local/lib/python3.6/site-packages/xonsh/ply/ply/yacc.py", line 194, in call_errorfunc
    r = errorfunc(token)
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 3464, in p_error
    p.value, self.currloc(lineno=p.lineno, column=p.lexpos)
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 649, in _parse_error
    raise_parse_error(msg, loc, self._source, self.lines)
  File "/usr/local/lib/python3.6/site-packages/xonsh/parsers/base.py", line 237, in raise_parse_error
    raise err
SyntaxError: d22bed98e1af1653c86aceefad5eacea:1:13: Unmatched ")" at line 1, column 13
syntaxerror())
             ^
```

## Exception in interactive use

### New Behavior
```shell
<user>@96f01cccfc63 /xonsh fix_tracebacks # $XONSH_SHOW_TRACEBACK = True
<user>@96f01cccfc63 /xonsh fix_tracebacks # $XONSH_TRACEBACK_LOGFILE = "log"
<user>@96f01cccfc63 /xonsh fix_tracebacks # def f():
...........................................     def g():
...........................................         raise Exception()
...........................................     g()
........................................... f()
...........................................
Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
  File "<stdin>", line 4, in f
  File "<stdin>", line 3, in g
Exception
```
### Old Behavior
```shell
<user>@4bf7f9865baf /xonsh main # $XONSH_SHOW_TRACEBACK = True
<user>@4bf7f9865baf /xonsh main # $XONSH_TRACEBACK_LOGFILE = "log"
<user>@4bf7f9865baf /xonsh main # def f():
.................................     def g():
.................................         raise Exception()
.................................     g()
................................. f()
.................................
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 17028, in default
    run_compiled_code(code, self.ctx, None, "single")
  File "/usr/local/lib/python3.6/site-packages/xonsh/__amalgam__.py", line 3814, in run_compiled_code
    func(code, glb, loc)
  File "<xonsh-code>", line 5, in <module>
  File "<xonsh-code>", line 4, in f
  File "<xonsh-code>", line 3, in g
Exception
```

# Changelog

**Added:**

* Support for pythons sys.last_type, sys.last_value, sys.last_traceback.

**Changed:**

* Made stacktraces behave like in python, i.e. when something in user-provided code fails (both interactively and non-interactively), only that part is shown, and the (static) part of the stacktrace showing the location where the user code was called in xonsh remains hidden. When an unexpected exception occurs inside xonsh, everything is shown like before.
* run_compiled_code, run_script_with_cache, run_code_with_cache now return sys.exc_info() triples instead of throwing errors
* SyntaxError tracebacks now by default hide the internal parser state (like in python); set XONSH_DEBUG >= 1 to enable it again.
* XonshError tracebacks now by default hide xonshs internal state; set XONSH_DEBUG >= 1 to enable it again.
* run_code_with_cache takes a new parameter display_filename to override the filename shown in exceptions (this is independent of caching)

**Fixed:**

* SyntaxErrors now get initialized with all available fields so that the error message can be formatted properly.
* Raising BaseException no longer causes Xonsh to crash (fix #4567)
* Exceptions in user code when using xonsh non-interactively no longer simply crash xonsh, rather a proper stacktrace is printed and also postmain() is called.
* Tracebacks will now show the correct filename (i.e. as in python) for interactive use "\<stdin\>", scripts read by stdin "\<stdin\>" and -c commands "\<string\>". (Instead of MD5 hashes as filenames or "\<xonsh-code\>")


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
