### PR TITLE
fix: setting builtins access to abbrevs

### DIFF
--- a/news/fix-abbrevs.rst
+++ b/news/fix-abbrevs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* fixed regression issue in loading `xontrib-abbrevs <https://github.com/xonsh/xonsh/pull/4757>`_
+
+**Security:**
+
+* <news item>

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -52,7 +52,7 @@ abbrevs: "dict[str, AbbrValType]" = dict()
 # XSH.builtins is a namespace and extendable
 XSH.builtins.abbrevs = abbrevs
 
-proxy = DynamicAccessProxy("abbrevs", "__xonsh__.abbrevs")
+proxy = DynamicAccessProxy("abbrevs", "__xonsh__.builtins.abbrevs")
 builtins.abbrevs = proxy  # type: ignore
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
