### PR TITLE
Returncode enhancements

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1554,6 +1554,8 @@ By default, the following variables are available for use:
   * ``localtime``: The current, local time as given by ``time.localtime()``.
     This is formatted with the time format string found in ``time_format``.
   * ``time_format``: A time format string, defaulting to ``"%H:%M:%S"``.
+  * ``last_return_code``: The return code of the last issued command. 
+  * ``last_return_code_if_nonzero``: The return code of the last issued command if it is non-zero, otherwise ``None``. This is useful for only printing the code in case of errors.
 
 .. note:: See the section below on ``PROMPT_FIELDS`` for more information on changing.
 

--- a/news/feat_returncode_enhancements.rst
+++ b/news/feat_returncode_enhancements.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Added a special '$?' environment variable to access the return code of the last issued command. (Only set during interactive use).
+* New prompt-customization fields: 'last_return_code_if_nonzero', 'last_return_code'.
+
+**Changed:**
+
+* '$?' is now legal syntax.
+* The default prompt (on unix-systems) now includes a red [<errorcode>] field in case a command failed.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -430,6 +430,7 @@ class BaseShell:
         """
         hist = XSH.history  # pylint: disable=no-member
         info["rtn"] = hist.last_cmd_rtn if hist is not None else None
+        XSH.env["LAST_RETURN_CODE"] = info["rtn"] or 0
         tee_out = tee_out or None
         last_out = hist.last_cmd_out if hist is not None else None
         if last_out is None and tee_out is None:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -920,6 +920,11 @@ class GeneralSetting(Xettings):
         "should cause an end to execution. This is less useful at a terminal. "
         "The error that is raised is a ``subprocess.CalledProcessError``.",
     )
+    LAST_RETURN_CODE = Var.with_default(
+        0,
+        "Can be accessed (read-only) with shortcut '$?'. Is only updated during interactive use, i.e. not during execution of scripts.",
+    )
+
     SHLVL = Var(
         is_valid_shlvl,
         to_shlvl,
@@ -2072,11 +2077,18 @@ class Env(cabc.MutableMapping):
     def set_swapped_values(self, swapped_values):
         self._d.set_local_overrides(swapped_values)
 
+    def _expanded_keyname(self, key):
+        # map "?" to a proper identifier so that $? can be declared using $LAST_RETURN_CODE
+        if key == "?":
+            key = "LAST_RETURN_CODE"
+        return key
+
     #
     # Mutable mapping interface
     #
 
     def __getitem__(self, key):
+        key = self._expanded_keyname(key)
         if key is Ellipsis:
             return self
         elif key in self._d:

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -158,6 +158,7 @@ def default_prompt():
             "{env_name}"
             "{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} "
             "{cwd}{branch_color}{curr_branch: {}}{RESET} "
+            "{RED}{last_return_code_if_nonzero:[{BOLD_INTENSE_RED}{}{RED}]}{RESET}"
             "{BOLD_BLUE}{prompt_end}{RESET} "
         )
     return dp
@@ -355,6 +356,10 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
                 vte_new_tab_cwd=vte_new_tab_cwd,
                 time_format="%H:%M:%S",
                 localtime=_localtime,
+                last_return_code=lambda: XSH.env.get("LAST_RETURN_CODE", 0),
+                last_return_code_if_nonzero=lambda: XSH.env.get("LAST_RETURN_CODE", 0)
+                if XSH.env.get("LAST_RETURN_CODE", 0) != 0
+                else None,
             )
         )
         for val in self.get_fields(gitstatus):

--- a/xonsh/tokenize.py
+++ b/xonsh/tokenize.py
@@ -271,7 +271,7 @@ def maybe(*choices):
 Whitespace = r"[ \f\t]*"
 Comment = r"#[^\r\n]*"
 Ignore = Whitespace + tokany(r"\\\r?\n" + Whitespace) + maybe(Comment)
-Name_RE = r"\$?\w+"
+Name_RE = r"\$?\w+|\$\?"
 
 Hexnumber = r"0[xX](?:_?[0-9a-fA-F])+"
 Binnumber = r"0[bB](?:_?[01])+"
@@ -1062,7 +1062,9 @@ def _tokenize(readline, encoding, tolerant=False):
                         break
                     else:  # ordinary string
                         yield TokenInfo(STRING, token, spos, epos, line)
-                elif token.startswith("$") and token[1:].isidentifier():
+                elif token.startswith("$") and (
+                    token[1:].isidentifier() or token[1:] == "?"
+                ):
                     yield TokenInfo(DOLLARNAME, token, spos, epos, line)
                 elif initial.isidentifier():  # ordinary name
                     if token in ("async", "await"):


### PR DESCRIPTION
This PR proposes these changes:

* Added a special '$?' environment variable to access the return code of the last issued command. (Only set during interactive use).
* New prompt-customization fields: ``last_return_code_if_nonzero``, ``last_return_code``.
* The default prompt (on unix-systems) now includes a red [\<errorcode\>] field in case a command failed. This offers a definitive visual cue that something went wrong (commands may produce messy output...). Inspired by the fish shell. See the video for a demonstration.

https://user-images.githubusercontent.com/25764660/167212732-f009a6b1-ff47-4e59-83b7-06db42f58c4b.mp4



## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
