### PR TITLE
fix(pyghooks): Fix some errors caused by an unset Xonsh session env when using XonshLexer as a Pygments plugin.

### DIFF
--- a/news/xonshlexer-fix.rst
+++ b/news/xonshlexer-fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed error caused by unintialized Xonsh session env when using Xonsh as a library just for its Pygments lexer plugin.
+
+**Security:**
+
+* <news item>

--- a/tests/test_pyghooks.py
+++ b/tests/test_pyghooks.py
@@ -9,8 +9,10 @@ import pytest
 from xonsh.environ import LsColors
 from xonsh.platform import ON_WINDOWS
 from xonsh.pyghooks import (
+    XSH,
     Color,
     Token,
+    XonshLexer,
     XonshStyle,
     code_by_name,
     color_file,
@@ -388,3 +390,15 @@ def test_register_custom_pygments_style(name, styles, refrules):
     for rule, color in refrules.items():
         assert rule in style.styles
         assert style.styles[rule] == color
+
+
+def test_can_use_xonsh_lexer_without_xession(xession, monkeypatch):
+    # When Xonsh is used as a library and simply for its lexer plugin, the
+    # xession's env can be unset, so test that it can yield tokens without
+    # that env being set.
+    monkeypatch.setattr(xession, "env", None)
+
+    assert XSH.env is None
+    lexer = XonshLexer()
+    assert XSH.env is not None
+    list(lexer.get_tokens_unprocessed("  some text"))

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1644,7 +1644,7 @@ class XonshLexer(Python3Lexer):
     def __init__(self, *args, **kwargs):
         # If the lexer is loaded as a pygment plugin, we have to mock
         # __xonsh__.env and __xonsh__.commands_cache
-        if not hasattr(XSH, "env"):
+        if getattr(XSH, "env", None) is None:
             XSH.env = {}
             if ON_WINDOWS:
                 pathext = os_environ.get("PATHEXT", [".EXE", ".BAT", ".CMD"])


### PR DESCRIPTION
Fixes #4859 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
