### PR TITLE
Make cli_utils.ArgParser compatible with new argparse.ArgumentParser

### DIFF
--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -354,7 +354,9 @@ class ArgParser(ap.ArgumentParser):
         add_args(parser, func, allowed_params=args, doc=doc)
         return parser
 
-    def _parse_known_args(self, arg_strings: list[str], namespace: ap.Namespace, *args, **kwargs):
+    def _parse_known_args(
+        self, arg_strings: list[str], namespace: ap.Namespace, *args, **kwargs
+    ):
         arg_set = set(arg_strings)
         if (
             self.commands

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -354,7 +354,7 @@ class ArgParser(ap.ArgumentParser):
         add_args(parser, func, allowed_params=args, doc=doc)
         return parser
 
-    def _parse_known_args(self, arg_strings: list[str], namespace: ap.Namespace):
+    def _parse_known_args(self, arg_strings: list[str], namespace: ap.Namespace, *args, **kwargs):
         arg_set = set(arg_strings)
         if (
             self.commands
@@ -363,7 +363,7 @@ class ArgParser(ap.ArgumentParser):
             and (set(self.commands.choices).isdisjoint(arg_set))
         ):
             arg_strings = [self.default_command] + arg_strings
-        return super()._parse_known_args(arg_strings, namespace)
+        return super()._parse_known_args(arg_strings, namespace, *args, **kwargs)
 
 
 def run_with_partial_args(func: tp.Callable, ns: dict[str, tp.Any]):


### PR DESCRIPTION
tl;dr
Xonsh's code in cli_utils overrides 'private' methods of argparser.ArgumentParser. Three weeks ago these 'private' methods were changed in the core library by the CPython team. Those changes were rolled out in Python 3.12.7

Confirmed fixes #5724 ~~This should hopefully fix #5724 . I'll test this later today~~

I think I've figured it (#5724) out. [This commit](https://github.com/python/cpython/pull/125839/files) in CPython 3 weeks ago changed the signature of the internal method ArgParser._parse_known_args (adding a boolean arg, intermixed). Other methods of the core library's ArgumentParser (in particular _parse_known_args2) call self._parse_known_args with this new signature. In Xonsh, cli_utils.ArgParser, a sub class of ap.ArgumentParser, had previously overridden _parse_known_args.

The old signature of cli_utils.ArgParser._parse_known_args (without intermixed) is incompatible with calls to the new signature of argparse.ArgumentParser._parse_known_args (intermixed doesn't have a default on the 'private' methods, but is set in calls from the 'public' API methods ArgumentParser.parse_known_intermixed_args and ArgumentParser.parse_known_args).

Hopefully the signature of cli_utils.ArgParser._parse_known_args just needs to have intermixed, or *args, **kwargs added to it. The latter would actually be the same fix as @frostming 's commit 3266 for pdm (quoted above).

I still haven't the faintest idea why it only affects gcc builds on Debian Trixie though (it is a testing repo, perhaps that just happens to be where the bug was first discovered). 

Copied from here:  https://github.com/xonsh/xonsh/issues/5724#issuecomment-2466716810

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
