### PR TITLE
Fix regex globbing for paths that contain special regex characters

### DIFF
--- a/news/fix-globbing-path-containing-regex.rst
+++ b/news/fix-globbing-path-containing-regex.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed regex globbing for file paths that contain special regex characters (e.g. "test*1/model")
+
+**Security:**
+
+* <news item>

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1,8 +1,10 @@
 """Tests the xonsh builtins."""
 import os
 import re
+import shutil
 import types
 from ast import AST, Expression, Interactive, Module
+from pathlib import Path
 
 import pytest
 
@@ -83,6 +85,26 @@ def test_repath_HOME_PATH_var_brace(home_env):
     obs = pathsearch(regexsearch, '${"HOME"}')
     assert 1 == len(obs)
     assert exp == obs[0]
+
+
+@pytest.mark.parametrize(
+    "path, pattern",
+    [
+        ("test/model", ".*/model"),
+        ("test+a/model", ".*/model"),
+        ("test*1/model", ".*/model"),
+        ("hello/test*1/model", "hello/.*/model"),
+    ],
+)
+def test_repath_containing_regex_chars(path, pattern):
+    base_testdir = Path("re_testdir")
+    testdir = base_testdir / path
+    testdir.mkdir(parents=True)
+    try:
+        obs = regexsearch(str(base_testdir / pattern))
+        assert [str(testdir)] == obs
+    finally:
+        shutil.rmtree(base_testdir)
 
 
 def test_helper_int(home_env):

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -87,16 +87,8 @@ def test_repath_HOME_PATH_var_brace(home_env):
     assert exp == obs[0]
 
 
-@pytest.mark.parametrize(
-    "path, pattern",
-    [
-        ("test/model", ".*/model"),
-        ("test+a/model", ".*/model"),
-        ("test*1/model", ".*/model"),
-        ("hello/test*1/model", "hello/.*/model"),
-    ],
-)
-def test_repath_containing_regex_chars(path, pattern):
+# helper
+def check_repath(path, pattern):
     base_testdir = Path("re_testdir")
     testdir = base_testdir / path
     testdir.mkdir(parents=True)
@@ -105,6 +97,29 @@ def test_repath_containing_regex_chars(path, pattern):
         assert [str(testdir)] == obs
     finally:
         shutil.rmtree(base_testdir)
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize(
+    "path, pattern",
+    [
+        ("test*1/model", ".*/model"),
+        ("hello/test*1/model", "hello/.*/model"),
+    ],
+)
+def test_repath_containing_asterisk(path, pattern):
+    check_repath(path, pattern)
+
+
+@pytest.mark.parametrize(
+    "path, pattern",
+    [
+        ("test+a/model", ".*/model"),
+        ("hello/test+1/model", "hello/.*/model"),
+    ],
+)
+def test_repath_containing_plus_sign(path, pattern):
+    check_repath(path, pattern)
 
 
 def test_helper_int(home_env):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -20,7 +20,7 @@ from ast import AST
 
 from xonsh.inspectors import Inspector
 from xonsh.lazyasd import lazyobject
-from xonsh.platform import ON_POSIX, ON_WINDOWS
+from xonsh.platform import ON_POSIX
 from xonsh.tools import (
     XonshCalledProcessError,
     XonshError,
@@ -92,12 +92,7 @@ def reglob(path, parts=None, i=None):
             base = ""
         elif len(parts) > 1:
             i += 1
-    regex = os.path.join(base, parts[i])
-    if ON_WINDOWS:
-        # currently unable to access regex backslash sequences
-        # on Windows due to paths using \.
-        regex = regex.replace("\\", "\\\\")
-    regex = re.compile(regex)
+    regex = re.compile(parts[i])
     files = os.listdir(subdir)
     files.sort()
     paths = []
@@ -105,12 +100,12 @@ def reglob(path, parts=None, i=None):
     if i1 == len(parts):
         for f in files:
             p = os.path.join(base, f)
-            if regex.fullmatch(p) is not None:
+            if regex.fullmatch(f) is not None:
                 paths.append(p)
     else:
         for f in files:
             p = os.path.join(base, f)
-            if regex.fullmatch(p) is None or not os.path.isdir(p):
+            if regex.fullmatch(f) is None or not os.path.isdir(p):
                 continue
             paths += reglob(p, parts=parts, i=i1)
     return paths


### PR DESCRIPTION
Fixes #4690

This PR fixes the issue that regex globbing for paths like `test+a/model` and `test*1/model` is broken. Currently, these paths do not get matched by the pattern `.*/model`.

## Cause of the issue
The cause of the issue is that `reglob()` currently joins `base` (part of the file path containing problematic special characters) with `parts[i]` (part of the intended regular expression), and _compiles the whole thing as a regular expression_. This causes special regex characters in file paths to be incorrectly interpreted as part of the search pattern:
https://github.com/xonsh/xonsh/blob/78f91952273f0a81dc226abf91ae16e07c125103/xonsh/built_ins.py#L95-L100

## Solution
This PR fixes the issue by not joining `base` into the regular expression, and instead matching `parts[i]` on the last component of the current path. `regex.fullmatch(p)` gets changed into `regex.fullmatch(f)`

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
