### PR TITLE
Update robots.txt: remove outdated linux.html

### DIFF
--- a/docs/_static/robots.txt
+++ b/docs/_static/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /dev/
 Disallow: /docs-ahundt-sphinx
+Disallow: /linux.html


### PR DESCRIPTION
I noticed:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/1708680/219605487-24bcf0ab-eae7-477e-a6b8-5e9497ca96ff.png">

But https://xon.sh/linux.html - 404

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
