### PR TITLE
fix(Windows): always run interpeted executable files via an interpreter

### DIFF
--- a/news/win_deinterp.rst
+++ b/news/win_deinterp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* (Windows) Inability to run .xsh scripts from xonsh
+
+**Security:**
+
+* <news item>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1510,6 +1510,44 @@ def test_shebang_cr(tmpdir):
     assert out == f"{expected_out}\n"
 
 
+@skip_if_no_xonsh
+@skip_if_on_unix
+def test_shebang_exe_cr(tmpdir, xession):
+    testdir = tmpdir.mkdir("xonsh_test_dir")
+    testfile = "shebang_cr.xsh"
+    testfile_exe = "shebang_exe_cr.xsh"
+    testfile_fail_x = "shebang_x_cr.xsh"
+    expected_out = "I'm .xsh with xonsh shebang␍"
+    (f := testdir / testfile).write_text(
+        f"""#!/usr/bin/env xonsh\r\nprint("{expected_out}")""", encoding="utf8"
+    )
+    expected_out_exe = "I'm .xsh with xonsh.exe shebang␍"
+    (f := testdir / testfile_exe).write_text(
+        f"""#!/usr/bin/env xonsh.exe\r\nprint("{expected_out_exe}")""", encoding="utf8"
+    )
+    (f := testdir / testfile_fail_x).write_text(
+        f"""#!/usr/bin/env xonsh.x\r\nprint("")""", encoding="utf8"
+    )
+    env = base_env
+    env["PATHEXT"] = ".COM;.EXE;.BAT;.XSH"
+    command = f"cd {testdir}; ./{testfile}\n"
+    out, err, rtn = run_xonsh(command, env=env)
+    assert out == f"{expected_out}\n"
+
+    command = f"cd {testdir}; ./{testfile_exe}\n"
+    out, err, rtn = run_xonsh(command, env=env)
+    assert out == f"{expected_out_exe}\n"
+
+    env["XONSH_SHOW_TRACEBACK"] = "0"
+    command = f"cd {testdir}; ./{testfile_fail_x}\n"
+    out, err, rtn = run_xonsh(command, env=env)
+    assert out.startswith(f"xonsh: subprocess mode: command not found: 'xonsh.x'")
+
+    env["PATHEXT"] = ".COM;.EXE;.BAT"
+    out, err, rtn = run_xonsh(command, env=env)
+    assert out == 'OSError: [WinError 193] %1 is not a valid Win32 application\n'
+
+
 test_code = [
     """
 $XONSH_SHOW_TRACEBACK = True

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -81,10 +81,11 @@ def _un_shebang(x):
 
 
 def get_script_subproc_command(fname, args):
-    """Given the name of a script outside the path, returns a list representing
-    an appropriate subprocess command to execute the script or None if
-    the argument is not readable or not a script. Raises PermissionError
-    if the script is not executable.
+    """Given the name of a script outside the path, returns
+    - a list representing an appropriate subprocess command to execute the script or None if
+    the argument is not readable or not a script.
+    - a bool representing whether an interpeter has been found
+    Raises PermissionError if the script is not executable.
     """
     # make sure file is executable
     if not os.access(fname, os.X_OK):
@@ -100,16 +101,17 @@ def get_script_subproc_command(fname, args):
         # execute permissions but not read/write permissions. This enables
         # things with the SUID set to be run. Needs to come before _is_binary()
         # is called, because that function tries to read the file.
-        return None
+        return None, False
     elif _is_binary(fname):
         # if the file is a binary, we should call it directly
-        return None
+        return None, False
     if xp.ON_WINDOWS:
         # Windows can execute various filetypes directly
         # as given in PATHEXT
         _, ext = os.path.splitext(fname)
-        if ext.upper() in XSH.env.get("PATHEXT"):
-            return [fname] + args
+        if ext.upper() in XSH.env.get("PATHEXT") and\
+           ext.upper() not in ['.PY','.XSH']: # still need interpeters for these
+            return [fname] + args, False
     # find interpreter
     with open(fname, "rb") as f:
         first_line = f.readline().decode().strip()
@@ -128,7 +130,7 @@ def get_script_subproc_command(fname, args):
         for i in interp:
             o.extend(_un_shebang(i))
         interp = o
-    return interp + [fname] + args
+    return interp + [fname] + args, True
 
 
 @xl.lazyobject
@@ -386,10 +388,13 @@ class SubprocSpec:
         stack : list of FrameInfo namedtuples or None
             The stack of the call-site of alias, if the alias requires it.
             None otherwise.
+        interp : bool
+            Whether a command has an interperter
         """
         self._stdin = self._stdout = self._stderr = None
         # args
         self.cmd = list(cmd)
+        self.interp = False
         self.cls = cls
         self.stdin = stdin
         self.stdout = stdout
@@ -522,7 +527,9 @@ class SubprocSpec:
             raise xt.XonshError("xonsh: subprocess mode: command is empty")
         bufsize = 1
         try:
-            if xp.ON_WINDOWS and self.binary_loc is not None:
+            if xp.ON_WINDOWS and self.binary_loc is not None and self.interp is None:
+                # files with an interpeter should not be run directly as it errors with
+                # [WinError 193] %1 is not a valid Win32 application
                 # launch process using full paths (https://bugs.python.org/issue8557)
                 cmd = [self.binary_loc] + self.cmd[1:]
             else:
@@ -780,7 +787,7 @@ class SubprocSpec:
         if self.binary_loc is None:
             return
         try:
-            scriptcmd = get_script_subproc_command(self.binary_loc, self.cmd[1:])
+            scriptcmd, self.interp = get_script_subproc_command(self.binary_loc, self.cmd[1:])
             if scriptcmd is not None:
                 self.cmd = scriptcmd
         except PermissionError as ex:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -76,7 +76,7 @@ def _un_shebang(x):
     elif x.endswith("python") or x.endswith("python.exe"):
         x = "python"
     if x == "xonsh":
-        return ["python", "-m", "xonsh.main"]
+        return ["python", "-m", "xonsh"]
     return [x]
 
 


### PR DESCRIPTION
And avoid `OSError: [WinError 193] %1 is not a valid Win32 application` when xonsh skips parsing shebangs in `.xsh` and other files and redirects them to the OS

Given that the opened issues (see the last list item) have gotten no better resolution suggestions, I'm PRing the slightly updated fix I've been using locally 

- [x]  added news
- [x] feature docs: not a feature
- [x] before-after: same usage, just old use got broken and is now fixed
- [x] Addresses #4555 and #4558 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
