### PR TITLE
Unset the default Semantic Prompt line continuation environment variables

### DIFF
--- a/news/multil.rst
+++ b/news/multil.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Unset the default line continuation environment variables (``$MULTILINE_PROMPT_PRE`` and ``$MULTILINE_PROMPT_POS``) to allow differentiating between user setting an empty value and not setting anything
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1390,7 +1390,7 @@ class PromptSetting(Xettings):
         is_string_or_callable,
         ensure_string,
         ensure_string,
-        "",
+        DefaultNotGiven,
         "Indicator inserted before the line continuation marks set "
         "in ``$MULTILINE_PROMPT``. Can be used to mark the start of "
         "a semantic continuation prompt "
@@ -1402,7 +1402,7 @@ class PromptSetting(Xettings):
         is_string_or_callable,
         ensure_string,
         ensure_string,
-        "",
+        DefaultNotGiven,
         "Indicator inserted after the line continuation marks set "
         "in ``$MULTILINE_PROMPT``. Can be used to mark the end of "
         "a semantic continuation prompt and the beginning of user input "


### PR DESCRIPTION
Unset the default Semantic Prompt line continuation environment variables (``$MULTILINE_PROMPT_PRE`` and ``$MULTILINE_PROMPT_POS``) to allow differentiating between user setting an empty value (so nothing should be added) and not setting anything (so it's ok to set them to something useful)


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
