### PR TITLE
test_tools: fix pathsep

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -953,12 +953,12 @@ def test_env_path_add(left, right, exp):
 def test_env_path_add_replace_no_dupes_front_replace_existing():
     # Test replaces without dupes when added to front when adding existing entry
     path = EnvPath(
-        [os.pathsep.join(["home", "wakka"]), os.pathsep.join(["home", "wakka", "bin"])]
+        [os.sep.join(["home", "wakka"]), os.sep.join(["home", "wakka", "bin"])]
     )
-    path.add(os.pathsep.join(["home", "wakka", "bin"]), front=True, replace=True)
+    path.add(os.sep.join(["home", "wakka", "bin"]), front=True, replace=True)
     assert path == [
-        os.pathsep.join(["home", "wakka", "bin"]),
-        os.pathsep.join(["home", "wakka"]),
+        os.sep.join(["home", "wakka", "bin"]),
+        os.sep.join(["home", "wakka"]),
     ]
 
 
@@ -966,15 +966,15 @@ def test_env_path_add_replace_no_dupes_front_replace_multiple():
     # Test replaces without dupes when added to front when multiple existing occurrences
     path = EnvPath(
         [
-            os.pathsep.join(["home", "wakka"]),
-            os.pathsep.join(["home", "wakka", "bin"]),
-            os.pathsep.join(["home", "wakka", "bin"]),
+            os.sep.join(["home", "wakka"]),
+            os.sep.join(["home", "wakka", "bin"]),
+            os.sep.join(["home", "wakka", "bin"]),
         ]
     )
-    path.add(os.pathsep.join(["home", "wakka", "bin"]), front=True, replace=True)
+    path.add(os.sep.join(["home", "wakka", "bin"]), front=True, replace=True)
     assert path == [
-        os.pathsep.join(["home", "wakka", "bin"]),
-        os.pathsep.join(["home", "wakka"]),
+        os.sep.join(["home", "wakka", "bin"]),
+        os.sep.join(["home", "wakka"]),
     ]
 
 
@@ -982,35 +982,35 @@ def test_env_path_add_replace_no_dupes_back_replace_multiple():
     # Test replaces without dupes when not added to front
     path = EnvPath(
         [
-            os.pathsep.join(["home", "wakka"]),
-            os.pathsep.join(["home", "wakka", "bin"]),
-            os.pathsep.join(["home", "wakka", "bin"]),
+            os.sep.join(["home", "wakka"]),
+            os.sep.join(["home", "wakka", "bin"]),
+            os.sep.join(["home", "wakka", "bin"]),
         ]
     )
-    path.add(os.pathsep.join(["home", "wakka", "bin"]), front=False, replace=True)
+    path.add(os.sep.join(["home", "wakka", "bin"]), front=False, replace=True)
     assert path == [
-        os.pathsep.join(["home", "wakka"]),
-        os.pathsep.join(["home", "wakka", "bin"]),
+        os.sep.join(["home", "wakka"]),
+        os.sep.join(["home", "wakka", "bin"]),
     ]
 
 
 def test_env_path_add_pathlib():
-    os.pathsep.join(["home", "wakka", "bin"])
+    os.sep.join(["home", "wakka", "bin"])
     path = EnvPath(
         [
-            os.pathsep.join(["home", "wakka"]),
-            os.pathsep.join(["home", "wakka", "bin"]),
-            os.pathsep.join(["home", "wakka", "bin"]),
+            os.sep.join(["home", "wakka"]),
+            os.sep.join(["home", "wakka", "bin"]),
+            os.sep.join(["home", "wakka", "bin"]),
         ]
     )
     path.add(
-        pathlib.Path(os.pathsep.join(["home", "wakka", "bin"])),
+        pathlib.Path(os.sep.join(["home", "wakka", "bin"])),
         front=False,
         replace=True,
     )
     assert path == [
-        os.pathsep.join(["home", "wakka"]),
-        os.pathsep.join(["home", "wakka", "bin"]),
+        os.sep.join(["home", "wakka"]),
+        os.sep.join(["home", "wakka", "bin"]),
     ]
 
 


### PR DESCRIPTION
`os.sep` - The character used by the operating system to separate pathname components i.e. `/` in posix.
`os.pathsep` - The character conventionally used by the operating system to separate search path components i.e. `:` in posix.

Fixed wrong usage `os.pathsep` instead of `os.sep` in test_tools.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
