### PR TITLE
Command cache: fix update cache logic

### DIFF
--- a/news/commands_cache_fix_update.rst
+++ b/news/commands_cache_fix_update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Commands Cache: Fixed cache update logic that lead to lagging during typing.
+
+**Security:**
+
+* <news item>

--- a/news/opt_sqlite.rst
+++ b/news/opt_sqlite.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* main: Importing sqlite became optional.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -187,8 +187,16 @@ def test_update_cache(xession, tmp_path):
     file1.touch()
     file1.chmod(0o755)
 
-    cache = CommandsCache({"PATH": [subdir2, subdir1]})
+    paths = [subdir2, subdir1]
+    cache = CommandsCache({"PATH": paths})
     cached = cache.update_cache()
+
+    # Check there are no changes after update cache.
+    c1 = list(cache._check_changes(paths))
+    c2 = list(cache._check_changes(paths))
+    c3 = list(cache._check_changes(paths))
+    assert any(c1)
+    assert c2 == c3 == [False, False]
 
     assert file1.samefile(cached[basename][0])
 

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -192,11 +192,10 @@ def test_update_cache(xession, tmp_path):
     cached = cache.update_cache()
 
     # Check there are no changes after update cache.
-    c1 = list(cache._check_changes(paths))
-    c2 = list(cache._check_changes(paths))
-    c3 = list(cache._check_changes(paths))
-    assert any(c1)
-    assert c2 == c3 == [False, False]
+    c1 = cache._update_and_check_changes(paths)
+    c2 = cache._update_and_check_changes(paths)
+    c3 = cache._update_and_check_changes(paths)
+    assert [c1, c2, c3] == [True, False, False]
 
     assert file1.samefile(cached[basename][0])
 

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -135,7 +135,6 @@ class CommandsCache(cabc.Mapping):
         is_paths_change = self._update_paths_cache(paths)
         return is_aliases_change or is_paths_change
 
-
     @property
     def all_commands(self):
         self.update_cache()

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -168,7 +168,6 @@ class CommandsCache(cabc.Mapping):
         # entries at the back.
         paths = tuple(reversed(tuple(self.remove_dups(env.get("PATH") or []))))
         if self._update_and_check_changes(paths):
-            print('load')
             all_cmds = CacheDict()
             for cmd, path in self._iter_binaries(paths):
                 # None     -> not in aliases

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -124,9 +124,9 @@ class CommandsCache(cabc.Mapping):
         yield self._update_paths_cache(paths)
 
         # did aliases change?
-        al_hash = hash(frozenset(self.aliases))
-        yield al_hash != self._alias_checksum
-        self._alias_checksum = al_hash
+        prev_hash = self._alias_checksum
+        self._alias_checksum = hash(frozenset(self.aliases))
+        yield prev_hash != self._alias_checksum
 
     @property
     def all_commands(self):


### PR DESCRIPTION
### Motivation

I noticed that when I type every letter in the prompt on the remote server the typing is lagging. I thought it's ssh but no.
After inspection the commands cache code I found that on every key press there is reading all 2000+ files in PATH because the code for cache update has funny issue.

### Quiz

```xsh
def f():
    print(1)
    yield False
    print(2)
    yield True
    print(3)

print(any(f()))
```
What will be in the output? Answer:

<details>

```
1
2
True
```

The execution of `print(3)` ignored because `any()` interrupts the execution of the function. 
If we call `print(list(f()))` the output will be `1 2 3 [False, True]`.

</details>

### Before

* Updating cache (read all files in PATH and list of aliases) two times after start.
* Updating cache (read all files in PATH and list of aliases) on every key press in prompt.

### After

* Update cache once at start.
* Update cache only when we have real changes of paths or aliases.

cc #4954 #3895 #5309

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
