### PR TITLE
fix: completions for command argument paths after equal signs

### DIFF
--- a/news/fix-bash-completion-after-equal-sign.rst
+++ b/news/fix-bash-completion-after-equal-sign.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed completions for command argument paths after equal signs
+
+**Security:**
+
+* <news item>

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -203,22 +203,22 @@ def test_bash_completer_empty_prefix():
         # dd status=pr -> dd status=progress
         (
             CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="status=pr"),
-            {"status=progress"},
-            9,
+            {"progress"},
+            2,
             True,
         ),
         # dd if=/et -> dd if=/etc/
         (
             CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="if=/et"),
-            {"if=/etc/"},
-            6,
+            {"/etc/"},
+            3,
             False,
         ),
         # dd of=/dev/nul -> dd of=/dev/null
         (
             CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="of=/dev/nul"),
-            {"of=/dev/null"},
-            11,
+            {"/dev/null"},
+            8,
             True,
         ),
     ),

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -184,28 +184,51 @@ def test_bash_completer_empty_prefix():
 @skip_if_on_darwin
 @skip_if_on_windows
 @pytest.mark.parametrize(
-    "command_context, completions, lprefix",
+    "command_context, completions, lprefix, exp_append_space",
     (
         # dd sta  ->  dd status=
         (
             CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="sta"),
             {"status="},
             3,
+            False,
         ),
         # date --da  ->  date --date=
         (
             CommandContext(args=(CommandArg("date"),), arg_index=1, prefix="--da"),
             {"--date="},
             4,
+            False,
+        ),
+        # dd status=pr -> dd status=progress
+        (
+            CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="status=pr"),
+            {"status=progress"},
+            9,
+            True,
+        ),
+        # dd if=/et -> dd if=/etc/
+        (
+            CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="if=/et"),
+            {"if=/etc/"},
+            6,
+            False,
+        ),
+        # dd of=/dev/nul -> dd of=/dev/null
+        (
+            CommandContext(args=(CommandArg("dd"),), arg_index=1, prefix="of=/dev/nul"),
+            {"of=/dev/null"},
+            11,
+            True,
         ),
     ),
 )
-def test_equal_sign_arg(command_context, completions, lprefix):
+def test_equal_sign_arg(command_context, completions, lprefix, exp_append_space):
     bash_completions, bash_lprefix = complete_from_bash(
         CompletionContext(command_context)
     )
     assert bash_completions == completions and bash_lprefix == lprefix
     assert all(
-        isinstance(comp, RichCompletion) and not comp.append_space
+        isinstance(comp, RichCompletion) and comp.append_space == exp_append_space
         for comp in bash_completions
-    )  # there should not be an appended space after the equal sign
+    )

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -427,15 +427,11 @@ def bash_completions(
     if "-o nospace" in complete_stmt:
         out = {x.rstrip() for x in out}
 
-    # For commands such as 'dd', the completion script only returns the part
-    # after '=' in the completion results. This is fixed by appending the part
-    # of the prefix up to '=' to the front of each completion result.
-    # For example, for the prefix 'status=pro', 'progress' is returned by bash,
-    # which gets transformed into 'status=progress'
+    # For arguments like 'status=progress', the completion script only returns
+    # the part after '=' in the completion results. This causes the strip_len
+    # to be incorrectly calculated, so it needs to be fixed here
     if "=" in prefix and "=" not in commprefix:
-        prefix_up_to_eq = prefix[: prefix.index("=") + 1]
-        out = {prefix_up_to_eq + x for x in out}
-        strip_len = 0
+        strip_len = prefix.index("=") + 1
 
     return out, max(len(prefix) - strip_len, 0)
 

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -427,6 +427,16 @@ def bash_completions(
     if "-o nospace" in complete_stmt:
         out = {x.rstrip() for x in out}
 
+    # For commands such as 'dd', the completion script only returns the part
+    # after '=' in the completion results. This is fixed by appending the part
+    # of the prefix up to '=' to the front of each completion result.
+    # For example, for the prefix 'status=pro', 'progress' is returned by bash,
+    # which gets transformed into 'status=progress'
+    if "=" in prefix and "=" not in commprefix:
+        prefix_up_to_eq = prefix[: prefix.index("=") + 1]
+        out = {prefix_up_to_eq + x for x in out}
+        strip_len = 0
+
     return out, max(len(prefix) - strip_len, 0)
 
 


### PR DESCRIPTION
Fixes #4746 
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
