### PR TITLE
Xonfig: show sensitive env variables that could affect the shell behavior.

### DIFF
--- a/news/xonfig_env.rst
+++ b/news/xonfig_env.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Xonfig: show sensitive env variables that could affect the shell behavior.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -562,7 +562,15 @@ def _info(
     data.extend([("RC file", XSH.rc_files)])
 
     # Show sensitive env variables that could affect the shell behavior.
-    envs = {'UPDATE_OS_ENVIRON': None, 'XONSH_CAPTURE_ALWAYS': None, 'THREAD_SUBPROCS': None, 'ENABLE_ASYNC_PROMPT': True, 'ENABLE_COMMANDS_CACHE': False, 'XONSH_CACHE_EVERYTHING': True, 'XONSH_CACHE_SCRIPTS':None}
+    envs = {
+        "UPDATE_OS_ENVIRON": None,
+        "XONSH_CAPTURE_ALWAYS": None,
+        "THREAD_SUBPROCS": None,
+        "ENABLE_ASYNC_PROMPT": True,
+        "ENABLE_COMMANDS_CACHE": False,
+        "XONSH_CACHE_EVERYTHING": True,
+        "XONSH_CACHE_SCRIPTS": None,
+    }
     for e, show_if in envs.items():
         if (val := XSH.env.get(e)) is not None and (show_if is None or val == show_if):
             data.extend([(e, val)])

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -565,6 +565,7 @@ def _info(
     envs = {
         "UPDATE_OS_ENVIRON": None,
         "XONSH_CAPTURE_ALWAYS": None,
+        "XONSH_SUBPROC_OUTPUT_FORMAT": None,
         "THREAD_SUBPROCS": None,
         "ENABLE_ASYNC_PROMPT": True,
         "ENABLE_COMMANDS_CACHE": False,

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -561,6 +561,12 @@ def _info(
     data.extend([("xontrib", xontribs_loaded())])
     data.extend([("RC file", XSH.rc_files)])
 
+    # Show sensitive env variables that could affect the shell behavior.
+    envs = {'UPDATE_OS_ENVIRON': None, 'XONSH_CAPTURE_ALWAYS': None, 'THREAD_SUBPROCS': None, 'ENABLE_ASYNC_PROMPT': True, 'ENABLE_COMMANDS_CACHE': False, 'XONSH_CACHE_EVERYTHING': True, 'XONSH_CACHE_SCRIPTS':None}
+    for e, show_if in envs.items():
+        if (val := XSH.env.get(e)) is not None and (show_if is None or val == show_if):
+            data.extend([(e, val)])
+
     formatter = _xonfig_format_json if to_json else _xonfig_format_human
     s = formatter(data)
     return s


### PR DESCRIPTION
### Motivation

I continue adding the information that can help to investigate cases around subprocess. Any time we have issues around subprocess behavior the main question is what `THREAD_SUBPROCS` and `XONSH_CAPTURE_ALWAYS` state because some old xontribs could change the behavior. It will be good to show this in xonfig.

### Before

```xsh
xonfig
+----------------------+----------------------+
| xonsh                | 0.16.0               |
| Git SHA              | e30dd960             |
| Commit Date          | Apr 20 20:33:07 2024 |
| Python               | 3.12.3               |
| PLY                  | 3.11                 |
| have readline        | True                 |
| prompt toolkit       | 3.0.40               |
| shell type           | prompt_toolkit       |
| history backend      | json                 |
| pygments             | 2.17.2               |
| on posix             | True                 |
| on linux             | False                |
| on darwin            | True                 |
| on windows           | False                |
| on cygwin            | False                |
| on msys2             | False                |
| is superuser         | False                |
| default encoding     | utf-8                |
| xonsh encoding       | utf-8                |
| encoding errors      | surrogateescape      |
| xontrib              | []                   |
| RC file              | []                   |
+----------------------+----------------------+

```

### After 

```xsh
xonfig
+----------------------+----------------------+
| xonsh                | 0.16.0               |
| Git SHA              | e30dd960             |
| Commit Date          | Apr 20 20:33:07 2024 |
| Python               | 3.12.3               |
| PLY                  | 3.11                 |
| have readline        | True                 |
| prompt toolkit       | 3.0.40               |
| shell type           | prompt_toolkit       |
| history backend      | json                 |
| pygments             | 2.17.2               |
| on posix             | True                 |
| on linux             | False                |
| on darwin            | True                 |
| on windows           | False                |
| on cygwin            | False                |
| on msys2             | False                |
| is superuser         | False                |
| default encoding     | utf-8                |
| xonsh encoding       | utf-8                |
| encoding errors      | surrogateescape      |
| xontrib              | []                   |
| RC file              | []                   |
| UPDATE_OS_ENVIRON    | False                | +++
| XONSH_CAPTURE_ALWAYS | False                | +++
| THREAD_SUBPROCS      | True                 | +++
| XONSH_CACHE_SCRIPTS  | True                 | +++
+----------------------+----------------------+

```
## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
