### PR TITLE
Do not capture unthreaded callable aliases run with `![]`

### DIFF
--- a/news/fix-procproxy-capture.rst
+++ b/news/fix-procproxy-capture.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* With ``$THREAD_SUBPROCS=False``: When a callable alias is executed with ``![]``, its standard output and standard error are no longer captured. This is because a separate thread is required in order to both capture the output and stream it to the terminal while the alias is running.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* With ``$THREAD_SUBPROCS=False``: When ``cd`` is used with an invalid directory, the error message is now correctly displayed.
+
+**Security:**
+
+* <news item>

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -168,12 +168,13 @@ def test_callable_alias_cls(thread_subprocs, xession):
     assert proc.f == obj
 
 
-def test_procproxy_not_captured(xession):
+@pytest.mark.parametrize("captured", ["hiddenobject", False])
+def test_procproxy_not_captured(xession, captured):
     xession.aliases["tst"] = lambda: 0
     cmds = (["tst", "/root"],)
 
     xession.env["THREAD_SUBPROCS"] = False
-    specs = cmds_to_specs(cmds, captured="hiddenobject")
+    specs = cmds_to_specs(cmds, captured)
 
     assert specs[0].cls is ProcProxy
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -166,3 +166,17 @@ def test_callable_alias_cls(thread_subprocs, xession):
     spec = cmds_to_specs(cmds, captured="stdout")[0]
     proc = spec.run()
     assert proc.f == obj
+
+
+def test_procproxy_not_captured(xession):
+    xession.aliases["tst"] = lambda: 0
+    cmds = (["tst", "/root"],)
+
+    xession.env["THREAD_SUBPROCS"] = False
+    specs = cmds_to_specs(cmds, captured="hiddenobject")
+
+    assert specs[0].cls is ProcProxy
+
+    # neither stdout nor stderr should be captured
+    assert specs[0].stdout is None
+    assert specs[0].stderr is None

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -737,7 +737,9 @@ def _update_last_spec(last):
         return
     callable_alias = callable(last.alias)
     if callable_alias:
-        pass
+        if last.cls is ProcProxy and captured == "hiddenobject":
+            # a ProcProxy run using ![] should not be captured
+            return
     else:
         cmds_cache = XSH.commands_cache
         thable = (


### PR DESCRIPTION
Fixes #4882

When `$THREAD_SUBPROCS=False`, `cd a_non_existent_directory` currently does not display an error message because xonsh silently captures the stderr.

When a callable alias that isn't threaded is run using `![]`, its output should not be captured because doing so requires a separate thread in order to both capture the output and stream the output to the terminal while the alias is running.
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
