### PR TITLE
Leverage sort for sorting items.

### DIFF
--- a/xonsh/pytest/plugin.py
+++ b/xonsh/pytest/plugin.py
@@ -34,14 +34,7 @@ def pytest_collection_modifyitems(items):
     """Move xsh test first to work around a bug in normal
     pytest cleanup. The order of tests are otherwise preserved.
     """
-    xsh_items = []
-    other_items = []
-    for item in items:
-        if isinstance(item, XshFunction):
-            xsh_items.append(item)
-        else:
-            other_items.append(item)
-    items[:] = xsh_items + other_items
+    items.sort(key=lambda item: -isinstance(item, XshFunction))
 
 
 def _limited_traceback(excinfo):


### PR DESCRIPTION
While reviewing xonsh tests for another issue, I noticed that the `pytest_collection_modifyitems` was replicating what the built-in sort function does. Why not use that?

I haven't filed an issue or updated any changelog as this change is mainly an internal implementation detail.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
