### PR TITLE
key_bindings: map `escape-right` as another word completer for macOS (#5056)

### DIFF
--- a/news/5056.rst
+++ b/news/5056.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* key_bindings: map `escape-f` as another word completer for macOS
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/ptk_shell/key_bindings.py
+++ b/xonsh/ptk_shell/key_bindings.py
@@ -429,4 +429,8 @@ def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
     # Complete a single auto-suggestion word
     create_alias([Keys.ControlRight], ["escape", "f"])
 
+    # since macOS uses Control as reserved, then we use the alt/option key instead
+    # which is mapped as the "escape" key
+    create_alias(["escape", "right"], ["escape", "f"])
+
     return key_bindings


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

Referencing #5056 

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
