### PR TITLE
correct scandalous misrepresentation of the friendly interactive shell's feature set

### DIFF
--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -82,7 +82,7 @@ table lists built in features and capabilities that various tools may or may not
       - ✓
       -
       - ✓
-      -
+      - ✓
       -
       - ✓
     * - Rich history


### PR DESCRIPTION
Hi there!

The name 'friendly interactive shell' -- abbreviated as `fish` actually has a double meaning! In addition to being an acronym, a 'fish' is also a kind of animal. Here is an example: 🐟. What a friendly little creature!

(your shell also looks pretty fin-tastic! it's a really neat idea!)