### PR TITLE
Fix incorrect IOREDIRECT tokens in Python mode

### DIFF
--- a/news/fix-pymode-ioredirect.rst
+++ b/news/fix-pymode-ioredirect.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Expressions like ``2>1`` are now parsed correctly as Python code instead of being treated like special io-redirection operators.
+
+**Security:**
+
+* <news item>

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -477,3 +477,36 @@ def test_tolerant_lexer(s):
     lexer.input(s)
     error_tokens = list(tok for tok in lexer if tok.type == "ERRORTOKEN")
     assert all(tok.value in s for tok in error_tokens)  # no error messages
+
+
+@pytest.mark.parametrize(
+    "s, exp",
+    [
+        ("2>1", [("NUMBER", "2", 0), ("GT", ">", 1), ("NUMBER", "1", 2)]),
+        ("a>b", [("NAME", "a", 0), ("GT", ">", 1), ("NAME", "b", 2)]),
+        (
+            "3>2>1",
+            [
+                ("NUMBER", "3", 0),
+                ("GT", ">", 1),
+                ("NUMBER", "2", 2),
+                ("GT", ">", 3),
+                ("NUMBER", "1", 4),
+            ],
+        ),
+        (
+            "36+2>>3",
+            [
+                ("NUMBER", "36", 0),
+                ("PLUS", "+", 2),
+                ("NUMBER", "2", 3),
+                ("RSHIFT", ">>", 4),
+                ("NUMBER", "3", 6),
+            ],
+        ),
+    ],
+)
+def test_pymode_not_ioredirect(s, exp):
+    # test that Python code like `2>1` is lexed correctly
+    # as opposed to being recognized as an IOREDIRECT token (issue #4994)
+    assert check_tokens(s, exp)

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -374,7 +374,7 @@ def handle_token(state, token):
         yield _new_token("ERRORTOKEN", m, token.start)
 
 
-def get_tokens(s, tolerant, tokenize_ioredirects=True):
+def get_tokens(s, tolerant, pymode=True, tokenize_ioredirects=True):
     """
     Given a string containing xonsh code, generates a stream of relevant PLY
     tokens using ``handle_token``.
@@ -382,7 +382,7 @@ def get_tokens(s, tolerant, tokenize_ioredirects=True):
     state = {
         "indents": [0],
         "last": None,
-        "pymode": [(True, "", "", (0, 0))],
+        "pymode": [(pymode, "", "", (0, 0))],
         "stream": tokenize(
             io.BytesIO(s.encode("utf-8")).readline, tolerant, tokenize_ioredirects
         ),
@@ -424,7 +424,7 @@ class Lexer:
 
     _tokens: tp.Optional[tuple[str, ...]] = None
 
-    def __init__(self, tolerant=False):
+    def __init__(self, tolerant=False, pymode=True):
         """
         Attributes
         ----------
@@ -437,12 +437,15 @@ class Lexer:
         tolerant : bool
             Tokenize without extra checks (e.g. paren matching).
             When True, ERRORTOKEN contains the erroneous string instead of an error msg.
+        pymode : bool
+            Start the lexer in Python mode.
 
         """
         self.fname = ""
         self.last = None
         self.beforelast = None
         self._tolerant = tolerant
+        self._pymode = pymode
         self._token_stream = iter(())
 
     @property
@@ -460,7 +463,7 @@ class Lexer:
 
     def input(self, s):
         """Calls the lexer on the string s."""
-        self._token_stream = get_tokens(s, self._tolerant)
+        self._token_stream = get_tokens(s, self._tolerant, self._pymode)
 
     def token(self):
         """Retrieves the next token."""

--- a/xonsh/parsers/completion_context.py
+++ b/xonsh/parsers/completion_context.py
@@ -350,7 +350,7 @@ class CompletionContextParser:
 
         self.error = None
         self.debug = debug
-        self.lexer = Lexer(tolerant=True)
+        self.lexer = Lexer(tolerant=True, pymode=False)
         self.tokens = tuple(self.used_tokens | self.artificial_tokens)
 
         yacc_kwargs = dict(


### PR DESCRIPTION
Fixes #4994 

## Problem

Currently, the tokenizer always recognizes `2>` as an `IOREDIRECT`, regardless of the context:
https://github.com/xonsh/xonsh/blob/a587e7ec8c92f3640a4f3a62a52845c3f75c81f7/xonsh/tokenize.py#L1012-L1013
As a result, when the Python expression `2>0`  is passed to the lexer, the output is
```python
[LexToken(IOREDIRECT,'2>',1,0), LexToken(NUMBER,'0',1,2)]
```
instead of
```python
[LexToken(NUMBER,'2',1,0), LexToken(GT,'>',1,1), LexToken(NUMBER,'0',1,2)]
```

## Solution

In this PR, when the lexer gets an `IOREDIRECT` token from the tokenizer, it checks whether the current state is Python mode. If it is not Python mode, then the lexer leaves the `IOREDIRECT` token unchanged and outputs it. If it *is* Python mode, then the token's string gets passed through the tokenizer again with the `tokenize_ioredirects=False` argument . There, the tokenizer uses the `PseudoTokenWithoutIO` regex instead of the `PseudoToken` regex to scan for the correct Python tokens.
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
