### PR TITLE
Update terminal title before executing subprocess

### DIFF
--- a/news/fix-term-title-update.rst
+++ b/news/fix-term-title-update.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The terminal's title is updated with the current command's name even if the command is a captured command or a callable alias
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* When using the sway window manager, ``swaymsg -t get_inputs`` no longer fails with the error "Unable to receive IPC response"
+* The ``current_job`` variable now works as expected when used in ``$TITLE``
+
+**Security:**
+
+* <news item>

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from xonsh.prompt import env as prompt_env
-from xonsh.prompt.base import PromptFields, PromptFormatter
+from xonsh.prompt.base import PromptField, PromptFields, PromptFormatter
 
 
 @pytest.fixture
@@ -40,8 +40,10 @@ def test_format_prompt(inp, exp, fields, formatter, xession):
             "a_string": "cats",
             "a_number": 7,
             "empty": "",
-            "current_job": (lambda: "sleep"),
+            "a_function": (lambda: "hello"),
+            "current_job": PromptField(value="sleep"),
             "none": (lambda: None),
+            "none_pf": PromptField(value=None),
         }
     ],
 )
@@ -49,7 +51,9 @@ def test_format_prompt(inp, exp, fields, formatter, xession):
     "inp, exp",
     [
         ("{a_number:{0:^3}}cats", " 7 cats"),
+        ("{a_function:{} | }xonsh", "hello | xonsh"),
         ("{current_job:{} | }xonsh", "sleep | xonsh"),
+        ("{none_pf:{} | }xonsh", "xonsh"),
         ("{none:{} | }{a_string}{empty:!}", "cats!"),
         ("{none:{}}", ""),
         ("{{{a_string:{{{}}}}}}", "{{cats}}"),

--- a/tests/prompt/test_job.py
+++ b/tests/prompt/test_job.py
@@ -1,0 +1,13 @@
+def test_current_job(xession):
+    prompts = xession.env["PROMPT_FIELDS"]
+    cmds = (["echo", "hello"], "|", ["grep", "h"])
+
+    prompts.reset()
+    assert format(prompts.pick("current_job")) == ""
+
+    with prompts["current_job"].update_current_cmds(cmds):
+        prompts.reset()
+        assert format(prompts.pick("current_job")) == "grep"
+
+    prompts.reset()
+    assert format(prompts.pick("current_job")) == ""

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -757,17 +757,8 @@ class HiddenCommandPipeline(CommandPipeline):
         return ""
 
 
-def pause_call_resume(p, f, *args, **kwargs):
-    """For a process p, this will call a function f with the remaining args and
-    and kwargs. If the process cannot accept signals, the function will be called.
-
-    Parameters
-    ----------
-    p : Popen object or similar
-    f : callable
-    args : remaining arguments
-    kwargs : keyword arguments
-    """
+def resume_process(p):
+    """Sends SIGCONT to a process if possible."""
     can_send_signal = (
         hasattr(p, "send_signal")
         and xp.ON_POSIX
@@ -776,15 +767,9 @@ def pause_call_resume(p, f, *args, **kwargs):
     )
     if can_send_signal:
         try:
-            p.send_signal(signal.SIGSTOP)
+            p.send_signal(signal.SIGCONT)
         except PermissionError:
             pass
-    try:
-        f(*args, **kwargs)
-    except Exception:
-        pass
-    if can_send_signal:
-        p.send_signal(signal.SIGCONT)
 
 
 class PrevProcCloser(threading.Thread):

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -16,7 +16,6 @@ import xonsh.jobs as xj
 import xonsh.lazyasd as xl
 import xonsh.lazyimps as xli
 import xonsh.platform as xp
-import xonsh.prompt.job as xpj
 import xonsh.tools as xt
 from xonsh.built_ins import XSH
 from xonsh.procs.pipelines import (
@@ -885,8 +884,8 @@ def run_subproc(cmds, captured=False, envs=None):
     specs = cmds_to_specs(cmds, captured=captured, envs=envs)
     if _should_set_title():
         # context manager updates the command information that gets
-        # accessed by _current_job() when setting the terminal's title
-        with xpj.update_current_cmds(cmds):
+        # accessed by CurrentJobField when setting the terminal's title
+        with XSH.env["PROMPT_FIELDS"]["current_job"].update_current_cmds(cmds):
             # remove current_job from prompt level cache
             XSH.env["PROMPT_FIELDS"].reset_key("current_job")
             # The terminal's title needs to be set before starting the

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -887,8 +887,8 @@ def run_subproc(cmds, captured=False, envs=None):
         # context manager updates the command information that gets
         # accessed by _current_job() when setting the terminal's title
         with xpj.update_current_cmds(cmds):
-            # clear prompt level cache
-            XSH.env["PROMPT_FIELDS"].reset()
+            # remove current_job from prompt level cache
+            XSH.env["PROMPT_FIELDS"].reset_key("current_job")
             # The terminal's title needs to be set before starting the
             # subprocess to avoid accidentally answering interactive questions
             # from commands such as `rm -i` (see #1436)

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -331,7 +331,7 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
             _replace_home_cwd,
         )
         from xonsh.prompt.env import env_name, vte_new_tab_cwd
-        from xonsh.prompt.job import _current_job
+        from xonsh.prompt.job import CurrentJobField
         from xonsh.prompt.times import _localtime
         from xonsh.prompt.vc import branch_bg_color, branch_color, current_branch
 
@@ -349,7 +349,7 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
                 curr_branch=current_branch,
                 branch_color=branch_color,
                 branch_bg_color=branch_bg_color,
-                current_job=_current_job,
+                current_job=CurrentJobField(name="current_job"),
                 env_name=env_name,
                 env_prefix="(",
                 env_postfix=") ",

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -403,6 +403,10 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
         """the results are cached and need to be reset between prompts"""
         self._cache.clear()
 
+    def reset_key(self, key):
+        """remove a single key from the cache (if it exists)"""
+        self._cache.pop(key, None)
+
 
 class BasePromptField:
     value = ""

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -252,7 +252,7 @@ def _format_value(val, spec, conv) -> str:
     and 'current_job' returns 'sleep', the result is 'sleep | ', and if
     'current_job' returns None, the result is ''.
     """
-    if val is None:
+    if val is None or (isinstance(val, BasePromptField) and val.value is None):
         return ""
     val = xt.FORMATTER.convert_field(val, conv)
 

--- a/xonsh/prompt/job.py
+++ b/xonsh/prompt/job.py
@@ -1,8 +1,9 @@
 """Prompt formatter for current jobs"""
 
 import contextlib
+import typing as tp
 
-_current_cmds = None
+_current_cmds: tp.Optional[list] = None
 
 
 @contextlib.contextmanager

--- a/xonsh/prompt/job.py
+++ b/xonsh/prompt/job.py
@@ -1,14 +1,26 @@
 """Prompt formatter for current jobs"""
 
-import xonsh.jobs as xj
+import contextlib
+
+_current_cmds = None
+
+
+@contextlib.contextmanager
+def update_current_cmds(cmds):
+    """Context manager that updates the information used by _current_job()"""
+    global _current_cmds
+    old_cmds = _current_cmds
+    try:
+        _current_cmds = cmds
+        yield
+    finally:
+        _current_cmds = old_cmds
 
 
 def _current_job():
-    j = xj.get_next_task()
-    if j is not None:
-        if not j["bg"]:
-            cmd = j["cmds"][-1]
-            s = cmd[0]
-            if s == "sudo" and len(cmd) > 1:
-                s = cmd[1]
-            return s
+    if _current_cmds is not None:
+        cmd = _current_cmds[-1]
+        s = cmd[0]
+        if s == "sudo" and len(cmd) > 1:
+            s = cmd[1]
+        return s

--- a/xonsh/prompt/job.py
+++ b/xonsh/prompt/job.py
@@ -3,25 +3,28 @@
 import contextlib
 import typing as tp
 
-_current_cmds: tp.Optional[list] = None
+from xonsh.prompt.base import PromptField
 
 
-@contextlib.contextmanager
-def update_current_cmds(cmds):
-    """Context manager that updates the information used by _current_job()"""
-    global _current_cmds
-    old_cmds = _current_cmds
-    try:
-        _current_cmds = cmds
-        yield
-    finally:
-        _current_cmds = old_cmds
+class CurrentJobField(PromptField):
+    _current_cmds: tp.Optional[list] = None
 
+    def update(self, ctx):
+        if self._current_cmds is not None:
+            cmd = self._current_cmds[-1]
+            s = cmd[0]
+            if s == "sudo" and len(cmd) > 1:
+                s = cmd[1]
+            self.value = s
+        else:
+            self.value = None
 
-def _current_job():
-    if _current_cmds is not None:
-        cmd = _current_cmds[-1]
-        s = cmd[0]
-        if s == "sudo" and len(cmd) > 1:
-            s = cmd[1]
-        return s
+    @contextlib.contextmanager
+    def update_current_cmds(self, cmds):
+        """Context manager that updates the information used to update the job name"""
+        old_cmds = self._current_cmds
+        try:
+            self._current_cmds = cmds
+            yield
+        finally:
+            self._current_cmds = old_cmds

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -635,6 +635,8 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             return self.mlprompt
         env = XSH.env  # pylint: disable=no-member
         p = env.get("PROMPT")
+        # clear prompt level cache
+        env["PROMPT_FIELDS"].reset()
         try:
             p = self.prompt_formatter(p)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Fixes #4913 

#4913 was caused by the caching mechanism in `PromptFields`. The cache needs to be cleared in order for the current job's name to be updated in the terminal's title.
 
Fixes #4034 (I've tested `swaymsg` with this fix)

#4034 was caused by `swaymsg` being stopped by `pause_call_resume` in the middle of the `recv` system call. This PR eliminates the need to use `pause_call_resume` by setting the terminal's title before the job is started. See https://github.com/xonsh/xonsh/issues/4034#issuecomment-1207513794 for more details about the system call issue.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
