### PR TITLE
Replace zero to nothing in --timings table

### DIFF
--- a/news/timing_table.rst
+++ b/news/timing_table.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``--timings`` table format to use contiguous box drawing symbols and remove empty 0.000
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -338,9 +338,11 @@ def setup_timings(argv):
             prevtime = tstart = times[0][1]
             for name, ts in times:
                 print(
-                    entry_format.format(name, ts - tstart, ts - prevtime).replace(
-                        "0.000", "     "
-                    )
+                    entry_format.format(name, ts - tstart, ts - prevtime)
+                    .replace("0.000", "     ")
+                    .replace("0.00", " .  ")
+                    .replace("0.0", " . ")
+                    .replace("0.", " .")
                 )
                 prevtime = ts
             print(endline)

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -325,16 +325,18 @@ def setup_timings(argv):
             times = list(_timings.items())
             times = sorted(times, key=lambda x: x[1])
             width = max(len(s) for s, _ in times) + 2
-            header_format = f"|{{:<{width}}}|{{:^11}}|{{:^11}}|"
-            entry_format = f"|{{:<{width}}}|{{:^11.3f}}|{{:^11.3f}}|"
-            sepline = "|{}|{}|{}|".format("-" * width, "-" * 11, "-" * 11)
+            begline = "┌{}┬{}┬{}┐".format("─" * width, "─" * 11, "─" * 11)
+            header_format = f"│{{:<{width}}}│{{:^11}}│{{:^11}}│"
+            entry_format = f"│{{:<{width}}}│{{:^11.3f}}│{{:^11.3f}}│"
+            sepline = "├{}┼{}┼{}┤".format("─" * width, "─" * 11, "─" * 11)
+            endline = "└{}┴{}┴{}┘".format("─" * width, "─" * 11, "─" * 11)
             # Print result table
             print(" Debug level: {}".format(os.getenv("XONSH_DEBUG", "Off")))
-            print(sepline)
+            print(begline)
             print(header_format.format("Event name", "Time (s)", "Delta (s)"))
             print(sepline)
             prevtime = tstart = times[0][1]
             for name, ts in times:
-                print(entry_format.format(name, ts - tstart, ts - prevtime))
+                print(entry_format.format(name, ts - tstart, ts - prevtime).replace('0.000','     '))
                 prevtime = ts
-            print(sepline)
+            print(endline)

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -337,6 +337,10 @@ def setup_timings(argv):
             print(sepline)
             prevtime = tstart = times[0][1]
             for name, ts in times:
-                print(entry_format.format(name, ts - tstart, ts - prevtime).replace('0.000','     '))
+                print(
+                    entry_format.format(name, ts - tstart, ts - prevtime).replace(
+                        "0.000", "     "
+                    )
+                )
                 prevtime = ts
             print(endline)


### PR DESCRIPTION
Use contiguous table separators

Remove empty `0.000` as those just obscure changes

Before
```
|-------------------------|-----------|-----------|
|Event name               | Time (s)  | Delta (s) |
|-------------------------|-----------|-----------|
|on_post_prompt           |   0.000   |   0.000   |
|on_pre_prompt_format     |   0.000   |   0.000   |
|on_pre_prompt_tokenize   |   0.000   |   0.000   |
|on_post_prompt_tokenize  |   0.001   |   0.001   |
|on_pre_prompt_style      |   0.001   |   0.000   |
|on_post_prompt_style     |   0.003   |   0.002   |
|on_pre_prompt            |   0.003   |   0.000   |
|-------------------------|-----------|-----------|
```

After (github doesn't connect vertical box lines for some reason, but it's contiguous in the terminal)
```
┌─────────────────────────┬───────────┬───────────┐
│Event name               │ Time (s)  │ Delta (s) │
├─────────────────────────┼───────────┼───────────┤
│on_post_prompt           │           │           │
│on_pre_prompt_format     │           │           │
│on_pre_prompt_tokenize   │           │           │
│on_post_prompt_tokenize  │   0.001   │   0.001   │
│on_pre_prompt_style      │   0.001   │           │
│on_post_prompt_style     │   0.003   │   0.002   │
│on_pre_prompt            │   0.003   │           │
└─────────────────────────┴───────────┴───────────┘
```

An even better design would be to remove non-significant 0s altogether - like here it's immediately clear there is only a single operation >1s since there is only a single number in that column
```
┌─────────────────────────┬───────────┬───────────┐
│Event name               │ Time (s)  │ Delta (s) │
├─────────────────────────┼───────────┼───────────┤
│on_post_prompt           │           │           │
│on_pre_prompt_format     │           │           │
│on_pre_prompt_tokenize   │           │           │
│on_post_prompt_tokenize  │    .  1   │    .  1   │
│on_pre_prompt_style      │    .  1   │           │
│on_post_prompt_style     │    .  3   │    .  2   │
│on_pre_prompt            │   1.003   │           │
└─────────────────────────┴───────────┴───────────┘
```

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. docs: no docs, a tiny formatting change
3. usage example: no difference
4. issue: without an issue


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
