### PR TITLE
Fix/parse multiline foreign shell aliases

### DIFF
--- a/news/fix-parse-multiline-aliases.rst
+++ b/news/fix-parse-multiline-aliases.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Correctly parse multi line foreign aliases
+
+**Security:**
+
+* <news item>

--- a/tests/test_foreign_shells.py
+++ b/tests/test_foreign_shells.py
@@ -53,12 +53,17 @@ def test_parse_env_equals():
 
 
 def test_parse_aliases():
-    exp = {"x": ["yes", "-1"], "y": ["echo", "no"]}
+    exp = {
+        "x": ["yes", "-1"],
+        "y": ["echo", "no"],
+        "z": ["echo", "True", "&&", "echo", "Next", "||", "echo", "False"],
+    }
     s = (
         "some garbage\n"
         "__XONSH_ALIAS_BEG__\n"
         "alias x='yes -1'\n"
         "alias y='echo    no'\n"
+        "alias z='echo True && \\\n echo Next || \\\n echo False'\n"  # noqa: E261,W605
         "__XONSH_ALIAS_END__\n"
         "more filth"
     )

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -313,6 +313,7 @@ def parse_aliases(s, shell, sourcer=None, files=(), extra_args=()):
     if m is None:
         return {}
     g1 = m.group(1)
+    g1 = g1.replace("\\\n", " ")
     items = [
         line.split("=", 1)
         for line in g1.splitlines()


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

Hello,

thanks for creating this amazing shell. I started trying it out and like it. 

While configuring and trying it out I found a little issue with parsing multi line bash aliases. Didn't find any existing issue mentioning multi line aliases but there is one for environments #4947 and other for multi line input #4851.

This PR updates the foreign parse aliases function to account for this case. Also added one test case specific to this.

Multi line aliases are parsed correctly but don't execute yet if they include any pipe. Couldn't find yet in the code where the execution of the alias is handled.

I hope someone can profit from this little fix.

Kind regards,
Wilfried

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
