### PR TITLE
Catch SystemExit in ProcProxy

### DIFF
--- a/news/fix-procproxy-sys-exit.rst
+++ b/news/fix-procproxy-sys-exit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Built-in commands such as `xonfig -h` and `xontrib -h` no longer cause the shell to exit
+
+**Security:**
+
+* <news item>

--- a/news/fix-procproxy-sys-exit.rst
+++ b/news/fix-procproxy-sys-exit.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* Now SystemExit that invoked from callable alias follows to exiting from callable alias instead of exiting the entire shell.
 
 **Deprecated:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Built-in commands such as `xonfig -h` and `xontrib -h` no longer cause the shell to exit
+* Built-in commands such as `xonfig -h` and `xontrib -h` no longer cause the shell to exit.
 
 **Security:**
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -336,6 +336,7 @@ from xonsh.tools import unthreadable
 
 @unthreadable
 def _f():
+    import sys
     sys.exit(42)
 
 aliases['f'] = _f

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -329,6 +329,21 @@ f
         "hello\n",
         0,
     ),
+    # test system exit in unthreadable alias (see #5689)
+    (
+        """
+from xonsh.tools import unthreadable
+
+@unthreadable
+def _f():
+    sys.exit(42)
+
+aliases['f'] = _f
+print(![f].returncode)
+""",
+        "42\n",
+        0,
+    ),
     # test ambiguous globs
     (
         """

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -792,6 +792,10 @@ class ProcProxy:
                         "stack": spec.stack,
                     },
                 )
+        except SystemExit as e:
+            # the alias function is running in the main thread, so we need to
+            # catch SystemExit to prevent the entire shell from exiting (see #5689)
+            r = e.code if isinstance(e.code, int) else int(bool(e.code))
         except Exception:
             xt.print_exception(source_msg="Exception in " + get_proc_proxy_name(self))
             r = 1


### PR DESCRIPTION
Fixes #5689

Instead of catching SystemExit in ArgParserAlias (which I tried in #5697), it makes more sense to catch it at the ProcProxy level so that `sys.exit` is works for all unthreadable callable aliases.

Also see explanation in https://github.com/xonsh/xonsh/issues/5689#issuecomment-2381902081

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
