### PR TITLE
fix: argparse based completions should work in newer python versions

### DIFF
--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -56,3 +56,27 @@ def test_skipper_arg(completion_context_parse, xession, monkeypatch):
     assert context.command == CommandContext(
         args=(CommandArg("grep"),), arg_index=1, prefix="--coun"
     )
+
+
+def test_argparse_completer(check_completer, monkeypatch):
+    assert check_completer("xonsh", prefix="-").issuperset(
+        {
+            "--cache-everything",
+            "--help",
+            "--interactive",
+            "--login",
+            "--no-env",
+            "--no-rc",
+            "--no-script-cache",
+            "--rc",
+            "--shell-type",
+            "--timings",
+            "--version",
+        }
+    )
+
+
+def test_argparse_completer_after_option(check_completer, tmp_path):
+    prefix = str(tmp_path)[:-1]
+    # has one or more completions including the above tmp_path
+    assert check_completer("xonsh --no-rc", prefix)

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -545,7 +545,7 @@ class ArgparseCompleter:
                 break
             # it is a valid option and advance
             self.remaining_args = self.remaining_args[1:]
-            act, _, value = act_res
+            act, *_, value = act_res
 
             # remove the found option
             # todo: not remove if append/extend


### PR DESCRIPTION
PS.
https://github.com/python/cpython/commit/e47ecbd0420528f1f9f282d9e7acfcf586a4caa1

fixes #5471
