### PR TITLE
Now last executed CommandPipeline is available in ``__xonsh__.last``

### DIFF
--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -101,10 +101,10 @@ line is ``#!/usr/bin/env xonsh``.
       - ``os.getpid()``
       - Get PID of the current shell.
     * - ``$?``
-      - ``_.rtn``
+      - ``__xonsh__.last.rtn`` anywhere or ``_.rtn`` in prompt mode
       - Returns the exit code, or status, of the previous command. The underscore ``_`` is working
         in the prompt mode. To get the exit code of the command in xonsh script
-        use captured subprocess ``!().rtn``.
+        use ``!().rtn`` for not interactive processes.
     * - ``!$``
       - ``__xonsh__.history[-1, -1]``
       - Get the last argument of the last command
@@ -116,17 +116,15 @@ line is ``#!/usr/bin/env xonsh``.
       - ``$ARGS``
       - List of all command line argument and parameter strings.
     * - ``while getopts``
-      - ``import argparse``
-      - Start from `argparse <https://docs.python.org/3/library/argparse.html>`_ library to describe
-        the command line arguments in your script. Next try
-        `xontrib-argcomplete <https://github.com/anki-code/xontrib-argcomplete>`_ to activate
-        tab completion for your script.
+      - Use `argparse <https://docs.python.org/3/library/argparse.html>`_ or `click <https://click.palletsprojects.com>`_
+      - See also `awesome-cli-app <https://github.com/anki-code/xonsh-awesome-cli-app>`_ and
+        `xontrib-argcomplete <https://github.com/anki-code/xontrib-argcomplete>`_ .
     * - ``complete``
       - ``completer list``
       - As with many other shells, xonsh ships with the ability to complete partially-specified arguments
         upon hitting the “tab” key.
     * - OhMyBash or BashIt
-      - `Xontribs <https://xon.sh/xontribs.html>`_
+      - `awesome-xontribs <https://github.com/xonsh/awesome-xontribs>`_
       - Xontributions, or ``xontribs``, are a set of tools and conventions for extending the functionality
         of xonsh beyond what is provided by default.
     * - Display completions as list

--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -116,7 +116,7 @@ line is ``#!/usr/bin/env xonsh``.
       - ``$ARGS``
       - List of all command line argument and parameter strings.
     * - ``while getopts``
-      - Use `argparse <https://docs.python.org/3/library/argparse.html>`_ or `click <https://click.palletsprojects.com>`_
+      - Use `argparse <https://docs.python.org/3/library/argparse.html>`_ or `click <https://click.palletsprojects.com>`_.
       - See also `awesome-cli-app <https://github.com/anki-code/xonsh-awesome-cli-app>`_ and
         `xontrib-argcomplete <https://github.com/anki-code/xontrib-argcomplete>`_ .
     * - ``complete``

--- a/news/last_cp.rst
+++ b/news/last_cp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Now last executed CommandPipeline is available in ``__xonsh__.last``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -566,6 +566,7 @@ class XonshSession:
         self._completers = None
         self.builtins = None
         self._initial_builtin_names = None
+        self.last = None  # Last executed CommandPipeline.
 
     @property
     def aliases(self):

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -966,7 +966,12 @@ def _run_command_pipeline(specs, cmds):
 
 def _run_specs(specs, cmds):
     cp = _run_command_pipeline(specs, cmds)
-    XSH.last, proc, captured, background = cp, cp.proc, specs[-1].captured, cp.spec.background
+    XSH.last, proc, captured, background = (
+        cp,
+        cp.proc,
+        specs[-1].captured,
+        cp.spec.background,
+    )
 
     # For some reason, some programs are in a stopped state when the flow
     # reaches this point, hence a SIGCONT should be sent to `proc` to make

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -966,7 +966,7 @@ def _run_command_pipeline(specs, cmds):
 
 def _run_specs(specs, cmds):
     cp = _run_command_pipeline(specs, cmds)
-    proc, captured, background = cp.proc, specs[-1].captured, cp.spec.background
+    XSH.last, proc, captured, background = cp, cp.proc, specs[-1].captured, cp.spec.background
 
     # For some reason, some programs are in a stopped state when the flow
     # reaches this point, hence a SIGCONT should be sent to `proc` to make


### PR DESCRIPTION
### Motivation

There is no way to access to the CommandPipeline of executed command in uncaptured mode. This causes:
 * No chance to get return code in one universal way.
 * Barrier to trace and inspection.

### Before

```xsh
$(ls nofile)
# No way to access to the CommandPipeline of executed command.
```

### After
```xsh
$(ls nofile)
__xonsh__.last.rtn  # In interactive or not interactive.
# 2
```
```xsh
# Sugar sir:
last = type('LastCP', (object,), {'__getattr__':lambda self, name: getattr(__xonsh__.last, name) })()

ls nofile
last.rtn
# 2
```

JFYI #5342

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
