### PR TITLE
fix: item order of pretty-printed dictionaries

### DIFF
--- a/news/fix-pretty-print-dict.rst
+++ b/news/fix-pretty-print-dict.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Dictionaries are now pretty-printed with their items in the correct order
+
+**Security:**
+
+* <news item>

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -51,6 +51,11 @@ cases = [
         id="long-dict",
     ),
     (re.compile("1"), "re.compile(r'1', re.UNICODE)"),
+    pytest.param(
+        dict([(0, 0), (2, 1), (1, 2), (4, 3), (3, 4)]),
+        "{0: 0, 2: 1, 1: 2, 4: 3, 3: 4}",
+        id="dict-preserve-order",
+    ),
 ]
 
 

--- a/xonsh/pretty.py
+++ b/xonsh/pretty.py
@@ -639,13 +639,6 @@ def _dict_pprinter_factory(start, end, basetype=None):
             return p.text("{...}")
         p.begin_group(1, start)
         keys = obj.keys()
-        # if dict isn't large enough to be truncated, sort keys before displaying
-        if not (p.max_seq_length and len(obj) >= p.max_seq_length):
-            try:
-                keys = sorted(keys)
-            except Exception:
-                # Sometimes the keys don't sort.
-                pass
         for idx, key in p._enumerate(keys):
             if idx:
                 p.text(",")


### PR DESCRIPTION
Fixes #4782

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
