### PR TITLE
fix: Error in completions with absolute paths (#5127)

### DIFF
--- a/news/fix-abs-path-completions-on-keypress.rst
+++ b/news/fix-abs-path-completions-on-keypress.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed an issue with completions when using absolute paths to commands and having $UPDATE_COMPLETIONS_ON_KEYPRESS set to True. https://github.com/xonsh/xonsh/issues/5127
+
+**Security:**
+
+* <news item>

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -114,7 +114,7 @@ def generate_options_of(cmd: str):
 
 @functools.lru_cache(maxsize=10)
 def _parse_man_page_options(cmd: str) -> "dict[str, tuple[str, ...]]":
-    path = get_man_completions_path() / f"{cmd}.json"
+    path = get_man_completions_path() / Path(cmd).with_suffix(".json").name
     if path.exists():
         return json.loads(path.read_text())
     options = dict(generate_options_of(cmd))


### PR DESCRIPTION
fixes #5127, an error in fetching command completions when `UPDATE_COMPLETIONS_ON_KEYPRESS` is enabled and the command is specified by absolute path.

Prior to this patch, typing `/usr/bin/ls -a` with `$UPDATE_COMPLETIONS_ON_KEYPRESS = True` set causes an exception while trying to write to `/usr/bin/ls.json` (assuming that the user does not have write access to `/usr/bin/`). The crux of the error was that the absolute path of the command was used during the path join. A join using an absolute path causes the other portion of the path to be discarded.

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
