### PR TITLE
Use %COMSPEC% not "cmd" to prevent hijacking. Fixes #5254

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -894,7 +894,7 @@ def make_default_aliases():
             "vol",
         }
         for alias in windows_cmd_aliases:
-            default_aliases[alias] = ["cmd", "/c", alias]
+            default_aliases[alias] = [os.getenv("COMSPEC"), "/c", alias]
         default_aliases["call"] = ["source-cmd"]
         default_aliases["source-bat"] = ["source-cmd"]
         default_aliases["clear"] = "cls"

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -894,7 +894,7 @@ def make_default_aliases():
             "vol",
         }
         for alias in windows_cmd_aliases:
-            default_aliases[alias] = [os.getenv("COMSPEC"), "/c", alias]
+            default_aliases[alias] = [os.getenv("COMSPEC", "cmd"), "/c", alias]
         default_aliases["call"] = ["source-cmd"]
         default_aliases["source-bat"] = ["source-cmd"]
         default_aliases["clear"] = "cls"

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -894,7 +894,7 @@ def make_default_aliases():
             "vol",
         }
         for alias in windows_cmd_aliases:
-            default_aliases[alias] = [os.getenv("COMSPEC", "cmd"), "/c", alias]
+            default_aliases[alias] = [os.getenv("COMSPEC"), "/c", alias]
         default_aliases["call"] = ["source-cmd"]
         default_aliases["source-bat"] = ["source-cmd"]
         default_aliases["clear"] = "cls"


### PR DESCRIPTION
**Security:**

* Security fix for vulnerability on Windows; Xonsh will no longer execute default cmd commands†
using a malicious "cmd.bat" file in the current directory.

† cls, copy, del, dir, echo, erase, md, mkdir, mklink, move, rd, ren, rename, rmdir, time, type, & vol

#issuenumber 5254