### PR TITLE
Fixed processing exit signals and exit exception

### DIFF
--- a/news/sig_exit_fix.rst
+++ b/news/sig_exit_fix.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed processing exit signals and exceptions (e.g. SIGHUP in #5381) to provide careful exiting with right exit code.
+* Fixed processing exit signals and exceptions (e.g. SIGHUP in #5381) to provide careful exiting with right exit code and TTY cleaning.
 
 **Security:**
 

--- a/news/sig_exit_fix.rst
+++ b/news/sig_exit_fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed processing exit signals (e.g. SIGHUP).
+
+**Security:**
+
+* <news item>

--- a/news/sig_exit_fix.rst
+++ b/news/sig_exit_fix.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed processing exit signals (e.g. SIGHUP).
+* Fixed processing exit signals and exceptions (e.g. SIGHUP in #5381) to provide careful exiting with right exit code.
 
 **Security:**
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -141,6 +141,7 @@ def test_capture_always(
 
 
 @skip_if_on_windows
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_interrupted_process_returncode(xonsh_session):
     xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
     cmd = [["python", "-c", "import os, signal; os.kill(os.getpid(), signal.SIGINT)"]]

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1068,4 +1068,7 @@ def test_catching_system_exit():
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
     )
-    assert ret == 2
+    if ON_WINDOWS:
+        assert ret == 1
+    else:
+        assert ret == 2

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1072,3 +1072,12 @@ def test_catching_system_exit():
         assert ret == 1
     else:
         assert ret == 2
+
+
+@skip_if_on_windows
+def test_catching_system_exit():
+    stdin_cmd = "kill -SIGHUP @(__import__('os').getpid())\n"
+    out, err, ret = run_xonsh(
+        cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
+    )
+    assert ret == 1

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1080,4 +1080,4 @@ def test_catching_system_exit():
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
     )
-    assert ret == 1
+    assert ret > 0

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -51,7 +51,7 @@ def run_xonsh(
     interactive=False,
     path=None,
     add_args: list = None,
-    timeout=20
+    timeout=20,
 ):
     env = dict(os.environ)
     if path is None:
@@ -1065,5 +1065,7 @@ def test_main_d():
 
 def test_catching_system_exit():
     stdin_cmd = "__import__('sys').exit(100)\n"
-    out, err, ret = run_xonsh(cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3)
+    out, err, ret = run_xonsh(
+        cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
+    )
     assert ret == 100

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1064,8 +1064,8 @@ def test_main_d():
 
 
 def test_catching_system_exit():
-    stdin_cmd = "__import__('sys').exit(100)\n"
+    stdin_cmd = "__import__('sys').exit(2)\n"
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3
     )
-    assert ret == 100
+    assert ret == 2

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1075,7 +1075,7 @@ def test_catching_system_exit():
 
 
 @skip_if_on_windows
-def test_catching_system_exit():
+def test_catching_exit_signal():
     stdin_cmd = "kill -SIGHUP @(__import__('os').getpid())\n"
     out, err, ret = run_xonsh(
         cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -44,12 +44,14 @@ skip_if_no_sleep = pytest.mark.skipif(
 def run_xonsh(
     cmd,
     stdin=sp.PIPE,
+    stdin_cmd=None,
     stdout=sp.PIPE,
     stderr=sp.STDOUT,
     single_command=False,
     interactive=False,
     path=None,
     add_args: list = None,
+    timeout=20
 ):
     env = dict(os.environ)
     if path is None:
@@ -72,6 +74,7 @@ def run_xonsh(
         input = cmd
     if add_args:
         args += add_args
+
     proc = sp.Popen(
         args,
         env=env,
@@ -81,8 +84,12 @@ def run_xonsh(
         universal_newlines=True,
     )
 
+    if stdin_cmd:
+        proc.stdin.write(stdin_cmd)
+        proc.stdin.flush()
+
     try:
-        out, err = proc.communicate(input=input, timeout=20)
+        out, err = proc.communicate(input=input, timeout=timeout)
     except sp.TimeoutExpired:
         proc.kill()
         raise
@@ -1054,3 +1061,9 @@ def test_main_d():
         single_command=True,
     )
     assert out == "dummy\n"
+
+
+def test_catching_system_exit():
+    stdin_cmd = "__import__('sys').exit(100)\n"
+    out, err, ret = run_xonsh(cmd=None, stdin_cmd=stdin_cmd, interactive=True, single_command=False, timeout=3)
+    assert ret == 100

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -62,7 +62,7 @@ def resetting_signal_handle(sig, f):
             """
             There is no immediate exiting here.
             The ``sys.exit()`` function raises a ``SystemExit`` exception.
-            This exception must be caught and processed in the downstream code e.g. ``shell.cmdloop()``.
+            This exception must be caught and processed in the downstream code.
             """
             sys.exit(sig)
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -55,7 +55,7 @@ def resetting_signal_handle(sig, f):
     """
     prev_signal_handler = signal.getsignal(sig)
 
-    def current_signal_handler(s=None, frame=None):
+    def new_signal_handler(s=None, frame=None):
         f(s, frame)
         signal.signal(sig, prev_signal_handler)
         if sig != 0:
@@ -66,7 +66,7 @@ def resetting_signal_handle(sig, f):
             """
             sys.exit(sig)
 
-    signal.signal(sig, current_signal_handler)
+    signal.signal(sig, new_signal_handler)
 
 
 def helper(x, name=""):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -53,15 +53,20 @@ def resetting_signal_handle(sig, f):
     """Sets a new signal handle that will automatically restore the old value
     once the new handle is finished.
     """
-    oldh = signal.getsignal(sig)
+    prev_signal_handler = signal.getsignal(sig)
 
-    def newh(s=None, frame=None):
+    def current_signal_handler(s=None, frame=None):
         f(s, frame)
-        signal.signal(sig, oldh)
+        signal.signal(sig, prev_signal_handler)
         if sig != 0:
+            """
+            There is no immediate exiting here.
+            The ``sys.exit()`` function raises a ``SystemExit`` exception.
+            This exception must be caught and processed in the downstream code e.g. ``shell.cmdloop()``.
+            """
             sys.exit(sig)
 
-    signal.signal(sig, newh)
+    signal.signal(sig, current_signal_handler)
 
 
 def helper(x, name=""):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -62,7 +62,7 @@ def resetting_signal_handle(sig, f):
             """
             There is no immediate exiting here.
             The ``sys.exit()`` function raises a ``SystemExit`` exception.
-            This exception must be caught and processed in the downstream code.
+            This exception must be caught and processed in the upstream code.
             """
             sys.exit(sig)
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -577,6 +577,8 @@ def main_xonsh(args):
         else:
             # pass error to finally clause
             exc_info = sys.exc_info()
+    except SystemExit:
+        exc_info = sys.exc_info()
     finally:
         if exc_info != (None, None, None):
             err_type, err, _ = exc_info

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -584,7 +584,7 @@ def main_xonsh(args):
             err_type, err, _ = exc_info
             if err_type is SystemExit:
                 XSH.exit = True
-                code = getattr(exc_info[1], 'code', 0)
+                code = getattr(exc_info[1], "code", 0)
                 exit_code = int(code) if code is not None else 0
             else:
                 exit_code = 1

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -584,7 +584,8 @@ def main_xonsh(args):
             err_type, err, _ = exc_info
             if err_type is SystemExit:
                 XSH.exit = True
-                exit_code = int(exc_info[1].code)
+                code = getattr(exc_info[1], 'code', 0)
+                exit_code = int(code) if code is not None else 0
             else:
                 exit_code = 1
                 print_exception(None, exc_info)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -583,9 +583,11 @@ def main_xonsh(args):
         if exc_info != (None, None, None):
             err_type, err, _ = exc_info
             if err_type is SystemExit:
-                raise err
-            print_exception(None, exc_info)
-            exit_code = 1
+                XSH.exit = True
+                exit_code = int(exc_info[1].code)
+            else:
+                exit_code = 1
+                print_exception(None, exc_info)
         events.on_exit.fire()
         postmain(args)
     return exit_code

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -7,6 +7,7 @@ from functools import wraps
 from types import MethodType
 
 from prompt_toolkit import ANSI
+from prompt_toolkit.application.current import get_app
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.clipboard import InMemoryClipboard
 from prompt_toolkit.enums import EditingMode
@@ -413,6 +414,8 @@ class PromptToolkitShell(BaseShell):
             except (KeyboardInterrupt, SystemExit) as e:
                 self.reset_buffer()
                 if isinstance(e, SystemExit):
+                    get_app().reset()  # Reset mouse handlers.
+                    self.restore_tty_sanity()  # Reset SIGINT handlers.
                     raise
             except EOFError:
                 if XSH.env.get("IGNOREEOF"):

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -414,8 +414,8 @@ class PromptToolkitShell(BaseShell):
             except (KeyboardInterrupt, SystemExit) as e:
                 self.reset_buffer()
                 if isinstance(e, SystemExit):
-                    get_app().reset()  # Reset mouse handlers.
-                    self.restore_tty_sanity()  # Reset SIGINT handlers.
+                    get_app().reset()  # Reset TTY mouse and keys handlers.
+                    self.restore_tty_sanity()  # Reset TTY SIGINT handlers.
                     raise
             except EOFError:
                 if XSH.env.get("IGNOREEOF"):

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -410,11 +410,10 @@ class PromptToolkitShell(BaseShell):
                     raw_line = line
                     line = self.precmd(line)
                     self.default(line, raw_line)
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, SystemExit) as e:
                 self.reset_buffer()
-            except SystemExit:
-                self.reset_buffer()
-                raise
+                if isinstance(e, SystemExit):
+                    raise
             except EOFError:
                 if XSH.env.get("IGNOREEOF"):
                     print('Use "exit" to leave the shell.', file=sys.stderr)

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -410,8 +410,11 @@ class PromptToolkitShell(BaseShell):
                     raw_line = line
                     line = self.precmd(line)
                     self.default(line, raw_line)
-            except (KeyboardInterrupt, SystemExit):
+            except KeyboardInterrupt:
                 self.reset_buffer()
+            except SystemExit as e:
+                self.reset_buffer()
+                raise
             except EOFError:
                 if XSH.env.get("IGNOREEOF"):
                     print('Use "exit" to leave the shell.', file=sys.stderr)

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -412,7 +412,7 @@ class PromptToolkitShell(BaseShell):
                     self.default(line, raw_line)
             except KeyboardInterrupt:
                 self.reset_buffer()
-            except SystemExit as e:
+            except SystemExit:
                 self.reset_buffer()
                 raise
             except EOFError:

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -588,8 +588,9 @@ class PromptToolkitShell(BaseShell):
 
     def restore_tty_sanity(self):
         """An interface for resetting the TTY stdin mode. This is highly
-        dependent on the shell backend. Also it is mostly optional since
-        it only affects ^Z backgrounding behaviour.
+        dependent on the shell backend.
+        For prompt-toolkit it allows to fix case when terminal lost
+        SIGINT catching and Ctrl+C is not working after abnormal exiting.
         """
         # PTK does not seem to need any specialization here. However,
         # if it does for some reason in the future...

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -618,11 +618,13 @@ class ReadlineShell(BaseShell, cmd.Cmd):
         while not XSH.exit:
             try:
                 self._cmdloop(intro=intro)
-            except (KeyboardInterrupt, SystemExit):
+            except (KeyboardInterrupt, SystemExit) as e:
                 print(file=self.stdout)  # Gives a newline
                 fix_readline_state_after_ctrl_c()
                 self.reset_buffer()
                 intro = None
+                if isinstance(e, SystemExit):
+                    raise
 
     @property
     def prompt(self):


### PR DESCRIPTION
### Before

Case 1: Handler catches the exit signal and do not pass it forward. As result xonsh could be suspended by OS or crash. Also exit code is wrong. See repeatable examples with SIGHUP in https://github.com/xonsh/xonsh/issues/5381#issuecomment-2097961804.

Case 2: From bash/zsh as login shell run xonsh. Then send quit signal to xonsh. The terminal state will be broken: disabled SIGINT, mouse pointer produces mouse state codes.

### After

Case 1: Xonsh exit normally with right exit code. Fixed #5381 #5304 #5371. 

Case 2: After exiting with right exit code the state of the terminal is good.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
