### PR TITLE
fix(xpip): patch in user site packages for xpip where needed

### DIFF
--- a/news/fix_xpip_unwriteable_sitepackages.rst
+++ b/news/fix_xpip_unwriteable_sitepackages.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``xonsh`` now adds the user site packages directory to ``sys.path`` where
+  required for proper ``xontrib`` discovery
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
`xpip` should always install `xontribs` in a place where the invoking instance of `xonsh` can find them.
In the case where `xonsh` resides in a non-user-writeable `site-packages` directory, we need to ensure that the location of the installed `xontribs` is part of `sys.path`.

Originally, this was handled by pre-pending `sudo` to the `python -m pip` call, but no one thought that was a good thing.  However, when we switched it to calling `--user` instead of `sudo`, we didn't add an additional step to ensure that the site-packages directory in userspace was included.

Here we add that in, using the same check of writeability of the `sys.executable` location to determine if we need to patch `sys.path`.

Fixes #5229 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
