### PR TITLE
executables: Added ``locate_relative_path`` functionality to ``locate_file``.

### DIFF
--- a/news/locate_relative.rst
+++ b/news/locate_relative.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* executables: Added ``locate_relative_path`` functionality to ``locate_file``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -8,6 +8,7 @@ from xonsh.procs.executables import (
     locate_executable,
     locate_file,
 )
+from xonsh.tools import chdir
 
 
 def test_get_possible_names():
@@ -24,6 +25,7 @@ def test_get_paths(tmpdir):
 
 
 def test_locate_executable(tmpdir, xession):
+    bindir0 = tmpdir.mkdir("bindir0")  # current working directory
     bindir1 = tmpdir.mkdir("bindir1")
     bindir2 = tmpdir.mkdir("bindir2")
     bindir3 = tmpdir.mkdir("bindir3")
@@ -36,6 +38,12 @@ def test_locate_executable(tmpdir, xession):
         if exefile in executables:
             os.chmod(f, 0o777)
 
+    # Test current working directory.
+    (bindir0 / "cwd_non_bin_file").write_text("binary", encoding="utf8")
+    (f := bindir0 / "cwd_bin_file").write_text("binary", encoding="utf8")
+    os.chmod(f, 0o777)
+
+
     # Test overlapping file names in different bin directories.
     (f := bindir3 / "file3").write_text("binary", encoding="utf8")
     os.chmod(f, 0o777)
@@ -43,7 +51,13 @@ def test_locate_executable(tmpdir, xession):
     pathext = [".EXE", ".COM"] if ON_WINDOWS else []
     with xession.env.swap(
         PATH=[str(bindir1), str(bindir2), str(bindir3)], PATHEXT=pathext
-    ):
+    ), chdir(str(bindir0)):
+        # From current working directory
+        assert locate_executable("./cwd_non_bin_file") is None
+        assert locate_executable("./cwd_bin_file")
+        assert locate_executable("../bindir0/cwd_bin_file")
+
+        # From PATH
         assert locate_executable("file1.EXE")
         assert locate_executable("nofile") is None
         assert locate_executable("file5") is None

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -53,9 +53,9 @@ def test_locate_executable(tmpdir, xession):
         PATH=[str(bindir1), str(bindir2), str(bindir3)], PATHEXT=pathext
     ), chdir(str(bindir0)):
         # From current working directory
-        assert locate_executable("./cwd_non_bin_file") is None
-        assert locate_executable("./cwd_bin_file")
-        assert locate_executable("../bindir0/cwd_bin_file")
+        assert locate_executable(f".{os.path.sep}cwd_non_bin_file") is None
+        assert locate_executable(f".{os.path.sep}cwd_bin_file")
+        assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file")
 
         # From PATH
         assert locate_executable("file1.EXE")

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -48,6 +48,8 @@ def test_locate_executable(tmpdir, xession):
     os.chmod(f, 0o777)
 
     pathext = [".EXE", ".COM"] if ON_WINDOWS else []
+    sep = os.path.sep
+
     with (
         xession.env.swap(
             PATH=[str(bindir1), str(bindir2), str(bindir3)], PATHEXT=pathext
@@ -55,14 +57,14 @@ def test_locate_executable(tmpdir, xession):
         chdir(str(bindir0)),
     ):
         # From current working directory
-        assert locate_executable(f".{os.path.sep}cwd_non_bin_file") is None
-        assert locate_executable(f".{os.path.sep}cwd_bin_file.EXE")
-        assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file.EXE")
+        assert locate_executable(f".{sep}cwd_non_bin_file") is None
+        assert locate_executable(f".{sep}cwd_bin_file.EXE")
+        assert locate_executable(f"..{sep}bindir0{sep}cwd_bin_file.EXE")
         assert locate_executable(str(bindir0 / "cwd_bin_file.EXE"))
         if ON_WINDOWS:
-            assert locate_executable(f".{os.path.sep}cwd_bin_file")
+            assert locate_executable(f".{sep}cwd_bin_file")
             assert locate_executable(str(bindir0 / "cwd_bin_file"))
-            assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file")
+            assert locate_executable(f"..{sep}bindir0{sep}cwd_bin_file")
 
         # From PATH
         assert locate_executable("file1.EXE")

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -40,7 +40,7 @@ def test_locate_executable(tmpdir, xession):
 
     # Test current working directory.
     (bindir0 / "cwd_non_bin_file").write_text("binary", encoding="utf8")
-    (f := bindir0 / "cwd_bin_file").write_text("binary", encoding="utf8")
+    (f := bindir0 / "cwd_bin_file.EXE").write_text("binary", encoding="utf8")
     os.chmod(f, 0o777)
 
     # Test overlapping file names in different bin directories.
@@ -56,8 +56,8 @@ def test_locate_executable(tmpdir, xession):
     ):
         # From current working directory
         assert locate_executable(f".{os.path.sep}cwd_non_bin_file") is None
-        assert locate_executable(f".{os.path.sep}cwd_bin_file")
-        assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file")
+        assert locate_executable(f".{os.path.sep}cwd_bin_file.EXE")
+        assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file.EXE")
 
         # From PATH
         assert locate_executable("file1.EXE")

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -58,6 +58,11 @@ def test_locate_executable(tmpdir, xession):
         assert locate_executable(f".{os.path.sep}cwd_non_bin_file") is None
         assert locate_executable(f".{os.path.sep}cwd_bin_file.EXE")
         assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file.EXE")
+        assert locate_executable(str(bindir0 / "cwd_bin_file.EXE"))
+        if ON_WINDOWS:
+            assert locate_executable(f".{os.path.sep}cwd_bin_file")
+            assert locate_executable(str(bindir0 / "cwd_bin_file"))
+            assert locate_executable(f"..{os.path.sep}bindir0{os.path.sep}cwd_bin_file")
 
         # From PATH
         assert locate_executable("file1.EXE")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1493,3 +1493,23 @@ def test_xonshrc(tmpdir, cmd, exp):
         out,
         re.MULTILINE | re.DOTALL,
     ), f"Case: xonsh {cmd},\nExpected: {exp!r},\nResult: {out!r},\nargs={args!r}"
+
+def make_executable(path):  # stackoverflow.com/a/30463972
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2  # copy R bits to X
+    os.chmod(path, mode)
+
+
+@skip_if_no_xonsh
+@skip_if_on_windows
+def test_shebang_cr(tmpdir):
+    testdir = tmpdir.mkdir("xonsh_test_dir")
+    testfile = "shebang_cr.xsh"
+    expected_out = "I'm xonsh with shebang␍"
+    (testdir / testfile).write_text(
+        f"""#!/usr/bin/env xonsh\r\nprint("{expected_out}")""", encoding="utf8"
+    )
+    make_executable(testdir / testfile)
+    command = f"cd {testdir}; ./{testfile}\n"
+    out, err, rtn = run_xonsh(command)
+    assert out == f"{expected_out}\n"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1494,6 +1494,7 @@ def test_xonshrc(tmpdir, cmd, exp):
         re.MULTILINE | re.DOTALL,
     ), f"Case: xonsh {cmd},\nExpected: {exp!r},\nResult: {out!r},\nargs={args!r}"
 
+
 def make_executable(path):  # stackoverflow.com/a/30463972
     mode = os.stat(path).st_mode
     mode |= (mode & 0o444) >> 2  # copy R bits to X

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1495,12 +1495,6 @@ def test_xonshrc(tmpdir, cmd, exp):
     ), f"Case: xonsh {cmd},\nExpected: {exp!r},\nResult: {out!r},\nargs={args!r}"
 
 
-def make_executable(path):  # stackoverflow.com/a/30463972
-    mode = os.stat(path).st_mode
-    mode |= (mode & 0o444) >> 2  # copy R bits to X
-    os.chmod(path, mode)
-
-
 @skip_if_no_xonsh
 @skip_if_on_windows
 def test_shebang_cr(tmpdir):
@@ -1510,7 +1504,7 @@ def test_shebang_cr(tmpdir):
     (testdir / testfile).write_text(
         f"""#!/usr/bin/env xonsh\r\nprint("{expected_out}")""", encoding="utf8"
     )
-    make_executable(testdir / testfile)
+    os.chmod(testdir / testfile, 0o777)
     command = f"cd {testdir}; ./{testfile}\n"
     out, err, rtn = run_xonsh(command)
     assert out == f"{expected_out}\n"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1501,10 +1501,10 @@ def test_shebang_cr(tmpdir):
     testdir = tmpdir.mkdir("xonsh_test_dir")
     testfile = "shebang_cr.xsh"
     expected_out = "I'm xonsh with shebang␍"
-    (testdir / testfile).write_text(
+    (f := testdir / testfile).write_text(
         f"""#!/usr/bin/env xonsh\r\nprint("{expected_out}")""", encoding="utf8"
     )
-    os.chmod(testdir / testfile, 0o777)
+    os.chmod(f, 0o777)
     command = f"cd {testdir}; ./{testfile}\n"
     out, err, rtn = run_xonsh(command)
     assert out == f"{expected_out}\n"

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -77,9 +77,9 @@ def locate_executable(name, env=None):
 
 def locate_file(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
-    return locate_relative_path(name, env, check_executable, use_pathext) or locate_file_in_path_env(
+    return locate_relative_path(
         name, env, check_executable, use_pathext
-    )
+    ) or locate_file_in_path_env(name, env, check_executable, use_pathext)
 
 
 def locate_relative_path(name, env=None, check_executable=False, use_pathext=False):
@@ -89,7 +89,11 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
     If directory has "binfile" it can be called only by providing prefix "./binfile" explicitly.
     """
     p = Path(name)
-    if name.startswith("." + os.path.sep) or name.startswith(".." + os.path.sep) or p.is_absolute():
+    if (
+        name.startswith("." + os.path.sep)
+        or name.startswith(".." + os.path.sep)
+        or p.is_absolute()
+    ):
         possible_names = get_possible_names(p.name, env) if use_pathext else [p.name]
         for possible_name in possible_names:
             filepath = p.parent / possible_name

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -90,7 +90,7 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
     """
     p = Path(name)
     if (
-        name.startswith(("./", "../", ".\\", "..\\"))
+        name.startswith(("./", "../", ".\\", "..\\", "~/"))
         or p.is_absolute()
     ):
         possible_names = get_possible_names(p.name, env) if use_pathext else [p.name]

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -90,10 +90,7 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
     """
     p = Path(name)
     if (
-        name.startswith("./")
-        or name.startswith("../")
-        or name.startswith(".\\")
-        or name.startswith("..\\")
+        name.startswith(("./", "../", ".\\", "..\\"))
         or p.is_absolute()
     ):
         possible_names = get_possible_names(p.name, env) if use_pathext else [p.name]

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -89,10 +89,7 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
     If directory has "binfile" it can be called only by providing prefix "./binfile" explicitly.
     """
     p = Path(name)
-    if (
-        name.startswith(("./", "../", ".\\", "..\\", "~/"))
-        or p.is_absolute()
-    ):
+    if name.startswith(("./", "../", ".\\", "..\\", "~/")) or p.is_absolute():
         possible_names = get_possible_names(p.name, env) if use_pathext else [p.name]
         for possible_name in possible_names:
             filepath = p.parent / possible_name

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -90,8 +90,10 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
     """
     p = Path(name)
     if (
-        name.startswith("." + os.path.sep)
-        or name.startswith(".." + os.path.sep)
+        name.startswith("./")
+        or name.startswith("../")
+        or name.startswith(".\\")
+        or name.startswith("..\\")
         or p.is_absolute()
     ):
         possible_names = get_possible_names(p.name, env) if use_pathext else [p.name]

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -76,6 +76,19 @@ def locate_executable(name, env=None):
 
 
 def locate_file(name, env=None, check_executable=False, use_pathext=False):
+    """Search file name in the current working directory and in ``$PATH`` and return full path."""
+    return locate_relative_path(name, check_executable) or locate_file_in_path_env(name, env, check_executable, use_pathext)
+
+
+def locate_relative_path(name, check_executable=False):
+    """Return absolute path by relative file path."""
+    if (name.stratwith("." + os.path.sep) or name.stratwith(".." + os.path.sep)) and (p := Path(name)).exists():
+        if check_executable and not is_executable(p):
+            return None
+        return str(p.absolute())
+
+
+def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
     Compromise. There is no way to get case sensitive file name without listing all files.

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -82,7 +82,7 @@ def locate_file(name, env=None, check_executable=False, use_pathext=False):
 
 def locate_relative_path(name, check_executable=False):
     """Return absolute path by relative file path."""
-    if (name.stratwith("." + os.path.sep) or name.stratwith(".." + os.path.sep)) and (p := Path(name)).exists():
+    if (name.startswith("." + os.path.sep) or name.startswith(".." + os.path.sep)) and (p := Path(name)).exists():
         if check_executable and not is_executable(p):
             return None
         return str(p.absolute())

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1600,9 +1600,7 @@ def _command_is_valid(cmd):
         cmd_abspath = os.path.abspath(os.path.expanduser(cmd))
     except OSError:
         return False
-    return ((cmd in XSH.aliases or locate_executable(cmd)) and not iskeyword(cmd)) or (
-        os.path.isfile(cmd_abspath) and os.access(cmd_abspath, os.X_OK)
-    )
+    return (cmd in XSH.aliases or locate_executable(cmd)) and not iskeyword(cmd)
 
 
 def _command_is_autocd(cmd):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1596,10 +1596,6 @@ def color_file(file_path: str, path_stat: os.stat_result) -> tuple[_TokenType, s
 
 
 def _command_is_valid(cmd):
-    try:
-        cmd_abspath = os.path.abspath(os.path.expanduser(cmd))
-    except OSError:
-        return False
     return (cmd in XSH.aliases or locate_executable(cmd)) and not iskeyword(cmd)
 
 


### PR DESCRIPTION
### Motivation

Added locate_relative_path functionality to locate_file for cases:
* `./binfile`
* `../binfile`
* `~/binfile`
* `/full/path/to/binfile`

Closes #5615 #5617

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
