### PR TITLE
feat: add --no-env flag to avoid inheriting parent-shell env

### DIFF
--- a/news/no_env.rst
+++ b/news/no_env.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``xonsh --no-env`` option to run xonsh with default environment. Now by running ``xonsh --no-rc --no-env`` you have clean xonsh session.
+* Added ``xonsh --no-env`` option to run xonsh with default environment. Now by running ``xonsh --no-rc --no-env`` you have pure xonsh session.
 
 **Changed:**
 

--- a/news/no_env.rst
+++ b/news/no_env.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``xonsh --no-env`` option to run xonsh with default environment. Now by running ``xonsh --no-rc --no-env`` you have clean xonsh session.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/no_env.rst
+++ b/news/no_env.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``xonsh --no-env`` option to run xonsh with default environment. Now by running ``xonsh --no-rc --no-env`` you have pure xonsh session.
+* Added ``xonsh --no-env`` option to run xonsh without inheriting the environment variables. Now by running ``xonsh --no-rc --no-env`` you have pure xonsh session.
 
 **Changed:**
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -611,7 +611,11 @@ class XonshSession:
         if ctx is not None:
             self.ctx = ctx
 
-        self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env() if load_env else {'XONSH_NO_ENV': True})
+        self.env = (
+            kwargs.pop("env")
+            if "env" in kwargs
+            else Env(default_env() if load_env else {"XONSH_NO_ENV": True})
+        )
 
         self.exit = False
         self.stdout_uncaptured = None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -602,7 +602,7 @@ class XonshSession:
             Xonsh execution object, may be None to start
         ctx : Mapping, optional
             Context to start xonsh session with.
-        load_env : bool
+        inherit_env : bool
             If ``True``: inherit environment variable values from ``os.environ``.
             If ``False``: use default values for environment variables and
             set ``$XONSH_ENV_INHERITED = False``.

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -603,7 +603,7 @@ class XonshSession:
         ctx : Mapping, optional
             Context to start xonsh session with.
         inherit_env : bool
-            If ``True``: inherit environment variable values from ``os.environ``.
+            If ``True``: inherit environment variables from ``os.environ``.
             If ``False``: use default values for environment variables and
             set ``$XONSH_ENV_INHERITED = False``.
         """

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -593,7 +593,7 @@ class XonshSession:
         if self._py_quit is not None:
             builtins.quit = self._py_quit
 
-    def load(self, execer=None, ctx=None, **kwargs):
+    def load(self, execer=None, ctx=None, load_env=True, **kwargs):
         """Loads the session with default values.
 
         Parameters
@@ -611,7 +611,7 @@ class XonshSession:
         if ctx is not None:
             self.ctx = ctx
 
-        self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env())
+        self.env = kwargs.pop("env") if "env" in kwargs else Env(default_env() if load_env else {'XONSH_NO_ENV': True})
 
         self.exit = False
         self.stdout_uncaptured = None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -602,6 +602,10 @@ class XonshSession:
             Xonsh execution object, may be None to start
         ctx : Mapping, optional
             Context to start xonsh session with.
+        load_env : bool
+            If ``True``: inherit environment variable values from ``os.environ``.
+            If ``False``: use default values for environment variables and
+            set ``$XONSH_ENV_INHERITED = False``.
         """
         from xonsh.commands_cache import CommandsCache
         from xonsh.environ import Env, default_env
@@ -611,11 +615,12 @@ class XonshSession:
         if ctx is not None:
             self.ctx = ctx
 
-        self.env = (
-            kwargs.pop("env")
-            if "env" in kwargs
-            else Env(default_env() if load_env else {"XONSH_NO_ENV": True})
-        )
+        if "env" in kwargs:
+            self.env = kwargs.pop("env")
+        elif load_env:
+            self.env = Env(default_env())
+        else:
+            self.env = Env({"XONSH_ENV_INHERITED": False})
 
         self.exit = False
         self.stdout_uncaptured = None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -593,7 +593,7 @@ class XonshSession:
         if self._py_quit is not None:
             builtins.quit = self._py_quit
 
-    def load(self, execer=None, ctx=None, load_env=True, **kwargs):
+    def load(self, execer=None, ctx=None, inherit_env=True, **kwargs):
         """Loads the session with default values.
 
         Parameters
@@ -617,7 +617,7 @@ class XonshSession:
 
         if "env" in kwargs:
             self.env = kwargs.pop("env")
-        elif load_env:
+        elif inherit_env:
             self.env = Env(default_env())
         else:
             self.env = Env({"XONSH_ENV_INHERITED": False})

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -897,6 +897,12 @@ class GeneralSetting(Xettings):
     if hasattr(locale, "LC_MESSAGES"):
         LC_MESSAGES = Var.for_locale("LC_MESSAGES")
 
+    PWD = Var.with_default(
+        _get_cwd() or ".",
+        "Current working directory.",
+        "os.getcwd()",
+        is_configurable=False,
+    )
     OLDPWD = Var.with_default(
         ".",
         "Used to represent a previous present working directory.",

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -350,8 +350,7 @@ def start_services(shell_kwargs, args, pre_env=None):
         scriptcache=shell_kwargs.get("scriptcache", True),
         cacheall=shell_kwargs.get("cacheall", False),
     )
-    is_load_env = not shell_kwargs["noenv"]
-    XSH.load(ctx=ctx, execer=execer, load_env=is_load_env)
+    XSH.load(ctx=ctx, execer=execer, load_env=shell_kwargs["load_env"])
     events.on_timingprobe.fire(name="post_execer_init")
 
     install_import_hooks(execer)
@@ -395,7 +394,7 @@ def premain(argv=None):
         shell_kwargs["norc"] = True
     elif args.rc:
         shell_kwargs["rc"] = args.rc
-    shell_kwargs["noenv"] = args.noenv
+    shell_kwargs["load_env"] = not args.noenv
     sys.displayhook = _pprint_displayhook
     if args.command is not None:
         args.mode = XonshMode.single_command

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -350,7 +350,7 @@ def start_services(shell_kwargs, args, pre_env=None):
         scriptcache=shell_kwargs.get("scriptcache", True),
         cacheall=shell_kwargs.get("cacheall", False),
     )
-    is_load_env = not shell_kwargs['noenv']
+    is_load_env = not shell_kwargs["noenv"]
     XSH.load(ctx=ctx, execer=execer, load_env=is_load_env)
     events.on_timingprobe.fire(name="post_execer_init")
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -350,7 +350,7 @@ def start_services(shell_kwargs, args, pre_env=None):
         scriptcache=shell_kwargs.get("scriptcache", True),
         cacheall=shell_kwargs.get("cacheall", False),
     )
-    XSH.load(ctx=ctx, execer=execer, inherit_env=shell_kwargs["inherit_env"])
+    XSH.load(ctx=ctx, execer=execer, inherit_env=shell_kwargs.get("inherit_env", True))
     events.on_timingprobe.fire(name="post_execer_init")
 
     install_import_hooks(execer)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -193,7 +193,7 @@ def parser():
     )
     p.add_argument(
         "--no-env",
-        help="Do not load parent environment.",
+        help="Do not load parent environment variables.",
         dest="noenv",
         action="store_true",
         default=False,
@@ -350,7 +350,8 @@ def start_services(shell_kwargs, args, pre_env=None):
         scriptcache=shell_kwargs.get("scriptcache", True),
         cacheall=shell_kwargs.get("cacheall", False),
     )
-    XSH.load(ctx=ctx, execer=execer)
+    is_load_env = not shell_kwargs['noenv']
+    XSH.load(ctx=ctx, execer=execer, load_env=is_load_env)
     events.on_timingprobe.fire(name="post_execer_init")
 
     install_import_hooks(execer)
@@ -394,7 +395,7 @@ def premain(argv=None):
         shell_kwargs["norc"] = True
     elif args.rc:
         shell_kwargs["rc"] = args.rc
-    shell_kwargs["noenv"] = args.norc
+    shell_kwargs["noenv"] = args.noenv
     sys.displayhook = _pprint_displayhook
     if args.command is not None:
         args.mode = XonshMode.single_command
@@ -492,10 +493,6 @@ def main_xonsh(args):
         signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
 
     events.on_post_init.fire()
-
-    from xonsh.environ import Env
-
-    XSH.env = Env([])
 
     env = XSH.env
     shell = XSH.shell

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -193,10 +193,10 @@ def parser():
     )
     p.add_argument(
         "--no-env",
-        help="Do not load parent environment variables.",
-        dest="noenv",
-        action="store_true",
-        default=False,
+        help="Do not inherit parent environment variables.",
+        dest="inherit_env",
+        action="store_false",
+        default=True,
     )
     p.add_argument(
         "--no-script-cache",
@@ -394,7 +394,7 @@ def premain(argv=None):
         shell_kwargs["norc"] = True
     elif args.rc:
         shell_kwargs["rc"] = args.rc
-    shell_kwargs["load_env"] = not args.noenv
+    shell_kwargs["load_env"] = args.inherit_env
     sys.displayhook = _pprint_displayhook
     if args.command is not None:
         args.mode = XonshMode.single_command

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -350,7 +350,7 @@ def start_services(shell_kwargs, args, pre_env=None):
         scriptcache=shell_kwargs.get("scriptcache", True),
         cacheall=shell_kwargs.get("cacheall", False),
     )
-    XSH.load(ctx=ctx, execer=execer, load_env=shell_kwargs["load_env"])
+    XSH.load(ctx=ctx, execer=execer, inherit_env=shell_kwargs["inherit_env"])
     events.on_timingprobe.fire(name="post_execer_init")
 
     install_import_hooks(execer)
@@ -394,7 +394,7 @@ def premain(argv=None):
         shell_kwargs["norc"] = True
     elif args.rc:
         shell_kwargs["rc"] = args.rc
-    shell_kwargs["load_env"] = args.inherit_env
+    shell_kwargs["inherit_env"] = args.inherit_env
     sys.displayhook = _pprint_displayhook
     if args.command is not None:
         args.mode = XonshMode.single_command

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -493,6 +493,7 @@ def main_xonsh(args):
     events.on_post_init.fire()
 
     from xonsh.environ import Env
+
     XSH.env = Env([])
 
     env = XSH.env

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -192,6 +192,13 @@ def parser():
         default=False,
     )
     p.add_argument(
+        "--no-env",
+        help="Do not load parent environment.",
+        dest="noenv",
+        action="store_true",
+        default=False,
+    )
+    p.add_argument(
         "--no-script-cache",
         help="Do not cache scripts as they are run.",
         dest="scriptcache",
@@ -386,6 +393,7 @@ def premain(argv=None):
         shell_kwargs["norc"] = True
     elif args.rc:
         shell_kwargs["rc"] = args.rc
+    shell_kwargs["noenv"] = args.norc
     sys.displayhook = _pprint_displayhook
     if args.command is not None:
         args.mode = XonshMode.single_command
@@ -483,6 +491,10 @@ def main_xonsh(args):
         signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
 
     events.on_post_init.fire()
+
+    from xonsh.environ import Env
+    XSH.env = Env([])
+
     env = XSH.env
     shell = XSH.shell
     history = XSH.history


### PR DESCRIPTION
### Motivation

Basically we use `xonsh --no-rc` to have pure xonsh. 
I noticed many times when parent environment can affect `xonsh --no-rc` e.g. `$XONSH_HISTORY_FILE`.
Current workaround is `env -i @$(which xonsh) --no-rc` but I think we need to have pure xonsh way.

Closes #4921

### Before

```xsh
xonsh --no-rc
$QWE = 1
xonsh --no-rc
$QWE
# 1
```

### After
```xsh
xonsh --no-rc
$QWE = 1
xonsh --no-rc --no-env
$QWE
# Unknown environment variable: $QWE

$XONSH_ENV_INHERITED  # Marker to have a way to catch this situation.
# False
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
