### PR TITLE
fix: workaround method calls on attributes set to `None`

### DIFF
--- a/news/fix_exit_error.rst
+++ b/news/fix_exit_error.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Silence spurious errors on exit due to out-of-order cleanup
+
+**Security:**
+
+* <news item>

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -191,8 +191,10 @@ class _TeeStd(io.TextIOBase):
 
     def flush(self):
         """Flushes both the original stdout and the buffer."""
-        self.std.flush()
-        self.mem.flush()
+        # In certain cases, `std` or `mem` may already be `None` when we're
+        # cleaning up in which case we don't care whether `flush` does anything
+        getattr(getattr(self, "std", lambda: None), "flush", lambda: None)()
+        getattr(getattr(self, "mem", lambda: None), "flush", lambda: None)()
 
     def fileno(self):
         """Tunnel fileno() calls to the std stream."""


### PR DESCRIPTION
Fixes #4806 

If `self.std` or `self.mem` is already set to `None` then we've cleaned up already and being able to `flush` doesn't really matter.  So let's not worry about them missing.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
