### PR TITLE
prompt: switching to prompt_toolkit in case of stdin with interactive mode

### DIFF
--- a/news/prompt_switch_to_ptk.rst
+++ b/news/prompt_switch_to_ptk.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* prompt: Switching to prompt_toolkit in edge case of sending stdin to interactive mode (#5462 #5517).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/lib/__init__.py
+++ b/xonsh/lib/__init__.py
@@ -1,0 +1,9 @@
+"""
+Originally posted by @scopatz in https://github.com/xonsh/xonsh/issues/2726#issuecomment-406447196 :
+
+    Recently @CJ-Wright has started up a ``xonsh.lib`` sub-package, which is usable from pure Python.
+    This is meant as a standard library for xonsh and downstream tools.
+    Currently there are some xonsh-ish wrappers around ``os`` and ``subprocess``.
+    We'd love to see more contributions to this effort! So if there is something
+    like ``sh()`` that you'd like to see, by all means please help us add it!
+"""

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -207,7 +207,9 @@ class Shell:
             `echo 'echo 1' | xonsh -i` and it's not working with `TERM=dumb` (#5462 #5517).
             So in this case we need to force using prompt_toolkit.
             """
-            is_stdin_to_interactive = not sys.stdin.isatty() and XSH.env.get("XONSH_INTERACTIVE", False)
+            is_stdin_to_interactive = not sys.stdin.isatty() and XSH.env.get(
+                "XONSH_INTERACTIVE", False
+            )
 
             if backend == "none":
                 from xonsh.base_shell import BaseShell as cls

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -207,9 +207,7 @@ class Shell:
             `echo 'echo 1' | xonsh -i` and it's not working with `TERM=dumb` (#5462 #5517).
             So in this case we need to force using prompt_toolkit.
             """
-            is_stdin_to_interactive = not sys.stdin.isatty() and XSH.env.get(
-                "XONSH_INTERACTIVE", False
-            )
+            is_stdin_to_interactive = XSH.env.get("XONSH_INTERACTIVE", False) and not sys.stdin.isatty()
 
             if backend == "none":
                 from xonsh.base_shell import BaseShell as cls

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -204,7 +204,8 @@ class Shell:
         else:
             """
             There is an edge case that we're using mostly in integration tests:
-            `echo 'echo 1' | xonsh -i` and it's not working with `TERM=dumb` (#5462 #5517).
+            `echo 'echo 1' | xonsh -i` and it's not working with `TERM=dumb` (#5462 #5517)
+            because `dumb` is readline where stdin is not supported yet. PR is very welcome!
             So in this case we need to force using prompt_toolkit.
             """
             is_stdin_to_interactive = XSH.env.get("XONSH_INTERACTIVE", False) and not sys.stdin.isatty()

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -202,9 +202,16 @@ class Shell:
         if is_class(backend):
             cls = backend
         else:
+            """
+            There is an edge case that we're using mostly in integration tests:
+            `echo 'echo 1' | xonsh -i` and it's not working with `TERM=dumb` (#5462 #5517).
+            So in this case we need to force using prompt_toolkit.
+            """
+            is_stdin_to_interactive = not sys.stdin.isatty() and XSH.env.get("XONSH_INTERACTIVE", False)
+
             if backend == "none":
                 from xonsh.base_shell import BaseShell as cls
-            elif backend == "prompt_toolkit":
+            elif backend == "prompt_toolkit" or is_stdin_to_interactive:
                 from xonsh.ptk_shell.shell import PromptToolkitShell as cls
             elif backend == "readline":
                 from xonsh.readline_shell import ReadlineShell as cls


### PR DESCRIPTION
### Motivation

There is an edge case that we're using mostly in integration tests from the beginning of the world:
`echo 'echo 1' | xonsh -i` and it's not working with `TERM=dumb` because dumb is readline.
So in this case we need to force using prompt_toolkit to avoid hanging.

Closes #5462 #5517

### Before

These all produces hanging because reading stdin is not implemented in readline backend:
```xsh
echo whoami | TERM=dumb xonsh -i --no-rc   # dumb is readline in fact
# or the same
echo whoami | xonsh -st dumb -i  # dumb is readline in fact
# or the same
echo whoami | xonsh -st readline -i
```

### After

Switching to prompt_toolkit in these cases.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
