### PR TITLE
XONTRIBS_AUTOLOAD_DISABLED --> XONTRIBS_AUTOLOAD

### DIFF
--- a/news/change_xontribs_autoload_env_var.rst
+++ b/news/change_xontribs_autoload_env_var.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* xontrib: Changed XONTRIBS_AUTOLOAD_DISABLED=1 to XONTRIBS_AUTOLOAD=False
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -334,7 +334,7 @@ def _load_rc_files(shell_kwargs: dict, args, env, execer, ctx):
 
 def _autoload_xontribs(env):
     events.on_timingprobe.fire(name="pre_xontribs_autoload")
-    disabled = env.get("XONTRIBS_AUTOLOAD_DISABLED", False)
+    disabled = env.get("XONTRIBS_AUTOLOAD", "True") == "False"
     if disabled is True:
         return
     blocked_xontribs = disabled or ()


### PR DESCRIPTION
Switches XONTRIBS_AUTOLOAD_DISABLED to XONTRIBS_AUTOLOAD in order to make it explicit when you disable autoload.

It might also be worth it to make this a strtobool type of string in the future but going for simplicity first.

Is part of addressing https://github.com/xonsh/xonsh/issues/5149

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR ().
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
