### PR TITLE
Send SIGHUP instead of SIGKILL to clean up jobs

### DIFF
--- a/news/cleanup-use-sighup.rst
+++ b/news/cleanup-use-sighup.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* SIGHUP (instead of SIGKILL) is sent to unfinished jobs when exiting the shell. This allows the `nohup` command to work properly.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Allows `nohup` command to work properly.

Fixes #2346

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
