### PR TITLE
fix: load autoloading (but not yet autoloaded) xontribs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ xonsh
     .. image:: https://repology.org/badge/tiny-repos/xonsh.svg
             :target: https://repology.org/project/xonsh/versions
             :alt: repology.org
-            
+
 First steps
 ***********
 
@@ -82,7 +82,7 @@ Jupyter-based interactive notebooks via `xontrib-jupyter <https://github.com/xon
 The xonsh shell community
 *************************
 
-The xonsh shell is developed by a community of volunteers and has no organization that can get grants, donations or additional support. There are few ways to help the xonsh shell: 
+The xonsh shell is developed by a community of volunteers and has no organization that can get grants, donations or additional support. There are few ways to help the xonsh shell:
 
 - `Write a tweet`_, post or an article to spread the good word about xonsh in the world.
 - Solve a `popular issue <https://github.com/xonsh/xonsh/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc>`_.

--- a/news/load_autoloaded.rst
+++ b/news/load_autoloaded.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* update load_xontrib pytest fixture to handle auto-loaded xontribs
+
+**Security:**
+
+* <news item>

--- a/xonsh/pytest/plugin.py
+++ b/xonsh/pytest/plugin.py
@@ -402,14 +402,16 @@ def load_xontrib():
     to_unload = []
 
     def wrapper(*names: str):
-        from xonsh.xontribs import xontribs_load
+        from xonsh.xontribs import xontrib_data, xontribs_load
+
+        xo_data = xontrib_data()
 
         for name in names:
-            module = f"xontrib.{name}"
+            module = xo_data[name]["module"]
             if module not in sys.modules:
                 to_unload.append(module)
 
-            _, stderr, res = xontribs_load([name])
+            _, stderr, res = xontribs_load([module], full_module=True)
             if stderr:
                 raise Exception(f"Failed to load xontrib: {stderr}")
         return

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -302,6 +302,7 @@ def xontrib_data():
             "name": xo_name,
             "loaded": xontrib.is_loaded,
             "auto": xontrib.is_auto_loaded,
+            "module": xontrib.module,
         }
 
     return dict(sorted(data.items()))


### PR DESCRIPTION
Xontrib template creates autoloaded xontribs in a `xontrib_X` folder instad of a `xontib/X.py`file, so you can't `xontrib load X` right after you install them

For example,
```xsh
# this works because xontrib is not autoloading, so installs in `xontrib/skim.py` which `xontrib load` can find right away
xpip install xontrib-skim
xontrib load skim
# this fails because xontrib is autoloading so it's install path is different `xontrib_cd` and can't be found by the current `xontrib load` resolution machinery
xpip install xontrib-cd
xontrib load cd
# you get the following errror:
# The following xontribs are enabled but not installed:
#   ['cd']
# Please make sure that they are installed correctly by checking https://xonsh.github.io/awesome-xontribs/
```

This also breaks **pytests**, so this PR 
Fixes: https://github.com/xonsh/xontrib-template/issues/22

I've added the extra module field data needed for this to work to `def xontrib_data():`, but haven't added it to the formatted output of the command `xontrib list` (not sure it's needed), though it's data-dumping friend `xontrib list -j` does include this new field

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
