### PR TITLE
Fix ExecAlias return value

### DIFF
--- a/news/fix-execalias_rtn.rst
+++ b/news/fix-execalias_rtn.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ExecAlias now sets the returncode of a command correctly
+
+**Security:**
+
+* <news item>

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -188,6 +188,17 @@ def test_exec_alias_args(xession):
     assert stack[0][0].f_locals["myarg0"] == "arg0"
 
 
+@pytest.mark.parametrize(
+    "exp_rtn",
+    [0, 1, 2],
+)
+def test_exec_alias_return_value(exp_rtn, xonsh_session, monkeypatch):
+    monkeypatch.setitem(xonsh_session.env, "RAISE_SUBPROC_ERROR", False)
+    stack = inspect.stack()
+    rtn = ExecAlias(f"python -c 'exit({exp_rtn})'")([], stack=stack)
+    assert rtn == exp_rtn
+
+
 def test_register_decorator(xession):
     aliases = Aliases()
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -255,6 +255,8 @@ class ExecAlias:
                 locs=frame.f_locals,
                 filename=self.filename,
             )
+        if XSH.history is not None:
+            return XSH.history.last_cmd_rtn
 
     def __repr__(self):
         return f"ExecAlias({self.src!r}, filename={self.filename!r})"


### PR DESCRIPTION
Fixes part of the ExecAlias issue described in #4752 

This PR fixes the returncode of an ExecAlias, but the stdin/stdout are still not set properly.
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
