### PR TITLE
fix(maybe): use generated token to push docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          repository: xonsh/xonsh-docs
       - name: Deploy to dev if not tagged
         if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Got the token to generate correctly, but now it's complaining about
scoping -- might be that it needs to be generated for xonsh/xonsh to
push to xonsh/xonsh-docs

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
