### PR TITLE
Fix typo Crtl+C -> Ctrl+C

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2721,7 +2721,7 @@ v0.8.6
     * Exits after concatenating normal files which have a finite size
     * Continues to run for special files which do not have a size,
       such as ``/dev/random``
-    * Is interruptable in all cases with Crtl-C.
+    * Is interruptable in all cases with Ctrl-C.
 * Callable aliases were not properly raising a ``CalledProcessError`` when they
   returned a non-zero exist status when ``$RAISE_SUBPROC_ERROR = True``. This has
   been fixed.
@@ -4463,7 +4463,7 @@ v0.5.0
 * Fixed many PEP8 violations that had gone unnoticed
 * Fix failure to detect an Anaconda python distribution if the python was install from the conda-forge channel.
 * current_branch will try and locate the vc binary once
-* May now Crtl-C out of an infinite loop with a subprocess, such as
+* May now Ctrl-C out of an infinite loop with a subprocess, such as
   ```while True: sleep 1``.
 * Fix for stdin redirects.
 * Backgrounding works with ``$XONSH_STORE_STDOUT``

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -70,7 +70,7 @@ independent of the setting of the $AUTO_CONTINUE option.
 ``EOF``, ``exit``, and ``quit``
 ===================================
 The commands ``EOF``, ``exit``, and ``quit`` all alias the same action, which is to
-leave xonsh in a safe manner. Typing ``Crtl-d`` is the same as typing ``EOF`` and
+leave xonsh in a safe manner. Typing ``Ctrl-d`` is the same as typing ``EOF`` and
 pressing enter.
 
 

--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -41,7 +41,7 @@ initializes your personal run control file (usually at ``~/.xonshrc``).  To invo
 .. code-block:: xonshcon
 
   >>> xonfig web
-  Web config started at 'http://localhost:8421'. Hit Crtl+C to stop.
+  Web config started at 'http://localhost:8421'. Hit Ctrl+C to stop.
   127.0.0.1 - - [23/Aug/2020 15:04:39] "GET / HTTP/1.1" 200 -
 
 This will open your default browser on a page served from a local server.  You can exit the server by typing ``Ctrl+c`` at any time.

--- a/xonsh/webconfig/main.py
+++ b/xonsh/webconfig/main.py
@@ -138,7 +138,7 @@ def bind_server_to(
 
             httpd = cls(("", port), handler_cls)
             url = f"http://localhost:{port}"
-            print(f"Web config started at '{url}'. Hit Crtl+C to stop.")
+            print(f"Web config started at '{url}'. Hit Ctrl+C to stop.")
             if browser:
                 import webbrowser
 


### PR DESCRIPTION
Fix a few occurences across the tree. Also fix it retroactively in the CHANGELOG for folks that are going through older changes.

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
