### PR TITLE
Update index.html: actual docker command

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -393,7 +393,8 @@ chmod +x xonsh-x86_64.AppImage
                                     <p>
                                     Run the xonsh shell in a small size docker container:
                                     </p>
-                                    <pre class="code">docker run -it --rm xonsh/xonsh:slim</pre>
+                                    <pre class="code">docker run --rm -it python:3.9-slim /bin/bash \<br>
+ -c "pip install 'xonsh[full]' && xonsh"</pre>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Sad but [xonsh docker container is not supported by docker hub maintainer](https://github.com/xonsh/container/issues/3#issuecomment-1198878977).

So this PR is to replace the docker command to the actual way to get fresh xonsh in docker.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
