### PR TITLE
fix: do not attempt to color traceback for error in xonshrc file

### DIFF
--- a/news/xonshrc-traceback.rst
+++ b/news/xonshrc-traceback.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* If an error is encountered while loading the xonshrc file, the traceback is now output as plain text rather than as a list of Tokens
+
+**Security:**
+
+* <news item>

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1109,7 +1109,8 @@ def display_colored_error_message(exc_info, strip_xonsh_error_types=True, limit=
     # color the traceback if available
     _, interactive = _get_manual_env_var("XONSH_INTERACTIVE", 0)
     _, color_results = _get_manual_env_var("COLOR_RESULTS", 0)
-    if not interactive or not color_results or not HAS_PYGMENTS:
+    shell_loaded = hasattr(xsh.shell, "shell")  # do not color traceback in xonshrc file
+    if not interactive or not color_results or not shell_loaded or not HAS_PYGMENTS:
         sys.stderr.write(traceback_str)
         return
 


### PR DESCRIPTION
Fixes #5324 

The traceback from a xonshrc file is currently printed incorrectly because coloring does not work until after the shell backend has been loaded.

The shell backend is loaded after the xonshrc file is read:
https://github.com/xonsh/xonsh/blob/a028c72deb9d130fd048805205a58d4f23f48956/xonsh/main.py#L355-L357

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
