### PR TITLE
fix: add M1 bash-completion path to osx defaults

### DIFF
--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -15,7 +15,7 @@ table lists built in features and capabilities that various tools may or may not
       - fish
       - IPython
       - xonsh
-    * - Sane language
+    * - Practical language
       -
       -
       - ✓

--- a/docs/tutorial_subproc_strings.rst
+++ b/docs/tutorial_subproc_strings.rst
@@ -90,7 +90,7 @@ In sh-langs, internal quote characters are removed. For instance:
     $ echo --key="value"
     --key=value
 
-Xonsh considers this behavior insane. Instead, xonsh treats these
+Xonsh considers this behavior suboptimal. Instead, xonsh treats these
 arguments as if they were surrounded in another, outer level of
 quotation (``'foo"bar"baz'``). Xonsh will keep the quotation marks
 when leading and trailing quotes are not matched.

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -316,7 +316,7 @@ def bash_completions(
         since it lazy-loads individual completion scripts. For both
         bash-completion v1.x and v2.x, paths of individual completion scripts
         (like ``.../completes/ssh``) do not need to be included here. The
-        default values are platform dependent, but sane.
+        default values are platform dependent, but reasonable.
     command : str or None, optional
         The /path/to/bash to use. If None, it will be selected based on the
         from the environment and platform.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1691,7 +1691,7 @@ This is to reduce the noise in generated completions.""",
         "For both bash-completion v1.x and v2.x, paths of individual completion "
         "scripts (like ``.../completes/ssh``) do not need to be included here. "
         "The default values are platform "
-        "dependent, but sane. To specify an alternate list, do so in the run "
+        "dependent, but reasonable. To specify an alternate list, do so in the run "
         "control file.",
         default=BASH_COMPLETIONS_DEFAULT,
         doc_default=(

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1699,7 +1699,8 @@ This is to reduce the noise in generated completions.""",
             "    ``('/usr/share/bash-completion/bash_completion', )``\n\n"
             "But, on Mac it is:\n\n"
             "    ``('/usr/local/share/bash-completion/bash_completion', "
-            "'/usr/local/etc/bash_completion')``\n\n"
+            "'/usr/local/etc/bash_completion', "
+            "'/opt/homebrew/share/bash-completion/bash_completion'),``\n\n"
             "Other OS-specific defaults may be added in the future."
         ),
         type_str="env_path",

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -494,8 +494,9 @@ def BASH_COMPLETIONS_DEFAULT():
     elif ON_DARWIN:
         bcd = (
             "/usr/local/share/bash-completion/bash_completion",  # v2.x
-            "/usr/local/etc/bash_completion",
-        )  # v1.x
+            "/usr/local/etc/bash_completion",  # v1.x
+            "/opt/homebrew/share/bash-completion/bash_completion",  # v2.x on M1
+        )
     elif ON_WINDOWS and git_for_windows_path():
         bcd = (
             os.path.join(

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -705,7 +705,7 @@ class SubprocSpec:
 
 
 def _safe_pipe_properties(fd, use_tty=False):
-    """Makes sure that a pipe file descriptor properties are sane."""
+    """Makes sure that a pipe file descriptor properties are reasonable."""
     if not use_tty:
         return
     # due to some weird, long standing issue in Python, PTYs come out


### PR DESCRIPTION
Small language changes as flagged by @jaraco in #4737