### PR TITLE
Show ``root`` and ``@#`` in prompt if user is superuser.

### DIFF
--- a/news/prompt_superuser.rst
+++ b/news/prompt_superuser.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Show ``root`` and ``@#`` in prompt if user is superuser.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -338,7 +338,8 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
         self.update(
             dict(
                 user=xp.os_environ.get(
-                    "USERNAME" if xp.ON_WINDOWS else "USER", "root" if xt.is_superuser() else "<user>"
+                    "USERNAME" if xp.ON_WINDOWS else "USER",
+                    "root" if xt.is_superuser() else "<user>",
                 ),
                 prompt_end="@#" if xt.is_superuser() else "@",
                 hostname=socket.gethostname().split(".", 1)[0],

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -338,9 +338,9 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
         self.update(
             dict(
                 user=xp.os_environ.get(
-                    "USERNAME" if xp.ON_WINDOWS else "USER", "<user>"
+                    "USERNAME" if xp.ON_WINDOWS else "USER", "root" if xt.is_superuser() else "<user>"
                 ),
-                prompt_end="#" if xt.is_superuser() else "@",
+                prompt_end="@#" if xt.is_superuser() else "@",
                 hostname=socket.gethostname().split(".", 1)[0],
                 cwd=_dynamically_collapsed_pwd,
                 cwd_dir=lambda: os.path.join(os.path.dirname(_replace_home_cwd()), ""),


### PR DESCRIPTION
### Before

```xsh
sudo xonsh --no-rc
# <user>@host ~ #
```


### After

```xsh
sudo xonsh --no-rc
# root@host ~ @#
```

It's in sync with:

```xsh
docker run -it ubuntu bash
# root@ce01c2856819:/#
echo $USER
# 
# root@ce01c2856819:/#
```
## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
