### PR TITLE
Update tutorial_macros.rst

### DIFF
--- a/docs/tutorial_macros.rst
+++ b/docs/tutorial_macros.rst
@@ -44,8 +44,6 @@ from being consumed.
 
 Other languages like Lisp, Forth, and Julia also provide their macro systems.
 Even restructured text (rST) directives could be considered macros.
-Haskell and other more purely functional languages do not need macros (since
-evaluation is lazy anyway), and so do not have them.
 
 If these seem unfamiliar to the Python world, note that Jupyter and IPython
 magics ``%`` and ``%%`` are macros!


### PR DESCRIPTION
This removes the false statement that Haskell and other functional programming languages does need nor not have macros.

Lisp is a functional programming language with macros at the core of the language. For Haskell specifically its called [Template Haskell](https://wiki.haskell.org/Template_Haskell).

There's also Erlang which has a token based macro system, something between the C preprocessor and Lisp. Elixir, a newer language in the same ecosystem as Erlang, has full procedural macros. This is similar to the macros in Xonsh; regular functions that take AST nodes as input and return a, potentially different, AST node.

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
