### PR TITLE
Revert jobs.obj rename

### DIFF
--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -210,7 +210,7 @@ if ON_WINDOWS:
 
     def _kill(job):
         subprocess.check_output(
-            ["taskkill", "/F", "/T", "/PID", str(job["proc"].pid)],
+            ["taskkill", "/F", "/T", "/PID", str(job["obj"].pid)],
             stderr=subprocess.STDOUT,
         )
 
@@ -231,7 +231,7 @@ if ON_WINDOWS:
         # Return when there are no foreground active task
         if active_task is None:
             return last_task
-        proc = active_task["proc"]
+        proc = active_task["obj"]
         _continue(active_task)
         while proc.returncode is None:
             try:
@@ -344,7 +344,7 @@ else:
         # Return when there are no foreground active task
         if active_task is None:
             return last_task
-        proc = active_task["proc"]
+        proc = active_task["obj"]
         info = {"backgrounded": False}
 
         try:
@@ -402,7 +402,7 @@ def _clear_dead_jobs():
     to_remove = set()
     tasks = get_tasks()
     for tid in tasks:
-        proc = get_task(tid)["proc"]
+        proc = get_task(tid)["obj"]
         if proc is None or proc.poll() is not None:
             to_remove.add(tid)
     for job in to_remove:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -956,7 +956,7 @@ def _run_command_pipeline(specs, cmds):
                 "cmds": cmds,
                 "pids": [i.pid for i in cp.procs],
                 "status": "suspended" if cp.suspended else "running",
-                "proc": proc,
+                "obj": proc,
                 "bg": background,
                 "pipeline": cp,
                 "pgrp": cp.term_pgid,


### PR DESCRIPTION
### Motivation

Closes #5441

In the nutshell [Starship uses "obj"](https://github.com/starship/starship/blob/86c1312a05116fb404ab6ae90af37f78915f77b8/src/init/starship.xsh#L4-L11) so let's revert [the renaming](https://github.com/xonsh/xonsh/commit/0f25a5a348e5569982d2b579a1bfa34d68df2418#diff-893f3d2e484910a3d1f57b499bdc81bf828ad764af9b7de0a8abb3d4e648d2c7L958) and will implement backwards compatibility when we switch jobs to singleton object some day.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
