### PR TITLE
Fix documented default loc parameter for add_one_completer()

### DIFF
--- a/docs/tutorial_completers.rst
+++ b/docs/tutorial_completers.rst
@@ -203,7 +203,7 @@ active completers via the ``completer add`` command or ``xonsh.completers.comple
 * ``">KEY"``, where ``KEY`` is a pre-existing name, indicates that this should be added after the completer named ``KEY``
 * ``"<KEY"``, where ``KEY`` is a pre-existing name, indicates that this should be added before the completer named ``KEY``
 
-If ``POS`` is not provided, it defaults to ``"start"``.
+If ``POS`` is not provided, it defaults to ``"end"``.
 
 .. note:: It is also possible to manipulate ``__xonsh__.completers`` directly,
           but this is the preferred method.

--- a/news/DanielSaunders-patch-1.rst
+++ b/news/DanielSaunders-patch-1.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fix documented default loc parameter for add_one_completer()


### PR DESCRIPTION
<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

I was struggling to get a Completer working as I expected based on the documentation at [Registering a Completer](https://xon.sh/tutorial_completers.html#registering-a-completer).

I realized the guide says the default position is `"start"` but the [implementation](https://github.com/xonsh/xonsh/blob/1da7118e23c1b7ccaec9bbac8ae699c7bc8f0c44/xonsh/completers/completer.py#L8) indicates the (current) default is `"end"`.

Happy to make any changes needed to accommodate contribution guidelines for this project that I might have missed.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
