### PR TITLE
Fix auto-suggestion completion stacking if no normal completion exists

### DIFF
--- a/news/4668-fix-autocomplete-suggest.rst
+++ b/news/4668-fix-autocomplete-suggest.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* #4668 Fix ptk completion stacking when auto-suggest is on and no normal completions are generated.
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/completer.py
+++ b/xonsh/ptk_shell/completer.py
@@ -72,6 +72,7 @@ class PromptToolkitCompleter(Completer):
             if sug_comp is None:
                 pass
             elif len(completions) == 0:
+                plen = len(prefix)
                 completions = (sug_comp,)
             else:
                 completions = set(completions)


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->
Fixes #4668 

It's possible I missed some edge cases, worked fine on 2 simple tests:

```sh
# run once to add in history (expected fail)
$ test-missing-command
# then test completion
test-missing- #<TAB>
```

```sh
$ ssh foobar@non-existent-host
$ ssh foobar@non- #<TAB>
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
