### PR TITLE
Disable executable lookup for workstations with ondemand antivirus scanners

### DIFF
--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1596,7 +1596,10 @@ def color_file(file_path: str, path_stat: os.stat_result) -> tuple[_TokenType, s
 
 
 def _command_is_valid(cmd):
-    return (cmd in XSH.aliases or locate_executable(cmd)) and not iskeyword(cmd)
+    if XSH.env.get("NO_EXECUTABLE_TOKENS"):
+        return cmd in XSH.aliases and not iskeyword(cmd)
+    else:
+        return (cmd in XSH.aliases or locate_executable(cmd)) and not iskeyword(cmd)
 
 
 def _command_is_autocd(cmd):


### PR DESCRIPTION
I run xonsh in an environment with on-demand scanners, which will pre-scan any file hit by the OS prior to allowing an I/O to be performed against it. This includes the many calls to `filepath.is_file()` on all files in the PATH env var and cwd.

This disables the lookup entirely using the NO_EXECUTABLE_TOKENS env var.

For reference, the mean length of time for `is_executable_in_windows()` on my workstation is 1.1928 ms
```
@ pstats.Stats('C:/TMP/xonsh-longrun.profile').sort_stats(SortKey.CUMULATIVE).print_stats('is_executable_in_windows')
Thu Aug 29 20:45:59 2024    C:/TMP/xonsh-longrun.profile

         7727767 function calls (7621195 primitive calls) in 80.831 seconds

   Ordered by: cumulative time
   List reduced from 4908 to 1 due to restriction <'is_executable_in_windows'>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     7743    0.014    0.000    9.236    0.001 C:\Users\XXXXXX\.local\pipx\venvs\xonsh\Lib\site-packages\xonsh\procs\executables.py:41(is_executable_in_windows)
```

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
