### PR TITLE
We can't be sure there's a python binary

### DIFF
--- a/tests/test_virtualenv_activator.py
+++ b/tests/test_virtualenv_activator.py
@@ -23,13 +23,19 @@ def test_xonsh_activator(tmp_path):
 
     # Sanity
     original_python = check_output(
-        [sys.executable, "-m", "xonsh", "-c", "which python3"]
+        [
+            sys.executable,
+            "-m",
+            "xonsh",
+            "-c",
+            "import shutil; shutil.which('python') or shutil.which('python3')",
+        ]
     ).decode()
     assert Path(original_python).parent != bin_path
 
     # Activate
     venv_python = check_output(
-        [sys.executable, "-m", "xonsh", "-c", f"source {activate_path}; which python3"]
+        [sys.executable, "-m", "xonsh", "-c", f"source {activate_path}; which python"]
     ).decode()
     assert Path(venv_python).parent == bin_path
 
@@ -40,7 +46,8 @@ def test_xonsh_activator(tmp_path):
             "-m",
             "xonsh",
             "-c",
-            f"source {activate_path}; deactivate; which python3",
+            f"source {activate_path}; deactivate; "
+            "import shutil; shutil.which('python') or shutil.which('python3')",
         ]
     ).decode()
     assert deactivated_python == original_python

--- a/tests/test_virtualenv_activator.py
+++ b/tests/test_virtualenv_activator.py
@@ -23,13 +23,13 @@ def test_xonsh_activator(tmp_path):
 
     # Sanity
     original_python = check_output(
-        [sys.executable, "-m", "xonsh", "-c", "which python"]
+        [sys.executable, "-m", "xonsh", "-c", "which python3"]
     ).decode()
     assert Path(original_python).parent != bin_path
 
     # Activate
     venv_python = check_output(
-        [sys.executable, "-m", "xonsh", "-c", f"source {activate_path}; which python"]
+        [sys.executable, "-m", "xonsh", "-c", f"source {activate_path}; which python3"]
     ).decode()
     assert Path(venv_python).parent == bin_path
 
@@ -40,7 +40,7 @@ def test_xonsh_activator(tmp_path):
             "-m",
             "xonsh",
             "-c",
-            f"source {activate_path}; deactivate; which python",
+            f"source {activate_path}; deactivate; which python3",
         ]
     ).decode()
     assert deactivated_python == original_python


### PR DESCRIPTION
Debian doesn't currently ship a `/usr/bin/python` binary, unless a user specifically installs `python-is-python3`.

However, we can safely assume that a `python3` binary exists.