### PR TITLE
fix: do not prepend `bg:` to `noinherit` style directives

### DIFF
--- a/news/no_background_inherit.rst
+++ b/news/no_background_inherit.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``pygments`` startup crash when incorrect prepending ``bg:`` to ``noinherit``
+  style directives
+
+**Security:**
+
+* <news item>

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -177,7 +177,10 @@ def color_name_to_pygments_code(name, styles):
             fgcolor = color
         else:
             fgcolor = styles[getattr(Color, color)]
-        res = "bg:" + fgcolor
+        if fgcolor == "noinherit":
+            res = "noinherit"
+        else:
+            res = f"bg:{fgcolor}"
     else:
         # have regular, non-background color
         mods = parts["modifiers"]


### PR DESCRIPTION
Pygments does not understand a "background" of `noinherit`, only `noinherit` -- so if we are setting `noinherit`, even for a background color, we do not prepend `bg:`

Fixes #4432 
Fixes #4934
