### PR TITLE
Using `repr(cmd)` for `command not found`

### DIFF
--- a/news/not_found_repr.rst
+++ b/news/not_found_repr.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The `command not found` error will show the ``repr(cmd)`` to uncover the cases when the command name has ``\n``, ``\t`` or not visible color codes and raises the error.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -201,7 +201,7 @@ def test_on_command_not_found_fires(xession):
     subproc = SubprocSpec.build(["xonshcommandnotfound"])
     with pytest.raises(XonshError) as expected:
         subproc.run()
-    assert "command not found: xonshcommandnotfound" in str(expected.value)
+    assert "command not found: 'xonshcommandnotfound'" in str(expected.value)
     assert fired
 
 
@@ -223,5 +223,5 @@ def test_on_command_not_found_doesnt_fire_in_non_interactive_mode(xession):
     subproc = SubprocSpec.build(["xonshcommandnotfound"])
     with pytest.raises(XonshError) as expected:
         subproc.run()
-    assert "command not found: xonshcommandnotfound" in str(expected.value)
+    assert "command not found: 'xonshcommandnotfound'" in str(expected.value)
     assert not fired

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -481,7 +481,7 @@ class SubprocSpec:
                     return self.cls(
                         ["man", cmd0.rstrip("?")], bufsize=bufsize, **kwargs
                     )
-            e = f"xonsh: subprocess mode: command not found: {cmd0}"
+            e = f"xonsh: subprocess mode: command not found: {repr(cmd0)}"
             env = XSH.env
             sug = xt.suggest_commands(cmd0, env)
             if len(sug.strip()) > 0:


### PR DESCRIPTION
The `command not found` error will show the ``repr(cmd)`` to uncover the cases when the command name has ``\n``, ``\t`` or not visible color codes and raises the error.

Before:

```xsh
# For example newbie don't know about @$() and trying to do something like this:

aliases['my'] = 'echo echo'

# BEFORE:

$(@(my))
# xonsh: subprocess mode: command not found: echo      <--- unclear output
#

# AFTER:

$(@(my))
# xonsh: subprocess mode: command not found: 'echo\n'   <-- pretty clear output
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
