### PR TITLE
Add `history delete` #4929

### DIFF
--- a/news/add_history_delete.rst
+++ b/news/add_history_delete.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``history delete`` command to both the JSON and SQLite history backends allowing users to delete commands from history that matches a pattern.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -174,6 +174,22 @@ class History:
         """
         pass
 
+    def delete(self, pattern):
+        """Deletes the history of the current session for commands that match
+        a user-provided pattern.
+
+        Parameters
+        ----------
+        pattern: str
+            The regex pattern to match commands against.
+
+        Returns
+        -------
+        int
+            The number of commands deleted from history.
+        """
+        pass
+
     @functools.cached_property
     def ignore_regex(self):
         compiled_regex = None

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -11,9 +11,11 @@ from xonsh.built_ins import XSH
 
 try:
     import ujson as json
+
     JSONDecodeError = json.JSONDecodeError  # type: ignore
 except ImportError:
     import json  # type: ignore
+
     JSONDecodeError = json.decoder.JSONDecodeError  # type: ignore
 
 import xonsh.lazyjson as xlj
@@ -629,7 +631,7 @@ class JsonHistory(History):
                         deleted += 1
 
                 file_content["cmds"] = commands
-                with open(f, 'w') as fp:
+                with open(f, "w") as fp:
                     xlj.ljdump(file_content, fp)
             except (JSONDecodeError, ValueError):
                 # file is corrupted somehow

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -11,10 +11,10 @@ from xonsh.built_ins import XSH
 
 try:
     import ujson as json
-    JSONDecodeError = json.JSONDecodeError
+    JSONDecodeError = json.JSONDecodeError  # type: ignore
 except ImportError:
     import json  # type: ignore
-    JSONDecodeError = json.decoder.JSONDecodeError
+    JSONDecodeError = json.decoder.JSONDecodeError  # type: ignore
 
 import xonsh.lazyjson as xlj
 import xonsh.tools as xt
@@ -601,7 +601,7 @@ class JsonHistory(History):
         self.flush()
 
     def delete(self, pattern):
-        """"""
+        """Deletes all entries in history which matches a pattern."""
         pattern = re.compile(pattern)
 
         deleted = 0

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -11,10 +11,10 @@ from xonsh.built_ins import XSH
 
 try:
     import ujson as json
-    from ujson import JSONDecodeError
+    JSONDecodeError = json.JSONDecodeError
 except ImportError:
     import json  # type: ignore
-    from json.decoder import JSONDecodeError
+    JSONDecodeError = json.decoder.JSONDecodeError
 
 import xonsh.lazyjson as xlj
 import xonsh.tools as xt

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -340,6 +340,19 @@ class HistoryAlias(xcli.ArgParserAlias):
         print("History cleared", file=sys.stderr)
 
     @staticmethod
+    def delete(pattern):
+        """Delete all commands matching a pattern
+
+        Parameters
+        ----------
+        pattern:
+            regex pattern to match against command history
+        """
+        hist = XSH.history
+        deleted = hist.delete(pattern)
+        print(f"Deleted {deleted} entries from history")
+
+    @staticmethod
     def file(_stdout):
         """Display the current history filename"""
         hist = XSH.history
@@ -466,6 +479,7 @@ class HistoryAlias(xcli.ArgParserAlias):
         parser.add_command(self.off)
         parser.add_command(self.on)
         parser.add_command(self.clear)
+        parser.add_command(self.delete)
         parser.add_command(self.gc)
         parser.add_command(self.transfer)
 

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -223,7 +223,7 @@ def xh_sqlite_wipe_session(sessionid=None, filename=None):
 
 def xh_sqlite_delete_input_matching(pattern, filename=None):
     """Deletes entries from the database where the input matches a pattern."""
-    sql = f"DELETE FROM xonsh_history WHERE inp LIKE '{pattern}' ESCAPE '\\';"
+    sql = f"DELETE FROM xonsh_history WHERE inp REGEXP '{pattern}' ESCAPE '\\';"
     with _xh_sqlite_get_conn(filename=filename) as conn:
         c = conn.cursor()
         _xh_sqlite_create_history_table(c)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -387,3 +387,6 @@ class SqliteHistory(History):
         self.cwds = []
 
         xh_sqlite_wipe_session(sessionid=self.sessionid, filename=self.filename)
+
+    def delete(self, pattern):
+        print('You called delete!')

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -228,7 +228,7 @@ def xh_sqlite_delete_input_matching(pattern, filename=None):
         _xh_sqlite_create_history_table(c)
         for inp, *_ in _xh_sqlite_get_records(c):
             if pattern.match(inp):
-                sql = f"DELETE FROM xonsh_history WHERE inp LIKE '{inp}'"
+                sql = f"DELETE FROM xonsh_history WHERE inp = '{inp}'"
                 c.execute(sql)
 
 

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -398,6 +398,6 @@ class SqliteHistory(History):
 
     def delete(self, pattern):
         """Deletes all entries in the database where the input matches a pattern."""
-        xh_sqlite_delete_input_matching(pattern=re.escape(pattern), filename=self.filename)
-
-
+        xh_sqlite_delete_input_matching(
+            pattern=re.escape(pattern), filename=self.filename
+        )

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -2,6 +2,7 @@
 import collections
 import json
 import os
+import re
 import sqlite3
 import sys
 import threading
@@ -222,6 +223,15 @@ def xh_sqlite_wipe_session(sessionid=None, filename=None):
         c.execute(sql, (str(sessionid),))
 
 
+def xh_sqlite_delete_input_matching(pattern, filename=None):
+    """Deletes entries from the database where the input matches a pattern."""
+    sql = f"DELETE FROM xonsh_history WHERE inp LIKE '{pattern}' ESCAPE '\\';"
+    with _xh_sqlite_get_conn(filename=filename) as conn:
+        c = conn.cursor()
+        _xh_sqlite_create_history_table(c)
+        c.execute(sql)
+
+
 class SqliteHistoryGC(threading.Thread):
     """Shell history garbage collection."""
 
@@ -389,4 +399,7 @@ class SqliteHistory(History):
         xh_sqlite_wipe_session(sessionid=self.sessionid, filename=self.filename)
 
     def delete(self, pattern):
-        print('You called delete!')
+        """Deletes all entries in the database where the input matches a pattern."""
+        xh_sqlite_delete_input_matching(pattern=re.escape(pattern), filename=self.filename)
+
+


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

This MR adds the `delete` command to `history`, which allows the user to only delete commands from the history,
that matches a specific pattern (in the form of a regular expression).

This is done by extending `xonsh.history.base.History` and `xonsh.history.main.HistoryAlias` as well as provide default implementations for the `JsonHistory` and `SqliteHistory` backends.

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
