### PR TITLE
Perform proper case-insensitive matching in command_cache on Windows

### DIFF
--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -241,3 +241,28 @@ You can add aliases to your ``~/.xonshrc`` to have it always
 available when xonsh starts.
 
 
+Working Directory on PATH
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Windows users, particularly those coming from the ``cmd.exe`` shell,
+might be accustomed to being able to run executables from the current
+directory by simply typing the program name.
+
+Since version 0.16, ``xonsh`` follows the more secure and modern
+approach of not including the current working directory in the search
+path, similar to Powershell and popular Unix shells. To invoke commands
+in the current directory on any platform, include the current directory
+explicitly:
+
+.. code-block:: xonshcon
+
+    >>> ./my-program
+
+Although not recommended, to restore the behavior found in the
+``cmd.exe`` shell, simply append ``.`` to the ``PATH``:
+
+.. code-block:: xonshcon
+
+    >>> $PATH.append('.')
+
+Add that to ``~/.xonshrc`` to enable that as the default behavior.

--- a/news/5477.rst
+++ b/news/5477.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Minor cleanup of ``commands_cache``, unifying behavior across platforms.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* No longer is ``.`` implied for running commands on Windows. Instead the behavior is the same across platforms. Windows users will need to prefix ``./`` or ``.\`` to run commands from the current directory (#5476).
+
+**Fixed:**
+
+* Commands on Windows now honor the case as they appear on the file system (#5469).
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ authors = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
 maintainers = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
 license = { text = "BSD 2-Clause License" }
 requires-python = ">=3.9"
+dependencies = [
+    "case-insensitive-dictionary; platform_system=='Windows'",
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "xonsh.__version__"}

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -203,20 +203,22 @@ def test_update_cache(xession, tmp_path):
     assert file2.samefile(cached[basename][0])
 
 
-def test_find_binary_retains_case(tmp_path):
-    faux_binary = tmp_path / "runme.exe"
-    faux_binary.touch()
-    faux_binary.chmod(0o755)
+@pytest.fixture
+def faux_binary(tmp_path):
+    binary = tmp_path / "runme.exe"
+    binary.touch()
+    binary.chmod(0o755)
+    return binary
+
+
+def test_find_binary_retains_case(faux_binary):
     cache = CommandsCache({"PATH": []})
     loc = cache.locate_binary(str(faux_binary))
     assert "runme.exe" in loc
 
 
-def test_exes_in_cwd_are_not_matched(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    faux_binary = tmp_path / "runme.exe"
-    faux_binary.touch()
-    faux_binary.chmod(0o755)
+def test_exes_in_cwd_are_not_matched(faux_binary, monkeypatch):
+    monkeypatch.chdir(faux_binary.parent)
     cache = CommandsCache({"PATH": []})
     assert cache.locate_binary("runme.exe") is None
 

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -157,7 +157,6 @@ def test_commands_cache_predictor_default(args, xession, tmp_path):
 
 
 class Test_is_only_functional_alias:
-    @skip_if_on_windows
     def test_cd(self, xession):
         xession.aliases["cd"] = lambda args: os.chdir(args[0])
         xession.env["PATH"] = []
@@ -204,7 +203,6 @@ def test_update_cache(xession, tmp_path):
     assert file2.samefile(cached[basename][0])
 
 
-@skip_if_on_windows
 def test_nixos_coreutils(tmp_path):
     """On NixOS the core tools are the symlinks to one universal ``coreutils`` binary file."""
     path = tmp_path / "core"

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -205,7 +205,12 @@ def test_update_cache(xession, tmp_path):
 
 @pytest.fixture
 def faux_binary(tmp_path):
-    binary = tmp_path / "runme.exe"
+    """
+    A fake binary in the temp path.
+
+    Uses mixed case so tests may make assertions about it.
+    """
+    binary = tmp_path / "RunMe.exe"
     binary.touch()
     binary.chmod(0o755)
     return binary
@@ -214,13 +219,13 @@ def faux_binary(tmp_path):
 def test_find_binary_retains_case(faux_binary):
     cache = CommandsCache({"PATH": []})
     loc = cache.locate_binary(str(faux_binary))
-    assert "runme.exe" in loc
+    assert faux_binary.name in loc
 
 
 def test_exes_in_cwd_are_not_matched(faux_binary, monkeypatch):
     monkeypatch.chdir(faux_binary.parent)
     cache = CommandsCache({"PATH": []})
-    assert cache.locate_binary("runme.exe") is None
+    assert cache.locate_binary(faux_binary.name) is None
 
 
 def test_nixos_coreutils(tmp_path):

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -99,8 +99,16 @@ class CommandsCache(cabc.Mapping):
         return len(self._cmds_cache) == 0
 
     def get_possible_names(self, name):
-        """Generates the possible `PATHEXT` extension variants of a given executable
-        name on Windows as a list, conserving the ordering in `PATHEXT`."""
+        """Expand name to all possible variants based on `PATHEXT`.
+
+        PATHEXT is a Windows convention containing extensions to be
+        considered when searching for an executable file.
+
+        Conserves order of any extensions found and gives precedence
+        to the bare name.
+
+        Incidentally, also uppercase the name on Windows (why?).
+        """
         if ON_WINDOWS:
             name = name.upper()
         pathext = [""] + self.env.get("PATHEXT", [])

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -262,7 +262,6 @@ class CommandsCache(cabc.Mapping):
             Force return of binary path even if alias of ``name`` exists
             (default ``False``)
         """
-        # make sure the cache is up to date by accessing the property
         self.update_cache()
         return self.lazy_locate_binary(name, ignore_alias)
 

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -100,14 +100,11 @@ class CommandsCache(cabc.Mapping):
 
     def get_possible_names(self, name):
         """Generates the possible `PATHEXT` extension variants of a given executable
-        name on Windows as a list, conserving the ordering in `PATHEXT`.
-        Returns a list as `name` being the only item in it on other platforms."""
+        name on Windows as a list, conserving the ordering in `PATHEXT`."""
         if ON_WINDOWS:
-            pathext = [""] + self.env.get("PATHEXT", [])
             name = name.upper()
-            return [name + ext for ext in pathext]
-        else:
-            return [name]
+        pathext = [""] + self.env.get("PATHEXT", [])
+        return [name + ext for ext in pathext]
 
     @staticmethod
     def remove_dups(paths):

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -111,8 +111,8 @@ class CommandsCache(cabc.Mapping):
         """
         if ON_WINDOWS:
             name = name.upper()
-        pathext = [""] + self.env.get("PATHEXT", [])
-        return [name + ext for ext in pathext]
+        extensions = [""] + self.env.get("PATHEXT", [])
+        return [name + ext for ext in extensions]
 
     @staticmethod
     def remove_dups(paths):

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -277,12 +277,6 @@ class CommandsCache(cabc.Mapping):
             (default ``False``)
         """
         possibilities = self.get_possible_names(name)
-        if ON_WINDOWS:
-            # Windows users expect to be able to execute files in the same
-            # directory without `./`
-            local_bin = next((fn for fn in possibilities if os.path.isfile(fn)), None)
-            if local_bin:
-                return os.path.abspath(local_bin)
         cached = next((cmd for cmd in possibilities if cmd in self._cmds_cache), None)
         if cached:
             (path, alias) = self._cmds_cache[cached]

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -217,13 +217,9 @@ class CommandsCache(cabc.Mapping):
 
     def cached_name(self, name):
         """Returns the name that would appear in the cache, if it exists."""
-        if name is None:
-            return None
         cached = pathbasename(name) if os.pathsep in name else name
-        if ON_WINDOWS:
-            keys = self.get_possible_names(cached)
-            cached = next((k for k in keys if k in self._cmds_cache), None)
-        return cached
+        keys = self.get_possible_names(cached)
+        return next((k for k in keys if k in self._cmds_cache), name)
 
     def lazyin(self, key):
         """Checks if the value is in the current cache without the potential to


### PR DESCRIPTION
Closes #5476
Closes #5469

- [x] Include a news file (https://xon.sh/devguide.html#changelog).
- [x] ~~Add the documentation for your feature into `/docs`.~~
- [x] Add the example of usage or before-after behavior.
- [x] Mention the issue that this PR is addressing e.g. `#1234`.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
