### PR TITLE
ci: Add 3.11 to CI and fix existing failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     name: Test Python ${{ matrix.python-version }} ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/tests/test_ptk_highlight.py
+++ b/tests/test_ptk_highlight.py
@@ -65,7 +65,7 @@ _cases = {
             (Literal.String.Double, "hello"),
             (Literal.String.Double, '"'),
             (Punctuation, ")"),
-            (Text, "\n"),
+            (Text.Whitespace, "\n"),
         ]
     },
     "invalid-cmd": {
@@ -111,7 +111,7 @@ _cases = {
             (Name.Builtin, "cd"),
             (Punctuation, ")"),
             (Punctuation, ")"),
-            (Text, "\n"),
+            (Text.Whitespace, "\n"),
         ],
         r'print(![echo "])\""])': [
             (Name.Builtin, "print"),
@@ -123,7 +123,7 @@ _cases = {
             (Literal.String.Double, '"])\\""'),
             (Punctuation, "]"),
             (Punctuation, ")"),
-            (Text, "\n"),
+            (Text.Whitespace, "\n"),
         ],
     },
     "subproc-args": {

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -817,7 +817,11 @@ def detect_xpip_alias():
             return basecmd
         elif IN_APPIMAGE:
             # In AppImage `sys.executable` is equal to path to xonsh.AppImage file and the real python executable is in $_
-            return [XSH.env.get("_", "APPIMAGE_PYTHON_EXECUTABLE_NOT_FOUND"), "-m", "pip"]
+            return [
+                XSH.env.get("_", "APPIMAGE_PYTHON_EXECUTABLE_NOT_FOUND"),
+                "-m",
+                "pip",
+            ]
         elif not os.access(os.path.dirname(sys.executable), os.W_OK):
             return (
                 sys.executable


### PR DESCRIPTION
~temporary fix while we sort out what broke upstream~

`Token.Text` for `\n` is now `Token.Text.Whitespace` -- doesn't really matter on our end since `prompt_toolkit` does the right thing, but I've updated the expected tokens in our tests.

Also adding 3.11 to CI, just to make things interesting.

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
