### PR TITLE
Add goat counter to track hits on the docs

### DIFF
--- a/docs/_templates_overwrite/index.html
+++ b/docs/_templates_overwrite/index.html
@@ -693,5 +693,7 @@ chmod +x xonsh-x86_64.AppImage
                 $( "#github_xontribs_api" ).html('');
             });
     </script>
+    <script data-goatcounter="https://xonsh.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 
 </body></html>


### PR DESCRIPTION
See goatcounter.com for more information.

Goat Counter strives to be privacy preserving and complies with GDPR.  Also doesn't use cookies for tracking so no annoying cookie announcement banner -- this is really just to track hits to the xonsh documentation to maybe start to get a sense of the size of the userbase.  Who knows?

Anyone in @xonsh/xore who wants access just ping me.