### PR TITLE
tools: using path in chdir

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -58,6 +58,7 @@ from xonsh.platform import (
 
 @contextmanager
 def chdir(adir, mkdir=False):
+    adir = pathlib.Path(adir)
     old_dir = os.getcwd()
     if mkdir:
         os.makedirs(adir, exist_ok=True)


### PR DESCRIPTION
### Motivation

Using pathlib.Path in chdir allows to do expanding automatically.

### Before

```xsh
from xonsh.tools import chdir

with chdir('~/.local'):
    echo 1

# No such file or dir '~/.local'
```

### After


```xsh
from xonsh.tools import chdir

with chdir('~/.local'):
    echo 1

# 1
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
