### PR TITLE
Moving `chdir` to `xonsh.tools`

### DIFF
--- a/news/tools_chdir.rst
+++ b/news/tools_chdir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``chdir`` to ``xonsh.tools``. This allows to use ``with chdir("dir"):`` to run commands block in the certain directory without manually cd-ing.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -11,9 +11,6 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 PARENT = os.path.dirname(HERE)
 
 
-
-
-
 def test_simple(xession):
     xession.env.update(dict(CDPATH=PARENT, PWD=PARENT))
     with chdir(PARENT):

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -1,22 +1,17 @@
 """Testing dirstack"""
 
 import os
-from contextlib import contextmanager
 
 import pytest  # noqa F401
 
 from xonsh import dirstack
+from xonsh.tools import chdir
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 PARENT = os.path.dirname(HERE)
 
 
-@contextmanager
-def chdir(adir):
-    old_dir = os.getcwd()
-    os.chdir(adir)
-    yield
-    os.chdir(old_dir)
+
 
 
 def test_simple(xession):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -37,7 +37,7 @@ import threading
 import traceback
 import typing as tp
 import warnings
-
+from contextlib import contextmanager
 
 # adding imports from further xonsh modules is discouraged to avoid circular
 # dependencies
@@ -52,8 +52,6 @@ from xonsh.platform import (
     os_environ,
     pygments_version_info,
 )
-
-from contextlib import contextmanager
 
 
 @contextmanager

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -38,6 +38,7 @@ import traceback
 import typing as tp
 import warnings
 
+
 # adding imports from further xonsh modules is discouraged to avoid circular
 # dependencies
 from xonsh import __version__
@@ -51,6 +52,16 @@ from xonsh.platform import (
     os_environ,
     pygments_version_info,
 )
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def chdir(adir):
+    old_dir = os.getcwd()
+    os.chdir(adir)
+    yield
+    os.chdir(old_dir)
 
 
 @functools.lru_cache(1)


### PR DESCRIPTION
Now you can use `chdir` from tools:
```xsh
from xonsh.tools import chdir

cd /tmp

pwd
# /tmp

with chdir("/"):
    pwd
    # /

pwd
# /tmp
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
