### PR TITLE
prompt: yellow env_name

### DIFF
--- a/news/prompt_end_nl.rst
+++ b/news/prompt_end_nl.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Prompt: ``env_name`` will have yellow color.
+* Prompt: ``prompt_end`` will be putted to the new line if the prompt size closer to terminal window width.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/prompt_env_name_yel.rst
+++ b/news/prompt_env_name_yel.rst
@@ -5,7 +5,6 @@
 **Changed:**
 
 * Prompt: ``env_name`` will have yellow color.
-* Prompt: ``prompt_end`` will be putted to the new line if the prompt size closer to terminal window width.
 
 **Deprecated:**
 

--- a/news/prompt_env_name_yel.rst
+++ b/news/prompt_env_name_yel.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Prompt: ``env_name`` will have yellow color.
+* Prompt: ``env_name`` will have yellow color by default.
 
 **Deprecated:**
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -169,7 +169,7 @@ class Aliases(cabc.MutableMapping):
         # only once.
         if (
             isinstance(value, cabc.Iterable)
-            and hasattr(value, '__len__')
+            and hasattr(value, "__len__")
             and len(value) > 1
             and (isinstance(mod := self._raw.get(str(value[0])), SpecModifierAlias))
         ):

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -151,7 +151,7 @@ def default_prompt():
             "{YELLOW}{env_name}{RESET}"
             "{BOLD_INTENSE_GREEN}{user}@{hostname}{BOLD_INTENSE_CYAN} "
             "{cwd}{branch_color}{curr_branch: {}}{RESET} "
-            "{prompt_end_nl}{BOLD_INTENSE_CYAN}{prompt_end}{RESET} "
+            "{BOLD_INTENSE_CYAN}{prompt_end}{RESET} "
         )
     else:
         dp = (
@@ -159,7 +159,7 @@ def default_prompt():
             "{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} "
             "{cwd}{branch_color}{curr_branch: {}}{RESET} "
             "{RED}{last_return_code_if_nonzero:[{BOLD_INTENSE_RED}{}{RED}] }{RESET}"
-            "{prompt_end_nl}{BOLD_BLUE}{prompt_end}{RESET} "
+            "{BOLD_BLUE}{prompt_end}{RESET} "
         )
     return dp
 
@@ -242,19 +242,6 @@ def is_template_string(template, PROMPT_FIELDS=None):
         fmtter = PROMPT_FIELDS
     known_names = set(fmtter.keys())
     return included_names <= known_names
-
-
-def prompt_end_nl():
-    """Add new line if the size of prompt is closer to the terminal width."""
-    try:
-        cols = os.get_terminal_size().columns
-        pt = XSH.env.get("PROMPT", "").replace("{prompt_end_nl}", "")
-        prompt = PromptFormatter()(template=pt, remove_unknown=True)
-        if cols and cols - len(prompt) < 10:
-            return f"\n"
-    except Exception as e:
-        pass
-    return ""
 
 
 def _format_value(val, spec, conv) -> str:
@@ -354,7 +341,6 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
                     "USERNAME" if xp.ON_WINDOWS else "USER",
                     "root" if xt.is_superuser() else "<user>",
                 ),
-                prompt_end_nl=prompt_end_nl,
                 prompt_end="@#" if xt.is_superuser() else "@",
                 hostname=socket.gethostname().split(".", 1)[0],
                 cwd=_dynamically_collapsed_pwd,

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -155,7 +155,7 @@ def default_prompt():
         )
     else:
         dp = (
-            "{env_name}"
+            "{YELLOW}{env_name}{RESET}"
             "{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} "
             "{cwd}{branch_color}{curr_branch: {}}{RESET} "
             "{RED}{last_return_code_if_nonzero:[{BOLD_INTENSE_RED}{}{RED}] }{RESET}"

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -109,7 +109,7 @@ class PromptFormatter:
         for literal, field, spec, conv in xt.FORMATTER.parse(tmpl):
             if literal:
                 toks.append(_ParsedToken(literal))
-            entry = self._format_field(field, spec, conv, idx=len(toks), remove_unknown=remove_unknown, **kwargs)
+            entry = self._format_field(field, spec, conv, idx=len(toks), **kwargs)
             if entry is not None:
                 toks.append(_ParsedToken(entry, field))
 
@@ -126,7 +126,7 @@ class PromptFormatter:
             return _format_value(val, spec, conv)
         else:
             # color or unknown field, return as is
-            return "" if remove_unknown else ("{" + field + "}")
+            return ("{" + field + "}")
 
     def _get_field_value(self, field, **_):
         try:

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -75,7 +75,7 @@ class PromptFormatter:
     uses the ``PROMPT_FIELDS`` envvar (no color formatting).
     """
 
-    def __call__(self, template=DEFAULT_PROMPT, fields=None, remove_unknown=False, **kwargs) -> str:
+    def __call__(self, template=DEFAULT_PROMPT, fields=None, **kwargs) -> str:
         """Formats a xonsh prompt template string."""
 
         if fields is None:
@@ -90,7 +90,7 @@ class PromptFormatter:
             self.fields = pflds
 
         try:
-            toks = self._format_prompt(template=template, remove_unknown=remove_unknown, **kwargs)
+            toks = self._format_prompt(template=template, **kwargs)
             prompt = toks.process()
         except Exception as ex:
             # make it obvious why it has failed
@@ -103,7 +103,7 @@ class PromptFormatter:
             return _failover_template_format(template)
         return prompt
 
-    def _format_prompt(self, template=DEFAULT_PROMPT, remove_unknown=False, **kwargs) -> ParsedTokens:
+    def _format_prompt(self, template=DEFAULT_PROMPT, **kwargs) -> ParsedTokens:
         tmpl = template() if callable(template) else template
         toks = []
         for literal, field, spec, conv in xt.FORMATTER.parse(tmpl):
@@ -115,7 +115,7 @@ class PromptFormatter:
 
         return ParsedTokens(toks, template)
 
-    def _format_field(self, field, spec="", conv=None, remove_unknown=False, **kwargs):
+    def _format_field(self, field, spec="", conv=None, **kwargs):
         if field is None:
             return
         elif field.startswith("$"):
@@ -155,7 +155,7 @@ def default_prompt():
         )
     else:
         dp = (
-            "{YELLOW}{env_name}{RESET}"
+            "{env_name}"
             "{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} "
             "{cwd}{branch_color}{curr_branch: {}}{RESET} "
             "{RED}{last_return_code_if_nonzero:[{BOLD_INTENSE_RED}{}{RED}] }{RESET}"
@@ -342,7 +342,7 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
                     "root" if xt.is_superuser() else "<user>",
                 ),
                 prompt_end="@#" if xt.is_superuser() else "@",
-                hostname=socket.gethostname().split(".", 1)[0],
+                hostname="host",#socket.gethostname().split(".", 1)[0],
                 cwd=_dynamically_collapsed_pwd,
                 cwd_dir=lambda: os.path.join(os.path.dirname(_replace_home_cwd()), ""),
                 cwd_base=lambda: os.path.basename(_replace_home_cwd()),

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -126,7 +126,7 @@ class PromptFormatter:
             return _format_value(val, spec, conv)
         else:
             # color or unknown field, return as is
-            return ("{" + field + "}")
+            return "{" + field + "}"
 
     def _get_field_value(self, field, **_):
         try:

--- a/xonsh/prompt/base.py
+++ b/xonsh/prompt/base.py
@@ -342,7 +342,7 @@ class PromptFields(tp.MutableMapping[str, "FieldType"]):
                     "root" if xt.is_superuser() else "<user>",
                 ),
                 prompt_end="@#" if xt.is_superuser() else "@",
-                hostname="host",#socket.gethostname().split(".", 1)[0],
+                hostname=socket.gethostname().split(".", 1)[0],
                 cwd=_dynamically_collapsed_pwd,
                 cwd_dir=lambda: os.path.join(os.path.dirname(_replace_home_cwd()), ""),
                 cwd_base=lambda: os.path.basename(_replace_home_cwd()),


### PR DESCRIPTION
### Motivation

When interact with default prompt I noticed that`env_name` has no color and when you type command or see the output it mix with `env_name` visually. Prompt is not highlighted when `env_name` has default color.

### Before

Output and env_name are visually mixed:

<img width="900" alt="image" src="https://github.com/xonsh/xonsh/assets/1708680/c843388e-6e72-4fba-ab0f-6cd3fb023cd2">


### After

Output and env_name are visually distinct:

<img width="918" alt="image" src="https://github.com/xonsh/xonsh/assets/1708680/09f45cd8-63d1-479a-bfab-c8063cf03aeb">



## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
