### PR TITLE
Fix quoting issue in virtualenv activator

### DIFF
--- a/news/fix-virtualenv-quoting.rst
+++ b/news/fix-virtualenv-quoting.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed incorrect quoting behaviour in `activate.xsh`
+
+**Security:**
+
+* <news item>

--- a/tests/test_virtualenv_activator.py
+++ b/tests/test_virtualenv_activator.py
@@ -2,12 +2,15 @@ import sys
 from pathlib import Path
 from subprocess import check_output
 
+import pytest
+
 from xonsh.pytest.tools import ON_WINDOWS
 
 
-def test_xonsh_activator(tmp_path):
+@pytest.mark.parametrize("dir_name", ["venv", "venv with space"])
+def test_xonsh_activator(tmp_path, dir_name):
     # Create virtualenv
-    venv_dir = tmp_path / "venv"
+    venv_dir = tmp_path / dir_name
     assert b"XonshActivator" in check_output(
         [sys.executable, "-m", "virtualenv", str(venv_dir)]
     )
@@ -35,7 +38,13 @@ def test_xonsh_activator(tmp_path):
 
     # Activate
     venv_python = check_output(
-        [sys.executable, "-m", "xonsh", "-c", f"source {activate_path}; which python"]
+        [
+            sys.executable,
+            "-m",
+            "xonsh",
+            "-c",
+            f"source r'{activate_path}'; which python",
+        ]
     ).decode()
     assert Path(venv_python).parent == bin_path
 
@@ -46,7 +55,7 @@ def test_xonsh_activator(tmp_path):
             "-m",
             "xonsh",
             "-c",
-            f"source {activate_path}; deactivate; "
+            f"source r'{activate_path}'; deactivate; "
             "import shutil; shutil.which('python') or shutil.which('python3')",
         ]
     ).decode()

--- a/xonsh/virtualenv/__init__.py
+++ b/xonsh/virtualenv/__init__.py
@@ -5,6 +5,11 @@ class XonshActivator(ViaTemplateActivator):
     def templates(self):
         yield "activate.xsh"
 
+    @staticmethod
+    def quote(string):
+        # leave string unchanged since we do quoting in activate.xsh (see #5699)
+        return string
+
     @classmethod
     def supports(cls, interpreter):
         return interpreter.version_info >= (3, 5)


### PR DESCRIPTION
Fixes #5699

For virtualenv version 20.26.6, the `quote` method of `XonshActivator` returns the string unchanged, overriding [the default `quote` method](https://github.com/pypa/virtualenv/blob/da72caac974b9a7e88d58b73c51a7c611e81ff04/src/virtualenv/activation/via_template.py#L25-L33). This fixes the issue where quotes are incorrectly inserted.

For older versions of virtualenv, the `quote` method does not get called, so the behaviour is the same.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
