### PR TITLE
Use interactive shell for generating completions

### DIFF
--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -386,7 +386,7 @@ def bash_completions(
         command = _bash_command(env=env)
     try:
         out = subprocess.check_output(
-            [command, "-c", script],
+            [command, "-i", "-c", script],
             text=True,
             stderr=subprocess.PIPE,
             env=env,


### PR DESCRIPTION
Non-interactive shells may not load all the appropriate config scripts to provide completions. Since completion is an interactive feature, it seems appropriate to ask interactive shell for completions. 

This should also make `$BASH_COMPLETIONS` largely unnecessary, since interactive shell will load whatever it needs.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
