### PR TITLE
fix(windows): Allow caching path dirs to achieve low input lag

### DIFF
--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -320,3 +320,14 @@ This will cache a list of files within these dirs per Xonsh session and thus avo
 on subsequent typing.
 However, if Xonsh or any other process changes the list of files in these dirs, you'll lose the
 accuracy of syntax highlighting since the cache will not be updated to reflect it
+Since paths are normalized before comparison, you might also want to do so in your config
+to avoid mismatches:
+
+.. code-block:: xonshcon
+
+    from xonsh.built_ins import XSH
+    import os
+    xonsh_win_path_dirs_to_list = [R"C:\my\path\to\list",]
+    XSH.env["XONSH_WIN_PATH_DIRS_TO_LIST"] = set(os.path.normpath(p) for p in xonsh_win_dir_session_cache)
+    xonsh_win_dir_session_cache = [R"C:\my\path\to\cache",]
+    XSH.env["XONSH_WIN_DIR_SESSION_CACHE"] = set(os.path.normpath(p) for p in xonsh_win_dir_session_cache)

--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -311,3 +311,12 @@ Typing can be slow due to testing whether the typed text is an executable file
 For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
 :ref:`$XONSH_DIR_CACHE_TO_LIST <xonsh_dir_cache_to_list>`
 to reduce typing lag
+
+And to the typing lag even more (at the cost of a small loss of precision of syntax highlighting)
+you can list all the rarely changing (like ``C:\Program Files\Python\``) or not very important dirs
+from your ``$PATH`` in
+:ref:`$XONSH_WIN_DIR_SESSION_CACHE <xonsh_win_dir_session_cache>`
+This will cache a list of files within these dirs per Xonsh session and thus avoid any IO checks
+on subsequent typing.
+However, if Xonsh or any other process changes the list of files in these dirs, you'll lose the
+accuracy of syntax highlighting since the cache will not be updated to reflect it

--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -309,5 +309,5 @@ Typing can be slow due to testing whether the typed text is an executable file
 - for each of 10+ file.pathext
 
 For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
-:ref:`$XONSH_WIN_PATH_DIRS_TO_LIST <xonsh_win_path_dirs_to_list>`
+:ref:`$XONSH_DIR_CACHE_TO_LIST <xonsh_dir_cache_to_list>`
 to reduce typing lag

--- a/docs/platform-issues.rst
+++ b/docs/platform-issues.rst
@@ -296,3 +296,18 @@ Although not recommended, to restore the behavior found in the
     >>> $PATH.append('.')
 
 Add that to ``~/.xonshrc`` to enable that as the default behavior.
+
+
+Reduce typing delay
+^^^^^^^^^^^^^^^^^^^
+
+Typing can be slow due to testing whether the typed text is an executable file
+(for color highlighting), which tests whether a file exists:
+
+- for each of the dozen of dirs in ``PATH``
+
+- for each of 10+ file.pathext
+
+For smaller dirs (~few dozen files) it's faster to list the dir, so you can add such dirs to
+:ref:`$XONSH_WIN_PATH_DIRS_TO_LIST <xonsh_win_path_dirs_to_list>`
+to reduce typing lag

--- a/news/cacheWinPathSession.rst
+++ b/news/cacheWinPathSession.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* (by a lot, though with a small loss of precision) Slow input lag on Windows due to testing whether the typed text is an executable file (for color highlighting) by caching a list of files in a user configured dirs (``$XONSH_WIN_DIR_SESSION_CACHE``) for the duration of the Xonsh session.
+* (by a lot, though with a small loss of precision) Slow input lag on Windows due to testing whether the typed text is an executable file (for color highlighting) by caching a list of files in a user configured dirs (``$XONSH_DIR_SESSION_CACHE``) for the duration of the Xonsh session (so any changes to executable files within this session will not be visible to the color highlighter).
 
 **Security:**
 

--- a/news/cacheWinPathSession.rst
+++ b/news/cacheWinPathSession.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (by a lot, though with a small loss of precision) Slow input lag on Windows due to testing whether the typed text is an executable file (for color highlighting) by caching a list of files in a user configured dirs (``$XONSH_WIN_DIR_SESSION_CACHE``) for the duration of the Xonsh session.
+
+**Security:**
+
+* <news item>

--- a/news/constPath.rst
+++ b/news/constPath.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by not cleaning up PATH on every keystroke, but using a cached version instead.
+
+**Security:**
+
+* <news item>

--- a/news/listWinDir.rst
+++ b/news/listWinDir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_WIN_PATH_DIRS_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
+
+**Security:**
+
+* <news item>

--- a/news/listWinDir.rst
+++ b/news/listWinDir.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_WIN_PATH_DIRS_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
+* (partially) Slow input lag due to testing whether the typed text is an executable file (for color highlighting) by scanning user-supplied (via XONSH_DIR_CACHE_TO_LIST, best for smaller dirs with a few dozen files) dirs in PATH instead of checking whether each defined executable extension exists
 
 **Security:**
 

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -103,24 +103,21 @@ def test_locate_file_clean_path_cache_time(tmpdir, xession):
     t0 = ttime()
     _f = locate_executable("nothing")
     t1 = ttime()
-    _f = locate_executable("nothing")
-    t2 = ttime()
-    _f = locate_executable("nothing")
-    t3 = ttime()
     dur1 = (t1 - t0) / ns
-    dur2 = (t2 - t1) / ns
-    dur3 = (t3 - t2) / ns
+    t0 = ttime()
+    iters = 100
+    for _i in range(iters):
+        _f = locate_executable("nothing")
+    t1 = ttime()
+    dur2 = (t1 - t0) / iters / ns
     env = xession.env
     env_path = env.get("PATH", [])
     if env_path and dur1 > 0:
         print("$PATH length = ", len(env_path))
-        print(
-            f"t1 (no cache) = {dur1:.6f}\nt2 (   cache) = {dur2:.6f}\nt3 (   cache) = {dur3:.6f}"
-        )
+        print(f"t1 (no cache) = {dur1:.6f}\nt2 (   cache) = {dur2:.6f}")
         assert (
             dur2 < 0.90 * dur1
-        )  # 2nd run with cache should always be noticeable faster
-        assert dur3 < 0.90 * dur1  # as well as all the subsequent calls
+        )  # 2nd+ run with cache should always be noticeable faster
 
 
 def test_xonsh_dir_cache_to_list(tmpdir, xession):

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -196,7 +196,7 @@ def test_xonsh_dir_session_cache(tmpdir, xession):
     # check that adding dirs to a XONSH_DIR_SESSION_CACHE var to cache a list of files in
     # them per session instead of checking for the existence of every file.pathext
     # is faster
-    if not ON_WINDOWS: # other OS use this for syntax checking benefit, not speed
+    if not ON_WINDOWS:  # other OS use this for syntax checking benefit, not speed
         return
 
     from os import walk

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -112,7 +112,7 @@ def test_locate_file_clean_path_cache_time(tmpdir, xession):
     dur3 = (t3 - t2) / ns
     env = xession.env
     env_path = env.get("PATH", [])
-    if env_path:
+    if env_path and dur1 > 0:
         print("$PATH length = ", len(env_path))
         print(
             f"t1 (no cache) = {dur1:.6f}\nt2 (   cache) = {dur2:.6f}\nt3 (   cache) = {dur3:.6f}"

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -91,3 +91,45 @@ def test_locate_file(tmpdir, xession):
     with xession.env.swap(PATH=[str(bindir1), str(bindir2), str(bindir3)]):
         f = locate_file("findme")
         assert str(f) == str(file)
+
+def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
+    # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
+    # instead of checking for the existence of every file.pathext
+    # is faster
+    if not ON_WINDOWS:
+        return
+
+    from os import walk
+    # create a list of smaller dirs in PATH
+    short_path = 50 # exact threshold depends on the number of pathext, this is very ~
+    env = xession.env
+    env_path = env.get("PATH",[])
+    pathext = ['.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC','.PY','.PYW','.XSH']
+    env['PATHEXT'] = pathext
+
+    if len(pathext) <= 2:
+        print(f"pathext is too short {len(pathext)} for direct listing of dirs to be faster")
+        return
+
+    xonsh_win_path_dirs_to_list = []
+    for path in env_path:
+        f = []
+        for (dirpath, dirnames, filenames) in walk(path):
+            f.extend(filenames)
+            break
+        if len(f) < short_path:
+            xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
+
+    from time import monotonic_ns as ttime
+    from math import pow
+    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+
+    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = None
+    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur1 = (t1 - t0)/ns
+
+    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = xonsh_win_path_dirs_to_list
+    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur2 = (t1 - t0)/ns
+
+    print(f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}")
+    print(f"🕐{{:.6f}}\t(file.ext)\n🕐{{:.6f}}\t(list small dirs)\t".format(dur1,dur2))
+    assert dur2 < 0.90 * dur1   # listing method should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -93,8 +93,8 @@ def test_locate_file(tmpdir, xession):
         assert str(f) == str(file)
 
 
-def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
-    # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
+def test_xonsh_dir_cache_to_list(tmpdir, xession):
+    # check that adding smaller dirs to a XONSH_DIR_CACHE_TO_LIST var to list them
     # instead of checking for the existence of every file.pathext
     # is faster
     if not ON_WINDOWS:
@@ -130,28 +130,28 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
         )
         return
 
-    xonsh_win_path_dirs_to_list = []
+    xonsh_dir_cache_to_list = []
     for path in env_path:
         f = []
         for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
         if len(f) < short_path:
-            xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
+            xonsh_dir_cache_to_list += [path.rstrip(os.path.sep)]
 
     from math import pow
     from time import monotonic_ns as ttime
 
     ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = None
+    env["XONSH_DIR_CACHE_TO_LIST"] = None
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing")
     t1 = ttime()
     dur1 = (t1 - t0) / ns
 
-    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = xonsh_win_path_dirs_to_list
+    env["XONSH_DIR_CACHE_TO_LIST"] = xonsh_dir_cache_to_list
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing")
@@ -159,7 +159,7 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
     dur2 = (t1 - t0) / ns
 
     print(
-        f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
+        f"{len(pathext)} file.exists checks; {len(xonsh_dir_cache_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
     )
     print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(list small dirs)\t")
     assert dur2 < 0.90 * dur1  # listing method should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -192,16 +192,16 @@ def test_xonsh_dir_cache_to_list(tmpdir, xession):
     assert dur2 < 0.90 * dur1  # listing method should be noticeable faster
 
 
-def test_xonsh_win_dir_session_cache(tmpdir, xession):
-    # check that adding dirs to a XONSH_WIN_DIR_SESSION_CACHE var to cache a list of files in
+def test_xonsh_dir_session_cache(tmpdir, xession):
+    # check that adding dirs to a XONSH_DIR_SESSION_CACHE var to cache a list of files in
     # them per session instead of checking for the existence of every file.pathext
     # is faster
-    if not ON_WINDOWS:
+    if not ON_WINDOWS: # other OS use this for syntax checking benefit, not speed
         return
 
     from os import walk
 
-    xonsh_win_dir_session_cache = []
+    xonsh_dir_session_cache = []
     env = xession.env
     pathext = env["PATHEXT"]
     env_path = env.get("PATH", [])
@@ -210,21 +210,21 @@ def test_xonsh_win_dir_session_cache(tmpdir, xession):
         for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
-        xonsh_win_dir_session_cache += [path.rstrip(os.path.sep)]
+        xonsh_dir_session_cache += [path.rstrip(os.path.sep)]
 
     from math import pow
     from time import monotonic_ns as ttime
 
     ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env["XONSH_WIN_DIR_SESSION_CACHE"] = None
+    env["XONSH_DIR_SESSION_CACHE"] = None
     t0 = ttime()
     for _i in range(100):
         f = locate_executable("nothing", use_dir_session_cache=True)
     t1 = ttime()
     dur1 = (t1 - t0) / ns
 
-    env["XONSH_WIN_DIR_SESSION_CACHE"] = xonsh_win_dir_session_cache
+    env["XONSH_DIR_SESSION_CACHE"] = xonsh_dir_session_cache
     f = locate_executable("nothing")  # to cache dirs
     t0 = ttime()
     for _i in range(100):
@@ -233,7 +233,7 @@ def test_xonsh_win_dir_session_cache(tmpdir, xession):
     dur2 = (t1 - t0) / ns
 
     print(
-        f"{len(pathext)} file.exists checks; {len(xonsh_win_dir_session_cache)} paths from ∑{len(env_path)}"
+        f"{len(pathext)} file.exists checks; {len(xonsh_dir_session_cache)} paths from ∑{len(env_path)}"
     )
     print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(cache dirs)\t")
     assert dur2 < 0.90 * dur1  # caching dirs should be noticeable faster

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -96,26 +96,31 @@ def test_locate_file(tmpdir, xession):
 def test_locate_file_clean_path_cache_time(tmpdir, xession):
     # check that subsequent calls to locate_executable run faster due to use of path cache
     # that skips doing IO calls to check that path dirs exist
-    from time import monotonic_ns as ttime
     from math import pow
-    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+    from time import monotonic_ns as ttime
+
+    ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
     t0 = ttime()
-    f1 = locate_executable("nothing")
+    _f = locate_executable("nothing")
     t1 = ttime()
-    f2 = locate_executable("nothing")
+    _f = locate_executable("nothing")
     t2 = ttime()
-    f3 = locate_executable("nothing")
+    _f = locate_executable("nothing")
     t3 = ttime()
-    dur1 = (t1 - t0)/ns
-    dur2 = (t2 - t1)/ns
-    dur3 = (t3 - t2)/ns
+    dur1 = (t1 - t0) / ns
+    dur2 = (t2 - t1) / ns
+    dur3 = (t3 - t2) / ns
     env = xession.env
     env_path = env.get("PATH", [])
     if env_path:
-        print(f"$PATH length = ",len(env_path))
-        print(f"t1 (no cache) = {{:.6f}}\nt2 (   cache) = {{:.6f}}\nt3 (   cache) = {{:.6f}}".format(dur1,dur2,dur3))
-        assert  dur2 < 0.90 * dur1   # 2nd run with cache should always be noticeable faster
-        assert  dur3 < 0.90 * dur1   # as well as all the subsequent calls
+        print("$PATH length = ", len(env_path))
+        print(
+            f"t1 (no cache) = {dur1:.6f}\nt2 (   cache) = {dur2:.6f}\nt3 (   cache) = {dur3:.6f}"
+        )
+        assert (
+            dur2 < 0.90 * dur1
+        )  # 2nd run with cache should always be noticeable faster
+        assert dur3 < 0.90 * dur1  # as well as all the subsequent calls
 
 
 def test_xonsh_dir_cache_to_list(tmpdir, xession):

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -220,7 +220,7 @@ def test_xonsh_win_dir_session_cache(tmpdir, xession):
     env["XONSH_WIN_DIR_SESSION_CACHE"] = None
     t0 = ttime()
     for _i in range(100):
-        f = locate_executable("nothing")
+        f = locate_executable("nothing", use_dir_session_cache=True)
     t1 = ttime()
     dur1 = (t1 - t0) / ns
 
@@ -228,7 +228,7 @@ def test_xonsh_win_dir_session_cache(tmpdir, xession):
     f = locate_executable("nothing")  # to cache dirs
     t0 = ttime()
     for _i in range(100):
-        f = locate_executable("nothing")
+        f = locate_executable("nothing", use_dir_session_cache=True)
     t1 = ttime()
     dur2 = (t1 - t0) / ns
 

--- a/tests/procs/test_executables.py
+++ b/tests/procs/test_executables.py
@@ -92,6 +92,7 @@ def test_locate_file(tmpdir, xession):
         f = locate_file("findme")
         assert str(f) == str(file)
 
+
 def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
     # check that adding smaller dirs to a XONSH_WIN_PATH_DIRS_TO_LIST var to list them
     # instead of checking for the existence of every file.pathext
@@ -100,36 +101,65 @@ def test_xonsh_win_path_dirs_to_list(tmpdir, xession):
         return
 
     from os import walk
+
     # create a list of smaller dirs in PATH
-    short_path = 50 # exact threshold depends on the number of pathext, this is very ~
+    short_path = 50  # exact threshold depends on the number of pathext, this is very ~
     env = xession.env
-    env_path = env.get("PATH",[])
-    pathext = ['.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC','.PY','.PYW','.XSH']
-    env['PATHEXT'] = pathext
+    env_path = env.get("PATH", [])
+    pathext = [
+        ".COM",
+        ".EXE",
+        ".BAT",
+        ".CMD",
+        ".VBS",
+        ".VBE",
+        ".JS",
+        ".JSE",
+        ".WSF",
+        ".WSH",
+        ".MSC",
+        ".PY",
+        ".PYW",
+        ".XSH",
+    ]
+    env["PATHEXT"] = pathext
 
     if len(pathext) <= 2:
-        print(f"pathext is too short {len(pathext)} for direct listing of dirs to be faster")
+        print(
+            f"pathext is too short {len(pathext)} for direct listing of dirs to be faster"
+        )
         return
 
     xonsh_win_path_dirs_to_list = []
     for path in env_path:
         f = []
-        for (dirpath, dirnames, filenames) in walk(path):
+        for _dirpath, _dirnames, filenames in walk(path):
             f.extend(filenames)
             break
         if len(f) < short_path:
             xonsh_win_path_dirs_to_list += [path.rstrip(os.path.sep)]
 
-    from time import monotonic_ns as ttime
     from math import pow
-    ns = pow(10,9) # nanosecond, which 'monotonic_ns' are measured in
+    from time import monotonic_ns as ttime
 
-    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = None
-    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur1 = (t1 - t0)/ns
+    ns = pow(10, 9)  # nanosecond, which 'monotonic_ns' are measured in
 
-    env['XONSH_WIN_PATH_DIRS_TO_LIST'] = xonsh_win_path_dirs_to_list
-    t0 = ttime(); f = locate_executable("nothing"); t1 = ttime(); dur2 = (t1 - t0)/ns
+    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = None
+    t0 = ttime()
+    for _i in range(100):
+        f = locate_executable("nothing")
+    t1 = ttime()
+    dur1 = (t1 - t0) / ns
 
-    print(f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}")
-    print(f"🕐{{:.6f}}\t(file.ext)\n🕐{{:.6f}}\t(list small dirs)\t".format(dur1,dur2))
-    assert dur2 < 0.90 * dur1   # listing method should be noticeable faster
+    env["XONSH_WIN_PATH_DIRS_TO_LIST"] = xonsh_win_path_dirs_to_list
+    t0 = ttime()
+    for _i in range(100):
+        f = locate_executable("nothing")
+    t1 = ttime()
+    dur2 = (t1 - t0) / ns
+
+    print(
+        f"{len(pathext)} file.exists checks; {len(xonsh_win_path_dirs_to_list)} paths with <{short_path} items from ∑{len(env_path)}"
+    )
+    print(f"🕐{dur1:.6f}\t(file.ext)\n🕐{dur2:.6f}\t(list small dirs)\t")
+    assert dur2 < 0.90 * dur1  # listing method should be noticeable faster

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1285,6 +1285,7 @@ class CacheSetting(Xettings):
         "This variable is a set of paths that should checked via direct listing.",
     )
 
+
 class ChangeDirSetting(Xettings):
     """``cd`` Behavior"""
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1275,14 +1275,13 @@ class CacheSetting(Xettings):
         "If enabled, the CommandsCache is saved between runs and can reduce the startup time.",
     )
 
-    XONSH_WIN_DIR_SESSION_CACHE = Var.with_default(
+    XONSH_DIR_SESSION_CACHE = Var.with_default(
         set(),
-        "Reduce typing delay via faster 'executable exists' checks for syntax highlighting."
+        "(Win) Reduce typing delay via faster 'executable exists' checks for syntax highlighting."
         "Cache a list of files in these dirs for the duration of Xonsh session to avoid"
         "re-checking whether an executable exists on every keystroke."
         "This is a 'lossy' option, if xonsh or another process changes the files,"
         "syntax highlighting will be wrong, but it may still be worth the lower input lag.",
-        is_configurable=ON_WINDOWS,
     )
 
     XONSH_DIR_CACHE_TO_LIST = Var.with_default(

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1275,6 +1275,15 @@ class CacheSetting(Xettings):
         "If enabled, the CommandsCache is saved between runs and can reduce the startup time.",
     )
 
+    XONSH_DIR_CACHE_TO_LIST = Var.with_default(
+        set(),
+        "(Win) Reduce typing delay via faster 'executable exists' checks."
+        "Color highlighting (green executable) is performend on every typed char,"
+        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
+        "which can be more expensive than simly listing the directory (if it's small)"
+        "and searching in this list."
+        "This variable is a set of paths that should checked via direct listing.",
+    )
 
 class ChangeDirSetting(Xettings):
     """``cd`` Behavior"""
@@ -1996,16 +2005,6 @@ class WindowsSetting(GeneralSetting):
         "when using the default terminal (``cmd.exe``) on Windows. Blue colors, "
         "which are hard to read, are replaced with cyan. Other colors are "
         "generally replaced by their bright counter parts.",
-        is_configurable=ON_WINDOWS,
-    )
-    XONSH_WIN_PATH_DIRS_TO_LIST = Var.with_default(
-        set(),
-        "Reduce typing delay via faster 'executable exists' checks."
-        "Color highlighting (green executable) is performend on every typed char,"
-        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
-        "which can be more expensive than simly listing the directory (if it's small)"
-        "and searching in this list."
-        "This variable is a set of paths that should checked via direct listing.",
         is_configurable=ON_WINDOWS,
     )
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1998,6 +1998,16 @@ class WindowsSetting(GeneralSetting):
         "generally replaced by their bright counter parts.",
         is_configurable=ON_WINDOWS,
     )
+    XONSH_WIN_PATH_DIRS_TO_LIST = Var.with_default(
+        set(),
+        "Reduce typing delay via faster 'executable exists' checks."
+        "Color highlighting (green executable) is performend on every typed char,"
+        "which is ~10+ 'file.pathext exists' checks in each directory in PATH on Windows,"
+        "which can be more expensive than simly listing the directory (if it's small)"
+        "and searching in this list."
+        "This variable is a set of paths that should checked via direct listing.",
+        is_configurable=ON_WINDOWS,
+    )
 
 
 # Please keep the following in alphabetic order - scopatz

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1275,6 +1275,16 @@ class CacheSetting(Xettings):
         "If enabled, the CommandsCache is saved between runs and can reduce the startup time.",
     )
 
+    XONSH_WIN_DIR_SESSION_CACHE = Var.with_default(
+        set(),
+        "Reduce typing delay via faster 'executable exists' checks for syntax highlighting."
+        "Cache a list of files in these dirs for the duration of Xonsh session to avoid"
+        "re-checking whether an executable exists on every keystroke."
+        "This is a 'lossy' option, if xonsh or another process changes the files,"
+        "syntax highlighting will be wrong, but it may still be worth the lower input lag.",
+        is_configurable=ON_WINDOWS,
+    )
+
     XONSH_DIR_CACHE_TO_LIST = Var.with_default(
         set(),
         "(Win) Reduce typing delay via faster 'executable exists' checks."

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -204,7 +204,7 @@ def locate_file_in_path_env(
                 f = {i.lower() for i in F}
                 PathCache.set_dir_cached(path, F, f)  # ... and cache it
             for possible_name in possible_names:
-                if possible_name not in f:
+                if possible_name.lower() not in f:
                     continue
                 if found := check_possible_name(path, possible_name, check_executable):
                     return found
@@ -219,7 +219,7 @@ def locate_file_in_path_env(
                 break  # no recursion into subdir
             f = {i.lower() for i in F}
             for possible_name in possible_names:
-                if possible_name not in f:
+                if possible_name.lower() not in f:
                     continue
                 if found := check_possible_name(path, possible_name, check_executable):
                     return found

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -171,33 +171,26 @@ def locate_file_in_path_env(
     path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
 
-    if path_to_list and (len(possible_names) > 2):
-        for path in paths:
-            if path in path_to_list:
-                f = []
-                for _dirpath, _dirnames, filenames in walk(path):
-                    f.extend(filenames)
-                    break  # no recursion into subdir
-                for possible_name in possible_names:
-                    if possible_name not in f:
-                        continue
-                    if found := check_possible_name(
-                        path, possible_name, check_executable
-                    ):
-                        return found
-                    else:
-                        continue
-            else:
-                for possible_name in possible_names:
-                    if found := check_possible_name(
-                        path, possible_name, check_executable
-                    ):
-                        return found
-                    else:
-                        continue
-    else:
-        for path, possible_name in itertools.product(paths, possible_names):
-            if found := check_possible_name(path, possible_name, check_executable):
-                return found
-            else:
-                continue
+    for path in paths:
+        if path in path_to_list:
+            f = []
+            for _dirpath, _dirnames, filenames in walk(path):
+                f.extend(filenames)
+                break  # no recursion into subdir
+            for possible_name in possible_names:
+                if possible_name not in f:
+                    continue
+                if found := check_possible_name(
+                    path, possible_name, check_executable
+                ):
+                    return found
+                else:
+                    continue
+        else:
+            for possible_name in possible_names:
+                if found := check_possible_name(
+                    path, possible_name, check_executable
+                ):
+                    return found
+                else:
+                    continue

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -192,13 +192,13 @@ def locate_file_in_path_env(
     May be in the future file systems as well as Python Path will be smarter to get the case sensitive name.
     The task for reading and returning case sensitive filename we give to completer in interactive mode
     with ``commands_cache``.
-    When listing a XONSH_WIN_PATH_DIRS_TO_LIST dir or using a XONSH_WIN_DIR_SESSION_CACHE cache of a dir listing,
+    When listing a XONSH_WIN_PATH_DIRS_TO_LIST dir or using a XONSH_DIR_SESSION_CACHE cache of a dir listing,
     we can get case sensitive file name.
 
     Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
     to scan a smaller dir and check whether those 10+ strings are in this list
     XONSH_DIR_CACHE_TO_LIST allows users to do just that
-    XONSH_WIN_DIR_SESSION_CACHE further allows to list a dir and cache the results to avoid
+    XONSH_DIR_SESSION_CACHE further allows to list a dir and cache the results to avoid
     doing any IO on subsequent calls
     """
     paths = []
@@ -219,7 +219,7 @@ def locate_file_in_path_env(
         env_path = env.get("PATH", [])
         paths = tuple(clear_paths(env_path))
     path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])
-    dir_to_cache = env.get("XONSH_WIN_DIR_SESSION_CACHE", [])
+    dir_to_cache = env.get("XONSH_DIR_SESSION_CACHE", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
     ext_count = len(possible_names)
 

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -82,11 +82,11 @@ def locate_executable(name, env=None, use_path_cache=True, use_dir_session_cache
     )
 
 
-class PathCleanCache:
+class PathCache:
     is_dirty = True
 
     @classmethod
-    def get(cls, env):
+    def get_clean(cls, env):
         if cls.is_dirty:
             env_path = env.get("PATH", [])
             cls.clean_paths = tuple(clear_paths(env_path))
@@ -161,7 +161,7 @@ def locate_file_in_path_env(
     if env is None:
         env = XSH.env
         if use_path_cache:  # for generic environment: use cache only if configured
-            paths = PathCleanCache.get(env)
+            paths = PathCache.get_clean(env)
         else:  #              otherwise              : clean paths every time
             env_path = env.get("PATH", [])
             paths = tuple(clear_paths(env_path))

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -104,6 +104,8 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
 
 
 from os import walk
+
+
 def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
@@ -123,24 +125,24 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
-    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST",[])
+    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
-    ext_count = len(possible_names)
 
-    if ext_count > 2 and path_to_list:
+    if path_to_list and (len(possible_names) > 2):
         for path in paths:
             if path in path_to_list:
                 f = []
-                for (_dirpath, _dirnames, filenames) in walk(path):
+                for _dirpath, _dirnames, filenames in walk(path):
                     f.extend(filenames)
-                    break # no recursion into subdir
+                    break  # no recursion into subdir
                 for possible_name in possible_names:
-                    if not possible_name in f:
+                    if possible_name not in f:
                         continue
                     filepath = Path(path) / possible_name
                     try:
-                        if not               filepath.is_file() or (check_executable and
-                           not is_executable(filepath)):
+                        if not filepath.is_file() or (
+                            check_executable and not is_executable(filepath)
+                        ):
                             continue
                         return str(filepath)
                     except PermissionError:
@@ -149,8 +151,9 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
                 for possible_name in possible_names:
                     filepath = Path(path) / possible_name
                     try:
-                        if not               filepath.is_file() or (check_executable and
-                           not is_executable(filepath)):
+                        if not filepath.is_file() or (
+                            check_executable and not is_executable(filepath)
+                        ):
                             continue
                         return str(filepath)
                     except PermissionError:
@@ -159,8 +162,9 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
         for path, possible_name in itertools.product(paths, possible_names):
             filepath = Path(path) / possible_name
             try:
-                if not               filepath.is_file() or (check_executable and
-                   not is_executable(filepath)):
+                if not filepath.is_file() or (
+                    check_executable and not is_executable(filepath)
+                ):
                     continue
                 return str(filepath)
             except PermissionError:

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -83,7 +83,7 @@ def locate_executable(name, env=None, use_path_cache=True, use_dir_session_cache
 
 class PathCache:
     is_dirty = True
-    dir_cache = dict()
+    dir_cache: dict[str, list] = dict()
 
     @classmethod
     def get_clean(cls, env):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -90,9 +90,11 @@ class PathCache:
     def get_clean(cls, env):
         if cls.is_dirty:
             env_path = env.get("PATH", [])
-            env_path_hash = hash_s_list(env_path) # to test whether it matches PATH before
+            env_path_hash = hash_s_list(
+                env_path
+            )  # to test whether it matches PATH before
             # returning the cleaned version (avoid wrong cache for a env.swap(PATH=['a']))
-            if not env_path_hash in cls.clean_paths:
+            if env_path_hash not in cls.clean_paths:
                 cls.clean_paths[env_path_hash] = tuple(clear_paths(env_path))
             cls.is_dirty = False
         return cls.clean_paths
@@ -155,18 +157,22 @@ def check_possible_name(path, possible_name, check_executable):
     except PermissionError:
         return
 
+
 import hashlib
 import struct
+
+
 def hash_s_list(s_list):
     """
     Serialize a list of strings and hash them using sha256
     """
     hash_o = hashlib.sha256()
-    for s in s_list: # Hash each string
-        length_encoded = struct.pack("I",len(s))
+    for s in s_list:  # Hash each string
+        length_encoded = struct.pack("I", len(s))
         hash_o.update(length_encoded)
-        hash_o.update(s.encode('utf-8'))
+        hash_o.update(s.encode("utf-8"))
     return hash_o.hexdigest()
+
 
 def locate_file_in_path_env(
     name,

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -70,9 +70,9 @@ def is_executable_in_posix(filepath):
 is_executable = is_executable_in_windows if ON_WINDOWS else is_executable_in_posix
 
 
-def locate_executable(name, env=None):
+def locate_executable(name, env=None, use_path_cache=True):
     """Search executable binary name in ``$PATH`` and return full path."""
-    return locate_file(name, env=env, check_executable=True, use_pathext=True)
+    return locate_file(name, env=env, check_executable=True, use_pathext=True, use_path_cache=use_path_cache)
 
 
 class PathCleanCache:
@@ -86,11 +86,11 @@ class PathCleanCache:
         return cls.clean_paths
 
 
-def locate_file(name, env=None, check_executable=False, use_pathext=False):
+def locate_file(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
     return locate_relative_path(
         name, env, check_executable, use_pathext
-    ) or locate_file_in_path_env(name, env, check_executable, use_pathext)
+    ) or locate_file_in_path_env(name, env, check_executable, use_pathext, use_path_cache)
 
 
 def locate_relative_path(name, env=None, check_executable=False, use_pathext=False):
@@ -127,7 +127,7 @@ def check_possible_name(path, possible_name, check_executable):
         return
 
 
-def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
+def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
     """Search file name in ``$PATH`` and return full path.
 
     Compromise. There is no way to get case sensitive file name without listing all files.

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -174,6 +174,8 @@ def locate_file_in_path_env(
     Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
     to scan a smaller dir and check whether those 10+ strings are in this list
     XONSH_DIR_CACHE_TO_LIST allows users to do just that
+    XONSH_WIN_DIR_SESSION_CACHE further allows to list a dir and cache the results to avoid
+    doing any IO on subsequent calls
     """
     paths = []
     if env is None:

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -83,7 +83,7 @@ def locate_executable(name, env=None, use_path_cache=True, use_dir_session_cache
 
 class PathCache:
     is_dirty = True
-    dir_cache: dict[str, list[list[str], list[str]]] = dict()
+    dir_cache: dict[str, list[list[str]]] = dict()
 
     @classmethod
     def get_clean(cls, env):
@@ -197,7 +197,7 @@ def locate_file_in_path_env(
 
     for path in paths:
         if dir_to_cache and path in dir_to_cache:  # use session dir cache
-            F,f = PathCache.get_dir_cached(path)
+            F, f = PathCache.get_dir_cached(path)
             if not F:  # not cached, scan the dir ...
                 F = []
                 for _dirpath, _dirnames, filenames in walk(path):
@@ -207,8 +207,8 @@ def locate_file_in_path_env(
                 PathCache.set_dir_cached(path, F, f)  # ... and cache it
             for possible_name in possible_names:
                 try:
-                  i = f.index(possible_name.lower())
-                  possible_Name = F[i]
+                    i = f.index(possible_name.lower())
+                    possible_Name = F[i]
                 except ValueError:
                     continue
                 if found := check_possible_name(path, possible_Name, check_executable):
@@ -225,8 +225,8 @@ def locate_file_in_path_env(
             f = [i.lower() for i in F]
             for possible_name in possible_names:
                 try:
-                  i = f.index(possible_name.lower())
-                  possible_Name = F[i]
+                    i = f.index(possible_name.lower())
+                    possible_Name = F[i]
                 except ValueError:
                     continue
                 if found := check_possible_name(path, possible_Name, check_executable):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -130,12 +130,12 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
 
     Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
     to scan a smaller dir and check whether those 10+ strings are in this list
-    XONSH_WIN_PATH_DIRS_TO_LIST allows users to do just that
+    XONSH_DIR_CACHE_TO_LIST allows users to do just that
     """
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
-    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST", [])
+    path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
 
     if path_to_list and (len(possible_names) > 2):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -28,7 +28,7 @@ def get_possible_names(name, env=None):
 
 def clear_paths(paths):
     """Remove duplicates and nonexistent directories from paths."""
-    return filter(os.path.isdir, unique_everseen(map(os.path.realpath, paths)))
+    return filter(os.path.isdir, unique_everseen(map(os.path.normpath, paths)))
 
 
 def get_paths(env=None):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -224,7 +224,9 @@ def locate_file_in_path_env(
     ext_count = len(possible_names)
 
     for path in paths:
-        if dir_to_cache and path in dir_to_cache:  # use session dir cache
+        if (
+            use_dir_session_cache and dir_to_cache and path in dir_to_cache
+        ):  # use session dir cache
             F, f = PathCache.get_dir_cached(path)
             if not F:  # not cached, scan the dir ...
                 F = []

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -70,7 +70,7 @@ def is_executable_in_posix(filepath):
 is_executable = is_executable_in_windows if ON_WINDOWS else is_executable_in_posix
 
 
-def locate_executable(name, env=None, use_path_cache=True):
+def locate_executable(name, env=None, use_path_cache=True, use_dir_session_cache=False):
     """Search executable binary name in ``$PATH`` and return full path."""
     return locate_file(
         name,
@@ -78,6 +78,7 @@ def locate_executable(name, env=None, use_path_cache=True):
         check_executable=True,
         use_pathext=True,
         use_path_cache=use_path_cache,
+        use_dir_session_cache=use_dir_session_cache,
     )
 
 
@@ -94,13 +95,13 @@ class PathCleanCache:
 
 
 def locate_file(
-    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True
+    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True, use_dir_session_cache=False
 ):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
     return locate_relative_path(
         name, env, check_executable, use_pathext
     ) or locate_file_in_path_env(
-        name, env, check_executable, use_pathext, use_path_cache
+        name, env, check_executable, use_pathext, use_path_cache, use_dir_session_cache
     )
 
 
@@ -139,7 +140,7 @@ def check_possible_name(path, possible_name, check_executable):
 
 
 def locate_file_in_path_env(
-    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True
+    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True, use_dir_session_cache=False
 ):
     """Search file name in ``$PATH`` and return full path.
 

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -1,6 +1,5 @@
 """Interfaces to locate executable files on file system."""
 
-import itertools
 import os
 from pathlib import Path
 
@@ -96,7 +95,7 @@ class PathCache:
 
     @classmethod
     def get_dir_cached(cls, path):
-        return cls.dir_cache.get(path,[])
+        return cls.dir_cache.get(path, [])
 
     @classmethod
     def set_dir_cached(cls, path, file_list):
@@ -104,7 +103,12 @@ class PathCache:
 
 
 def locate_file(
-    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True, use_dir_session_cache=False
+    name,
+    env=None,
+    check_executable=False,
+    use_pathext=False,
+    use_path_cache=True,
+    use_dir_session_cache=False,
 ):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
     return locate_relative_path(
@@ -149,7 +153,12 @@ def check_possible_name(path, possible_name, check_executable):
 
 
 def locate_file_in_path_env(
-    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True, use_dir_session_cache=False
+    name,
+    env=None,
+    check_executable=False,
+    use_pathext=False,
+    use_path_cache=True,
+    use_dir_session_cache=False,
 ):
     """Search file name in ``$PATH`` and return full path.
 
@@ -183,22 +192,24 @@ def locate_file_in_path_env(
     ext_count = len(possible_names)
 
     for path in paths:
-        if path in dir_to_cache: # use session dir cache
-            if not (f := PathCache.get_dir_cached(path)): # not cached, scan the dir ...
+        if path in dir_to_cache:  # use session dir cache
+            if not (
+                f := PathCache.get_dir_cached(path)
+            ):  # not cached, scan the dir ...
                 for _dirpath, _dirnames, filenames in walk(path):
                     f.extend(filenames)
                     break  # no recursion into subdir
-                PathCache.set_dir_cached(path, f) # ... and cache it
+                PathCache.set_dir_cached(path, f)  # ... and cache it
             for possible_name in possible_names:
                 if possible_name not in f:
                     continue
-                if found := check_possible_name(
-                    path, possible_name, check_executable
-                ):
+                if found := check_possible_name(path, possible_name, check_executable):
                     return found
                 else:
                     continue
-        elif path in path_to_list and ext_count > 2: # list a dir vs checking many files
+        elif (
+            path in path_to_list and ext_count > 2
+        ):  # list a dir vs checking many files
             f = []
             for _dirpath, _dirnames, filenames in walk(path):
                 f.extend(filenames)
@@ -206,17 +217,13 @@ def locate_file_in_path_env(
             for possible_name in possible_names:
                 if possible_name not in f:
                     continue
-                if found := check_possible_name(
-                    path, possible_name, check_executable
-                ):
+                if found := check_possible_name(path, possible_name, check_executable):
                     return found
                 else:
                     continue
-        else: # check that file(s) exists individually
+        else:  # check that file(s) exists individually
             for possible_name in possible_names:
-                if found := check_possible_name(
-                    path, possible_name, check_executable
-                ):
+                if found := check_possible_name(path, possible_name, check_executable):
                     return found
                 else:
                     continue

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -155,6 +155,18 @@ def check_possible_name(path, possible_name, check_executable):
     except PermissionError:
         return
 
+import hashlib
+import struct
+def hash_s_list(s_list):
+    """
+    Serialize a list of strings and hash them using sha256
+    """
+    hash_o = hashlib.sha256()
+    for s in s_list: # Hash each string
+        length_encoded = struct.pack("I",len(s))
+        hash_o.update(length_encoded)
+        hash_o.update(s.encode('utf-8'))
+    return hash_o.hexdigest()
 
 def locate_file_in_path_env(
     name,

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -84,6 +84,7 @@ def locate_executable(name, env=None, use_path_cache=True, use_dir_session_cache
 
 class PathCache:
     is_dirty = True
+    dir_cache = dict()
 
     @classmethod
     def get_clean(cls, env):
@@ -92,6 +93,14 @@ class PathCache:
             cls.clean_paths = tuple(clear_paths(env_path))
             cls.is_dirty = False
         return cls.clean_paths
+
+    @classmethod
+    def get_dir_cached(cls, path):
+        return cls.dir_cache.get(path,[])
+
+    @classmethod
+    def set_dir_cached(cls, path, file_list):
+        cls.dir_cache[path] = file_list
 
 
 def locate_file(

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -170,6 +170,8 @@ def locate_file_in_path_env(
     May be in the future file systems as well as Python Path will be smarter to get the case sensitive name.
     The task for reading and returning case sensitive filename we give to completer in interactive mode
     with ``commands_cache``.
+    When listing a XONSH_WIN_PATH_DIRS_TO_LIST dir or using a XONSH_WIN_DIR_SESSION_CACHE cache of a dir listing,
+    we can get case sensitive file name.
 
     Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
     to scan a smaller dir and check whether those 10+ strings are in this list

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -103,6 +103,7 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
                 continue
 
 
+from os import walk
 def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False):
     """Search file name in ``$PATH`` and return full path.
 
@@ -114,19 +115,53 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     May be in the future file systems as well as Python Path will be smarter to get the case sensitive name.
     The task for reading and returning case sensitive filename we give to completer in interactive mode
     with ``commands_cache``.
+
+    Typing speed boost: on Windows instead of checking that 10+ file.pathext files exist it's faster
+    to scan a smaller dir and check whether those 10+ strings are in this list
+    XONSH_WIN_PATH_DIRS_TO_LIST allows users to do just that
     """
     env = env if env is not None else XSH.env
     env_path = env.get("PATH", [])
     paths = tuple(clear_paths(env_path))
+    path_to_list = env.get("XONSH_WIN_PATH_DIRS_TO_LIST",[])
     possible_names = get_possible_names(name, env) if use_pathext else [name]
+    ext_count = len(possible_names)
 
-    for path, possible_name in itertools.product(paths, possible_names):
-        filepath = Path(path) / possible_name
-        try:
-            if not filepath.is_file() or (
-                check_executable and not is_executable(filepath)
-            ):
+    if ext_count > 2 and path_to_list:
+        for path in paths:
+            if path in path_to_list:
+                f = []
+                for (_dirpath, _dirnames, filenames) in walk(path):
+                    f.extend(filenames)
+                    break # no recursion into subdir
+                for possible_name in possible_names:
+                    if not possible_name in f:
+                        continue
+                    filepath = Path(path) / possible_name
+                    try:
+                        if not               filepath.is_file() or (check_executable and
+                           not is_executable(filepath)):
+                            continue
+                        return str(filepath)
+                    except PermissionError:
+                        return
+            else:
+                for possible_name in possible_names:
+                    filepath = Path(path) / possible_name
+                    try:
+                        if not               filepath.is_file() or (check_executable and
+                           not is_executable(filepath)):
+                            continue
+                        return str(filepath)
+                    except PermissionError:
+                        continue
+    else:
+        for path, possible_name in itertools.product(paths, possible_names):
+            filepath = Path(path) / possible_name
+            try:
+                if not               filepath.is_file() or (check_executable and
+                   not is_executable(filepath)):
+                    continue
+                return str(filepath)
+            except PermissionError:
                 continue
-            return str(filepath)
-        except PermissionError:
-            continue

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -192,7 +192,7 @@ def locate_file_in_path_env(
     ext_count = len(possible_names)
 
     for path in paths:
-        if path in dir_to_cache:  # use session dir cache
+        if dir_to_cache and path in dir_to_cache:  # use session dir cache
             if not (
                 f := PathCache.get_dir_cached(path)
             ):  # not cached, scan the dir ...
@@ -208,7 +208,7 @@ def locate_file_in_path_env(
                 else:
                     continue
         elif (
-            path in path_to_list and ext_count > 2
+            ext_count > 2 and path_to_list and path in path_to_list
         ):  # list a dir vs checking many files
             f = []
             for _dirpath, _dirnames, filenames in walk(path):

--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -72,13 +72,20 @@ is_executable = is_executable_in_windows if ON_WINDOWS else is_executable_in_pos
 
 def locate_executable(name, env=None, use_path_cache=True):
     """Search executable binary name in ``$PATH`` and return full path."""
-    return locate_file(name, env=env, check_executable=True, use_pathext=True, use_path_cache=use_path_cache)
+    return locate_file(
+        name,
+        env=env,
+        check_executable=True,
+        use_pathext=True,
+        use_path_cache=use_path_cache,
+    )
 
 
 class PathCleanCache:
     is_dirty = True
+
     @classmethod
-    def get(cls,env):
+    def get(cls, env):
         if cls.is_dirty:
             env_path = env.get("PATH", [])
             cls.clean_paths = tuple(clear_paths(env_path))
@@ -86,11 +93,15 @@ class PathCleanCache:
         return cls.clean_paths
 
 
-def locate_file(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
+def locate_file(
+    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True
+):
     """Search file name in the current working directory and in ``$PATH`` and return full path."""
     return locate_relative_path(
         name, env, check_executable, use_pathext
-    ) or locate_file_in_path_env(name, env, check_executable, use_pathext, use_path_cache)
+    ) or locate_file_in_path_env(
+        name, env, check_executable, use_pathext, use_path_cache
+    )
 
 
 def locate_relative_path(name, env=None, check_executable=False, use_pathext=False):
@@ -127,7 +138,9 @@ def check_possible_name(path, possible_name, check_executable):
         return
 
 
-def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=False, use_path_cache=True):
+def locate_file_in_path_env(
+    name, env=None, check_executable=False, use_pathext=False, use_path_cache=True
+):
     """Search file name in ``$PATH`` and return full path.
 
     Compromise. There is no way to get case sensitive file name without listing all files.
@@ -146,12 +159,12 @@ def locate_file_in_path_env(name, env=None, check_executable=False, use_pathext=
     paths = []
     if env is None:
         env = XSH.env
-        if use_path_cache: # for generic environment: use cache only if configured
+        if use_path_cache:  # for generic environment: use cache only if configured
             paths = PathCleanCache.get(env)
-        else:              # otherwise              : clean paths every time
+        else:  #              otherwise              : clean paths every time
             env_path = env.get("PATH", [])
             paths = tuple(clear_paths(env_path))
-    else:                  # for custom  environment: clean paths every time
+    else:  #                  for custom  environment: clean paths every time
         env_path = env.get("PATH", [])
         paths = tuple(clear_paths(env_path))
     path_to_list = env.get("XONSH_DIR_CACHE_TO_LIST", [])

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1596,7 +1596,7 @@ def color_file(file_path: str, path_stat: os.stat_result) -> tuple[_TokenType, s
 
 
 def _command_is_valid(cmd):
-    use_dir_session_cache = "XONSH_WIN_DIR_SESSION_CACHE" in XSH.env.keys()
+    use_dir_session_cache = "XONSH_DIR_SESSION_CACHE" in XSH.env.keys()
     return (
         cmd in XSH.aliases
         or locate_executable(cmd, use_dir_session_cache=use_dir_session_cache)

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1596,8 +1596,11 @@ def color_file(file_path: str, path_stat: os.stat_result) -> tuple[_TokenType, s
 
 
 def _command_is_valid(cmd):
-    use_dir_session_cache = 'XONSH_WIN_DIR_SESSION_CACHE' in XSH.env.keys()
-    return (cmd in XSH.aliases or locate_executable(cmd, use_dir_session_cache=use_dir_session_cache)) and not iskeyword(cmd)
+    use_dir_session_cache = "XONSH_WIN_DIR_SESSION_CACHE" in XSH.env.keys()
+    return (
+        cmd in XSH.aliases
+        or locate_executable(cmd, use_dir_session_cache=use_dir_session_cache)
+    ) and not iskeyword(cmd)
 
 
 def _command_is_autocd(cmd):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1596,7 +1596,8 @@ def color_file(file_path: str, path_stat: os.stat_result) -> tuple[_TokenType, s
 
 
 def _command_is_valid(cmd):
-    return (cmd in XSH.aliases or locate_executable(cmd)) and not iskeyword(cmd)
+    use_dir_session_cache = 'XONSH_WIN_DIR_SESSION_CACHE' in XSH.env.keys()
+    return (cmd in XSH.aliases or locate_executable(cmd, use_dir_session_cache=use_dir_session_cache)) and not iskeyword(cmd)
 
 
 def _command_is_autocd(cmd):

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -28,7 +28,7 @@ from xonsh.built_ins import XSH
 from xonsh.events import events
 from xonsh.lib.lazyimps import pyghooks, pygments, winutils
 from xonsh.platform import HAS_PYGMENTS, ON_POSIX, ON_WINDOWS
-from xonsh.procs.executables import PathCleanCache
+from xonsh.procs.executables import PathCache
 from xonsh.pygments_cache import get_all_styles
 from xonsh.shell import transform_command
 from xonsh.shells.base_shell import BaseShell
@@ -298,7 +298,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
-        PathCleanCache.is_dirty = True
+        PathCache.is_dirty = True
         events.on_pre_prompt_format.fire()
         env = XSH.env
         mouse_support = env.get("MOUSE_SUPPORT")

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -28,6 +28,7 @@ from xonsh.built_ins import XSH
 from xonsh.events import events
 from xonsh.lib.lazyimps import pyghooks, pygments, winutils
 from xonsh.platform import HAS_PYGMENTS, ON_POSIX, ON_WINDOWS
+from xonsh.procs.executables import PathCleanCache
 from xonsh.pygments_cache import get_all_styles
 from xonsh.shell import transform_command
 from xonsh.shells.base_shell import BaseShell
@@ -297,6 +298,7 @@ class PromptToolkitShell(BaseShell):
         kwarg flags whether the input should be stored in PTK's in-memory
         history.
         """
+        PathCleanCache.is_dirty = True
         events.on_pre_prompt_format.fire()
         env = XSH.env
         mouse_support = env.get("MOUSE_SUPPORT")

--- a/xonsh/shells/readline_shell.py
+++ b/xonsh/shells/readline_shell.py
@@ -38,6 +38,7 @@ from xonsh.platform import (
     ON_WINDOWS,
     os_environ,
 )
+from xonsh.procs.executables import PathCleanCache
 from xonsh.prompt.base import multiline_prompt
 from xonsh.shells.base_shell import BaseShell
 from xonsh.tools import (
@@ -390,6 +391,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             except ImportError:
                 store_in_history = True
             pos = readline.get_current_history_length() - 1
+        PathCleanCache.is_dirty = True
         events.on_pre_prompt_format.fire()
         prompt = self.prompt
         events.on_pre_prompt.fire()

--- a/xonsh/shells/readline_shell.py
+++ b/xonsh/shells/readline_shell.py
@@ -38,7 +38,7 @@ from xonsh.platform import (
     ON_WINDOWS,
     os_environ,
 )
-from xonsh.procs.executables import PathCleanCache
+from xonsh.procs.executables import PathCache
 from xonsh.prompt.base import multiline_prompt
 from xonsh.shells.base_shell import BaseShell
 from xonsh.tools import (
@@ -391,7 +391,7 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             except ImportError:
                 store_in_history = True
             pos = readline.get_current_history_length() - 1
-        PathCleanCache.is_dirty = True
+        PathCache.is_dirty = True
         events.on_pre_prompt_format.fire()
         prompt = self.prompt
         events.on_pre_prompt.fire()


### PR DESCRIPTION
This PR (with others) finally allows to have no input lag on Windows!!!

(it's on top of the other related PRs https://github.com/xonsh/xonsh/pull/5620 https://github.com/xonsh/xonsh/pull/5652 to avoid code conflicts and allow using all optimizations, and given that the expectation of merging either of the changes are the same)

It allows a user to provide a list of dirs from the PATH to cache the content of and thus avoid having to do 15+ file.exists checks in them on every keystroke.

The downside is that this cache persists per session, but for a lot of paths this is a well worthy tradeoff.

In principle, some future PR could have another config for more granular caching, e.g.:
  - cache some dirs per prompt so that you only get the lag for the first key (or not even that as some hooks may refresh the cache before a user starts typing?)
  - cache some dirs per duration (e.g., an hour?). Maybe this could be useful for some large dirs that add a noticeable delay when listing (so not great even for the first key), but yet need to be kept relatively "fresh"?
  - cache some dirs semi-permanently per OS update, but that's likely covered by this refactoring proposal https://github.com/xonsh/xonsh/issues/5541

By the way, even though the current method is precise in theory as it does the checks on every keystroke, it's imprecise in practice (though this might be some other bug, so opened a separate https://github.com/xonsh/xonsh/issues/5655):

There is one `qqqqqq.exe` executable in a dir from `PATH`, so when you type `qqqqqq` 6 times you should get a glimpse of green color

However, the current method can skip a key, so you get no color highlighting, but q×5 jumps to q×7 skipping q×6!

https://github.com/user-attachments/assets/7e2c5b92-596c-44a0-bcfe-1ac497e546e0

(not tested it thoroughly enough, it seems to work fine after you type slowly to find q×6 in path, then even holding the key matches on q×6 where it previously didn't match, so maybe it's not because it's slow but due to something else?)

If you add enough of dirs from PATHs to be cached `XONSH_WIN_DIR_SESSION_CACHE` (and yet others to be listed `XONSH_WIN_PATH_DIRS_TO_LIST` instead of  doing 15+ file.ext.exists()), then the new methods eliminates input lag completely!

https://github.com/user-attachments/assets/059a72d9-4d8e-4761-9d92-e05103355733

(the delay after the first `q` isn't lag, but platform key repeat delay)

Checklist
- [x] Include a news file 
- [x] doc: updated platform tips
- [x] before-after: no use difference, just faster if you add the var documented in the tips
- [x] addressing https://github.com/xonsh/xonsh/issues/5612

------------
ADDED
------------

> You closed a working solution with a reference to a broken one

PR #5654 vs PR #6183: Comparison

### Problem — the same

Slow syntax highlighting on Windows/WSL due to repeated `stat()` / `is_file()` calls in `locate_executable()` on every keystroke.

### Fundamental Architectural Difference: Synchronous vs Asynchronous

This is **the key** difference between the two PRs.

**#5654 — synchronous approach.** `locate_executable()` is still called **on the main thread** on every keystroke inside `_command_is_valid()`. The optimization only makes the call itself faster via caches:

```python
# pyghooks.py in #5654
def _command_is_valid(cmd):
    use_dir_session_cache = "XONSH_DIR_SESSION_CACHE" in XSH.env.keys()
    return (
        cmd in XSH.aliases
        or locate_executable(cmd, use_dir_session_cache=use_dir_session_cache)
    ) and not iskeyword(cmd)
```

**#6183 — asynchronous approach.** `locate_executable()` is moved to a **background thread** with debounce (10ms). The main thread is never blocked on I/O:

```python
# pyghooks.py in #6183
def _command_is_valid(cmd):
    if cmd in _cmd_valid_cache:
        return _cmd_valid_cache[cmd]      # O(1), no I/O
    if cmd in XSH.aliases:
        return True                        # O(1)
    # Expensive locate_executable → background thread
    _pending_cmds.add(cmd)
    _schedule_bg_validation()              # 10ms debounce + bg thread
    return False                           # Pessimistic default until validated
```

This means in #6183 **even with a cold cache** (first time, uncached directory) typing never lags. In #5654 — it lags until the cache warms up.

---

## Caching Strategies

| | #5654 | #6183 |
|---|---|---|
| **Strategies** | 3 | 1 + async |
| **PATH cleanup cache** | Yes — `PathCache` class with sha256 hash of PATH | No (unnecessary due to async) |
| **Dir listing cache** | `XONSH_DIR_CACHE_TO_LIST` — re-reads directory every time (accurate but slower) | No |
| **Session cache** | `XONSH_DIR_SESSION_CACHE` — cached for the entire session | `XONSH_COMMANDS_CACHE_READ_DIR_ONCE` — cached for the entire session |
| **Cache structure** | `dict[str, list[list[str]]]` + sha256 | `dict[str, frozenset[str]]` (simpler, O(1) lookup) |
| **Matching** | Exact path (`path in dir_to_cache`) | Prefix-based (`path.startswith(prefix)`) — more convenient |

---

## Configuration and Defaults

**#5654**: Fully opt-in, defaults to empty `set()`. The user must figure out and configure everything manually. Variable names are Windows-specific (`XONSH_WIN_DIR_SESSION_CACHE`).

**#6183**: Smart per-platform defaults:
- Windows → `['C:\Windows']` (automatically from `%WINDIR%`)
- WSL → auto-detects `/mnt/*/Windows`
- Linux/Mac → `[]`

Works out of the box. Cross-platform naming (`XONSH_COMMANDS_CACHE_*`). Includes a debug mode (`XONSH_COMMANDS_CACHE_DEBUG`).

---

## Invasiveness of Changes

**#5654** is more invasive:
- Changes signatures of `locate_executable()` and `locate_file()` (breaks API)
- Changes `clear_paths()` from `realpath` → `normpath` (global behavior change)
- Introduces `PathCache` class with `is_dirty` flag
- Modifies `ptk_shell/__init__.py` and `readline_shell.py` for cache invalidation
- 45 commits

**#6183** is less invasive:
- Does not change existing signatures — caching is transparent inside `locate_file_in_path_env()`
- Does not touch `clear_paths()`
- Uses module-level variables instead of a class
- Async logic is isolated in `pyghooks.py`
- 22 commits

---

## Where #6183 is Better

1. **Non-blocking input** — the fundamental advantage. Even with a cold cache, typing never lags. #5654 does not solve this: uncached directories will still cause lag.

2. **Works out of the box** — smart defaults vs fully manual configuration.

3. **Simpler** — fewer moving parts, no sha256 hashing, no class with dirty flag, no breaking API changes.

4. **Cross-platform** — naming and defaults account for Windows, WSL, and POSIX.

5. **Generation tokens** — correct handling of rapid typing (debounce + cancellation of stale threads).

## Where #5654 is Better

1. **No "flash of invalid command"** — in #6183 a command is briefly highlighted as invalid (red) until the background thread confirms it. In #5654 highlighting is always immediately correct (once the cache is warm).

2. **Intermediate `DIR_CACHE_TO_LIST` strategy** — for small directories, re-reads contents every time, which is more accurate than session cache but faster than per-file `stat()`. #6183 has no such middle ground.

3. **`clear_paths()` optimization** — replacing `realpath` with `normpath` removes unnecessary symlink resolution overhead. #6183 does not touch `clear_paths()`.

4. **No threading complexity** — synchronous code is easier to debug, no race conditions.

---

## Summary

Both PRs solve the same problem but at **different levels**:

- **#5654** optimizes **the call itself** to `locate_executable()` (makes it faster) but does not remove it from the main thread.
- **#6183** removes **the entire expensive call** from the main thread + caches results.

The #6183 approach is architecturally stronger because even a perfectly fast synchronous `locate_executable()` on network/WSL drives can take tens of milliseconds, while the async approach guarantees 0ms input lag. The trade-off is a brief "flash" of incorrect highlighting when typing a new command for the first time.

eugenesvk's claim that #6183 is "broken" is likely related to exactly this: they see commands briefly flash green only after the background thread validates them, and consider this a bug. From their perspective, synchronous correct highlighting is more important than zero-lag input.



## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
