### PR TITLE
colors: ``COLOR_RESULTS`` switched to ``False`` for non-interactive command case

### DIFF
--- a/news/disable_colors_non_int.rst
+++ b/news/disable_colors_non_int.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``COLOR_RESULTS`` switched to ``False`` for non-interactive command case to improve speed in default behavior.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/disable_colors_non_int.rst
+++ b/news/disable_colors_non_int.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* ``COLOR_RESULTS`` switched to ``False`` for non-interactive command case to improve speed in default behavior.
+* ``COLOR_RESULTS`` switched to ``False`` for non-interactive command case to improve speed in default behavior (#5562).
 
 **Deprecated:**
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -426,7 +426,7 @@ def premain(argv=None):
         "XONSH_INTERACTIVE": args.force_interactive
         or (args.mode == XonshMode.interactive),
     }
-    pre_env["COLOR_RESULTS"] = pre_env["XONSH_INTERACTIVE"]
+    pre_env["COLOR_RESULTS"] = os.getenv("COLOR_RESULTS",pre_env["XONSH_INTERACTIVE"])
 
     # Load -DVAR=VAL arguments.
     if args.defines is not None:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -426,7 +426,7 @@ def premain(argv=None):
         "XONSH_INTERACTIVE": args.force_interactive
         or (args.mode == XonshMode.interactive),
     }
-    pre_env["COLOR_RESULTS"] = os.getenv("COLOR_RESULTS",pre_env["XONSH_INTERACTIVE"])
+    pre_env["COLOR_RESULTS"] = os.getenv("COLOR_RESULTS", pre_env["XONSH_INTERACTIVE"])
 
     # Load -DVAR=VAL arguments.
     if args.defines is not None:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -424,8 +424,9 @@ def premain(argv=None):
     pre_env = {
         "XONSH_LOGIN": shell_kwargs["login"],
         "XONSH_INTERACTIVE": args.force_interactive
-        or (args.mode == XonshMode.interactive),
+        or (args.mode == XonshMode.interactive)
     }
+    pre_env["COLOR_RESULTS"] = pre_env["XONSH_INTERACTIVE"]
 
     # Load -DVAR=VAL arguments.
     if args.defines is not None:


### PR DESCRIPTION
### Motivation

Running commands with disabled `COLOR_RESULTS` around 40% faster. It should be by default.

```xsh
zsh

time xonsh --no-rc --no-env -c '2+2'
# 0.17s user 0.06s system 65% cpu 0.377 total

time xonsh --no-rc --no-env -DCOLOR_RESULTS=0 -c '2+2'
# 0.11s user 0.04s system 72% cpu 0.202 total
```

You can switch it to `True` any time by providing `-DCOLOR_RESULTS=1`:
```xsh
zsh

xonsh --no-rc --no-env -DCOLOR_RESULTS=1 -c '{"q":1}'
# {"q":1}  # colors!

COLOR_RESULTS=1 xonsh --no-rc --no-env -c '{"q":1}'
# {"q":1}  # colors!
```

Closes #5561

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
