### PR TITLE
list_lines: list for single line output

### DIFF
--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -186,8 +186,8 @@ def test_specs_with_suspended_captured_process_pipeline(
 @pytest.mark.parametrize(
     "cmds, exp_stream_lines, exp_list_lines",
     [
-        ([["echo", "-n", "1"]], "1", "1"),
-        ([["echo", "-n", "1\n"]], "1", "1"),
+        ([["echo", "-n", "1"]], "1", ["1"]),
+        ([["echo", "-n", "1\n"]], "1", ["1"]),
         ([["echo", "-n", "1\n2\n3\n"]], "1\n2\n3\n", ["1", "2", "3"]),
         ([["echo", "-n", "1\r\n2\r3\r\n"]], "1\n2\n3\n", ["1", "2", "3"]),
         ([["echo", "-n", "1\n2\n3"]], "1\n2\n3", ["1", "2", "3"]),

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -671,7 +671,7 @@ class CommandPipeline:
             if not lines:
                 return lines
             elif len(lines) == 1:
-                return lines[0].rstrip("\n")
+                return [lines[0].rstrip("\n")]
             else:
                 return [line.rstrip("\n") for line in lines]
         elif callable(format):


### PR DESCRIPTION
### Motivation

This is fix for introduced before `$XONSH_SUBPROC_OUTPUT_FORMAT='list_lines'` (#5377) so news file is not needed.

We need to return the list for single line output to avoid unintended reading the string.

### Before
```xsh
$XONSH_SUBPROC_OUTPUT_FORMAT='list_lines'
mkdir -p /tmp/list_lines
cd /tmp/list_lines
touch 123

du $(ls)
# 0	123

for f in $(ls):
    print(f)
# 1
# 2
# 3

touch 321

for f in $(ls):
    print(f)
# 123
# 321
```

### After

```xsh
$XONSH_SUBPROC_OUTPUT_FORMAT='list_lines'
mkdir -p /tmp/list_lines
cd /tmp/list_lines
touch 123

du $(ls)
# 0	123  # no changes

for f in $(ls):
    print(f)
# 123  # now it works right

touch 321

for f in $(ls):
    print(f)
# 123   # no changes
# 321
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
