### PR TITLE
fix(windows): Allow listing small Win dirs in PATH instead of testing for file.ext.exists() 

### DIFF
--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -309,5 +309,5 @@ Typing can be slow due to testing whether the typed text is an executable file
 - for each of 10+ file.pathext
 
 For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
-:ref:`$XONSH_WIN_PATH_DIRS_TO_LIST <xonsh_win_path_dirs_to_list>`
+:ref:`$XONSH_DIR_CACHE_TO_LIST <xonsh_dir_cache_to_list>`
 to reduce typing lag

--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -296,3 +296,18 @@ Although not recommended, to restore the behavior found in the
     >>> $PATH.append('.')
 
 Add that to ``~/.xonshrc`` to enable that as the default behavior.
+
+
+Reduce typing delay
+^^^^^^^^^^^^^^^^^^^
+
+Typing can be slow due to testing whether the typed text is an executable file
+(for color highlighting), which tests whether a file exists:
+
+- for each of the dozen of dirs in ``PATH``
+
+- for each of 10+ file.pathext
+
+For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
+:ref:`$XONSH_WIN_PATH_DIRS_TO_LIST <xonsh_win_path_dirs_to_list>`
+to reduce typing lag

--- a/news/listWinDir.rst
+++ b/news/listWinDir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_WIN_PATH_DIRS_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
+
+**Security:**
+
+* <news item>

--- a/news/listWinDir.rst
+++ b/news/listWinDir.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_WIN_PATH_DIRS_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_DIR_CACHE_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
 
 **Security:**
 

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -91,3 +91,45 @@ def test_locate_file(tmpdir, xession):
     with xession.env.swap(PATH=[str(bindir1), str(bindir2), str(bindir3)]):
         f = locate_file("findme")
         assert str(f) == str(file)
+
+def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
+    # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
+    # instead of checking for the existence of every file.pathext
+    # is faster
+    if not ON_WINDOWS:
+        return
+
+    from os import walk
+    # create a list of smaller dirs in PATH
+    short_path = 50 # exact threshold depends on the number of pathext, this is very ~
+    env = xession.env
+    env_path = env.get("PATH",[])
+    pathext = ['.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC','.PY','.PYW','.XSH']
+    env['PATHEXT'] = pathext
+
+    if len(pathext) <= 2:
+        print(f"pathext is too short {len(pathext)} for direct listing of dirs to be faster")
+        return
+
+    xonsh_win_path_dirs_to_list = []
+    for path in env_path:
+        f = []
+        for (dirpath, dirnames, filenames) in walk(path):
+            f.extend(filenames)
+            break
+        if len(f) < short_path:
+            xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
+
+    from time import monotonic_ns as ttime
+    from math import pow
+    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+
+    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = None
+    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur1 = (t1 - t0)/ns
+
+    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = xonsh_win_path_dirs_to_list
+    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur2 = (t1 - t0)/ns
+
+    print(f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}")
+    print(f"🕐{{:.6f}}\t(file.ext)\n🕐{{:.6f}}\t(list small dirs)\t".format(dur1,dur2))
+    assert dur2 < 0.90 * dur1   # listing method should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -93,8 +93,8 @@ def test_locate_file(tmpdir, xession):
         assert str(f) == str(file)
 
 
-def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
-    # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
+def test_xonsh_dir_cache_to_list(tmpdir, xession):
+    # check that adding smaller dirs to a XONSH_DIR_CACHE_TO_LIST var to list them
     # instead of checking for the existence of every file.pathext
     # is faster
     if not ON_WINDOWS:
@@ -130,28 +130,28 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
         )
         return
 
-    xonsh_win_path_dirs_to_list = []
+    xonsh_dir_cache_to_list = []
     for path in env_path:
         f = []
         for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
         if len(f) < short_path:
-            xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
+            xonsh_dir_cache_to_list += [path.rstrip(os.path.sep)]
 
     from math import pow
     from time import monotonic_ns as ttime
 
     ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = None
+    env["XONSH_DIR_CACHE_TO_LIST"] = None
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing")
     t1 = ttime()
     dur1 = (t1 - t0) / ns
 
-    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = xonsh_win_path_dirs_to_list
+    env["XONSH_DIR_CACHE_TO_LIST"] = xonsh_dir_cache_to_list
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing")
@@ -159,7 +159,7 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
     dur2 = (t1 - t0) / ns
 
     print(
-        f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
+        f"{len(pathext)} file.exists checks; {len(xonsh_dir_cache_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
     )
     print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(list small dirs)\t")
     assert dur2 < 0.90 * dur1  # listing method should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -92,6 +92,7 @@ def test_locate_file(tmpdir, xession):
         f = locate_file("findme")
         assert str(f) == str(file)
 
+
 def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
     # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
     # instead of checking for the existence of every file.pathext
@@ -100,36 +101,65 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
         return
 
     from os import walk
+
     # create a list of smaller dirs in PATH
-    short_path = 50 # exact threshold depends on the number of pathext, this is very ~
+    short_path = 50  # exact threshold depends on the number of pathext, this is very ~
     env = xession.env
-    env_path = env.get("PATH",[])
-    pathext = ['.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC','.PY','.PYW','.XSH']
-    env['PATHEXT'] = pathext
+    env_path = env.get("PATH", [])
+    pathext = [
+        ".COM",
+        ".EXE",
+        ".BAT",
+        ".CMD",
+        ".VBS",
+        ".VBE",
+        ".JS",
+        ".JSE",
+        ".WSF",
+        ".WSH",
+        ".MSC",
+        ".PY",
+        ".PYW",
+        ".XSH",
+    ]
+    env["PATHEXT"] = pathext
 
     if len(pathext) <= 2:
-        print(f"pathext is too short {len(pathext)} for direct listing of dirs to be faster")
+        print(
+            f"pathext is too short {len(pathext)} for direct listing of dirs to be faster"
+        )
         return
 
     xonsh_win_path_dirs_to_list = []
     for path in env_path:
         f = []
-        for (dirpath, dirnames, filenames) in walk(path):
+        for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
         if len(f) < short_path:
             xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
 
-    from time import monotonic_ns as ttime
     from math import pow
-    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+    from time import monotonic_ns as ttime
 
-    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = None
-    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur1 = (t1 - t0)/ns
+    ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = xonsh_win_path_dirs_to_list
-    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur2 = (t1 - t0)/ns
+    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = None
+    t0 = ttime()
+    for _i in range(100):
+        f = locate_executable("nothing")
+    t1 = ttime()
+    dur1 = (t1 - t0) / ns
 
-    print(f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}")
-    print(f"🕐{{:.6f}}\t(file.ext)\n🕐{{:.6f}}\t(list small dirs)\t".format(dur1,dur2))
-    assert dur2 < 0.90 * dur1   # listing method should be noticeable faster
+    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = xonsh_win_path_dirs_to_list
+    t0 = ttime()
+    for _i in range(100):
+        f = locate_executable("nothing")
+    t1 = ttime()
+    dur2 = (t1 - t0) / ns
+
+    print(
+        f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
+    )
+    print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(list small dirs)\t")
+    assert dur2 < 0.90 * dur1  # listing method should be noticeable faster

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1285,6 +1285,7 @@ class CacheSetting(Xettings):
         "This variable is a set of paths that should checked via direct listing.",
     )
 
+
 class ChangeDirSetting(Xettings):
     """``cd`` Behavior"""
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1275,6 +1275,15 @@ class CacheSetting(Xettings):
         "If enabled, the CommandsCache is saved between runs and can reduce the startup time.",
     )
 
+    XONSH_DIR_CACHE_TO_LIST = Var.with_default(
+        set(),
+        "(Win) Reduce typing delay via faster 'executable exists' checks."
+        "Color highlighting (green executable) is performend on every typed char,"
+        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
+        "which can be more expensive than simly listing the directory (if it's small)"
+        "and searching in this list."
+        "This variable is a set of paths that should checked via direct listing.",
+    )
 
 class ChangeDirSetting(Xettings):
     """``cd`` Behavior"""
@@ -1996,16 +2005,6 @@ class WindowsSetting(GeneralSetting):
         "when using the default terminal (``cmd.exe``) on Windows. Blue colors, "
         "which are hard to read, are replaced with cyan. Other colors are "
         "generally replaced by their bright counter parts.",
-        is_configurable=ON_WINDOWS,
-    )
-    XONSH_WIN_PATH_DIRS_TO_LIST = Var.with_default(
-        set(),
-        "Reduce typing delay via faster 'executable exists' checks."
-        "Color highlighting (green executable) is performend on every typed char,"
-        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
-        "which can be more expensive than simly listing the directory (if it's small)"
-        "and searching in this list."
-        "This variable is a set of paths that should checked via direct listing.",
         is_configurable=ON_WINDOWS,
     )
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1998,6 +1998,16 @@ class WindowsSetting(GeneralSetting):
         "generally replaced by their bright counter parts.",
         is_configurable=ON_WINDOWS,
     )
+    XONSH_WIN_PATH_DIRS_TO_LIST = Var.with_default(
+        set(),
+        "Reduce typing delay via faster 'executable exists' checks."
+        "Color highlighting (green executable) is performend on every typed char,"
+        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
+        "which can be more expensive than simly listing the directory (if it's small)"
+        "and searching in this list."
+        "This variable is a set of paths that should checked via direct listing.",
+        is_configurable=ON_WINDOWS,
+    )
 
 
 # Please keep the following in alphabetic order - scopatz

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -104,6 +104,8 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
 
 
 from os import walk
+
+
 def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
@@ -123,24 +125,24 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
-    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST",[])
+    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
-    ext_count = len(possible_names)
 
-    if ext_count > 2 and path_to_list:
+    if path_to_list and (len(possible_names) > 2):
         for path in paths:
             if path in path_to_list:
                 f = []
-                for (_dirpath, _dirnames, filenames) in walk(path):
+                for _dirpath, _dirnames, filenames in walk(path):
                     f.extend(filenames)
-                    break # no recursion into subdir
+                    break  # no recursion into subdir
                 for possible_name in possible_names:
-                    if not possible_name in f:
+                    if possible_name not in f:
                         continue
                     filepath = Path(path) / possible_name
                     try:
-                        if not               filepath.is_file() or (check_executable and
-                           not is_executable(filepath)):
+                        if not filepath.is_file() or (
+                            check_executable and not is_executable(filepath)
+                        ):
                             continue
                         return str(filepath)
                     except PermissionError:
@@ -149,8 +151,9 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
                 for possible_name in possible_names:
                     filepath = Path(path) / possible_name
                     try:
-                        if not               filepath.is_file() or (check_executable and
-                           not is_executable(filepath)):
+                        if not filepath.is_file() or (
+                            check_executable and not is_executable(filepath)
+                        ):
                             continue
                         return str(filepath)
                     except PermissionError:
@@ -159,8 +162,9 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
         for path, possible_name in itertools.product(paths, possible_names):
             filepath = Path(path) / possible_name
             try:
-                if not               filepath.is_file() or (check_executable and
-                   not is_executable(filepath)):
+                if not filepath.is_file() or (
+                    check_executable and not is_executable(filepath)
+                ):
                     continue
                 return str(filepath)
             except PermissionError:

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -130,12 +130,12 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
 
     Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
     to scan a smaller dir and check whether those 10+ strings are in this list
-    XONSH_WIN_PATH_DIRS_TO_LIST allows users to do just that
+    XONSH_DIR_CACHE_TO_LIST allows users to do just that
     """
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
-    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST", [])
+    path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
 
     if path_to_list and (len(possible_names) > 2):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -103,6 +103,7 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
                 continue
 
 
+from os import walk
 def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
@@ -114,19 +115,53 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     May be in the future file systems as well as Python Path will be smarter to get the case sensitive name.
     The task for reading and returning case sensitive filename we give to completer in interactive mode
     with ``commands_cache``.
+
+    Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
+    to scan a smaller dir and check whether those 10+ strings are in this list
+    XONSH_WIN_PATH_DIRS_TO_LIST allows users to do just that
     """
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
+    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST",[])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
+    ext_count = len(possible_names)
 
-    for path, possible_name in itertools.product(paths, possible_names):
-        filepath = Path(path) / possible_name
-        try:
-            if not filepath.is_file() or (
-                check_executable and not is_executable(filepath)
-            ):
+    if ext_count > 2 and path_to_list:
+        for path in paths:
+            if path in path_to_list:
+                f = []
+                for (_dirpath, _dirnames, filenames) in walk(path):
+                    f.extend(filenames)
+                    break # no recursion into subdir
+                for possible_name in possible_names:
+                    if not possible_name in f:
+                        continue
+                    filepath = Path(path) / possible_name
+                    try:
+                        if not               filepath.is_file() or (check_executable and
+                           not is_executable(filepath)):
+                            continue
+                        return str(filepath)
+                    except PermissionError:
+                        return
+            else:
+                for possible_name in possible_names:
+                    filepath = Path(path) / possible_name
+                    try:
+                        if not               filepath.is_file() or (check_executable and
+                           not is_executable(filepath)):
+                            continue
+                        return str(filepath)
+                    except PermissionError:
+                        continue
+    else:
+        for path, possible_name in itertools.product(paths, possible_names):
+            filepath = Path(path) / possible_name
+            try:
+                if not               filepath.is_file() or (check_executable and
+                   not is_executable(filepath)):
+                    continue
+                return str(filepath)
+            except PermissionError:
                 continue
-            return str(filepath)
-        except PermissionError:
-            continue


### PR DESCRIPTION
Checking for an executable on every keystroke (for syntax highlighting) is slow on Windows because for each of a dozen of dirs in `PATH` you need to check whether ~15 files exist (due to `PATHEXT`)

(on non-Win this will be used later to highlight typos in command names, even though not useful for a speed boost)

This PR allows to list smaller (user-defined in `XONSH_DIR_CACHE_TO_LIST`) dirs to be listed directly, which is faster than those file.exists checks

- pre: ~2.5ms per check of 16 files per dir, which for a few dozen dirs makes it visibly slow (see #5612 for a video)
- pos: ~0.1–2 ms per dir listing (depending on how large the dir is) and checking whether a file.ext is in the list


- [x] Include a news file
- [x] docs: added tips (and think autodoc generation would pick up the desription of the new environment variable?)
- [x] before-after: no use difference, just faster if you add the var documented in the tips
- [x] added a test that checks speed of executable lookup with smaller dirs added to the new `XONSH_DIR_CACHE_TO_LIST`
- [x] Addressing #5612



## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
