### PR TITLE
Fix typo in help text for 'which'

### DIFF
--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -28,7 +28,7 @@ def _which_create_parser():
         "-s",
         "--skip-alias",
         action="store_true",
-        help="Do not search inxonsh.aliases",
+        help="Do not search in xonsh.aliases",
         dest="skip",
     )
     parser.add_argument(


### PR DESCRIPTION
I don't think this is really worthy of a changelog entry, let me know if you'd still prefer me to add one.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
