### PR TITLE
chore(metadata): swap in shorter email address

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "xonsh"
 dynamic = ["version", "readme"]
 description = "Python-powered shell. Full-featured and cross-platform."
 authors = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
-maintainers = [{ name = "Xonsh Community" }, { email = "xonsh-email.d8c44838e5348844fa397b54d705ce30.show-sender.include-footer.include-quotes@streams.zulipchat.com" }]
+maintainers = [{ name = "Xonsh Community" }, { email = "xonsh@gil.forsyth.dev" }]
 license = { text = "BSD 2-Clause License" }
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
The zulip email is too long and breaks publishing:

```
 WARNING  Error during upload. Retry with the --verbose option for more details.
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         'xonsh-email.d8c44838e5348844fa397b54d705ce30.show-sender.include-foote
         r.include-quotes@streams.zulipchat.com' is not a valid email address:
         The email address is too long before the @-sign (22 characters too
         many). See https://packaging.python.org/specifications/core-metadata
         for more information.
```

I don't care what email we use, but I'm putting in a temporary one so I can get the release out.
