### PR TITLE
Added support of NixOS core tools in ``predict_threadable``

### DIFF
--- a/news/fix_nix.rst
+++ b/news/fix_nix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added support of NixOS core tools in ``predict_threadable``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -203,6 +203,7 @@ def test_update_cache(xession, tmp_path):
 
     assert file2.samefile(cached[basename][0])
 
+
 def test_nixos_coreutils(tmp_path):
     """On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file."""
     path = tmp_path / "core"

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -202,3 +202,20 @@ def test_update_cache(xession, tmp_path):
     cached = cache.update_cache()
 
     assert file2.samefile(cached[basename][0])
+
+def test_nixos_coreutils(tmp_path):
+    """On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file."""
+    path = tmp_path / "core"
+    coreutils = path / "coreutils"
+    echo = path / "echo"
+    cat = path / "cat"
+
+    path.mkdir()
+    coreutils.touch()
+    echo.symlink_to(coreutils)
+    cat.symlink_to(coreutils)
+
+    cache = CommandsCache({"PATH": [path]})
+
+    assert cache.predict_threadable(["echo"]) is True
+    assert cache.predict_threadable(["cat"]) is False

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -203,7 +203,7 @@ def test_update_cache(xession, tmp_path):
 
     assert file2.samefile(cached[basename][0])
 
-
+@skip_if_on_windows
 def test_nixos_coreutils(tmp_path):
     """On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file."""
     path = tmp_path / "core"

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -132,6 +132,12 @@ class CommandsCache(cabc.Mapping):
         self.update_cache()
         return self._cmds_cache
 
+    def readsymlink(self, path):
+        try:
+            return os.readlink(path)
+        except Exception:
+            return None
+
     def update_cache(self):
         env = self.env
         # iterate backwards so that entries at the front of PATH overwrite
@@ -382,6 +388,12 @@ class CommandsCache(cabc.Mapping):
         if fname is None:
             return failure
         if not os.path.isfile(fname):
+            return failure
+        if (link := self.readsymlink(fname)) and link.endswith('coreutils'):
+            """
+            On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file. 
+            Detect it and use the default mode.
+            """
             return failure
 
         try:

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -389,9 +389,9 @@ class CommandsCache(cabc.Mapping):
             return failure
         if not os.path.isfile(fname):
             return failure
-        if (link := self.readsymlink(fname)) and link.endswith('coreutils'):
+        if (link := self.readsymlink(fname)) and link.endswith("coreutils"):
             """
-            On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file. 
+            On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file.
             Detect it and use the default mode.
             """
             return failure

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -153,7 +153,6 @@ class CommandsCache(cabc.Mapping):
 
         return current_path
 
-
     def update_cache(self):
         env = self.env
         # iterate backwards so that entries at the front of PATH overwrite


### PR DESCRIPTION
### Motivation

Closes #5003

### The case

Core utils in Nix are symlinks to one binary file that contains all utils:

```xsh
docker run --rm -it nixos/nix bash

which echo
# /nix/store/k6h0vjh342kqlkq69sxjj8i5y50l6jfr-coreutils-9.3/bin/echo

ls -la /nix/store/k6h0vjh342kqlkq69sxjj8i5y50l6jfr-coreutils-9.3/bin/
# b2sum -> coreutils
# base32 -> coreutils
# ...
# All tools are symlinks to one binary file - `coreutils`.
```

When [`default_predictor_readbin`](https://github.com/xonsh/xonsh/blob/61bda708c992a300eab212f877718cf0050a5e3a/xonsh/commands_cache.py#L392) read `coreutils` it catches `(b'isatty', b'tcgetattr', b'tcsetattr')` and return `threadable=False` forever.

The list of Nix coreutils tools are exactly the same as in [brew coreutils](https://formulae.brew.sh/formula/coreutils). So I can check the real predicts on distinct binaries and see that only 2 tools among 106 are unthreadable and they already covered by `default_threadable_predictors` (If it's wrong please add unthreadable tools to the [default_threadable_predictors](https://github.com/xonsh/xonsh/blob/61bda708c992a300eab212f877718cf0050a5e3a/xonsh/commands_cache.py#L518)):

```xsh
brew install coreutils

ls /opt/homebrew/opt/coreutils/libexec/gnubin/ | wc -l
# 106

for t in p`/opt/homebrew/opt/coreutils/libexec/gnubin/.*`:
    if not (th := __xonsh__.commands_cache.predict_threadable([t.name])):
        print($(which @(t.name)), th)
# /opt/homebrew/opt/coreutils/libexec/gnubin/cat False
# /opt/homebrew/opt/coreutils/libexec/gnubin/yes False

defaults = __import__('xonsh').commands_cache.default_threadable_predictors().keys()
defaults['cat']
# <function xonsh.commands_cache.predict_false>
defaults['yes']
# <function xonsh.commands_cache.predict_false>
```

So the rest of we need is to check the symlink and apply default prediction if the tools is the symlink to coreutils. This implements this PR. Test included.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
