### PR TITLE
Fix job control for callable aliases

### DIFF
--- a/news/fix-callable-alias-subproc.rst
+++ b/news/fix-callable-alias-subproc.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* A callable alias containing subprocess commands no longer freezes when piped to another command
+* ``less`` no longer stops when a callable alias containing subprocess commands is piped into it
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -588,6 +588,58 @@ xexec python3 -c 'import os; print(os.environ["SHLVL"])' # == 4
 """,
         0,
     ),
+    # test $() inside piped callable alias
+    (
+        r"""
+def _callme(args):
+    result = $(python -c 'print("tree");print("car")')
+    print(result[::-1])
+    print('one\ntwo\nthree')
+
+aliases['callme'] = _callme
+callme | grep t
+""",
+        """eert
+two
+three
+""",
+        0,
+    ),
+    # test ![] inside piped callable alias
+    (
+        r"""
+def _callme(args):
+    python -c 'print("tree");print("car")'
+    print('one\ntwo\nthree')
+
+aliases['callme'] = _callme
+callme | grep t
+""",
+        """tree
+two
+three
+""",
+        0,
+    ),
+    # test $[] inside piped callable alias
+    pytest.param(
+        (
+            r"""
+def _callme(args):
+    $[python -c 'print("tree");print("car")']
+    print('one\ntwo\nthree')
+
+aliases['callme'] = _callme
+callme | grep t
+""",
+            """tree
+two
+three
+""",
+            0,
+        ),
+        marks=pytest.mark.xfail(reason="$[] does not send stdout through the pipe"),
+    ),
 ]
 
 if not ON_WINDOWS:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -31,6 +31,6 @@ def test_disown_completion(
     }
     all_jobs = {1: job, 2: job}
 
-    monkeypatch.setattr(xsh_with_aliases, "all_jobs", all_jobs)
-    monkeypatch.setattr(jobs, "tasks", [2, 1])
+    monkeypatch.setattr(jobs._jobs_thread_local, "jobs", all_jobs, raising=False)
+    monkeypatch.setattr(jobs._jobs_thread_local, "tasks", [2, 1], raising=False)
     assert check_completer(args, prefix=prefix) == exp

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -13,9 +13,9 @@ from xonsh.pytest.tools import skip_if_on_unix, skip_if_on_windows
 
 @pytest.fixture(autouse=True)
 def patched_events(monkeypatch, xonsh_events, xonsh_session):
-    from xonsh.jobs import tasks
+    from xonsh.jobs import get_tasks
 
-    tasks.clear()
+    get_tasks().clear()
     # needed for ci tests
     monkeypatch.setitem(
         xonsh_session.env, "RAISE_SUBPROC_ERROR", False

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -21,18 +21,16 @@ from xonsh.tools import on_main_thread, unthreadable
 # exit can kill all jobs and exit.
 _last_exit_time: tp.Optional[float] = None
 
+# Thread-local data for job control. Allows threadable callable aliases
+# (ProcProxyThread) to maintain job control information separate from the main
+# thread.
+#
+# _jobs_thread_local.tasks is a queue used to keep track of the tasks. On
+# the main thread, it is set to _tasks_main.
+#
+# _jobs_thread_local.jobs is a dictionary used to keep track of the jobs.
+# On the main thread, it is set to XSH.all_jobs.
 _jobs_thread_local = threading.local()
-
-# Queue used to keep track of the tasks.
-# This is thread local, so threadable callable aliases (ProcProxyThread) each
-# get their own separate queues.
-_jobs_thread_local.tasks: tp.Deque[int]
-
-# Dictionary used to keep track of the jobs.
-# It is thread local. On the main thread, it is set to XSH.all_jobs,
-# whereas in a threadable callable alias (ProcProxyThread), it is a
-# separate dictionary.
-_jobs_thread_local.jobs: tp.Dict[int, tp.Dict]
 
 # Task queue for the main thread
 # The use_main_jobs context manager uses this variable to access the tasks on

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -152,6 +152,13 @@ class CommandPipeline:
 
         background = self.spec.background
         pipeline_group = None
+        if xp.ON_POSIX and not xt.on_main_thread():
+            # If we are inside a ProcProxyThread, then run commands in the same
+            # process group as xonsh. This fixes case 2 of issue #4277, where
+            # the terminal is given to a command inside the ProcProxyThread,
+            # taking the terminal away from the `less` command, causing `less`
+            # to stop.
+            pipeline_group = os.getpgid(0)
         for spec in specs:
             if self.starttime is None:
                 self.starttime = time.time()

--- a/xonsh/pytest/plugin.py
+++ b/xonsh/pytest/plugin.py
@@ -20,7 +20,7 @@ from xonsh.built_ins import XSH, XonshSession
 from xonsh.completer import Completer
 from xonsh.events import events
 from xonsh.execer import Execer
-from xonsh.jobs import tasks
+from xonsh.jobs import get_tasks
 from xonsh.main import setup
 from xonsh.parsers.completion_context import CompletionContextParser
 
@@ -228,7 +228,7 @@ def xonsh_session(xonsh_events, session_execer, os_env, monkeypatch):
     )
     yield XSH
     XSH.unload()
-    tasks.clear()  # must to this to enable resetting all_jobs
+    get_tasks().clear()  # must do this to enable resetting all_jobs
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #4277
Fixes #4281

## Problem
Piping a callable alias containing a subprocess call into another command is currently broken. This is because the job control inside the callable alias gets confused by the main thread's job control. For example, the following example is given in #4277:
```xonsh
def _callme(args):
    $(echo 1)
    print('one\ntwo\nthree')

aliases['callme'] = _callme
callme | grep t
```
After the callable alias `callme` spawns the `echo 1` command, it calls `wait_for_active_job`:
https://github.com/xonsh/xonsh/blob/1e20ee04c83389500a6328262af83982e35e865e/xonsh/jobs.py#L200-L230
The first active job is `echo 1`. `wait_for_active_job` correctly waits for `echo 1` to complete, and then it starts waiting for the *next* active job, which it determines is the `grep t` command. This causes a deadlock because the `grep` command is still waiting for more input from `callme`, but `callme` is stuck inside the `wait_for_active_job` function waiting for `grep` to finish.

## Solution
This PR solves this problem by separating callable alias' job control from the main thread's job control. It makes the job control variables `jobs` and `tasks` thread-local. This way, callable aliases can manage their own jobs without getting affected by what is happening on the main thread. In the `callme | grep t` example, the `wait_for_active_job` call inside `callme` would wait for `echo 1` to complete, and since there would be no other jobs on the thread, it would return. This would avoid the deadlock.

An issue with making the job control thread-local is that threaded commands such as `jobs`, `bg`, and `disown` stop working because they need access to the main thread's job control. This is solved using the `use_main_jobs` context manager, which temporarily replaces a thread's job control information with that of the main thread.

Apart from the callable alias job control issue, there are two other minor issues:

1. (Addressed in this PR) In case 2 of #4277, the `less` command doesn't work because xonsh uses `give_terminal_to` inside the callable alias to give the terminal to the `echo` command. This takes the terminal away from the `less` command, causing it to stop. [This issue is addressed in this PR by making `echo` run in the same process group as xonsh.](https://github.com/xonsh/xonsh/commit/6ef2084448b83d974f17578d828336827724efcb)
2. (Not addressed in this PR) When `$[]` is used inside a callable alias, it does not properly redirect its output to the callable alias' output. [This is demonstrated in the integration test that I have marked as `xfail`](https://github.com/xonsh/xonsh/blob/52b4bacec276117e544acabd906612834dabea58/tests/test_integrations.py#L624-L642). I'll also make a separate issue for this.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
