### PR TITLE
refactor(aliases): source foreign shell funcs without interactive mode

### DIFF
--- a/news/source_foreign_notinteractive.rst
+++ b/news/source_foreign_notinteractive.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``source_foreign_fn`` now does not run subshells in interactive mode, so
+  associated RC files like ``zshrc`` and ``bashrc`` will not be auto-loaded on
+  sourcing.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/aliases/test_source.py
+++ b/tests/aliases/test_source.py
@@ -78,4 +78,5 @@ def test_source_foreign_fn_parser(alias, xession):
         "suppress_skip_message",
         "show",
         "dryrun",
+        "interactive",
     ]


### PR DESCRIPTION
supercedes #5343 because I forgot which remote I was on

