### PR TITLE
Update .gitignore: exclude xontrib/__init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ docs/envvarsbody
 docs/xontribsbody
 docs/eventsbody
 xonsh/dev.githash
+xontrib/__init__.py
 
 # temporary files from vim and emacs
 *~


### PR DESCRIPTION
subj

> xontrib is an implicit namespace package. DO NOT add an `__init__.py` file to this directory.

no news

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
