### PR TITLE
fix: guard modal cursor import for prompt toolkit

### DIFF
--- a/news/guard_cursor_shape.rst
+++ b/news/guard_cursor_shape.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Allow xonsh to start gracefully even if modal cursors aren't in the available
+  prompt_toolkit version
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -7,7 +7,6 @@ from types import MethodType
 
 from prompt_toolkit import ANSI
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.cursor_shapes import ModalCursorShapeConfig
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.formatted_text import PygmentsTokens, to_formatted_text
 from prompt_toolkit.history import ThreadedHistory
@@ -43,6 +42,13 @@ try:
     HAVE_SYS_CLIPBOARD = True
 except ImportError:
     HAVE_SYS_CLIPBOARD = False
+
+try:
+    from prompt_toolkit.cursor_shapes import ModalCursorShapeConfig
+
+    HAVE_CURSOR_SHAPE = True
+except ImportError:
+    HAVE_CURSOR_SHAPE = False
 
 CAPITAL_PATTERN = re.compile(r"([a-z])([A-Z])")
 Token = _TokenType()
@@ -356,7 +362,7 @@ class PromptToolkitShell(BaseShell):
             for attr, val in self.get_lazy_ptk_kwargs():
                 prompt_args[attr] = val
 
-        if editing_mode == EditingMode.VI:
+        if editing_mode == EditingMode.VI and HAVE_CURSOR_SHAPE:
             prompt_args["cursor"] = ModalCursorShapeConfig()
         events.on_pre_prompt.fire()
         line = self.prompter.prompt(**prompt_args)


### PR DESCRIPTION
We shouldn't fail to start if the available PTK version doesn't support
modal cursor stuff.
(We should probably also make modal cursor stuff optional, but that can
happen later)

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
