### PR TITLE
spec: added raise_subproc_error

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue.md
+++ b/.github/ISSUE_TEMPLATE/new-issue.md
@@ -26,7 +26,7 @@ Traceback (if applicable):
 </details>
 
 ## Expected Behavior
-<!--- What you expect -->
+<!--- What you expect and what is your real life use case. -->
 
 ## xonfig
 

--- a/news/spec_raise_subproc_error.rst
+++ b/news/spec_raise_subproc_error.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via SpecModifierAlias (#5494).
+* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via ``SpecModifierAlias`` (#5494).
 
 **Changed:**
 

--- a/news/spec_raise_subproc_error.rst
+++ b/news/spec_raise_subproc_error.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via SpecModifierAlias.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/spec_raise_subproc_error.rst
+++ b/news/spec_raise_subproc_error.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via ``SpecModifierAlias`` (#5494).
+* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via SpecModifierAlias (#5494).
 
 **Changed:**
 

--- a/news/spec_raise_subproc_error.rst
+++ b/news/spec_raise_subproc_error.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via SpecModifierAlias.
+* Added ``spec.raise_subproc_error`` for fine-tuning exceptions via SpecModifierAlias (#5494).
 
 **Changed:**
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -3,7 +3,7 @@
 import itertools
 import signal
 import sys
-from subprocess import Popen
+from subprocess import Popen, CalledProcessError
 
 import pytest
 
@@ -161,6 +161,52 @@ def test_interrupted_process_returncode(xonsh_session, captured, interactive):
     specs = cmds_to_specs(cmd, captured="stdout")
     (p := _run_command_pipeline(specs, cmd)).end()
     assert p.proc.returncode == -signal.SIGINT
+
+
+@skip_if_on_windows
+def test_proc_raise_subproc_error(xonsh_session):
+    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+
+    specs = cmds_to_specs(cmd := [['ls']], captured="stdout")
+    specs[-1].raise_subproc_error = True
+    exception = None
+    try:
+        (p := _run_command_pipeline(specs, cmd)).end()
+        assert p.proc.returncode == 0
+    except Exception as e:
+        exception = e
+    assert exception is None
+
+    specs = cmds_to_specs(cmd := [['ls', 'nofile']], captured="stdout")
+    specs[-1].raise_subproc_error = False
+    exception = None
+    try:
+        (p := _run_command_pipeline(specs, cmd)).end()
+        assert p.proc.returncode > 0
+    except Exception as e:
+        exception = e
+    assert exception is None
+
+    specs = cmds_to_specs(cmd := [['ls', 'nofile']], captured="stdout")
+    specs[-1].raise_subproc_error = True
+    exception = None
+    try:
+        (p := _run_command_pipeline(specs, cmd)).end()
+    except Exception as e:
+        assert p.proc.returncode > 0
+        exception = e
+    assert isinstance(exception, CalledProcessError)
+
+    xonsh_session.env["RAISE_SUBPROC_ERROR"] = True
+    specs = cmds_to_specs(cmd := [['ls', 'nofile']], captured="stdout")
+    exception = None
+    try:
+        (p := _run_command_pipeline(specs, cmd)).end()
+    except Exception as e:
+        assert p.proc.returncode > 0
+        exception = e
+    assert isinstance(exception, CalledProcessError)
+
 
 
 @skip_if_on_windows

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -627,7 +627,10 @@ class CommandPipeline:
         spec = self.spec
         rtn = self.returncode
 
-        if rtn is None or rtn == 0 or not XSH.env.get("RAISE_SUBPROC_ERROR"):
+        if spec.raise_subproc_error is None:
+            if rtn is None or rtn == 0 or not XSH.env.get("RAISE_SUBPROC_ERROR"):
+                return
+        elif spec.raise_subproc_error is False:
             return
 
         try:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -421,6 +421,7 @@ class SubprocSpec:
         self.stack = None
         self.spec_modifiers = []  # List of SpecModifierAlias objects that applied to spec.
         self.output_format = XSH.env.get("XONSH_SUBPROC_OUTPUT_FORMAT", "stream_lines")
+        self.raise_subproc_error = None  # Spec-based $RAISE_SUBPROC_ERROR variable.
 
     def __str__(self):
         s = self.__class__.__name__ + "(" + str(self.cmd) + ", "

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -421,7 +421,7 @@ class SubprocSpec:
         self.stack = None
         self.spec_modifiers = []  # List of SpecModifierAlias objects that applied to spec.
         self.output_format = XSH.env.get("XONSH_SUBPROC_OUTPUT_FORMAT", "stream_lines")
-        self.raise_subproc_error = None  # Spec-based $RAISE_SUBPROC_ERROR variable.
+        self.raise_subproc_error = None  # Spec-based alternative to $RAISE_SUBPROC_ERROR variable.
 
     def __str__(self):
         s = self.__class__.__name__ + "(" + str(self.cmd) + ", "

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -421,7 +421,9 @@ class SubprocSpec:
         self.stack = None
         self.spec_modifiers = []  # List of SpecModifierAlias objects that applied to spec.
         self.output_format = XSH.env.get("XONSH_SUBPROC_OUTPUT_FORMAT", "stream_lines")
-        self.raise_subproc_error = None  # Spec-based alternative to $RAISE_SUBPROC_ERROR variable.
+        self.raise_subproc_error = (
+            None  # Spec-based alternative to $RAISE_SUBPROC_ERROR variable.
+        )
 
     def __str__(self):
         s = self.__class__.__name__ + "(" + str(self.cmd) + ", "

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -421,9 +421,7 @@ class SubprocSpec:
         self.stack = None
         self.spec_modifiers = []  # List of SpecModifierAlias objects that applied to spec.
         self.output_format = XSH.env.get("XONSH_SUBPROC_OUTPUT_FORMAT", "stream_lines")
-        self.raise_subproc_error = (
-            None  # Spec-based alternative to $RAISE_SUBPROC_ERROR variable.
-        )
+        self.raise_subproc_error = None  # Spec-based $RAISE_SUBPROC_ERROR.
 
     def __str__(self):
         s = self.__class__.__name__ + "(" + str(self.cmd) + ", "


### PR DESCRIPTION
### Motivation

Add `spec.raise_subproc_error` to have an ability to use `SpecModifierAlias` to manage the errors. Also this is the first step to #4351.

Generally in scripts it's good to have  RAISE_SUBPROC_ERROR=True to avoid processing the error for every executed command. But in some cases (e.g. `![]`) it's needed to avoid raising the error. To more elegant doing this we can make an ability to create SpecModifier.

### After

```xsh
from xonsh.procs.specs import SpecModifierAlias
class SpecModifierNoErrAlias(SpecModifierAlias):
    def on_modifer_added(self, spec):
        spec.raise_subproc_error = False
aliases['noraise'] = SpecModifierNoErrAlias()

$RAISE_SUBPROC_ERROR = True

if ![noraise git pull]:
    git add --all
```

Cc #5443 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
