### PR TITLE
Add Semantic Prompt support to multiline continuation lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ include/
 venv/
 .venv*/
 
+# Python project version files
+.python-version
 
 # Mac
 .DS_Store

--- a/news/multil.rst
+++ b/news/multil.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add support for `Semantic Prompt <https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md>`_ for line continuations in multiline prompts via two environment variables: ``$MULTILINE_PROMPT_PRE`` (e.g., ``\x01\x1b]133;P;k=c\x07\x02``), and ``$MULTILINE_PROMPT_POS`` (e.g., ``\x01\x1b]133;B\x07\x02``) that are inserted before/after each continuation line 'dots' block to mark input
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1386,6 +1386,30 @@ class PromptSetting(Xettings):
         "Prompt text for 2nd+ lines of input, may be str or function which "
         "returns a str.",
     )
+    MULTILINE_PROMPT_PRE = Var(
+        is_string_or_callable,
+        ensure_string,
+        ensure_string,
+        "",
+        "Indicator inserted before the line continuation marks set "
+        "in ``$MULTILINE_PROMPT``. Can be used to mark the start of "
+        "a semantic continuation prompt "
+        "(see `Semantic Prompts <https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md>`_ "
+        "or `WezTerm <https://wezfurlong.org/wezterm/shell-integration.html>`_ "
+        "for more details). May be str or function which returns a str.",
+    )
+    MULTILINE_PROMPT_POS = Var(
+        is_string_or_callable,
+        ensure_string,
+        ensure_string,
+        "",
+        "Indicator inserted after the line continuation marks set "
+        "in ``$MULTILINE_PROMPT``. Can be used to mark the end of "
+        "a semantic continuation prompt and the beginning of user input "
+        "(see `Semantic Prompts <https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md>`_ "
+        "or `WezTerm <https://wezfurlong.org/wezterm/shell-integration.html>`_ "
+        "for more details). May be str or function which returns a str.",
+    )
     PRETTY_PRINT_RESULTS = Var.with_default(
         True,
         'Flag for "pretty printing" return values.',

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -471,7 +471,8 @@ class PromptToolkitShell(BaseShell):
         basetoks = self.format_color(dots)
         baselen = sum(len(t[1]) for t in basetoks)
         if baselen == 0:
-            return [(Token, " " * (width + 1))]
+            toks = [(Token, " " * (width + 1))]
+            return PygmentsTokens(toks)
         toks = basetoks * (width // baselen)
         n = width % baselen
         count = 0


### PR DESCRIPTION
This PR allows marking each line of the multiline continuation prompt to allow the terminal to separate user input from the `...` continuation dots and do something useful with it (e.g., select&copy all the multiline input that you can safely paste elsewhere)
It does so by adding two environment variables that other [xonribs](https://github.com/jnoortheen/xontrib-term-integrations/pull/9) can then use to insert invisible markers that a given terminal supports
(this also fixes a bug where an empty `{BLUE}` dots would lead to a concatenation error)

Tested it live, but don't understand how to make a proper test for this, tried to copy the `test_ptk_multiline.py`'s https://github.com/xonsh/xonsh/blob/eae3fcc255d9c540b3fae34a35e659f5fd7c1e7d/tests/test_ptk_multiline.py#L69

by adding 
```py
prefix = '\x01\x1b]133;P;k=c\x07\x02'
xession.env
envx["MULTILINE_PROMPT_PRE"] = prefix # or even a random "string" doesn't show up in the output
```

but it doesn't seem to have any effect as it's not running through that `continuation_tokens` path it seems, so any tips on which function to invoke to call the changed code path are welcome


Closes #5058

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
