### PR TITLE
history pull

### DIFF
--- a/docs/tutorial_hist.rst
+++ b/docs/tutorial_hist.rst
@@ -255,6 +255,13 @@ may be useful to share entries between shell sessions. In such a case, one can u
 the ``flush`` action to immediately save the session history to disk and make it
 accessible from other shell sessions.
 
+``pull`` action
+================
+Tries to pull the history from parallel sessions and add to the current session.
+
+For example if there are two parallel terminal windows the run of ``history pull``
+command from the second terminal window will get the commands from the first terminal.
+
 ``clear`` action
 ================
 Deletes the history from the current session up until this point. Later commands

--- a/news/history_pull.rst
+++ b/news/history_pull.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``history pull`` command to SQLite history backend to pull the history from parallel sessions into the current sessions.
+* Added ``history pull`` command to SQLite history backend to pull the history from parallel sessions and add to the current session.
 
 **Changed:**
 

--- a/news/history_pull.rst
+++ b/news/history_pull.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``history pull`` command to SQLite history backend to pull the history from parallel sessions into the current sessions.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -130,6 +130,10 @@ class History:
         """
         pass
 
+    def pull(self, **kwargs):
+        """Pull history from other parallel sessions."""
+        raise NotImplementedError
+
     def flush(self, **kwargs):
         """Flush the history items to disk from a buffer."""
         pass

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -282,6 +282,31 @@ class HistoryAlias(xcli.ArgParserAlias):
         print(str(hist.sessionid), file=_stdout)
 
     @staticmethod
+    def pull(show_commands=False, _stdout=None):
+        """Pull history from other parallel sessions.
+
+        Parameters
+        ----------
+        show_commands: -c, --show-commands
+            show pulled commands
+        """
+
+        hist = XSH.history
+
+        if hist.pull.__module__ == "xonsh.history.base":
+            backend = XSH.env.get("XONSH_HISTORY_BACKEND", "unknown")
+            print(
+                f"Pull method is not supported in {backend} history backend.",
+                file=_stdout,
+            )
+
+        lines_added = hist.pull(show_commands)
+        if lines_added:
+            print(f"Added {lines_added} records!", file=_stdout)
+        else:
+            print(f"No records found!", file=_stdout)
+
+    @staticmethod
     def flush(_stdout):
         """Flush the current history to disk"""
 
@@ -428,7 +453,7 @@ class HistoryAlias(xcli.ArgParserAlias):
 
         dest.flush()
 
-        self.out("done.")
+        self.out("Done")
 
     def build(self):
         parser = self.create_parser(prog="history")
@@ -436,6 +461,7 @@ class HistoryAlias(xcli.ArgParserAlias):
         parser.add_command(self.id_cmd, prog="id")
         parser.add_command(self.file)
         parser.add_command(self.info)
+        parser.add_command(self.pull)
         parser.add_command(self.flush)
         parser.add_command(self.off)
         parser.add_command(self.on)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -357,7 +357,7 @@ class SqliteHistory(History):
 
     def pull(self, show_commands=False):
         if not hasattr(XSH.shell.shell, "prompter"):
-            print(f"Prompt {XSH.shell.shell} is not supported.")
+            print(f"Shell type {XSH.shell.shell} is not supported.")
             return 0
 
         cnt = 0

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -356,6 +356,10 @@ class SqliteHistory(History):
         return data
 
     def pull(self, show_commands=False):
+        if not hasattr(XSH.shell.shell, "prompter"):
+            print(f"Prompt {XSH.shell.shell} is not supported.")
+            return 0
+
         cnt = 0
         for r in xh_sqlite_pull(
             self.filename, self.last_pull_time, str(self.sessionid)


### PR DESCRIPTION
Added `history pull` command to SQLite history backend to pull the history from parallel sessions into the current sessions.

To review just open two parallel terminal windows. Run a couple of commands in the first terminal window. Run `history pull` from the second terminal window to get the commands from the first terminal.

Closes #5044

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
