### PR TITLE
Fixing bash completion bug when prefix started with '>', '<', or ':'

### DIFF
--- a/news/fix-bash-completion.rst
+++ b/news/fix-bash-completion.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bash completion bug when prefixing a file path with '<' or '>' (for redirecting stdin/stdout/stderr)
+* Fixed a bash completion bug when completing a git branch name when deleting a remote branch (e.g. `git push origin :dev-branch`)
+
+**Security:**
+
+* <news item>

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from xonsh.completers.bash import complete_from_bash
@@ -305,6 +306,6 @@ def test_git_delete_remote_branch():
     )
     assert bash_completions == {"main"} and bash_lprefix == 3
     assert all(
-        isinstance(comp, RichCompletion) and comp.append_space == False
+        isinstance(comp, RichCompletion) and comp.append_space is False
         for comp in bash_completions
     )

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -234,56 +234,6 @@ def test_equal_sign_arg(command_context, completions, lprefix, exp_append_space)
     )
 
 
-@skip_if_on_darwin
-@skip_if_on_windows
-@pytest.mark.parametrize(
-    "command_context, completions, lprefix, exp_append_space",
-    (
-        # date >/dev/nul<TAB>  ->  date >/dev/null
-        (
-            CommandContext(args=(CommandArg("date"),), arg_index=1, prefix=">/dev/nul"),
-            {"/dev/null"},
-            8,
-            True,
-        ),
-        # date 2>/dev/nul<TAB>  ->  date 2>/dev/null
-        (
-            CommandContext(
-                args=(CommandArg("date"),), arg_index=1, prefix="2>/dev/nul"
-            ),
-            {"/dev/null"},
-            8,
-            True,
-        ),
-        # date >>/dev/nul<TAB>  ->  date >>/dev/null
-        (
-            CommandContext(
-                args=(CommandArg("date"),), arg_index=1, prefix=">>/dev/nul"
-            ),
-            {"/dev/null"},
-            8,
-            True,
-        ),
-        # cat </dev/nul<TAB>  ->  cat </dev/null
-        (
-            CommandContext(args=(CommandArg("cat"),), arg_index=1, prefix="</dev/nul"),
-            {"/dev/null"},
-            8,
-            True,
-        ),
-    ),
-)
-def test_arg_prefix(command_context, completions, lprefix, exp_append_space):
-    bash_completions, bash_lprefix = complete_from_bash(
-        CompletionContext(command_context)
-    )
-    assert bash_completions == completions and bash_lprefix == lprefix
-    assert all(
-        isinstance(comp, RichCompletion) and comp.append_space == exp_append_space
-        for comp in bash_completions
-    )
-
-
 @pytest.fixture
 def bash_completer(fake_process):
     fake_process.register_subprocess(

--- a/tests/completers/test_bash_completer.py
+++ b/tests/completers/test_bash_completer.py
@@ -234,6 +234,7 @@ def test_equal_sign_arg(command_context, completions, lprefix, exp_append_space)
         for comp in bash_completions
     )
 
+
 @skip_if_on_darwin
 @skip_if_on_windows
 @pytest.mark.parametrize(
@@ -248,14 +249,18 @@ def test_equal_sign_arg(command_context, completions, lprefix, exp_append_space)
         ),
         # date 2>/dev/nul<TAB>  ->  date 2>/dev/null
         (
-            CommandContext(args=(CommandArg("date"),), arg_index=1, prefix="2>/dev/nul"),
+            CommandContext(
+                args=(CommandArg("date"),), arg_index=1, prefix="2>/dev/nul"
+            ),
             {"/dev/null"},
             8,
             True,
         ),
         # date >>/dev/nul<TAB>  ->  date >>/dev/null
         (
-            CommandContext(args=(CommandArg("date"),), arg_index=1, prefix=">>/dev/nul"),
+            CommandContext(
+                args=(CommandArg("date"),), arg_index=1, prefix=">>/dev/nul"
+            ),
             {"/dev/null"},
             8,
             True,
@@ -279,13 +284,22 @@ def test_arg_prefix(command_context, completions, lprefix, exp_append_space):
         for comp in bash_completions
     )
 
+
 # git push origin :mai<TAB>  ->  git push origin :main
 def test_git_delete_remote_branch():
     # cd to xonsh directory to have a git repo with a remote branch
     test_file_dir = os.path.dirname(__file__)
     os.chdir(test_file_dir)
 
-    command_context = CommandContext(args=(CommandArg("git"), CommandArg("push"), CommandArg("origin"),), arg_index=3, prefix=":mai")
+    command_context = CommandContext(
+        args=(
+            CommandArg("git"),
+            CommandArg("push"),
+            CommandArg("origin"),
+        ),
+        arg_index=3,
+        prefix=":mai",
+    )
     bash_completions, bash_lprefix = complete_from_bash(
         CompletionContext(command_context)
     )

--- a/tests/test_completion_context.py
+++ b/tests/test_completion_context.py
@@ -130,7 +130,15 @@ COMMAND_EXAMPLES = (
     (
         f"command >/dev/nul{X}",
         CommandContext(
-            args=(CommandArg("command"), CommandArg(">")),
+            args=(CommandArg("command"), CommandArg(">", is_io_redir=True)),
+            arg_index=2,
+            prefix="/dev/nul",
+        ),
+    ),
+    (
+        f"command 2>/dev/nul{X}",
+        CommandContext(
+            args=(CommandArg("command"), CommandArg("2>", is_io_redir=True)),
             arg_index=2,
             prefix="/dev/nul",
         ),
@@ -138,7 +146,7 @@ COMMAND_EXAMPLES = (
     (
         f"command >>/dev/nul{X}",
         CommandContext(
-            args=(CommandArg("command"), CommandArg(">>")),
+            args=(CommandArg("command"), CommandArg(">>", is_io_redir=True)),
             arg_index=2,
             prefix="/dev/nul",
         ),
@@ -146,7 +154,7 @@ COMMAND_EXAMPLES = (
     (
         f"command </dev/nul{X}",
         CommandContext(
-            args=(CommandArg("command"), CommandArg("<")),
+            args=(CommandArg("command"), CommandArg("<", is_io_redir=True)),
             arg_index=2,
             prefix="/dev/nul",
         ),

--- a/tests/test_completion_context.py
+++ b/tests/test_completion_context.py
@@ -127,6 +127,30 @@ COMMAND_EXAMPLES = (
             suffix="b",
         ),
     ),
+    (
+        f"command >/dev/nul{X}",
+        CommandContext(
+            args=(CommandArg("command"), CommandArg(">")),
+            arg_index=2,
+            prefix="/dev/nul",
+        ),
+    ),
+    (
+        f"command >>/dev/nul{X}",
+        CommandContext(
+            args=(CommandArg("command"), CommandArg(">>")),
+            arg_index=2,
+            prefix="/dev/nul",
+        ),
+    ),
+    (
+        f"command </dev/nul{X}",
+        CommandContext(
+            args=(CommandArg("command"), CommandArg("<")),
+            arg_index=2,
+            prefix="/dev/nul",
+        ),
+    ),
 )
 
 EMPTY_COMMAND_EXAMPLES = (

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -432,6 +432,10 @@ def bash_completions(
     # to be incorrectly calculated, so it needs to be fixed here
     if "=" in prefix and "=" not in commprefix:
         strip_len = prefix.index("=") + 1
+    # Fix case where remote git branch is being deleted
+    # (e.g. 'git push origin :dev-branch')
+    elif ":" in prefix and ":" not in commprefix:
+        strip_len = prefix.index(":") + 1
 
     return out, max(len(prefix) - strip_len, 0)
 

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -432,6 +432,16 @@ def bash_completions(
     # to be incorrectly calculated, so it needs to be fixed here
     if "=" in prefix and "=" not in commprefix:
         strip_len = prefix.index("=") + 1
+    # Fix cases where stdout/stderr is being redirected (e.g. 'ls >out.txt')
+    elif ">" in prefix and ">" not in commprefix:
+        strip_len = prefix.rindex(">") + 1
+    # Fix cases where stdin is being redirected (e.g. 'cat <in.txt')
+    elif "<" in prefix and "<" not in commprefix:
+        strip_len = prefix.rindex("<") + 1
+    # Fix case where remote git branch is being deleted
+    # (e.g. 'git push origin :dev-branch')
+    elif ":" in prefix and ":" not in commprefix:
+        strip_len = prefix.index(":") + 1
 
     return out, max(len(prefix) - strip_len, 0)
 

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -432,16 +432,6 @@ def bash_completions(
     # to be incorrectly calculated, so it needs to be fixed here
     if "=" in prefix and "=" not in commprefix:
         strip_len = prefix.index("=") + 1
-    # Fix cases where stdout/stderr is being redirected (e.g. 'ls >out.txt')
-    elif ">" in prefix and ">" not in commprefix:
-        strip_len = prefix.rindex(">") + 1
-    # Fix cases where stdin is being redirected (e.g. 'cat <in.txt')
-    elif "<" in prefix and "<" not in commprefix:
-        strip_len = prefix.rindex("<") + 1
-    # Fix case where remote git branch is being deleted
-    # (e.g. 'git push origin :dev-branch')
-    elif ":" in prefix and ":" not in commprefix:
-        strip_len = prefix.index(":") + 1
 
     return out, max(len(prefix) - strip_len, 0)
 

--- a/xonsh/parsers/completion_context.py
+++ b/xonsh/parsers/completion_context.py
@@ -328,8 +328,14 @@ class CompletionContextParser:
         "OR",
     }
     used_tokens |= multi_tokens
+    redir_tokens = {
+        "GT",
+    }
+    used_tokens |= redir_tokens
     artificial_tokens = {"ANY"}
     ignored_tokens = {"INDENT", "DEDENT", "WS"}
+
+    redir_raw_strings = {">"}
 
     def __init__(
         self,
@@ -727,7 +733,10 @@ class CompletionContextParser:
         joined_raw = f"{last_arg.value.raw_value}{in_between}{new_arg.value.raw_value}"
         string_literal = self.try_parse_string_literal(joined_raw)
 
-        if string_literal is not None or not in_between:
+        is_redir = new_arg.value.raw_value in self.redir_raw_strings
+        is_redir |= last_arg.value.raw_value in self.redir_raw_strings
+
+        if string_literal is not None or (not in_between and not is_redir):
             if string_literal is not None:
                 # we're appending to a partial string, e.g. `"a b`
                 arg = string_literal

--- a/xonsh/parsers/completion_context.py
+++ b/xonsh/parsers/completion_context.py
@@ -329,13 +329,15 @@ class CompletionContextParser:
     }
     used_tokens |= multi_tokens
     redir_tokens = {
+        "LT",
         "GT",
+        "RIGHTSHIFT",
     }
     used_tokens |= redir_tokens
     artificial_tokens = {"ANY"}
     ignored_tokens = {"INDENT", "DEDENT", "WS"}
 
-    redir_raw_strings = {">"}
+    redir_raw_strings = {"<", ">", ">>"}
 
     def __init__(
         self,


### PR DESCRIPTION
This fixes a bug in bash completion when the argument being completed was prefixed with certain characters such as when piping output to a file.

For example, `ls >/dev/nul<TAB>` would complete to `ls >/dev/nu/dev/null` instead of `ls >/dev/null`.

I noticed that issue #2976 was related, so I fixed it as well.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
