### PR TITLE
Fix: exception when completing in python-only context

### DIFF
--- a/news/fix_python_only_completion.rst
+++ b/news/fix_python_only_completion.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* completion: Fixed exception when in python-only completion context (#5632).
+* completer: Fixed exception when in python-only completion context (#5632).
 
 **Security:**
 

--- a/news/fix_python_only_completion.rst
+++ b/news/fix_python_only_completion.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed exception when in python-only completion context.
+* completion: Fixed exception when in python-only completion context (#5632).
 
 **Security:**
 

--- a/news/fix_python_only_completion.rst
+++ b/news/fix_python_only_completion.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed exception when in python-only completion context.
+
+**Security:**
+
+* <news item>

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -168,3 +168,8 @@ def test_env_completer_sort(completer, completers_mock):
         "$WOW", "$WOW", 4, 0, {}, multiline_text="'$WOW'", cursor_index=4
     )
     assert set(comps[0]) == {"$WOW0", "$WOW1", "$MID_WOW", "$SUPER_WOW"}
+
+
+def test_python_only_context(completer, completers_mock):
+    assert completer.complete_line("echo @(") != ()
+    assert completer.complete("", "echo @(", 0, 0, {}, "echo @(", 7) != ()

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -48,10 +48,16 @@ class Completer:
         suffix is not supported; text after last space is parsed as prefix.
         """
         ctx = self.parse(text)
-        cmd_ctx = ctx.command
-        if not cmd_ctx:
-            raise RuntimeError("Only Command context is empty")
-        prefix = cmd_ctx.prefix
+
+        if not ctx:
+            raise RuntimeError("CompletionContext is None")
+
+        if ctx.python is not None:
+            prefix = ctx.python.prefix
+        elif ctx.command is not None:
+            prefix = ctx.command.prefix
+        else:
+            raise RuntimeError("CompletionContext is empty")
 
         line = text
         begidx = text.rfind(prefix)
@@ -284,9 +290,14 @@ class Completer:
                     )
                 break
 
-        prefix = None
         if completion_context:
-            prefix = completion_context.command.prefix
+            if completion_context.python is not None:
+                prefix = completion_context.python.prefix
+            elif completion_context.commmand is not None:
+                prefix = completion_context.command.prefix
+            else:
+                raise RuntimeError("Completion context is empty")
+
             if prefix.startswith("$"):
                 prefix = prefix[1:]
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -293,7 +293,7 @@ class Completer:
         if completion_context:
             if completion_context.python is not None:
                 prefix = completion_context.python.prefix
-            elif completion_context.commmand is not None:
+            elif completion_context.command is not None:
                 prefix = completion_context.command.prefix
             else:
                 raise RuntimeError("Completion context is empty")


### PR DESCRIPTION
Closes #5625

The comments on [CompletionContext](https://github.com/xonsh/xonsh/blob/ec5f4d85595a004b4a72c881893379d404da5b0c/xonsh/parsers/completion_context.py#L130) say CompletionContext.command is None when in a Python context, but [Completer.complete_with_context](https://github.com/xonsh/xonsh/blob/ec5f4d85595a004b4a72c881893379d404da5b0c/xonsh/completer.py#L261) and [Completer.complete_line](https://github.com/xonsh/xonsh/blob/ec5f4d85595a004b4a72c881893379d404da5b0c/xonsh/completer.py#L43) depend on it to get the prefix.

This PR fixes the above: the python context prefix is favored if available, otherwise the command context prefix is used. Completer.complete_line now only raises an exception if both the command and python contexts are None.

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
