### PR TITLE
fix(styles): fall back to default style if style not found

### DIFF
--- a/news/dont_crash_without_pygments.rst
+++ b/news/dont_crash_without_pygments.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Warn and continue if a user without ``pygments`` tries to load an unknown style
+
+**Security:**
+
+* <news item>

--- a/xonsh/ansi_colors.py
+++ b/xonsh/ansi_colors.py
@@ -1149,7 +1149,8 @@ def ansi_style_by_name(name):
     if name in ANSI_STYLES:
         return ANSI_STYLES[name]
     elif not HAS_PYGMENTS:
-        raise KeyError(f"could not find style {name!r}")
+        print(f"could not find style {name!r}, using 'default'")
+        return ANSI_STYLES["default"]
     from pygments.util import ClassNotFound
 
     from xonsh.pygments_cache import get_style_by_name


### PR DESCRIPTION
The fallback is already the default behavior if the user has `pygments`
installed, but if they don't we were awkwardly bailing out here and
preventing startup.

Fixes #4905

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
