### PR TITLE
Mention 3.6 instead of 3.5 in docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -54,7 +54,7 @@
     </p>
 
 Xonsh is a Python-powered, cross-platform, Unix-gazing shell language and
-command prompt. The language is a superset of Python 3.5+ with additional
+command prompt. The language is a superset of Python 3.6+ with additional
 shell primitives that you are used to from Bash and IPython. It works on
 all major systems including Linux, Mac OSX, and Windows. Xonsh is meant
 for the daily use of experts and novices alike.


### PR DESCRIPTION
The homepage mentions 3.6, so I update this section to be in line, hope this doesn't need a news item.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
