### PR TITLE
fix: remove os.path.basename from _get_git_branch()

### DIFF
--- a/news/fix-git-branch-name.rst
+++ b/news/fix-git-branch-name.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* fix: remove os.path.basename from _get_git_branch()
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -37,7 +37,7 @@ def _get_git_branch(q):
         with contextlib.suppress(subprocess.CalledProcessError, OSError):
             branch = xt.decode_bytes(_run_git_cmd(cmds.split()))
             if branch:
-                q.put(os.path.basename(branch.splitlines()[0]))
+                q.put(branch.splitlines()[0])
                 return
     # all failed
     q.put(None)


### PR DESCRIPTION
I don't know why the `os.path.basename()` was called on the git branch name in the first place but it's wrong.
I usually create branches named: `refactor/*`, `bugfix/*` and `feature/*` so I require the full branch name.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
