### PR TITLE
Tutorial: add info about non-blocking `!()`

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -405,8 +405,8 @@ read the captured output later:
     >>> p.output
     'snail'
 
-The ending will be forced automatically in case of getting the return code,
-printing the object or reading from ``out`` attribute:
+You can force ``xonsh`` to block and wait for the command to complete by asking for the return code,
+printing the object or reading the ``out`` attribute:
 
 .. code-block:: xonshcon
 


### PR DESCRIPTION
Closes #3394

### Motivation

After reading [the history of threading and operators](https://github.com/xonsh/xonsh/issues/5444) I realized that this was intended, to make the `!()` operator non-blocking. So let's write about this in tutorial.

### Next steps

In the future we need to solve these points:
* Confusion around `.output` and `.out`.
* Show good cases where non-blocking is doing perfect work to people. Or remove the non-blocking functionality [to remove threading](https://github.com/xonsh/xonsh/discussions/4710).

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
