### PR TITLE
make env_name aware of prompt in pyvenv.cfg

### DIFF
--- a/news/vox-respect-prompt.rst
+++ b/news/vox-respect-prompt.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* ``prompt.env.env_name`` is now aware of the "prompt" key in ``pyvenv.cfg`` - search order from first to last is: ``$VIRTUAL_ENV_PROMPT``, ``pyvenv.cfg``, ``$VIRTUAL_ENV``
+* ``prompt.env.env_name`` is now aware of the "prompt" key in ``pyvenv.cfg`` - search order from first to last is: ``$VIRTUAL_ENV_PROMPT``, ``pyvenv.cfg``, ``$VIRTUAL_ENV``, $``CONDA_DEFAULT_ENV``
 
 **Changed:**
 

--- a/news/vox-respect-prompt.rst
+++ b/news/vox-respect-prompt.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ``prompt.env.env_name`` is now aware of the "prompt" key in ``pyvenv.cfg`` - search order from first to last is: ``$VIRTUAL_ENV_PROMPT``, ``pyvenv.cfg``, ``$VIRTUAL_ENV``
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -147,10 +147,10 @@ class TestPromptFromVenvCfg:
 
     @pytest.mark.parametrize("text", CONFIGS)
     def test_determine_env_name_from_cfg(self, monkeypatch, tmp_path, text):
-        monkeypatch.setattr(prompt_env, "surround_env_name", lambda x: x)
+        monkeypatch.setattr(prompt_env, "_surround_env_name", lambda x: x)
         (tmp_path / "pyvenv.cfg").write_text(text)
         wanted = self.WANTED if self.WANTED in text else tmp_path.name
-        assert prompt_env.determine_env_name(tmp_path) == wanted
+        assert prompt_env._determine_env_name(tmp_path) == wanted
 
 
 class TestEnvNamePrompt:
@@ -195,7 +195,7 @@ class TestEnvNamePrompt:
         pyvenv_cfg.unlink()
         # In the interest of speed the calls are cached, but if the user
         # fiddles with environments this will bite them. I will not do anythin
-        prompt_env.determine_env_name.cache_clear()
+        prompt_env._determine_env_name.cache_clear()
         assert fmt() == f"({third}) "
 
         xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 1
@@ -221,9 +221,9 @@ class TestEnvNamePrompt:
         """
         cfg = tmp_path / "pyvenv.cfg"
         cfg.write_text("prompt=fromfile")
-        assert prompt_env.determine_env_name(cfg.parent) == "fromfile"
+        assert prompt_env._determine_env_name(cfg.parent) == "fromfile"
         cfg.unlink()
-        assert prompt_env.determine_env_name(cfg.parent) == cfg.parent.name
+        assert prompt_env._determine_env_name(cfg.parent) == cfg.parent.name
 
 
 @pytest.mark.parametrize("disable", [0, 1])

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -1,8 +1,11 @@
+import functools
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 from xonsh.prompt.base import PROMPT_FIELDS, PromptFormatter
+from xonsh.prompt import env as prompt_env
 
 
 @pytest.fixture
@@ -118,10 +121,10 @@ def test_format_prompt_with_various_prepost(formatter, xession, live_fields, pre
 
     xession.env["VIRTUAL_ENV"] = "env"
 
-    live_fields.update({"env_prefix": pre, "env_postfix": post})
-
+    lf_copy = dict(live_fields)  # live_fields fixture is not idempotent!
+    lf_copy.update({"env_prefix": pre, "env_postfix": post})
     exp = pre + "env" + post
-    assert formatter("{env_name}", fields=live_fields) == exp
+    assert formatter("{env_name}", fields=lf_copy) == exp
 
 
 def test_noenv_with_disable_set(formatter, xession, live_fields):
@@ -130,6 +133,65 @@ def test_noenv_with_disable_set(formatter, xession, live_fields):
 
     exp = ""
     assert formatter("{env_name}", fields=live_fields) == exp
+
+
+class TestPromptFromVenvCfg:
+    WANTED = "wanted"
+    CONFIGS = [
+        f"prompt = '{WANTED}'",
+        f'prompt = "{WANTED}"',
+        f'\t prompt =  "{WANTED}"   ',
+        f"prompt \t=    {WANTED}   ",
+        "nothing = here",
+    ]
+    CONFIGS.extend([f"other = fluff\n{t}\nmore = fluff" for t in CONFIGS])
+
+    @pytest.mark.parametrize("text", CONFIGS)
+    def test_prompt_from_venv_cfg(self, monkeypatch, text):
+        monkeypatch.setattr(Path, "is_file", lambda *_: True)
+        monkeypatch.setattr(Path, "read_text", lambda *_: text)
+        wanted = self.WANTED if self.WANTED in text else None
+        assert prompt_env.prompt_from_pyvenv_cfg(Path("dontccare")) == wanted
+
+
+class TestEnvNamePrompt:
+    def test_no_prompt(self, formatter, live_fields):
+        assert formatter("{env_name}", fields=live_fields) == ""
+
+    def test_search_order(self, monkeypatch, formatter, xession, live_fields):
+        xession.shell.prompt_formatter = formatter
+
+        first = "first"
+        second = "second"
+        third = "third"
+
+        monkeypatch.setattr(prompt_env, "prompt_from_pyvenv_cfg", lambda *_: second)
+        fmt = functools.partial(formatter, "{env_name}", fields=live_fields)
+        xession.env.update(dict(VIRTUAL_ENV_PROMPT=first, VIRTUAL_ENV=third))
+
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 0
+        assert fmt() == first
+
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 1
+        assert fmt() == ""
+
+        del xession.env["VIRTUAL_ENV_PROMPT"]
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 0
+        assert fmt() == f"({second}) "
+
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 1
+        assert fmt() == ""
+
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 0
+        monkeypatch.setattr(prompt_env, "prompt_from_pyvenv_cfg", lambda *_: None)
+        assert fmt() == f"({third}) "
+
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 1
+        assert fmt() == ""
+
+        xession.env["VIRTUAL_ENV_DISABLE_PROMPT"] = 0
+        del xession.env["VIRTUAL_ENV"]
+        assert fmt() == ""
 
 
 @pytest.mark.parametrize("disable", [0, 1])

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -1,5 +1,4 @@
 import functools
-from pathlib import Path
 from unittest.mock import Mock
 
 import pytest

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -2,7 +2,6 @@
 import functools
 import re
 from pathlib import Path
-from typing import Optional
 
 from xonsh.built_ins import XSH
 

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -1,39 +1,55 @@
 """Prompt formatter for virtualenv and others"""
 
-import os
+import re
+from pathlib import Path
 
 from xonsh.built_ins import XSH
 
 
-def find_env_name():
-    """Finds the current environment name from $VIRTUAL_ENV or
-    $CONDA_DEFAULT_ENV if that is set.
-    """
-    env_path = XSH.env.get("VIRTUAL_ENV", "")
-    if env_path:
-        env_name = os.path.basename(env_path)
-    else:
-        env_name = XSH.env.get("CONDA_DEFAULT_ENV", "")
-    return env_name
-
-
 def env_name():
-    """Returns the current env_name if it non-empty, surrounded by the
-    ``{env_prefix}`` and ``{env_postfix}`` fields.
-    """
-    env_name = find_env_name()
-    if XSH.env.get("VIRTUAL_ENV_DISABLE_PROMPT") or not env_name:
-        # env name prompt printing disabled, or no environment; just return
-        return
+    """Build env_name based on different sources. Respect order of precedence.
 
-    venv_prompt = XSH.env.get("VIRTUAL_ENV_PROMPT")
-    if venv_prompt is not None:
-        return venv_prompt
-    else:
-        pf = XSH.shell.prompt_formatter
-        pre = pf._get_field_value("env_prefix")
-        post = pf._get_field_value("env_postfix")
-        return pre + env_name + post
+    Name from VIRTUAL_ENV_PROMPT will be used as-is.
+    Names from other sources are surrounded with ``{env_prefix}`` and
+    ``{env_postfix}`` fields.
+    """
+    if XSH.env.get("VIRTUAL_ENV_DISABLE_PROMPT"):
+        return
+    virtual_env_prompt = XSH.env.get("VIRTUAL_ENV_PROMPT")
+    if virtual_env_prompt:
+        return virtual_env_prompt
+    virtual_env = XSH.env.get("VIRTUAL_ENV")
+    if virtual_env:
+        venv_path = Path(virtual_env)
+        pyvenv_cfg_prompt = prompt_from_pyvenv_cfg(venv_path)
+        if pyvenv_cfg_prompt:
+            return surround_env_name(pyvenv_cfg_prompt)
+        return surround_env_name(venv_path.name)
+    from_conda = XSH.env.get("CONDA_DEFAULT_ENV")
+    if from_conda:
+        return surround_env_name(from_conda)
+    return
+
+
+def prompt_from_pyvenv_cfg(venv_path):
+    """Grab the prompt from the venv configuration, if it exists.
+
+    Tries to be resilient to subtle changes in whitespace and quoting in the
+    configuration file format as it adheres to no clear standard.
+    """
+    assert isinstance(venv_path, Path), venv_path
+    pyvenv_cfg = venv_path / "pyvenv.cfg"
+    if pyvenv_cfg.is_file():
+        match = re.search(r"prompt\s*=\s*(.*)", pyvenv_cfg.read_text())
+        if match:
+            return match.group(1).strip().lstrip("'\"").rstrip("'\"")
+
+
+def surround_env_name(name):
+    pf = XSH.shell.prompt_formatter
+    pre = pf._get_field_value("env_prefix")
+    post = pf._get_field_value("env_postfix")
+    return f"{pre}{name}{post}"
 
 
 def vte_new_tab_cwd():

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -7,7 +7,7 @@ from typing import Optional
 from xonsh.built_ins import XSH
 
 
-def env_name() -> Optional[str]:
+def env_name() -> str:
     """Build env_name based on different sources. Respect order of precedence.
 
     Name from VIRTUAL_ENV_PROMPT will be used as-is.
@@ -15,7 +15,7 @@ def env_name() -> Optional[str]:
     ``{env_postfix}`` fields.
     """
     if XSH.env.get("VIRTUAL_ENV_DISABLE_PROMPT"):
-        return
+        return ""
     virtual_env_prompt = XSH.env.get("VIRTUAL_ENV_PROMPT")
     if virtual_env_prompt:
         return virtual_env_prompt

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -2,11 +2,12 @@
 import functools
 import re
 from pathlib import Path
+from typing import Optional
 
 from xonsh.built_ins import XSH
 
 
-def env_name():
+def env_name() -> Optional[str]:
     """Build env_name based on different sources. Respect order of precedence.
 
     Name from VIRTUAL_ENV_PROMPT will be used as-is.
@@ -29,7 +30,7 @@ def env_name():
 
 
 @functools.lru_cache(maxsize=5)
-def determine_env_name(virtual_env):
+def determine_env_name(virtual_env: str) -> str:
     """Use prompt setting from pyvenv.cfg or basename of virtual_env.
 
     Tries to be resilient to subtle changes in whitespace and quoting in the
@@ -44,14 +45,14 @@ def determine_env_name(virtual_env):
     return venv_path.name
 
 
-def surround_env_name(name):
+def surround_env_name(name: str) -> str:
     pf = XSH.shell.prompt_formatter
     pre = pf._get_field_value("env_prefix")
     post = pf._get_field_value("env_postfix")
     return f"{pre}{name}{post}"
 
 
-def vte_new_tab_cwd():
+def vte_new_tab_cwd() -> None:
     """This prints an escape sequence that tells VTE terminals the hostname
     and pwd. This should not be needed in most cases, but sometimes is for
     certain Linux terminals that do not read the PWD from the environment


### PR DESCRIPTION
prompt.env.env_name is now aware of the "prompt" key in ``pyvenv.cfg`` - search order from first to last is: ``$VIRTUAL_ENV_PROMPT``, ``$VIRTUAL_ENV`` (prompt from ``pyvenv.cfg`` or basename of venv path if not set), ``$CONDA_DEFAULT_ENV``.

fixes #4670

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
