### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -31,7 +31,7 @@ You may also set the interpreter used to create the virtual environment by passi
 
 Under the hood, vox uses Python 3's ``venv`` module to create Python 3 virtualenvs. [this is the default]
 
-If a Python 2 intrepreter is chosen, it will use the Python 2 interpreter's ``virtualenv`` module.
+If a Python 2 interpreter is chosen, it will use the Python 2 interpreter's ``virtualenv`` module.
 
 By default, environments are stored in ``~/.virtualenvs``, but you can override it by setting the ``$VIRTUALENV_HOME`` environment variable.
 

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ class xbuild_py(build_py):
 class xbdist(bdist_wheel):
     def initialize_options(self):
         super().initialize_options()
-        # becuase XonshParser will be build for each minor python version, we need separate builds
+        # because XonshParser will be build for each minor python version, we need separate builds
         self.python_tag = python_tag()
 
 

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -301,7 +301,7 @@ class SubprocSpec:
         universal_newlines : bool
             Whether or not to use universal newlines.
         close_fds : bool
-            Whether or not to close the file descriptiors when the
+            Whether or not to close the file descriptors when the
             process exits.
         captured : bool or str, optional
             The flag for if the subprocess is captured, may be one of:

--- a/xontrib/abbrevs.py
+++ b/xontrib/abbrevs.py
@@ -1,7 +1,7 @@
 """
 Command abbreviations.
 
-This expands input words from `abbrevs` disctionary as you type.
+This expands input words from `abbrevs` dictionary as you type.
 Adds ``abbrevs`` dictionary to hold user-defined "command abbreviations.
 The dictionary is searched as you type the matching words are replaced
 at the command line by the corresponding dictionary contents once you hit


### PR DESCRIPTION
There are small typos in:
- docs/python_virtual_environments.rst
- setup.py
- xonsh/procs/specs.py
- xontrib/abbrevs.py

Fixes:
- Should read `interpreter` rather than `intrepreter`.
- Should read `dictionary` rather than `disctionary`.
- Should read `descriptors` rather than `descriptiors`.
- Should read `because` rather than `becuase`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md