### PR TITLE
Read stop signals from the process and update the process state.

### DIFF
--- a/news/fix_interactive_suspended_subproc.rst
+++ b/news/fix_interactive_suspended_subproc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Reading stop signals from the process and update the process state #5361.
+* Reading stop signals from the process and update the process state (#5361).
 
 **Changed:**
 

--- a/news/fix_interactive_suspended_subproc.rst
+++ b/news/fix_interactive_suspended_subproc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Processing a suspended process in the captured mode (#5361).
+* Reading stop signals from the process and update the process state (#5361).
 
 **Changed:**
 

--- a/news/fix_interactive_suspended_subproc.rst
+++ b/news/fix_interactive_suspended_subproc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added processing the case where interactive command was suspended by OS in full captured mode (#5361).
+* Processing the suspended process in capture mode (#5361).
 
 **Changed:**
 

--- a/news/fix_interactive_suspended_subproc.rst
+++ b/news/fix_interactive_suspended_subproc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added processing the case where interactive command was suspended by OS in full captured mode.
+* Added processing the case where interactive command was suspended by OS in full captured mode (#5361).
 
 **Changed:**
 

--- a/news/fix_interactive_suspended_subproc.rst
+++ b/news/fix_interactive_suspended_subproc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Processing the suspended process in capture mode (#5361).
+* Processing a suspended process in the captured mode (#5361).
 
 **Changed:**
 

--- a/news/fix_interactive_suspended_subproc.rst
+++ b/news/fix_interactive_suspended_subproc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Reading stop signals from the process and update the process state (#5361).
+* Reading stop signals from the process and update the process state #5361.
 
 **Changed:**
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -20,7 +20,7 @@ from xonsh.tools import XonshError
 
 
 def cmd_sig(sig):
-    return ["python", "-c", f"import os, signal; os.kill(os.getpid(), signal.{sig})"]
+    return ["python", "-c", f"import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.{sig})"]
 
 
 @skip_if_on_windows

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -1,7 +1,6 @@
 """Tests the xonsh.procs.specs"""
 
 import itertools
-import os
 import signal
 import sys
 from subprocess import Popen

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -152,6 +152,7 @@ def test_interrupted_process_returncode(xonsh_session):
 
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
+@pytest.mark.timeout(2)
 def test_suspended_captured_process_pipeline(xonsh_session):
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
     specs = cmds_to_specs(cmd, captured="object")
@@ -186,7 +187,9 @@ def test_suspended_captured_process_pipeline(xonsh_session):
 
     from xonsh import jobs
 
-    for j in jobs.get_jobs().values():
+    jobs = jobs.get_jobs().values()
+    assert len(jobs) == 3
+    for j in jobs:
         assert j["status"] == "suspended"
 
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -142,9 +142,10 @@ def test_capture_always(
 
 @skip_if_on_windows
 @pytest.mark.parametrize("captured", ["stdout", "object"])
+@pytest.mark.parametrize("interactive", [True, False])
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
-def test_interrupted_process_returncode(xonsh_session, captured):
-    xonsh_session.env["XONSH_INTERACTIVE"] = True
+def test_interrupted_process_returncode(xonsh_session, captured, interactive):
+    xonsh_session.env["XONSH_INTERACTIVE"] = interactive
     xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGINT)"]]
     specs = cmds_to_specs(cmd, captured="stdout")
@@ -208,6 +209,7 @@ def test_specs_with_suspended_captured_process_pipeline(xonsh_session):
         ([["echo", "-n", "1\n2 3"]], "1\n2 3", ["1", "2 3"]),
     ],
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_subproc_output_format(cmds, exp_stream_lines, exp_list_lines, xonsh_session):
     xonsh_session.env["XONSH_SUBPROC_OUTPUT_FORMAT"] = "stream_lines"
     output = run_subproc(cmds, "stdout")

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -20,7 +20,11 @@ from xonsh.tools import XonshError
 
 
 def cmd_sig(sig):
-    return ["python", "-c", f"import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.{sig})"]
+    return [
+        "python",
+        "-c",
+        f"import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.{sig})",
+    ]
 
 
 @skip_if_on_windows

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -152,7 +152,6 @@ def test_interrupted_process_returncode(xonsh_session):
 
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
-@pytest.mark.timeout(2)
 def test_suspended_captured_process_pipeline(xonsh_session):
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
     specs = cmds_to_specs(cmd, captured="object")

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -141,8 +141,10 @@ def test_capture_always(
 
 
 @skip_if_on_windows
+@pytest.mark.parametrize("captured", ["stdout", "object"])
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
-def test_interrupted_process_returncode(xonsh_session):
+def test_interrupted_process_returncode(xonsh_session, captured):
+    xonsh_session.env["XONSH_INTERACTIVE"] = True
     xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGINT)"]]
     specs = cmds_to_specs(cmd, captured="stdout")

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -152,7 +152,7 @@ def test_interrupted_process_returncode(xonsh_session):
 
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
-def test_suspended_captured_process_pipeline(xonsh_session):
+def test_specs_with_suspended_captured_process_pipeline(xonsh_session):
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
     specs = cmds_to_specs(cmd, captured="object")
     p = _run_command_pipeline(specs, cmd)

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -157,12 +157,17 @@ def test_interrupted_process_returncode(xonsh_session, captured, interactive):
 
 
 @skip_if_on_windows
-@pytest.mark.parametrize("suspended_pipeline", [
-    [cmd_sig("SIGTTIN")],
-    [["echo", "1"],"|",cmd_sig("SIGTTIN")],
-    [["echo", "1"],"|",cmd_sig("SIGTTIN"),"|",["head"]]
-])
-def test_specs_with_suspended_captured_process_pipeline(xonsh_session, suspended_pipeline):
+@pytest.mark.parametrize(
+    "suspended_pipeline",
+    [
+        [cmd_sig("SIGTTIN")],
+        [["echo", "1"], "|", cmd_sig("SIGTTIN")],
+        [["echo", "1"], "|", cmd_sig("SIGTTIN"), "|", ["head"]],
+    ],
+)
+def test_specs_with_suspended_captured_process_pipeline(
+    xonsh_session, suspended_pipeline
+):
     xonsh_session.env["XONSH_INTERACTIVE"] = True
     specs = cmds_to_specs(suspended_pipeline, captured="object")
     p = _run_command_pipeline(specs, suspended_pipeline)

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -191,8 +191,6 @@ def test_suspended_captured_process_pipeline(xonsh_session):
     assert len(jobs) == 3
     for j in jobs:
         assert j["status"] == "suspended"
-        for pid in j["pids"]:
-            os.kill(pid, signal.SIGKILL)
 
 
 @skip_if_on_windows

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -143,7 +143,6 @@ def test_capture_always(
 @skip_if_on_windows
 @pytest.mark.parametrize("captured", ["stdout", "object"])
 @pytest.mark.parametrize("interactive", [True, False])
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_interrupted_process_returncode(xonsh_session, captured, interactive):
     xonsh_session.env["XONSH_INTERACTIVE"] = interactive
     xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
@@ -154,7 +153,6 @@ def test_interrupted_process_returncode(xonsh_session, captured, interactive):
 
 
 @skip_if_on_windows
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_specs_with_suspended_captured_process_pipeline(xonsh_session):
     xonsh_session.env["XONSH_INTERACTIVE"] = True
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -160,14 +160,24 @@ def test_suspended_captured_process_pipeline(xonsh_session):
     p.end()
     assert p.suspended
 
-    cmd = [["echo", "1"], "|", ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
+    cmd = [
+        ["echo", "1"],
+        "|",
+        ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"],
+    ]
     specs = cmds_to_specs(cmd, captured="object")
     p = _run_command_pipeline(specs, cmd)
     p.proc.send_signal(signal.SIGCONT)
     p.end()
     assert p.suspended
 
-    cmd = [["echo", "1"], "|", ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"], "|", ["head"]]
+    cmd = [
+        ["echo", "1"],
+        "|",
+        ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"],
+        "|",
+        ["head"],
+    ]
     specs = cmds_to_specs(cmd, captured="object")
     p = _run_command_pipeline(specs, cmd)
     p.proc.send_signal(signal.SIGCONT)
@@ -175,10 +185,9 @@ def test_suspended_captured_process_pipeline(xonsh_session):
     assert p.suspended
 
     from xonsh import jobs
+
     for n, j in jobs.get_jobs().items():
-        assert j['status'] == 'suspended'
-
-
+        assert j["status"] == "suspended"
 
 
 @skip_if_on_windows

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -186,7 +186,7 @@ def test_suspended_captured_process_pipeline(xonsh_session):
 
     from xonsh import jobs
 
-    for n, j in jobs.get_jobs().items():
+    for j in jobs.get_jobs().values():
         assert j["status"] == "suspended"
 
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -151,48 +151,6 @@ def test_interrupted_process_returncode(xonsh_session):
 
 
 @skip_if_on_windows
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
-def test_suspended_captured_process_pipeline(xonsh_session):
-    cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
-    specs = cmds_to_specs(cmd, captured="object")
-    p = _run_command_pipeline(specs, cmd)
-    p.proc.send_signal(signal.SIGCONT)
-    p.end()
-    assert p.suspended
-
-    cmd = [
-        ["echo", "1"],
-        "|",
-        ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"],
-    ]
-    specs = cmds_to_specs(cmd, captured="object")
-    p = _run_command_pipeline(specs, cmd)
-    p.proc.send_signal(signal.SIGCONT)
-    p.end()
-    assert p.suspended
-
-    cmd = [
-        ["echo", "1"],
-        "|",
-        ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"],
-        "|",
-        ["head"],
-    ]
-    specs = cmds_to_specs(cmd, captured="object")
-    p = _run_command_pipeline(specs, cmd)
-    p.proc.send_signal(signal.SIGCONT)
-    p.end()
-    assert p.suspended
-
-    from xonsh import jobs
-
-    jobs = jobs.get_jobs().values()
-    assert len(jobs) == 3
-    for j in jobs:
-        assert j["status"] == "suspended"
-
-
-@skip_if_on_windows
 @pytest.mark.parametrize(
     "cmds, exp_stream_lines, exp_list_lines",
     [

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -153,6 +153,8 @@ def test_interrupted_process_returncode(xonsh_session):
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_specs_with_suspended_captured_process_pipeline(xonsh_session):
+    xonsh_session.env['XONSH_INTERACTIVE'] = True
+
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
     specs = cmds_to_specs(cmd, captured="object")
     p = _run_command_pipeline(specs, cmd)

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -1,6 +1,7 @@
 """Tests the xonsh.procs.specs"""
 
 import itertools
+import os
 import signal
 import sys
 from subprocess import Popen
@@ -190,6 +191,8 @@ def test_suspended_captured_process_pipeline(xonsh_session):
     assert len(jobs) == 3
     for j in jobs:
         assert j["status"] == "suspended"
+        for pid in j["pids"]:
+            os.kill(pid, signal.SIGKILL)
 
 
 @skip_if_on_windows

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -151,6 +151,37 @@ def test_interrupted_process_returncode(xonsh_session):
 
 
 @skip_if_on_windows
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
+def test_suspended_captured_process_pipeline(xonsh_session):
+    cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
+    specs = cmds_to_specs(cmd, captured="object")
+    p = _run_command_pipeline(specs, cmd)
+    p.proc.send_signal(signal.SIGCONT)
+    p.end()
+    assert p.suspended
+
+    cmd = [["echo", "1"], "|", ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"]]
+    specs = cmds_to_specs(cmd, captured="object")
+    p = _run_command_pipeline(specs, cmd)
+    p.proc.send_signal(signal.SIGCONT)
+    p.end()
+    assert p.suspended
+
+    cmd = [["echo", "1"], "|", ["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGTTIN)"], "|", ["head"]]
+    specs = cmds_to_specs(cmd, captured="object")
+    p = _run_command_pipeline(specs, cmd)
+    p.proc.send_signal(signal.SIGCONT)
+    p.end()
+    assert p.suspended
+
+    from xonsh import jobs
+    for n, j in jobs.get_jobs().items():
+        assert j['status'] == 'suspended'
+
+
+
+
+@skip_if_on_windows
 @pytest.mark.parametrize(
     "cmds, exp_stream_lines, exp_list_lines",
     [

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -23,7 +23,7 @@ def cmd_sig(sig):
     return [
         "python",
         "-c",
-        f"import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.{sig})",
+        f"import os, signal; os.kill(os.getpid(), signal.{sig})",
     ]
 
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1255,7 +1255,7 @@ def test_catching_exit_signal():
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_suspended_captured_process_pipeline():
-    """See also test_specs.py:test_suspended_captured_process_pipeline"""
+    """See also test_specs.py:test_specs_with_suspended_captured_process_pipeline"""
     stdin_cmd = (
         "!(python -c 'import os, signal; os.kill(os.getpid(), signal.SIGTTIN)')\n"
     )

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1255,7 +1255,8 @@ def test_catching_exit_signal():
 
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
-def test_catching_exit_signal():
+def test_suspended_captured_process_pipeline():
+    """See also test_specs.py:test_suspended_captured_process_pipeline"""
     stdin_cmd = (
         "!(python -c 'import os, signal; os.kill(os.getpid(), signal.SIGTTIN)')\n"
     )

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -90,7 +90,7 @@ def run_xonsh(
 
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
-        out = out.replace("Warning: Input is not a terminal (fd=0).", "").strip()
+        out = out.replace("Warning: Input is not a terminal (fd=0).", "")
     except sp.TimeoutExpired:
         proc.kill()
         raise

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -64,7 +64,7 @@ def run_xonsh(
     env["FOREIGN_ALIASES_SUPPRESS_SKIP_MESSAGE"] = "1"
     env["PROMPT"] = ""
     xonsh = shutil.which("xonsh", path=PATH)
-    args = [xonsh, "--no-rc", "-DPROMPT='@'"]
+    args = [xonsh, "--no-rc"]
     if interactive:
         args.append("-i")
     if single_command:

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1251,3 +1251,15 @@ def test_catching_exit_signal():
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
     )
     assert ret > 0
+
+
+@skip_if_on_windows
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
+def test_catching_exit_signal():
+    stdin_cmd = "!(python -c 'import os, signal; os.kill(os.getpid(), signal.SIGTTIN)')\n"
+    out, err, ret = run_xonsh(
+        cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=5
+    )
+    match = ".*suspended=True.*"
+    assert re.match(match, out, re.MULTILINE | re.DOTALL), f"\nFailed:\n```\n{stdin_cmd.strip()}\n```,\nresult: {out!r}\nexpected: {match!r}."
+

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -90,7 +90,6 @@ def run_xonsh(
 
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
-        out = out.replace("Warning: Input is not a terminal (fd=0).", "")
     except sp.TimeoutExpired:
         proc.kill()
         raise

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1244,6 +1244,7 @@ def test_catching_system_exit():
 
 
 @skip_if_on_windows
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_catching_exit_signal():
     stdin_cmd = "kill -SIGHUP @(__import__('os').getpid())\n"
     out, err, ret = run_xonsh(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1254,9 +1254,7 @@ def test_catching_exit_signal():
 @skip_if_on_windows
 def test_suspended_captured_process_pipeline():
     """See also test_specs.py:test_specs_with_suspended_captured_process_pipeline"""
-    stdin_cmd = (
-        "!(python -c 'import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.SIGTTIN)')\n"
-    )
+    stdin_cmd = "!(python -c 'import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.SIGTTIN)')\n"
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=5
     )

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -64,7 +64,7 @@ def run_xonsh(
     env["FOREIGN_ALIASES_SUPPRESS_SKIP_MESSAGE"] = "1"
     env["PROMPT"] = ""
     xonsh = shutil.which("xonsh", path=PATH)
-    args = [xonsh, "--no-rc"]
+    args = [xonsh, "--no-rc", "-DPROMPT='@'"]
     if interactive:
         args.append("-i")
     if single_command:
@@ -90,6 +90,7 @@ def run_xonsh(
 
     try:
         out, err = proc.communicate(input=input, timeout=timeout)
+        out = out.replace("Warning: Input is not a terminal (fd=0).", "").strip()
     except sp.TimeoutExpired:
         proc.kill()
         raise

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1234,7 +1234,6 @@ def test_main_d():
     assert out == "dummy\n"
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_catching_system_exit():
     stdin_cmd = "__import__('sys').exit(2)\n"
     out, err, ret = run_xonsh(
@@ -1244,7 +1243,6 @@ def test_catching_system_exit():
 
 
 @skip_if_on_windows
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_catching_exit_signal():
     stdin_cmd = "kill -SIGHUP @(__import__('os').getpid())\n"
     out, err, ret = run_xonsh(
@@ -1254,7 +1252,6 @@ def test_catching_exit_signal():
 
 
 @skip_if_on_windows
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_suspended_captured_process_pipeline():
     """See also test_specs.py:test_specs_with_suspended_captured_process_pipeline"""
     stdin_cmd = (

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1244,7 +1244,7 @@ def test_catching_system_exit():
 
 @skip_if_on_windows
 def test_catching_exit_signal():
-    stdin_cmd = "kill -SIGHUP @(__import__('os').getpid())\n"
+    stdin_cmd = "sleep 0.2; kill -SIGHUP @(__import__('os').getpid())\n"
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
     )
@@ -1255,7 +1255,7 @@ def test_catching_exit_signal():
 def test_suspended_captured_process_pipeline():
     """See also test_specs.py:test_specs_with_suspended_captured_process_pipeline"""
     stdin_cmd = (
-        "!(python -c 'import os, signal; os.kill(os.getpid(), signal.SIGTTIN)')\n"
+        "!(python -c 'import os, signal, time; time.sleep(0.2); os.kill(os.getpid(), signal.SIGTTIN)')\n"
     )
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=5

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1256,10 +1256,13 @@ def test_catching_exit_signal():
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_catching_exit_signal():
-    stdin_cmd = "!(python -c 'import os, signal; os.kill(os.getpid(), signal.SIGTTIN)')\n"
+    stdin_cmd = (
+        "!(python -c 'import os, signal; os.kill(os.getpid(), signal.SIGTTIN)')\n"
+    )
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=5
     )
     match = ".*suspended=True.*"
-    assert re.match(match, out, re.MULTILINE | re.DOTALL), f"\nFailed:\n```\n{stdin_cmd.strip()}\n```,\nresult: {out!r}\nexpected: {match!r}."
-
+    assert re.match(
+        match, out, re.MULTILINE | re.DOTALL
+    ), f"\nFailed:\n```\n{stdin_cmd.strip()}\n```,\nresult: {out!r}\nexpected: {match!r}."

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -62,7 +62,7 @@ def waitpid_sigtt(pid):
      * https://www.linusakesson.net/programming/tty/
      * http://curiousthing.org/sigttin-sigttou-deep-dive-linux
      * https://www.gnu.org/software/libc/manual/html_node/Job-Control-Signals.html
-    Maybe we need to use `psutil` here to have strong confirmation of process state.
+    Maybe we need to use ``psutil`` here to have strong confirmation of process state.
     """
     if ON_WINDOWS:
         return 0

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -227,11 +227,11 @@ if ON_WINDOWS:
         # Return when there are no foreground active task
         if active_task is None:
             return last_task
-        obj = active_task["proc"]
+        proc = active_task["proc"]
         _continue(active_task)
-        while obj.returncode is None:
+        while proc.returncode is None:
             try:
-                obj.wait(0.01)
+                proc.wait(0.01)
             except subprocess.TimeoutExpired:
                 pass
             except KeyboardInterrupt:
@@ -398,8 +398,8 @@ def _clear_dead_jobs():
     to_remove = set()
     tasks = get_tasks()
     for tid in tasks:
-        obj = get_task(tid)["proc"]
-        if obj is None or obj.poll() is not None:
+        proc = get_task(tid)["proc"]
+        if proc is None or proc.poll() is not None:
             to_remove.add(tid)
     for job in to_remove:
         tasks.remove(job)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -75,7 +75,7 @@ def proc_untraced_waitpid(proc, hang, task=None, raise_child_process_error=False
         that we will have return code 0 instead of real return code.
         """
         if raise_child_process_error:
-            raise ChildProcessError("The process PID not found.")
+            raise ChildProcessError("Process Identifier (PID) not found.")
         else:
             return info
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -428,7 +428,7 @@ def format_job_string(num: int, format="dict") -> str:
     if format == "posix":
         r["pos"] = "+" if tasks[0] == num else "-" if tasks[1] == num else " "
         r["bg"] = " &" if job["bg"] else ""
-        r["pid"] = f"({",".join(str(pid) for pid in r['pids'])})" if r["pids"] else ""
+        r["pid"] = f"({','.join(str(pid) for pid in r['pids'])})" if r["pids"] else ""
         return "[{num}]{pos} {status}: {cmd}{bg} {pid}".format(**r)
     else:
         return repr(r)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -428,7 +428,7 @@ def format_job_string(num: int, format="dict") -> str:
     if format == "posix":
         r["pos"] = "+" if tasks[0] == num else "-" if tasks[1] == num else " "
         r["bg"] = " &" if job["bg"] else ""
-        r["pid"] = f"({r['pid']})" if r["pid"] else ""
+        r["pid"] = f"({",".join(str(pid) for pid in r['pids'])})" if r["pids"] else ""
         return "[{num}]{pos} {status}: {cmd}{bg} {pid}".format(**r)
     else:
         return repr(r)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -71,7 +71,7 @@ def proc_untraced_waitpid(proc, hang, task=None, raise_child_process_error=False
     if proc is not None and getattr(proc, "pid", None) is None:
         """
         When the process stopped before os.waitpid it has no pid.
-        Note that in this case there is high probability 
+        Note that in this case there is high probability
         that we will have return code 0 instead of real return code.
         """
         if raise_child_process_error:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -69,7 +69,11 @@ def proc_untraced_waitpid(proc, hang, task=None, raise_child_process_error=False
         return info
 
     if proc is not None and getattr(proc, "pid", None) is None:
-        # When the process stopped before os.waitpid it has no pid.
+        """
+        When the process stopped before os.waitpid it has no pid.
+        Note that in this case there is high probability 
+        that we will have return code 0 instead of real return code.
+        """
         if raise_child_process_error:
             raise ChildProcessError("The process PID not found.")
         else:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -64,7 +64,7 @@ def waitpid_sigtt(pid):
      * https://www.gnu.org/software/libc/manual/html_node/Job-Control-Signals.html
     Maybe we need to use ``psutil`` here to have strong confirmation of process state.
     """
-    if ON_WINDOWS:
+    if pid is None or ON_WINDOWS:
         return 0
 
     try:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -41,7 +41,7 @@ _tasks_main: collections.deque[int] = collections.deque()
 
 def proc_untraced_waitpid(proc, hang, task=None, raise_child_process_error=False):
     """
-    Read stop signals from the process and update the process state.
+    Read a stop signals from the process and update the process state.
 
     Return code
     ===========

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -68,7 +68,7 @@ def waitpid_sigtt(pid):
         return 0
 
     try:
-        pid, proc_status = os.waitpid(pid, os.WUNTRACED)
+        pid, proc_status = os.waitpid(pid, os.WUNTRACED | os.WNOHANG)
         if os.WIFSTOPPED(proc_status) and (stopsig := os.WSTOPSIG(proc_status)) in [
             signal.SIGTTOU,
             signal.SIGTTIN,

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -341,6 +341,7 @@ else:
         if active_task is None:
             return last_task
         proc = active_task["proc"]
+        info = {"backgrounded": False}
 
         try:
             info = proc_untraced_waitpid(proc, hang=True, task=active_task, raise_child_process_error=True)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -68,7 +68,7 @@ def waitpid_sigtt(pid):
         return 0
 
     try:
-        pid, proc_status = os.waitpid(pid, os.WUNTRACED | os.WNOHANG)
+        pid, proc_status = waitpid(pid, os.WUNTRACED | os.WNOHANG)
         if os.WIFSTOPPED(proc_status) and (stopsig := os.WSTOPSIG(proc_status)) in [
             signal.SIGTTOU,
             signal.SIGTTIN,

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -69,7 +69,10 @@ def waitpid_sigtt(pid):
 
     try:
         pid, proc_status = os.waitpid(pid, os.WUNTRACED)
-        if os.WIFSTOPPED(proc_status) and (stopsig := os.WSTOPSIG(proc_status)) in [signal.SIGTTOU, signal.SIGTTIN]:
+        if os.WIFSTOPPED(proc_status) and (stopsig := os.WSTOPSIG(proc_status)) in [
+            signal.SIGTTOU,
+            signal.SIGTTIN,
+        ]:
             return stopsig
     except ChildProcessError:
         # Process could be already stopped.

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -41,7 +41,7 @@ _tasks_main: collections.deque[int] = collections.deque()
 
 def proc_untraced_waitpid(proc, hang, task=None, raise_child_process_error=False):
     """
-    Read signals from the process and update the process state.
+    Read stop signals from the process and update the process state.
 
     Return code
     ===========

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -528,6 +528,7 @@ def main_xonsh(args):
             ignore_sigtstp()
             if (
                 env["XONSH_INTERACTIVE"]
+                and sys.stdin.isatty()  # In case the interactive mode is forced but no tty (input from pipe).
                 and not any(os.path.isfile(i) for i in env["XONSHRC"])
                 and not any(os.path.isdir(i) for i in env["XONSHRC_DIR"])
             ):

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -523,7 +523,7 @@ class CommandPipeline:
 
     def _procs_suspended(self):
         for p in self.procs:
-            if (sigtt := xj.waitpid_sigtt(p.pid)):
+            if sigtt := xj.waitpid_sigtt(p.pid):
                 proc = getattr(p, "proc", p)
                 procname = f"{getattr(proc, 'args', '')} with pid {p.pid}".strip()
                 signame = f"{sigtt} {xt.get_signal_name(sigtt)}".strip()

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -294,8 +294,8 @@ class CommandPipeline:
         prev_end_time = None
         i = j = cnt = 1
         while proc.poll() is None:
-            if getattr(proc, "suspended", False) or (suspended_proc := self._procs_suspended()):
-                self.suspended = suspended_proc.suspended = True
+            if getattr(proc, "suspended", False) or self._procs_suspended() is not None:
+                self.suspended = True
                 xj.update_job_attr(proc.pid, "status", "suspended")
                 return
             elif getattr(proc, "in_alt_mode", False):

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -188,14 +188,15 @@ class CommandPipeline:
         self.proc = self.procs[-1]
 
     def __repr__(self):
+        debug = XSH.env.get("XONSH_DEBUG", False)
         attrs = self.attrnames + (
-            self.attrnames_ext if XSH.env.get("XONSH_DEBUG", False) else ()
+            self.attrnames_ext if debug else ()
         )
         s = self.__class__.__name__ + "(\n  "
         s += ",\n  ".join(
             a + "=" + repr(getattr(self, a))
             for a in attrs
-            if getattr(self, a) is not None
+            if debug or getattr(self, a) is not None
         )
         s += "\n)"
         return s

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -192,7 +192,11 @@ class CommandPipeline:
             self.attrnames_ext if XSH.env.get("XONSH_DEBUG", False) else ()
         )
         s = self.__class__.__name__ + "(\n  "
-        s += ",\n  ".join(a + "=" + repr(getattr(self, a)) for a in attrs if getattr(self, a) is not None)
+        s += ",\n  ".join(
+            a + "=" + repr(getattr(self, a))
+            for a in attrs
+            if getattr(self, a) is not None
+        )
         s += "\n)"
         return s
 

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -524,17 +524,17 @@ class CommandPipeline:
 
     def _procs_suspended(self):
         """Check procs and return suspended proc."""
-        for p in self.procs:
-            if sigtt := xj.waitpid_sigtt(p.pid):
-                proc = getattr(p, "proc", p)
-                procname = f"{getattr(proc, 'args', '')} with pid {p.pid}".strip()
-                signame = f"{sigtt} {xt.get_signal_name(sigtt)}".strip()
+        for proc in self.procs:
+            info = xj.proc_untraced_waitpid(proc, hang=False)
+            if getattr(proc, 'suspended', False):
+                proc = getattr(proc, "proc", proc)
+                procname = f"{getattr(proc, 'args', '')} with pid {proc.pid}".strip()
                 print(
-                    f"Process {procname} suspended with signal {signame} and stay in `jobs`.\n"
+                    f"Process {procname} suspended with signal {info['signal_name']} and stay in `jobs`.\n"
                     f"This happends when process start waiting for input but there is no terminal attached in captured mode.",
                     file=sys.stderr,
                 )
-                return p
+                return proc
 
     def _prev_procs_done(self):
         """Boolean for if all previous processes have completed. If there

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -529,8 +529,8 @@ class CommandPipeline:
                 proc = getattr(proc, "proc", proc)
                 procname = f"{getattr(proc, 'args', '')} with pid {proc.pid}".strip()
                 print(
-                    f"Process {procname} suspended with signal {info['signal_name']} and stay in `jobs`.\n"
-                    f"This happends when process start waiting for input but there is no terminal attached in captured mode.",
+                    f"Process {procname} was suspended with signal {info['signal_name']} and placed in `jobs`.\n"
+                    f"This happens when a process starts waiting for input but there is no terminal attached in captured mode.",
                     file=sys.stderr,
                 )
                 return proc

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -94,6 +94,7 @@ class CommandPipeline:
 
     attrnames = (
         "returncode",
+        "suspended",
         "pid",
         "args",
         "alias",
@@ -102,7 +103,6 @@ class CommandPipeline:
         "input",
         "output",
         "errors",
-        "suspended",
     )
 
     attrnames_ext = (

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -522,7 +522,7 @@ class CommandPipeline:
         safe_fdclose(handle, cache=self._closed_handle_cache)
 
     def _procs_suspended(self):
-        for s, p in zip(self.specs, self.procs):
+        for p in self.procs:
             if (sigtt := xj.waitpid_sigtt(p.pid)):
                 proc = getattr(p, "proc", p)
                 procname = f"{getattr(proc, 'args', '')} with pid {p.pid}".strip()

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -192,7 +192,7 @@ class CommandPipeline:
             self.attrnames_ext if XSH.env.get("XONSH_DEBUG", False) else ()
         )
         s = self.__class__.__name__ + "(\n  "
-        s += ",\n  ".join(a + "=" + repr(getattr(self, a)) for a in attrs)
+        s += ",\n  ".join(a + "=" + repr(getattr(self, a)) for a in attrs if getattr(self, a) is not None)
         s += "\n)"
         return s
 

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -523,6 +523,7 @@ class CommandPipeline:
         safe_fdclose(handle, cache=self._closed_handle_cache)
 
     def _procs_suspended(self):
+        """Check procs and return suspended proc."""
         for p in self.procs:
             if sigtt := xj.waitpid_sigtt(p.pid):
                 proc = getattr(p, "proc", p)

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -521,12 +521,11 @@ class CommandPipeline:
     def _safe_close(self, handle):
         safe_fdclose(handle, cache=self._closed_handle_cache)
 
-
     def _procs_suspended(self):
         for s, p in zip(self.specs, self.procs):
             sigtt = xj.waitpid_sigtt(p.pid)
             if sigtt:
-                proc = getattr(p, 'proc', p)
+                proc = getattr(p, "proc", p)
                 procname = f"{getattr(proc, 'args', '')} with pid {p.pid}".strip()
                 signame = f"{sigtt} {xt.get_signal_name(sigtt)}".strip()
                 print(

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -523,8 +523,7 @@ class CommandPipeline:
 
     def _procs_suspended(self):
         for s, p in zip(self.specs, self.procs):
-            sigtt = xj.waitpid_sigtt(p.pid)
-            if sigtt:
+            if (sigtt := xj.waitpid_sigtt(p.pid)):
                 proc = getattr(p, "proc", p)
                 procname = f"{getattr(proc, 'args', '')} with pid {p.pid}".strip()
                 signame = f"{sigtt} {xt.get_signal_name(sigtt)}".strip()

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -102,6 +102,7 @@ class CommandPipeline:
         "input",
         "output",
         "errors",
+        "suspended"
     )
 
     attrnames_ext = (

--- a/xonsh/procs/posix.py
+++ b/xonsh/procs/posix.py
@@ -14,12 +14,12 @@ import xonsh.lazyimps as xli
 import xonsh.platform as xp
 import xonsh.tools as xt
 from xonsh.built_ins import XSH
+from xonsh.jobs import waitpid_sigtt
 from xonsh.procs.readers import (
     BufferedFDParallelReader,
     NonBlockingFDReader,
     safe_fdclose,
 )
-from xonsh.jobs import waitpid_sigtt
 
 # The following escape codes are xterm codes.
 # See http://rtfm.etla.org/xterm/ctlseq.html for more.
@@ -169,7 +169,7 @@ class PopenThread(threading.Thread):
         # loop over reads while process is running.
         i = j = cnt = 1
         while proc.poll() is None:
-            if (sigtt := waitpid_sigtt(proc.pid)):
+            if sigtt := waitpid_sigtt(proc.pid):
                 self.suspended = True
                 if XSH.env.get("XONSH_DEBUG", False):
                     procname = f"{getattr(proc, 'args', '')} {proc.pid}".strip()

--- a/xonsh/procs/posix.py
+++ b/xonsh/procs/posix.py
@@ -14,7 +14,7 @@ import xonsh.lazyimps as xli
 import xonsh.platform as xp
 import xonsh.tools as xt
 from xonsh.built_ins import XSH
-from xonsh.jobs import waitpid_sigtt
+from xonsh.jobs import proc_untraced_waitpid
 from xonsh.procs.readers import (
     BufferedFDParallelReader,
     NonBlockingFDReader,
@@ -169,12 +169,13 @@ class PopenThread(threading.Thread):
         # loop over reads while process is running.
         i = j = cnt = 1
         while proc.poll() is None:
-            if sigtt := waitpid_sigtt(proc.pid):
+            info = proc_untraced_waitpid(proc, hang=False)
+            if getattr(proc, 'suspended', False):
                 self.suspended = True
                 if XSH.env.get("XONSH_DEBUG", False):
                     procname = f"{getattr(proc, 'args', '')} {proc.pid}".strip()
                     print(
-                        f"Process {procname} suspended with signal {sigtt} {xt.get_signal_name(sigtt)}.",
+                        f"Process {procname} suspended with signal {info['signal_name']}.",
                         file=sys.stderr,
                     )
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2857,6 +2857,7 @@ def describe_waitpid_status(status):
         os.WTERMSIG,
         os.WIFSTOPPED,
         os.WSTOPSIG,
+        os.WCOREDUMP,
     ]
     for f in funcs:
         s = f(status)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2840,6 +2840,14 @@ def to_repr_pretty_(inst, p, cycle):
             p.pretty(dict(inst))
 
 
+def get_signal_name(signum):
+    """Return a signal name by the signal number."""
+    for name in dir(signal):
+        if name.startswith("SIG") and getattr(signal, name) == signum:
+            return name
+    return ""
+
+
 def describe_waitpid_status(status):
     """Describes ``pid, status = os.waitpid(pid, opt)`` status."""
     funcs = [
@@ -2851,15 +2859,8 @@ def describe_waitpid_status(status):
         os.WSTOPSIG,
     ]
     for f in funcs:
-        print(f.__name__, "-", f(status), "-", f.__doc__)
-
-
-def get_signal_name(signum):
-    """Return a signal name by the signal number."""
-    for name in dir(signal):
-        if name.startswith("SIG") and getattr(signal, name) == signum:
-            return name
-    return ""
+        s = f(status)
+        print(f.__name__, "-", s, get_signal_name(s), "-", f.__doc__)
 
 
 def unquote(s: str, chars="'\""):


### PR DESCRIPTION
Reading stop signals from the process and update the process state.

### The issue

Technically. In a couple of places that critical for processing signals we have `os.waitpid()`. The function behavior is pretty unobvious and one of things is processing return code after catching the signal. We had no good signal processing around this and this PR fixes this. See also `proc_untraced_waitpid` function description.

From user perspective. For example we have process that is waiting for user input from terminal e.g. `python -c "input()"` or `fzf`. If this process will be in captured pipeline e.g. `!(echo 1 | fzf | head)` it will be suspended by OS and the pipeline will be in the endless loop with future crashing and corrupting std at the end. This PR fixes this.

### The solution

Technically. The key function is `proc_untraced_waitpid` - it catches the stop signals and updates the process state.

From user perspective. First of all we expect that users will use captured object `!()` only for capturable processes. Because of it our goal here is to just make the behavior in this case stable.
In this PR we detect that process in the pipeline is suspended and we need to finish the command pipeline carefully:
* Show the message about suspended process.
* Keep suspended process in `jobs`. The same behavior we can see in bash. This is good because we don't know what process suspended and why. May be experienced user will want to continue it manually.
* Finish the CommandPipeline with returncode=None and suspended=True.

### Before

```xsh
!(fzf) # or !(python -c "input()")
# Hanging / Exceptions / OSError / No way to end the command.
# After exception:
$(echo 1)
# OSError / IO error
```

### After

```xsh
!(fzf) # or `!(ls | fzf | head)` or `!(python -c "input()")`
# Process ['fzf'] with pid 60000 suspended with signal 22 SIGTTOU and stay in `jobs`.
# This happends when process start waiting for input but there is no terminal attached in captured mode.
# CommandPipeline(returncode=None, suspended=True, ...)

$(echo 1)
# Success.
```
Closes #4752 #4577

### Notes

* There is pretty edge case situation when the process was terminated so fast that we can't catch pid alive and check signal ([src](https://github.com/xonsh/xonsh/blob/67d672783db6397bdec7ae44a9d9727b1e20a772/xonsh/jobs.py#L71-L80)). I leave it as is for now. 

### Mentions

#2159

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
