### PR TITLE
Add missing space before link in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -302,7 +302,7 @@ new module ``mymod``.  The following explains how to add hooks.
 Python Hooks
 ------------------------
 Python API documentation is generated for the entries in ``docs/api.rst``.
-`sphinx-autosummary<https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>`_
+`sphinx-autosummary <https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>`_
 is used to generate documentation for the modules.
 Mention your module ``mymod`` under appropriate header.
 This will discover all of the docstrings in ``mymod`` and create the


### PR DESCRIPTION
Resolves:
```
docs/devguide.rst:304: ERROR: Unknown target name: "sphinx-autosummary<https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>".
```