### PR TITLE
Added encoding="utf-8" to os.path.isfile(fname) 'with' statement

### DIFF
--- a/xonsh/webconfig/file_writes.py
+++ b/xonsh/webconfig/file_writes.py
@@ -52,7 +52,7 @@ def insert_into_xonshrc(
     # get current contents
     fname = os.path.expanduser(xonshrc)
     if os.path.isfile(fname):
-        with open(fname) as f:
+        with open(fname, encoding="utf-8") as f:
             s = f.read()
         before, _, s = s.partition(prefix)
         _, _, after = s.partition(suffix)


### PR DESCRIPTION
Using Windows, receive error when changing prompt via `xonfig web`:
```
Web config started at 'http://localhost:8421'. Hit Crtl+C to stop.
127.0.0.1 - - [10/Oct/2022 11:03:29] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [10/Oct/2022 11:03:29] code 404, message File not found
127.0.0.1 - - [10/Oct/2022 11:03:29] "GET /js/xonsh_sticker.svg HTTP/1.1" 404 -
127.0.0.1 - - [10/Oct/2022 11:03:31] "GET /prompts HTTP/1.1" 200 -
127.0.0.1 - - [10/Oct/2022 11:03:32] code 404, message File not found
127.0.0.1 - - [10/Oct/2022 11:03:32] "GET /js/xonsh_sticker.svg HTTP/1.1" 404 -
127.0.0.1 - - [10/Oct/2022 11:03:34] "GET /prompts?selected=default HTTP/1.1" 200 -
127.0.0.1 - - [10/Oct/2022 11:03:34] code 404, message File not found
127.0.0.1 - - [10/Oct/2022 11:03:34] "GET /js/xonsh_sticker.svg HTTP/1.1" 404 -
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 52861)
Traceback (most recent call last):
  File "C:\Python310\lib\socketserver.py", line 316, in _handle_request_noblock
    self.process_request(request, client_address)
  File "C:\Python310\lib\socketserver.py", line 347, in process_request
    self.finish_request(request, client_address)
  File "C:\Python310\lib\socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "C:\Python310\lib\http\server.py", line 658, in __init__
    super().__init__(*args, **kwargs)
  File "C:\Python310\lib\socketserver.py", line 747, in __init__
    self.handle()
  File "C:\Python310\lib\http\server.py", line 432, in handle
    self.handle_one_request()
  File "C:\Python310\lib\http\server.py", line 420, in handle_one_request
    method()
  File "C:\Python310\lib\site-packages\xonsh\webconfig\main.py", line 111, in do_POST
    new_route = route.post(data) or route
  File "C:\Python310\lib\site-packages\xonsh\webconfig\routes.py", line 244, in post
    self.update_rc(prompt=prompt)
  File "C:\Python310\lib\site-packages\xonsh\webconfig\routes.py", line 82, in update_rc
    insert_into_xonshrc(kwargs)
  File "C:\Python310\lib\site-packages\xonsh\webconfig\file_writes.py", line 56, in insert_into_xonshrc 
    s = f.read()
  File "C:\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 62: character maps to <undefined>
----------------------------------------
```

I believe specifying the encoding in the open statement should resolve this issue.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
