### PR TITLE
Add support for Fossil SCM branch names in vc.py.

### DIFF
--- a/news/vc.rst
+++ b/news/vc.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Display the current branch of Fossil VCS checkouts in the prompt,
+  similar to git and hg.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
The xonsh prompt now shows the currently active Fossil branch, while inside a Fossil checkout.

See also https://fossil-scm.org

The feature works similarly to how git and hg are currently handled: While inside a Fossil checkout, the currently active branch is shown in the prompt between the path and `$`.


Note: 

There are further possibilities for refactoring in [vc.py](https://github.com/xonsh/xonsh/blob/main/xonsh/prompt/vc.py). The old code used for git and hg uses manual thread management and passes data via queues to implement a command timeout. This can be replaced completely by using the `timeout` parameter of [`subprocess.check_output()`](https://docs.python.org/3/library/subprocess.html#subprocess.check_output). I guess the code once targeted Python < 3.3

I did not include the refactoring here, as that’s out of scope for this particular PR. If you wish, I can include that in follow-up commits or submit as a new PR.

Additional note:

The default value for `$VC_BRANCH_TIMEOUT` can be a little low. I run into it when switching branches with larger amount of differences

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
