### PR TITLE
doc: remove references to deprecated RC location, update changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -355,6 +355,7 @@ v0.12.0
 
 **Changed:**
 
+* BREAKING CHANGE: ``/etc/xonshrc`` location for run control file has been deprecated in favor of ``/etc/xonsh/xonshrc``.
 * Both ``*.xsh`` and ``*.py`` files inside ``$XONSHRC_DIR`` will get loaded now.
 * Environment-variables of no predefined type or path environment variables are now represented as strings via the empty string.
 * Made stacktraces behave like in python, i.e. when something in user-provided code fails (both interactively and non-interactively), only that part is shown, and the (static) part of the stacktrace showing the location where the user code was called in xonsh remains hidden. When an unexpected exception occurs inside xonsh, everything is shown like before.

--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -56,7 +56,7 @@ which by default configures paths in bash and other POSIX or C  shells. Without
 including these paths, common tools including those installed by Homebrew
 may be unavailable. See ``/etc/profile`` for details on how it is done.
 To ensure the path helper is invoked on xonsh (for all users), add the
-following to ``/etc/xonshrc``:
+following to ``/etc/xonsh/xonshrc``:
 
 .. code-block:: xonshcon
 

--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -12,7 +12,7 @@ The control file usually contains:
 * `Alias definitions <aliases.html>`_, many of which invoke the above functions with specified arguments.
 
 The system-wide ``xonshrc`` file controls options that are applied to all users of Xonsh on a given system.
-You can create this file in ``/etc/xonshrc`` for Linux and OSX and in ``%ALLUSERSPROFILE%\xonsh\xonshrc`` on Windows.
+You can create this file in ``/etc/xonsh/xonshrc`` for Linux and OSX and in ``%ALLUSERSPROFILE%\xonsh\xonshrc`` on Windows.
 
 Xonsh also allows a per-user run control file in your home directory, either
 directly in the home directory at ``~/.xonshrc`` or, for XDG compliance, at ``~/.config/xonsh/rc.xsh``.


### PR DESCRIPTION
Updating docs to remove remaining references to deprecated RC location and added a (late) notice to the changelog about the breaking change.

cc @das-g @samlukeyes

xref #4761 #4635 