### PR TITLE
Decorator to register function as an alias

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -99,6 +99,17 @@ class Aliases(cabc.MutableMapping):
 
         return wrapper
 
+    def add(self, func):
+        """Decorator to add function as an alias. Add `@aliases.add` before the `__my` function to register the `my` alias."""
+        if func.__name__.startswith("__"):
+            self[func.__name__[2:]] = func
+            return None
+        else:
+            print(
+                f'aliases.add: Function name must start from "__" instead of "{func.__name__}".'
+            )
+            return func
+    
     def get(self, key, default=None):
         """Returns the (possibly modified) value. If the key is not present,
         then `default` is returned.


### PR DESCRIPTION
We have pattern:
```xsh
def hello():                  # step 1
    echo world
aliases['hello'] = hello      # step 2
del hello                     # step 3

hello
# world
```
I want to simplify this. This PR adds decorator:
```xsh
@aliases.add                  # just step 1
def __hello():
    echo world

hello
# world
```
It looks pretty sane.

Note:
* The name of function should begin with `__` to avoid intersection between function name and alias.
* There will be `'__hello': None` in `globals()` after running this. 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
