### PR TITLE
Make gitstatus prompt field values `None` when there is no git repo

### DIFF
--- a/news/fix-gitstatus-no-git.rst
+++ b/news/fix-gitstatus-no-git.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* When there is no git repository, the values of all ``gitstatus`` prompt fields are now ``None``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* When there is no git repository, ``$PROMPT`` format strings like ``{gitstatus: hello {}}`` now work as expected.
+
+**Security:**
+
+* <news item>

--- a/tests/prompt/test_gitstatus.py
+++ b/tests/prompt/test_gitstatus.py
@@ -79,19 +79,14 @@ def test_gitstatus_clean(prompts, fake_proc):
 def test_no_git(prompts, fake_process, tmp_path):
     os.chdir(tmp_path)
     err = b"fatal: not a git repository (or any of the parent directories): .git"
-    for cmd in (
-        "git status --porcelain --branch",
-        "git rev-parse --git-dir",
-        "git diff --numstat",
-    ):
-        fake_process.register_subprocess(
-            command=cmd,
-            stderr=err,
-            returncode=128,
-        )
+    fake_process.register_subprocess(
+        command="git rev-parse --git-dir", stderr=err, returncode=128
+    )
 
-    exp = ""
-    assert prompts.pick_val("gitstatus.repo_path") == ""
-    assert format(prompts.pick("gitstatus")) == exp
-    assert _format_value(prompts.pick("gitstatus"), None, None) == exp
-    assert _format_value(prompts.pick("gitstatus"), "{}", None) == exp
+    # test that all gitstatus fields (gitstatus, gitstatus.branch,
+    # gitstatus.porceclain, etc) are None and are formatted correctly in a
+    # format string like {gitstatus: hello {}}
+    for field in prompts.get_fields(gitstatus):
+        assert prompts.pick_val(field) is None
+        assert _format_value(prompts.pick(field), None, None) == ""
+        assert _format_value(prompts.pick(field), "hello {}", None) == ""


### PR DESCRIPTION
Fixes #4900

This PR makes the values of all `gitstatus` prompt fields `None` when there is no git repository. This allows format strings like `{gitstatus: hello {}}` to work as expected.
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
