### PR TITLE
fix(cache): Cache clean paths for per-keystroke checks

### DIFF
--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -309,5 +309,5 @@ Typing can be slow due to testing whether the typed text is an executable file
 - for each of 10+ file.pathext
 
 For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
-:ref:`$XONSH_WIN_PATH_DIRS_TO_LIST <xonsh_win_path_dirs_to_list>`
+:ref:`$XONSH_DIR_CACHE_TO_LIST <xonsh_dir_cache_to_list>`
 to reduce typing lag

--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -296,3 +296,18 @@ Although not recommended, to restore the behavior found in the
     >>> $PATH.append('.')
 
 Add that to ``~/.xonshrc`` to enable that as the default behavior.
+
+
+Reduce typing delay
+^^^^^^^^^^^^^^^^^^^
+
+Typing can be slow due to testing whether the typed text is an executable file
+(for color highlighting), which tests whether a file exists:
+
+- for each of the dozen of dirs in ``PATH``
+
+- for each of 10+ file.pathext
+
+For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
+:ref:`$XONSH_WIN_PATH_DIRS_TO_LIST <xonsh_win_path_dirs_to_list>`
+to reduce typing lag

--- a/news/constPath.rst
+++ b/news/constPath.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by not cleaning up PATH on every keystroke, but using a cached version instead.
+
+**Security:**
+
+* <news item>

--- a/news/listWinDir.rst
+++ b/news/listWinDir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_WIN_PATH_DIRS_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
+
+**Security:**
+
+* <news item>

--- a/news/listWinDir.rst
+++ b/news/listWinDir.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_WIN_PATH_DIRS_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_DIR_CACHE_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
 
 **Security:**
 

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -91,3 +91,45 @@ def test_locate_file(tmpdir, xession):
     with xession.env.swap(PATH=[str(bindir1), str(bindir2), str(bindir3)]):
         f = locate_file("findme")
         assert str(f) == str(file)
+
+def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
+    # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
+    # instead of checking for the existence of every file.pathext
+    # is faster
+    if not ON_WINDOWS:
+        return
+
+    from os import walk
+    # create a list of smaller dirs in PATH
+    short_path = 50 # exact threshold depends on the number of pathext, this is very ~
+    env = xession.env
+    env_path = env.get("PATH",[])
+    pathext = ['.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC','.PY','.PYW','.XSH']
+    env['PATHEXT'] = pathext
+
+    if len(pathext) <= 2:
+        print(f"pathext is too short {len(pathext)} for direct listing of dirs to be faster")
+        return
+
+    xonsh_win_path_dirs_to_list = []
+    for path in env_path:
+        f = []
+        for (dirpath, dirnames, filenames) in walk(path):
+            f.extend(filenames)
+            break
+        if len(f) < short_path:
+            xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
+
+    from time import monotonic_ns as ttime
+    from math import pow
+    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+
+    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = None
+    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur1 = (t1 - t0)/ns
+
+    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = xonsh_win_path_dirs_to_list
+    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur2 = (t1 - t0)/ns
+
+    print(f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}")
+    print(f"🕐{{:.6f}}\t(file.ext)\n🕐{{:.6f}}\t(list small dirs)\t".format(dur1,dur2))
+    assert dur2 < 0.90 * dur1   # listing method should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -93,8 +93,8 @@ def test_locate_file(tmpdir, xession):
         assert str(f) == str(file)
 
 
-def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
-    # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
+def test_xonsh_dir_cache_to_list(tmpdir, xession):
+    # check that adding smaller dirs to a XONSH_DIR_CACHE_TO_LIST var to list them
     # instead of checking for the existence of every file.pathext
     # is faster
     if not ON_WINDOWS:
@@ -130,28 +130,28 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
         )
         return
 
-    xonsh_win_path_dirs_to_list = []
+    xonsh_dir_cache_to_list = []
     for path in env_path:
         f = []
         for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
         if len(f) < short_path:
-            xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
+            xonsh_dir_cache_to_list += [path.rstrip(os.path.sep)]
 
     from math import pow
     from time import monotonic_ns as ttime
 
     ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = None
+    env["XONSH_DIR_CACHE_TO_LIST"] = None
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing")
     t1 = ttime()
     dur1 = (t1 - t0) / ns
 
-    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = xonsh_win_path_dirs_to_list
+    env["XONSH_DIR_CACHE_TO_LIST"] = xonsh_dir_cache_to_list
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing")
@@ -159,7 +159,7 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
     dur2 = (t1 - t0) / ns
 
     print(
-        f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
+        f"{len(pathext)} file.exists checks; {len(xonsh_dir_cache_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
     )
     print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(list small dirs)\t")
     assert dur2 < 0.90 * dur1  # listing method should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -96,26 +96,31 @@ def test_locate_file(tmpdir, xession):
 def test_locate_file_clean_path_cache_time(tmpdir, xession):
     # check that subsequent calls to locate_executable run faster due to use of path cache
     # that skips doing IO calls to check that path dirs exist
-    from time import monotonic_ns as ttime
     from math import pow
-    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+    from time import monotonic_ns as ttime
+
+    ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
     t0 = ttime()
-    f1 = locate_executable("nothing")
+    _f = locate_executable("nothing")
     t1 = ttime()
-    f2 = locate_executable("nothing")
+    _f = locate_executable("nothing")
     t2 = ttime()
-    f3 = locate_executable("nothing")
+    _f = locate_executable("nothing")
     t3 = ttime()
-    dur1 = (t1 - t0)/ns
-    dur2 = (t2 - t1)/ns
-    dur3 = (t3 - t2)/ns
+    dur1 = (t1 - t0) / ns
+    dur2 = (t2 - t1) / ns
+    dur3 = (t3 - t2) / ns
     env = xession.env
     env_path = env.get("PATH", [])
     if env_path:
-        print(f"$PATH length = ",len(env_path))
-        print(f"t1 (no cache) = {{:.6f}}\nt2 (   cache) = {{:.6f}}\nt3 (   cache) = {{:.6f}}".format(dur1,dur2,dur3))
-        assert  dur2 < 0.90 * dur1   # 2nd run with cache should always be noticeable faster
-        assert  dur3 < 0.90 * dur1   # as well as all the subsequent calls
+        print("$PATH length = ", len(env_path))
+        print(
+            f"t1 (no cache) = {dur1:.6f}\nt2 (   cache) = {dur2:.6f}\nt3 (   cache) = {dur3:.6f}"
+        )
+        assert (
+            dur2 < 0.90 * dur1
+        )  # 2nd run with cache should always be noticeable faster
+        assert dur3 < 0.90 * dur1  # as well as all the subsequent calls
 
 
 def test_xonsh_dir_cache_to_list(tmpdir, xession):

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -92,6 +92,7 @@ def test_locate_file(tmpdir, xession):
         f = locate_file("findme")
         assert str(f) == str(file)
 
+
 def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
     # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
     # instead of checking for the existence of every file.pathext
@@ -100,36 +101,65 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
         return
 
     from os import walk
+
     # create a list of smaller dirs in PATH
-    short_path = 50 # exact threshold depends on the number of pathext, this is very ~
+    short_path = 50  # exact threshold depends on the number of pathext, this is very ~
     env = xession.env
-    env_path = env.get("PATH",[])
-    pathext = ['.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC','.PY','.PYW','.XSH']
-    env['PATHEXT'] = pathext
+    env_path = env.get("PATH", [])
+    pathext = [
+        ".COM",
+        ".EXE",
+        ".BAT",
+        ".CMD",
+        ".VBS",
+        ".VBE",
+        ".JS",
+        ".JSE",
+        ".WSF",
+        ".WSH",
+        ".MSC",
+        ".PY",
+        ".PYW",
+        ".XSH",
+    ]
+    env["PATHEXT"] = pathext
 
     if len(pathext) <= 2:
-        print(f"pathext is too short {len(pathext)} for direct listing of dirs to be faster")
+        print(
+            f"pathext is too short {len(pathext)} for direct listing of dirs to be faster"
+        )
         return
 
     xonsh_win_path_dirs_to_list = []
     for path in env_path:
         f = []
-        for (dirpath, dirnames, filenames) in walk(path):
+        for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
         if len(f) < short_path:
             xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
 
-    from time import monotonic_ns as ttime
     from math import pow
-    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+    from time import monotonic_ns as ttime
 
-    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = None
-    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur1 = (t1 - t0)/ns
+    ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = xonsh_win_path_dirs_to_list
-    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur2 = (t1 - t0)/ns
+    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = None
+    t0 = ttime()
+    for _i in range(100):
+        f = locate_executable("nothing")
+    t1 = ttime()
+    dur1 = (t1 - t0) / ns
 
-    print(f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}")
-    print(f"🕐{{:.6f}}\t(file.ext)\n🕐{{:.6f}}\t(list small dirs)\t".format(dur1,dur2))
-    assert dur2 < 0.90 * dur1   # listing method should be noticeable faster
+    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = xonsh_win_path_dirs_to_list
+    t0 = ttime()
+    for _i in range(100):
+        f = locate_executable("nothing")
+    t1 = ttime()
+    dur2 = (t1 - t0) / ns
+
+    print(
+        f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
+    )
+    print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(list small dirs)\t")
+    assert dur2 < 0.90 * dur1  # listing method should be noticeable faster

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1285,6 +1285,7 @@ class CacheSetting(Xettings):
         "This variable is a set of paths that should checked via direct listing.",
     )
 
+
 class ChangeDirSetting(Xettings):
     """``cd`` Behavior"""
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1275,6 +1275,15 @@ class CacheSetting(Xettings):
         "If enabled, the CommandsCache is saved between runs and can reduce the startup time.",
     )
 
+    XONSH_DIR_CACHE_TO_LIST = Var.with_default(
+        set(),
+        "(Win) Reduce typing delay via faster 'executable exists' checks."
+        "Color highlighting (green executable) is performend on every typed char,"
+        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
+        "which can be more expensive than simly listing the directory (if it's small)"
+        "and searching in this list."
+        "This variable is a set of paths that should checked via direct listing.",
+    )
 
 class ChangeDirSetting(Xettings):
     """``cd`` Behavior"""
@@ -1996,16 +2005,6 @@ class WindowsSetting(GeneralSetting):
         "when using the default terminal (``cmd.exe``) on Windows. Blue colors, "
         "which are hard to read, are replaced with cyan. Other colors are "
         "generally replaced by their bright counter parts.",
-        is_configurable=ON_WINDOWS,
-    )
-    XONSH_WIN_PATH_DIRS_TO_LIST = Var.with_default(
-        set(),
-        "Reduce typing delay via faster 'executable exists' checks."
-        "Color highlighting (green executable) is performend on every typed char,"
-        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
-        "which can be more expensive than simly listing the directory (if it's small)"
-        "and searching in this list."
-        "This variable is a set of paths that should checked via direct listing.",
         is_configurable=ON_WINDOWS,
     )
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1998,6 +1998,16 @@ class WindowsSetting(GeneralSetting):
         "generally replaced by their bright counter parts.",
         is_configurable=ON_WINDOWS,
     )
+    XONSH_WIN_PATH_DIRS_TO_LIST = Var.with_default(
+        set(),
+        "Reduce typing delay via faster 'executable exists' checks."
+        "Color highlighting (green executable) is performend on every typed char,"
+        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
+        "which can be more expensive than simly listing the directory (if it's small)"
+        "and searching in this list."
+        "This variable is a set of paths that should checked via direct listing.",
+        is_configurable=ON_WINDOWS,
+    )
 
 
 # Please keep the following in alphabetic order - scopatz

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -104,6 +104,8 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
 
 
 from os import walk
+
+
 def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
@@ -123,24 +125,24 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
-    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST",[])
+    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
-    ext_count = len(possible_names)
 
-    if ext_count > 2 and path_to_list:
+    if path_to_list and (len(possible_names) > 2):
         for path in paths:
             if path in path_to_list:
                 f = []
-                for (_dirpath, _dirnames, filenames) in walk(path):
+                for _dirpath, _dirnames, filenames in walk(path):
                     f.extend(filenames)
-                    break # no recursion into subdir
+                    break  # no recursion into subdir
                 for possible_name in possible_names:
-                    if not possible_name in f:
+                    if possible_name not in f:
                         continue
                     filepath = Path(path) / possible_name
                     try:
-                        if not               filepath.is_file() or (check_executable and
-                           not is_executable(filepath)):
+                        if not filepath.is_file() or (
+                            check_executable and not is_executable(filepath)
+                        ):
                             continue
                         return str(filepath)
                     except PermissionError:
@@ -149,8 +151,9 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
                 for possible_name in possible_names:
                     filepath = Path(path) / possible_name
                     try:
-                        if not               filepath.is_file() or (check_executable and
-                           not is_executable(filepath)):
+                        if not filepath.is_file() or (
+                            check_executable and not is_executable(filepath)
+                        ):
                             continue
                         return str(filepath)
                     except PermissionError:
@@ -159,8 +162,9 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
         for path, possible_name in itertools.product(paths, possible_names):
             filepath = Path(path) / possible_name
             try:
-                if not               filepath.is_file() or (check_executable and
-                   not is_executable(filepath)):
+                if not filepath.is_file() or (
+                    check_executable and not is_executable(filepath)
+                ):
                     continue
                 return str(filepath)
             except PermissionError:

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -70,9 +70,9 @@ def is_executable_in_posix(filepath):
 is_executable = is_executable_in_windows if ON_WINDOWS else is_executable_in_posix
 
 
-def locate_executable(name, env=None):
+def locate_executable(name, env=None, use_path_cache=True):
     """Search executable binary name in ``$PATH`` and return full path."""
-    return locate_file(name, env=env, check_executable=True, use_pathext=True)
+    return locate_file(name, env=env, check_executable=True, use_pathext=True, use_path_cache=use_path_cache)
 
 
 class PathCleanCache:
@@ -86,11 +86,11 @@ class PathCleanCache:
         return cls.clean_paths
 
 
-def locate_file(name, env=None, check_executable=False, use_pathext=False):
+def locate_file(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
     return locate_relative_path(
         name, env, check_executable, use_pathext
-    ) or locate_file_in_path_env(name, env, check_executable, use_pathext)
+    ) or locate_file_in_path_env(name, env, check_executable, use_pathext, use_path_cache)
 
 
 def locate_relative_path(name, env=None, check_executable=False, use_pathext=False):
@@ -127,7 +127,7 @@ def check_possible_name(path, possible_name, check_executable):
         return
 
 
-def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
+def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
     """Search file name in ``$PATH`` and return full path.
 
     Compromise. There is no way to get case sensitive file name without listing all files.

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -130,12 +130,12 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
 
     Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
     to scan a smaller dir and check whether those 10+ strings are in this list
-    XONSH_WIN_PATH_DIRS_TO_LIST allows users to do just that
+    XONSH_DIR_CACHE_TO_LIST allows users to do just that
     """
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
-    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST", [])
+    path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
 
     if path_to_list and (len(possible_names) > 2):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -103,6 +103,7 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
                 continue
 
 
+from os import walk
 def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
@@ -114,19 +115,53 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     May be in the future file systems as well as Python Path will be smarter to get the case sensitive name.
     The task for reading and returning case sensitive filename we give to completer in interactive mode
     with ``commands_cache``.
+
+    Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
+    to scan a smaller dir and check whether those 10+ strings are in this list
+    XONSH_WIN_PATH_DIRS_TO_LIST allows users to do just that
     """
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
+    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST",[])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
+    ext_count = len(possible_names)
 
-    for path, possible_name in itertools.product(paths, possible_names):
-        filepath = Path(path) / possible_name
-        try:
-            if not filepath.is_file() or (
-                check_executable and not is_executable(filepath)
-            ):
+    if ext_count > 2 and path_to_list:
+        for path in paths:
+            if path in path_to_list:
+                f = []
+                for (_dirpath, _dirnames, filenames) in walk(path):
+                    f.extend(filenames)
+                    break # no recursion into subdir
+                for possible_name in possible_names:
+                    if not possible_name in f:
+                        continue
+                    filepath = Path(path) / possible_name
+                    try:
+                        if not               filepath.is_file() or (check_executable and
+                           not is_executable(filepath)):
+                            continue
+                        return str(filepath)
+                    except PermissionError:
+                        return
+            else:
+                for possible_name in possible_names:
+                    filepath = Path(path) / possible_name
+                    try:
+                        if not               filepath.is_file() or (check_executable and
+                           not is_executable(filepath)):
+                            continue
+                        return str(filepath)
+                    except PermissionError:
+                        continue
+    else:
+        for path, possible_name in itertools.product(paths, possible_names):
+            filepath = Path(path) / possible_name
+            try:
+                if not               filepath.is_file() or (check_executable and
+                   not is_executable(filepath)):
+                    continue
+                return str(filepath)
+            except PermissionError:
                 continue
-            return str(filepath)
-        except PermissionError:
-            continue

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -72,13 +72,20 @@ is_executable = is_executable_in_windows if ON_WINDOWS else is_executable_in_pos
 
 def locate_executable(name, env=None, use_path_cache=True):
     """Search executable binary name in ``$PATH`` and return full path."""
-    return locate_file(name, env=env, check_executable=True, use_pathext=True, use_path_cache=use_path_cache)
+    return locate_file(
+        name,
+        env=env,
+        check_executable=True,
+        use_pathext=True,
+        use_path_cache=use_path_cache,
+    )
 
 
 class PathCleanCache:
     is_dirty = True
+
     @classmethod
-    def get(cls,env):
+    def get(cls, env):
         if cls.is_dirty:
             env_path = env.get("PATH", [])
             cls.clean_paths = tuple(clear_paths(env_path))
@@ -86,11 +93,15 @@ class PathCleanCache:
         return cls.clean_paths
 
 
-def locate_file(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
+def locate_file(
+    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True
+):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
     return locate_relative_path(
         name, env, check_executable, use_pathext
-    ) or locate_file_in_path_env(name, env, check_executable, use_pathext, use_path_cache)
+    ) or locate_file_in_path_env(
+        name, env, check_executable, use_pathext, use_path_cache
+    )
 
 
 def locate_relative_path(name, env=None, check_executable=False, use_pathext=False):
@@ -127,7 +138,9 @@ def check_possible_name(path, possible_name, check_executable):
         return
 
 
-def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
+def locate_file_in_path_env(
+    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True
+):
     """Search file name in ``$PATH`` and return full path.
 
     Compromise. There is no way to get case sensitive file name without listing all files.
@@ -146,12 +159,12 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     paths = []
     if env is None:
         env = XSH.env
-        if use_path_cache: # for generic environment: use cache only if configured
+        if use_path_cache:  # for generic environment: use cache only if configured
             paths = PathCleanCache.get(env)
-        else:              # otherwise              : clean paths every time
+        else:  #              otherwise              : clean paths every time
             env_path = env.get("PATH", [])
             paths = tuple(clear_paths(env_path))
-    else:                  # for custom  environment: clean paths every time
+    else:  #                  for custom  environment: clean paths every time
         env_path = env.get("PATH", [])
         paths = tuple(clear_paths(env_path))
     path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -28,6 +28,7 @@ from xonsh.built_ins import XSH
 from xonsh.events import events
 from xonsh.lib.lazyimps import pyghooks, pygments, winutils
 from xonsh.platform import HAS_PYGMENTS, ON_POSIX, ON_WINDOWS
+from xonsh.procs.executables import PathCleanCache
 from xonsh.pygments_cache import get_all_styles
 from xonsh.shell import transform_command
 from xonsh.shells.base_shell import BaseShell
@@ -297,6 +298,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
+        PathCleanCache.is_dirty = True
         events.on_pre_prompt_format.fire()
         env = XSH.env
         mouse_support = env.get("MOUSE_SUPPORT")

--- a/xonsh/shells/readline_shell.py
+++ b/xonsh/shells/readline_shell.py
@@ -38,6 +38,7 @@ from xonsh.platform import (
     ON_WINDOWS,
     os_environ,
 )
+from xonsh.procs.executables import PathCleanCache
 from xonsh.prompt.base import multiline_prompt
 from xonsh.shells.base_shell import BaseShell
 from xonsh.tools import (
@@ -390,6 +391,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             except ImportError:
                 store_in_history = True
             pos = readline.get_current_history_length() - 1
+        PathCleanCache.is_dirty = True
         events.on_pre_prompt_format.fire()
         prompt = self.prompt
         events.on_pre_prompt.fire()


### PR DESCRIPTION
Cache a list of cleaned paths to avoid wasting time cleaning it on every keystroke (which on Windows seems to be especially noticeable since the number of items in path is higher and isdir/isrealpath seems to be more expensive? and can be in some cases as expensive as actually checking whether the typed string exists as an executable)

(this is on top https://github.com/xonsh/xonsh/pull/5652 to avoid merging conflicts)

This is done only for the default XSH environment (when no env is passed)
And cache is set to dirty (and reset on the next request) on new prompt (before every `on_pre_prompt_format` event is fired)

**Assumption** here is that while you're typing you can't change the list of dirs in `$PATH` (NOT the list of actual files within those dirs, this PR is only about cleaning up the list of dirs in the env var, file check is done separately and this PR doesn't improve that part), so there is no risk of missing some color highlighting just because a new folder with the command you're typing is added while you're typing it

2. no docs as it's a perf improvement
3. Add the example of usage or before-after behavior: regular typing after is faster than before on Windows
4. partially addresses https://github.com/xonsh/xonsh/issues/5612 (the other part should come from caching the list of dirs/files https://github.com/xonsh/xonsh/issues/5541)



Sorry, dont get these tests: for example, the [Mac](https://github.com/xonsh/xonsh/actions/runs/10046102773/job/27764856296?pr=5620) one says 
`tests/aliases/test_source.py .F..                                        [  0%]`

but local `pytest tests/aliases/test_source.py` doesn't fail?

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
