### PR TITLE
use recommended pytest entry point in docs and comments

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -204,7 +204,7 @@ Running the Tests - Basic
 
 Run all the tests using pytest::
 
-    $ py.test -q
+    $ pytest -q
 
 Use "-q" to keep pytest from outputting a bunch of info for every test.
 
@@ -214,16 +214,16 @@ Running the Tests - Advanced
 
 To perform all unit tests::
 
-    $ py.test
+    $ pytest
 
 If you want to run specific tests you can specify the test names to
 execute. For example to run test_aliases::
 
-    $ py.test test_aliases.py
+    $ pytest test_aliases.py
 
 Note that you can pass multiple test names in the above examples::
 
-    $ py.test test_aliases.py test_environ.py
+    $ pytest test_aliases.py test_environ.py
 
 ----------------------------------
 Writing the Tests - Advanced
@@ -241,7 +241,7 @@ has to be prefixed with `test_`::
 The conftest.py in tests directory defines fixtures for mocking various
 parts of xonsh for more test isolation. For a list of the various fixtures::
 
-    $ py.test --fixtures
+    $ pytest --fixtures
 
 when writing tests it's best to use pytest features i.e. parametrization::
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,2 @@
-# empty file to trick py.test into adding the root folder to sys.path
+# empty file to trick pytest into adding the root folder to sys.path
 # see https://github.com/pytest-dev/pytest/issues/911 for more info

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -24,7 +24,7 @@ def has_kwargs(func):
 def debug_level():
     if XSH.env:
         return XSH.env.get("XONSH_DEBUG")
-    # FIXME: Under py.test, return 1(?)
+    # FIXME: Under pytest, return 1(?)
     else:
         return 0  # Optimize for speed, not guaranteed correctness
 


### PR DESCRIPTION
Since pytest 3.0 (2016) - the recommended commandline invocation is pytest (without the dot).

py.test is still available for backwards compatibility but might be removed at some point in the future and the new entry point is already well established.

I didn't add a changelog enry as this is only a teeny tiny correction/improvement of the docs and comments and not really worth mentioning.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
