### PR TITLE
fix: web config tool including \r in prompt

### DIFF
--- a/xonsh/webconfig/file_writes.py
+++ b/xonsh/webconfig/file_writes.py
@@ -1,7 +1,7 @@
 """functions to update rc files"""
 import os
-import typing as tp
 import re
+import typing as tp
 
 RENDERERS: tp.List[tp.Callable] = []
 

--- a/xonsh/webconfig/file_writes.py
+++ b/xonsh/webconfig/file_writes.py
@@ -1,6 +1,7 @@
 """functions to update rc files"""
 import os
 import typing as tp
+import re
 
 RENDERERS: tp.List[tp.Callable] = []
 
@@ -39,7 +40,7 @@ def config_to_xonsh(
     for func in RENDERERS:
         lines.extend(func(config))
     lines.append(suffix)
-    return "\n".join(lines)
+    return re.sub(r"\\r", "", "\n".join(lines))
 
 
 def insert_into_xonshrc(

--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -1,9 +1,8 @@
 import cgi
 import inspect
+import re
 import sys
 from typing import TYPE_CHECKING
-
-import re
 
 from xonsh.environ import Env
 
@@ -241,7 +240,7 @@ class PromptsPage(Routes):
 
     def post(self, data: "cgi.FieldStorage"):
         if data:
-            prompt = data.getvalue(self.var_name).replace("\r","")
+            prompt = data.getvalue(self.var_name).replace("\r", "")
             self.env[self.var_name] = prompt
             self.update_rc(prompt=prompt)
 

--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -3,6 +3,8 @@ import inspect
 import sys
 from typing import TYPE_CHECKING
 
+import re
+
 from xonsh.environ import Env
 
 from ..built_ins import XonshSession
@@ -239,9 +241,12 @@ class PromptsPage(Routes):
 
     def post(self, data: "cgi.FieldStorage"):
         if data:
-            prompt = data.getvalue(self.var_name)
+            prompt = data.getvalue(self.var_name).replace("\r","")
             self.env[self.var_name] = prompt
             self.update_rc(prompt=prompt)
+
+    def ee(self, str):
+        return re.sub(r"\\r", "", str)
 
 
 class XontribsPage(Routes):

--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -244,6 +244,7 @@ class PromptsPage(Routes):
             self.env[self.var_name] = prompt
             self.update_rc(prompt=prompt)
 
+
 class XontribsPage(Routes):
     path = "/xontribs"
     nav_title = "Xontribs"

--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -244,10 +244,6 @@ class PromptsPage(Routes):
             self.env[self.var_name] = prompt
             self.update_rc(prompt=prompt)
 
-    def ee(self, str):
-        return re.sub(r"\\r", "", str)
-
-
 class XontribsPage(Routes):
     path = "/xontribs"
     nav_title = "Xontribs"

--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -1,6 +1,5 @@
 import cgi
 import inspect
-import re
 import sys
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

hi guys, this is my first commit. please let me know if i've done anything wrong :)

previously using the xonsh web config tool to set a prompt with a newline added "^M" at the end of the prompt. this fix strips all \r characters in the config file and strips all \r characters in the prompt page's post request.

closes #4960 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
