### PR TITLE
which: fix handling of `None` results (#5358)

### DIFF
--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -162,7 +162,10 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         original_os_path = xp.os_environ["PATH"]
         xp.os_environ["PATH"] = XSH.env.detype()["PATH"]
         matches = _which.whichgen(arg, exts=exts, verbose=verbose)
-        for abs_name, from_where in matches:
+        for match in matches:
+            if match is None:
+                continue
+            abs_name, from_where = match
             print_path(abs_name, from_where, stdout, verbose, captured)
             nmatches += 1
             if not pargs.all:


### PR DESCRIPTION
Close #5358
<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
