### PR TITLE
History: Saving history in case of any type of exiting the shell.

### DIFF
--- a/news/history_save_unload.rst
+++ b/news/history_save_unload.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Saving history in case of any type of exiting the shell.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_history_json.py
+++ b/tests/test_history_json.py
@@ -70,6 +70,18 @@ def test_hist_flush(hist, xession):
         assert not cmd.get("out", None)
 
 
+def test_hist_flush_on_xonsh_unload(hist, xession):
+    hf = hist.flush()
+    assert hf is None
+    xession.env["HISTCONTROL"] = set()
+    hist.append({"inp": "save me if you unload", "rtn": 0, "out": "yes"})
+    xession.unload()
+    with LazyJSON(hist.filename) as lj:
+        assert len(lj["cmds"]) == 1
+        cmd = lj["cmds"][0]
+        assert cmd["inp"] == "save me if you unload"
+
+
 def test_hist_flush_with_store_stdout(hist, xession):
     """Verify explicit flushing of the history works."""
     hf = hist.flush()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -687,7 +687,7 @@ class XonshSession:
         if not self.builtins_loaded:
             return
 
-        if self.history:
+        if self.history is not None:
             self.history.flush(at_exit=True)
 
         self.unlink_builtins()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -686,6 +686,10 @@ class XonshSession:
 
         if not self.builtins_loaded:
             return
+
+        if self.history:
+            self.history.flush(at_exit=True)
+
         self.unlink_builtins()
         delattr(builtins, "__xonsh__")
         self.builtins_loaded = False


### PR DESCRIPTION
### Before

```xsh
echo 1 
echo 2
# <<Crash>>
# No json history
```

### After

Closes #2657

```xsh
echo 1 
echo 2
# <<Crash>>
# In json history
# echo 1
# echo 2
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
