### PR TITLE
Downgrade prompt-toolkit to `>=3.0.29,<3.0.40`

### DIFF
--- a/news/downgrade_ptk.rst
+++ b/news/downgrade_ptk.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Pinned prompt-toolkit version 3.0.29-3.0.39 to workaround upstream issue. More info in issue 5393.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ changelog = "https://github.com/xonsh/xonsh/blob/main/CHANGELOG.rst"
 
 [project.optional-dependencies]
 ptk = [
-    "prompt-toolkit>=3.0.29,<3.0.41",
+    "prompt-toolkit>=3.0.29,<3.0.40",
     "pyperclip",
 ]
 pygments = ["pygments>=2.2"]
@@ -98,7 +98,7 @@ full = [
     "ujson",
 ]
 bestshell = [
-    "prompt_toolkit>=3.0.29",
+    "prompt-toolkit>=3.0.29,<3.0.40",
     "pygments>=2.2",
 ]
 test = [
@@ -110,7 +110,7 @@ test = [
     "pytest-timeout",
     "pytest-subprocess",
     "pytest-rerunfailures",
-    "prompt-toolkit>=3.0.29,<3.0.41",
+    "prompt-toolkit>=3.0.29,<3.0.40",
     "pygments>=2.2",
     "coverage>=5.3.1",
     "pyte>=0.8.0",


### PR DESCRIPTION
This downgrade continues previous (#5288). Found issue in prompt-toolkit 3.0.40 (#5393).

JFYI #5241

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
