### PR TITLE
note that xonsh requires pip 24 for an editable install

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,6 +19,8 @@ develop xonsh.
 Making Your First Change
 ========================
 
+.. note:: xonsh requires at least `pip 24.0` for `pyproject.toml` support. You can upgrade old versions using `pip install -U pip`.
+
 First, install xonsh from source and open a xonsh shell in your favorite
 terminal application. See installation instructions for details, but it
 is recommended to do an 'editable' install via `pip'


### PR DESCRIPTION
with pip 22, i was getting extremely strange errors like this one:
```
$ pip install '.[dev]'
Processing /home/jyn/src/xonsh
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
WARNING: unknown 0.0.0 does not provide the extra 'dev'
Building wheels for collected packages: UNKNOWN
  Building wheel for UNKNOWN (pyproject.toml) ... done

Successfully installed UNKNOWN-0.0.0
```

see https://xonsh.zulipchat.com/#narrow/stream/435069-xonsh-dev/topic/install.20xonsh.20for.20development.20without.20sudo.20rights for more context.

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
