### PR TITLE
fix(dirstack): use XSH.env for $HOME check, not os.path

### DIFF
--- a/news/fix-cd-home-no-os-environ.rst
+++ b/news/fix-cd-home-no-os-environ.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``cd`` with no arguments will always return to ``$HOME``
+
+**Security:**
+
+* <news item>

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -101,3 +101,16 @@ def test_cd_autopush(xession, tmpdir):
             dirstack.popd([])
 
     assert old_dir == os.getcwd()
+
+
+def test_cd_home(xession, tmpdir):
+    target = str(tmpdir)
+
+    old_home = xession.env.get("HOME")
+
+    xession.env.update(dict(HOME=target, PWD=os.getcwd(), AUTO_PUSHD=True))
+    dirstack.cd([])
+    assert target == os.getcwd()
+    dirstack.popd([])
+
+    xession.env.update(dict(HOME=old_home))

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -215,7 +215,7 @@ def cd(args, stdin=None):
         del args[0]
 
     if len(args) == 0:
-        d = os.path.expanduser("~")
+        d = env.get("HOME", os.path.expanduser("~"))
     elif len(args) == 1:
         d = os.path.expanduser(args[0])
         if not os.path.isdir(d):


### PR DESCRIPTION
`os.path.expanduser` relies on the value of `$HOME` set in `os.environ`. This meant that a user who set `$HOME` would then not end up in that directory with a no-argument call to `cd` unless they had set `UPDATE_OS_ENVIRON`.

Now the value of `$HOME` is respected regardless of the setting in `UPDATE_OS_ENVIRON`

Fixes #5205 

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
