### PR TITLE
commands_cache: ignore mtime check on non-darwin os

### DIFF
--- a/news/bugfix_commands_cache.rst
+++ b/news/bugfix_commands_cache.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* commands_cache: add a configurable value to disable cache. useful for running scripts
+
+**Security:**
+
+* <news item>

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -175,8 +175,10 @@ class CommandsCache(cabc.Mapping):
         updated = False
         for path in paths:
             modified_time = os.stat(path).st_mtime
-            if (path not in self._paths_cache) or (
-                self._paths_cache[path].mtime != modified_time
+            if (
+                (not self.env.get("ENABLE_COMMANDS_CACHE", True))
+                or (path not in self._paths_cache)
+                or (self._paths_cache[path].mtime != modified_time)
             ):
                 updated = True
                 self._paths_cache[path] = _Commands(

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -865,7 +865,7 @@ class GeneralSetting(Xettings):
     ENABLE_COMMANDS_CACHE = Var(
         default=True,
         doc="command names in a directory are cached when enabled.",
-        doc_default="It makes use of directory's modified time. "
+        doc_default="True"
         "On some platforms it may not be accurate enough"
         "(e.g. Windows, Linux save mtime in seconds). "
         "setting it to False would disable the caching mechanism "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -111,7 +111,6 @@ cause a recursion until the limit.
 """,
 )
 
-
 events.doc(
     "on_envvar_change",
     """
@@ -123,7 +122,6 @@ cause a recursion until the limit.
 """,
 )
 
-
 events.doc(
     "on_pre_spec_run_ls",
     """
@@ -133,7 +131,6 @@ Fires right before a SubprocSpec.run() is called for the ls
 command.
 """,
 )
-
 
 events.doc(
     "on_lscolors_change",
@@ -863,6 +860,16 @@ class GeneralSetting(Xettings):
     COMMANDS_CACHE_SAVE_INTERMEDIATE = Var.with_default(
         False,
         "If enabled, the CommandsCache is saved between runs and can reduce the startup time.",
+    )
+
+    ENABLE_COMMANDS_CACHE = Var(
+        default=True,
+        doc="command names in a directory are cached when enabled.",
+        doc_default="It makes use of directory's modified time. "
+        "On some platforms it may not be accurate enough"
+        "(e.g. Windows, Linux save mtime in seconds). "
+        "setting it to False would disable the caching mechanism "
+        "and may slow down the shell",
     )
 
     HOSTNAME = Var.with_default(


### PR DESCRIPTION
darwin's stat uses nano seconds accuracy for the files mtime property, whereas
on linux it returns a unix timestamp (seconds), meaning we cannot rely on that
field when checking for dir modifications per each path for creating `CommandsCache`.

consider the following shell script:

```shell
cp /path/to/executable /bin/new_executable

new_executable
```

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
