### PR TITLE
Add len() protocol to LazyObject to support Sphinx 5+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ doc = [
     "xonsh[bestshell]",
     "furo",
     "numpydoc",
-    "sphinx<5,>=3.1",
+    "sphinx>=3.1",
     "psutil",
     "pyzmq",
     "matplotlib",

--- a/xonsh/lazyasd.py
+++ b/xonsh/lazyasd.py
@@ -117,6 +117,9 @@ class LazyObject:
     def __repr__(self):
         return repr(self._lazy_obj())
 
+    def __len__(self):
+        return len(self._lazy_obj())
+
 
 RT = tp.TypeVar("RT")
 


### PR DESCRIPTION
Required by Sphinx 5+

Fixes: #5248