### PR TITLE
commands_cache: fix `_update_cmds_cache()`

### DIFF
--- a/news/fix_bug_in_cache.rst
+++ b/news/fix_bug_in_cache.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* _update_cmds_cache
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* fix `_update_cmds_cache()`
+
+**Security:**
+
+* <news item>

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -197,7 +197,8 @@ class CommandsCache(cabc.Mapping):
 
         for cmd, path in self._get_all_cmds(paths).items():
             key = cmd.upper() if ON_WINDOWS else cmd
-            allcmds[key] = (path, aliases.get(key, None))
+            if key not in allcmds:
+                allcmds[key] = (path, aliases.get(key, None))
 
         warn_cnt = env.get("COMMANDS_CACHE_SIZE_WARNING")
         if warn_cnt and len(allcmds) > warn_cnt:


### PR DESCRIPTION
Prevent adding the same path to `allcmds` when `key` already exists.
This could result is wrong command resolution.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
