### PR TITLE
chore: update `mypy`

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -18,9 +18,7 @@ pre-commit
 pyte>=0.8.0
 
 # types related
-# mypy==0.931
-git+git://github.com/python/mypy.git@9b3147701f054bf8ef42bd96e33153b05976a5e1
-# TODO: replace above with mypy==0.940 once its released
+mypy==0.940
 types-ujson
 
 # ensure tests run with the amalgamated (==production) xonsh

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -20,6 +20,7 @@ _unc_tempDrives: tp.Dict[str, str] = {}
 """ drive: sharePath for temp drive letters we create for UNC mapping"""
 
 
+@tp.no_type_check
 def _unc_check_enabled() -> bool:
     r"""Check whether CMD.EXE is enforcing no-UNC-as-working-directory check.
 


### PR DESCRIPTION
Github stopped allowing `git+ssh` installs and we were due to move to `0.940`