### PR TITLE
Fix virtualenv Path import and bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ test = [
     "pygments>=2.2",
     "coverage>=5.3.1",
     "pyte>=0.8.0",
-    "virtualenv>=20.7.2",
+    "virtualenv>=20.16.2",
 ]
 dev = [
     "xonsh[test,doc]",

--- a/xonsh/virtualenv/__init__.py
+++ b/xonsh/virtualenv/__init__.py
@@ -1,5 +1,6 @@
+from pathlib import Path
+
 from virtualenv.activation.via_template import ViaTemplateActivator  # type: ignore
-from virtualenv.util.path import Path  # type: ignore
 
 
 class XonshActivator(ViaTemplateActivator):


### PR DESCRIPTION
This should fix the failing `tests/test_virtualenv_activator.py::test_xonsh_activator` test

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
