### PR TITLE
Ignore ptk warning

### DIFF
--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -185,8 +185,12 @@ class PromptToolkitShell(BaseShell):
 
     def __init__(self, **kwargs):
         if not XSH.env.get("XONSH_DEBUG", False):
-            __import__('warnings').filterwarnings('ignore', 'There is no current event loop', DeprecationWarning,
-                                                  module='prompt_toolkit.application.application')
+            __import__("warnings").filterwarnings(
+                "ignore",
+                "There is no current event loop",
+                DeprecationWarning,
+                module="prompt_toolkit.application.application",
+            )
 
         ptk_args = kwargs.pop("ptk_args", {})
         super().__init__(**kwargs)

--- a/xonsh/ptk_shell/shell.py
+++ b/xonsh/ptk_shell/shell.py
@@ -184,6 +184,10 @@ class PromptToolkitShell(BaseShell):
     }
 
     def __init__(self, **kwargs):
+        if not XSH.env.get("XONSH_DEBUG", False):
+            __import__('warnings').filterwarnings('ignore', 'There is no current event loop', DeprecationWarning,
+                                                  module='prompt_toolkit.application.application')
+
         ptk_args = kwargs.pop("ptk_args", {})
         super().__init__(**kwargs)
         if ON_WINDOWS:


### PR DESCRIPTION
Because we downgraded ptk in https://github.com/xonsh/xonsh/pull/5403

### Before

```xsh
xonsh --no-rc
# /Users/pc/.local/mamba-envs/lib/python3.12/site-packages/prompt_toolkit/application/application.py:961: DeprecationWarning: There is no current event loop
#  loop = asyncio.get_event_loop()
#@
```

### After

```xsh
xonsh --no-rc
#@
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
