### PR TITLE
xonfig: added links

### DIFF
--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -258,15 +258,29 @@ class XontribsPage(Routes):
     def get(self):
         yield t.card()[
             t.card_body()[
-                t.card_title()[
-                    "Popular xontrib sources"
-                ],
+                t.card_title()["Popular xontrib sources"],
                 t.card_body()[
-                    t.li()[t.a(href="https://github.com/topics/xontrib")["Xontribs on Github"]],
-                    t.li()[t.a(href="https://github.com/xonsh/awesome-xontribs")["Awesome xontribs"]],
-                    t.li()[t.a(href="https://xon.sh/api/_autosummary/xontribs/xontrib.html")["Core xontribs"]],
-                    t.li()[t.a(href="https://github.com/xonsh/xontrib-template")["Create a xontrib step by step from template"]],
-                ]
+                    t.li()[
+                        t.a(href="https://github.com/topics/xontrib")[
+                            "Xontribs on Github"
+                        ]
+                    ],
+                    t.li()[
+                        t.a(href="https://github.com/xonsh/awesome-xontribs")[
+                            "Awesome xontribs"
+                        ]
+                    ],
+                    t.li()[
+                        t.a(
+                            href="https://xon.sh/api/_autosummary/xontribs/xontrib.html"
+                        )["Core xontribs"]
+                    ],
+                    t.li()[
+                        t.a(href="https://github.com/xonsh/xontrib-template")[
+                            "Create a xontrib step by step from template"
+                        ]
+                    ],
+                ],
             ]
         ]
         yield t.br()

--- a/xonsh/webconfig/routes.py
+++ b/xonsh/webconfig/routes.py
@@ -256,6 +256,20 @@ class XontribsPage(Routes):
         ]
 
     def get(self):
+        yield t.card()[
+            t.card_body()[
+                t.card_title()[
+                    "Popular xontrib sources"
+                ],
+                t.card_body()[
+                    t.li()[t.a(href="https://github.com/topics/xontrib")["Xontribs on Github"]],
+                    t.li()[t.a(href="https://github.com/xonsh/awesome-xontribs")["Awesome xontribs"]],
+                    t.li()[t.a(href="https://xon.sh/api/_autosummary/xontribs/xontrib.html")["Core xontribs"]],
+                    t.li()[t.a(href="https://github.com/xonsh/xontrib-template")["Create a xontrib step by step from template"]],
+                ]
+            ]
+        ]
+        yield t.br()
         for name, data in self.xontribs.items():
             yield t.row()[t.col()[self.xontrib_card(name, data),]]
             yield t.br()


### PR DESCRIPTION
Added links to xontribs in `xonfig web`

### After

<img width="764" alt="image" src="https://github.com/xonsh/xonsh/assets/1708680/cf5a32e6-f04c-4718-a175-2bfc863632ba">


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
