### PR TITLE
Move note about last subprocess

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -276,6 +276,11 @@ Running subprocess commands should work like in any other shell.
 
 This should feel very natural.
 
+.. note::
+
+    Access the last run subprocess command using ``__xonsh__.last``;
+    e.g. to get the return code, run ``__xonsh__.last.rtn``.
+
 
 Python-mode vs Subprocess-mode
 ================================
@@ -370,11 +375,6 @@ For example,
     By default the output is represented as one single block of output with new
     line characters. You can set ``$XONSH_SUBPROC_OUTPUT_FORMAT`` to ``list_lines``
     to have a list of distinct lines in the commands like ``du -h $(ls)``.
-
-.. note::
-
-    You can access a subprocess command you ran using ``__xonsh__.last``
-    e.g. to get the return code run ``__xonsh__.last.rtn``.
 
 
 The ``!()`` syntax captured more information about the command, as an instance


### PR DESCRIPTION
When found only in the 'Captured Subprocess' section, it implies that the behavior is only available for captured subprocesses, when in fact it's available for any command. This bit could have gone into its own section, but since it's already carved out as a 'Note', it seems fine to put it here in the Running Commands section.

Closes #5591

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
