### PR TITLE
chore: update black to fix CI broken with new click release

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -12,7 +12,7 @@ pytest-rerunfailures
 prompt-toolkit>=3.0.27
 pygments>=2.2
 coverage>=5.3.1
-black==22.1.0
+black==22.3.0
 isort >= 5.10
 pre-commit
 pyte>=0.8.0


### PR DESCRIPTION
xref: https://github.com/psf/black/issues/2964

TLDR: Click removed an internal module that `black` was relying on and it broke stuff.  Updating `black` to unbreak CI.
