### PR TITLE
fix: '~' replaced to `home/user` by bash  completion scripts breaks autocompletion

### DIFF
--- a/news/bash-autocompletion.rst
+++ b/news/bash-autocompletion.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Some of the bash completions scripts can change path starting with '~/' to `/home/user/` during autocompletion.
+  xonsh `bash_completions` does not expect that, so it breaks autocompletion by producing paths like `~/f/home/user/foo`.
+  After the fix if bash returns changed paths then `/home/user` prefix will be replaced with `~/`.
+
+**Security:**
+
+* <news item>

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -39,6 +39,12 @@ def setup(monkeypatch, tmp_path, xession):
             {"'testdir/'", "'spaced dir/'"},
             0,
         ),
+        # tar replaces "~/" with "/home/user/", the change should be rolledback by us.
+        (
+            CommandContext(args=(CommandArg("tar"),), arg_index=1, prefix="~/"),
+            {"~/c", "~/u", "~/t", "~/d", "~/A", "~/r", "~/x"},
+            2,
+        ),
         (
             CommandContext(
                 args=(CommandArg("ls"),), arg_index=1, prefix="", opening_quote="'"

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -409,6 +409,12 @@ def bash_completions(
 
     # Ensure input to `commonprefix` is a list (now required by Python 3.6)
     commprefix = os.path.commonprefix(list(out))
+
+    if prefix.startswith('~') and commprefix and prefix not in commprefix:
+        home_ = os.path.expanduser("~")
+        out = {f'~/{os.path.relpath(p, home_)}' for p in out}
+        commprefix = f'~/{os.path.relpath(commprefix, home_)}'
+
     strip_len = 0
     strip_prefix = prefix.strip("\"'")
     while strip_len < len(strip_prefix) and strip_len < len(commprefix):

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -410,10 +410,10 @@ def bash_completions(
     # Ensure input to `commonprefix` is a list (now required by Python 3.6)
     commprefix = os.path.commonprefix(list(out))
 
-    if prefix.startswith('~') and commprefix and prefix not in commprefix:
+    if prefix.startswith("~") and commprefix and prefix not in commprefix:
         home_ = os.path.expanduser("~")
-        out = {f'~/{os.path.relpath(p, home_)}' for p in out}
-        commprefix = f'~/{os.path.relpath(commprefix, home_)}'
+        out = {f"~/{os.path.relpath(p, home_)}" for p in out}
+        commprefix = f"~/{os.path.relpath(commprefix, home_)}"
 
     strip_len = 0
     strip_prefix = prefix.strip("\"'")


### PR DESCRIPTION
* add protection againts bash completion scripts which changes ~ to /home/user (#4664)

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
