### PR TITLE
refactor: Disable double check is_file on Windows systems to speedup IO

### DIFF
--- a/xonsh/procs/executables.py
+++ b/xonsh/procs/executables.py
@@ -122,7 +122,8 @@ def locate_relative_path(name, env=None, check_executable=False, use_pathext=Fal
             filepath = p.parent / possible_name
             try:
                 if not is_file(filepath) or (
-                    check_executable and not is_executable(filepath, check_file_exist=False)
+                    check_executable
+                    and not is_executable(filepath, check_file_exist=False)
                 ):
                     continue
                 return str(p.absolute())


### PR DESCRIPTION
### Motivation

Windows has slow IO operation on is_file check. So this PR is to reduce running is_file two times.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
