### PR TITLE
try just using CaseSenssitiveDict from requests to see if it works

### DIFF
--- a/news/remove-caseinsdict.rst
+++ b/news/remove-caseinsdict.rst
@@ -4,7 +4,8 @@
 
 **Changed:**
 
-* <news item>
+* replaced `case_insensitive_dictionary` dependency with local
+  `CaseInsensitiveDict` class
 
 **Deprecated:**
 
@@ -12,7 +13,7 @@
 
 **Removed:**
 
-* `case_insensitive_dictionary` dependency
+* <news item>
 
 **Fixed:**
 

--- a/news/remove-caseinsdict.rst
+++ b/news/remove-caseinsdict.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* `case_insensitive_dictionary` dependency
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
 maintainers = [{ name = "Xonsh Community" }, { email = "xonsh@gil.forsyth.dev" }]
 license = { text = "BSD 2-Clause License" }
 requires-python = ">=3.9"
-dependencies = ["requests; platform_system=='Windows'",]
+dependencies = []
 
 [tool.setuptools.dynamic]
 version = {attr = "xonsh.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
 maintainers = [{ name = "Xonsh Community" }, { email = "xonsh@gil.forsyth.dev" }]
 license = { text = "BSD 2-Clause License" }
 requires-python = ">=3.9"
-dependencies = []
+dependencies = ["requests; platform_system=='Windows'",]
 
 [tool.setuptools.dynamic]
 version = {attr = "xonsh.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ authors = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
 maintainers = [{ name = "Xonsh Community" }, { email = "xonsh@gil.forsyth.dev" }]
 license = { text = "BSD 2-Clause License" }
 requires-python = ">=3.9"
-dependencies = [
-    "case-insensitive-dictionary; platform_system=='Windows'",
-]
+dependencies = []
 
 [tool.setuptools.dynamic]
 version = {attr = "xonsh.__version__"}

--- a/tests/test_commands_cache.py
+++ b/tests/test_commands_cache.py
@@ -8,6 +8,7 @@ import pytest
 
 from xonsh.commands_cache import (
     SHELL_PREDICTOR_PARSER,
+    CaseInsensitiveDict,
     CommandsCache,
     _Commands,
     executables_in,
@@ -306,3 +307,77 @@ def test_executables_in(xession):
             else:
                 result = set(executables_in(test_path))
     assert expected == result
+
+
+def test_caseinsdict_constructor():
+    actual = CaseInsensitiveDict({"key1": "val1", "Key2": "Val2"})
+    assert isinstance(actual, CaseInsensitiveDict)
+    assert actual["key1"] == "val1"
+    assert actual["Key2"] == "Val2"
+
+
+def test_caseinsdict_getitem():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    assert actual["Key1"] == "Val1"
+    assert actual["key1"] == "Val1"
+
+
+def test_caseinsdict_setitem():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    actual["Key1"] = "Val2"
+    assert actual["Key1"] == "Val2"
+    assert actual["key1"] == "Val2"
+    actual["key1"] = "Val3"
+    assert actual["Key1"] == "Val3"
+    assert actual["key1"] == "Val3"
+
+
+def test_caseinsdict_delitem():
+    actual = CaseInsensitiveDict({"Key1": "Val1", "Key2": "Val2"})
+    del actual["Key1"]
+    assert actual == CaseInsensitiveDict({"Key2": "Val2"})
+    del actual["key2"]
+    assert actual == CaseInsensitiveDict({})
+
+
+def test_caseinsdict_contains():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    assert actual.__contains__("Key1")
+    assert actual.__contains__("key1")
+    assert not actual.__contains__("key2")
+
+
+def test_caseinsdict_get():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    assert actual.get("Key1") == "Val1"
+    assert actual.get("key1") == "Val1"
+    assert actual.get("key2", "no val") == "no val"
+    assert actual.get("key1", "no val") == "Val1"
+
+
+def test_caseinsdict_update():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    actual.update({"Key2": "Val2"})
+    assert actual["key2"] == "Val2"
+
+
+def test_caseinsdict_keys():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    assert next(actual.keys()) == "Key1"
+
+
+def test_caseinsdict_items():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    assert next(actual.items()) == ("Key1", "Val1")
+
+
+def test_caseinsdict_repr():
+    actual = CaseInsensitiveDict({"Key1": "Val1"})
+    assert actual.__repr__() == "CaseInsensitiveDict({'Key1': 'Val1'})"
+
+
+def test_caseinsdict_copy():
+    initial = CaseInsensitiveDict({"Key1": "Val1"})
+    actual = initial.copy()
+    assert actual == initial
+    assert id(actual) != id(initial)

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -24,7 +24,7 @@ from xonsh.procs.executables import (
 )
 
 
-class CaseInsensitiveDict(dict[str, tp.Any]):
+class CaseInsensitiveDict(dict[tp.Any, tp.Any]):
     def __init__(self, *args, **kwargs):
         super().__init__()
         self._store = {}
@@ -32,21 +32,21 @@ class CaseInsensitiveDict(dict[str, tp.Any]):
 
     def __setitem__(self, key, value):
         # Store the key in lowercase but preserve the original case for display
-        self._store[key.lower()] = key
-        super().__setitem__(key.lower(), value)
+        self._store[key.casefold()] = key
+        super().__setitem__(key.casefold(), value)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.lower())
+        return super().__getitem__(key.casefold())
 
     def __delitem__(self, key):
-        del self._store[key.lower()]
-        super().__delitem__(key.lower())
+        del self._store[key.casefold()]
+        super().__delitem__(key.casefold())
 
     def __contains__(self, key):
-        return key.lower() in self._store
+        return key.casefold() in self._store
 
     def get(self, key, default=None):
-        return super().get(key.lower(), default)
+        return super().get(key.casefold(), default)
 
     def update(self, *args, **kwargs):
         for k, v in dict(*args, **kwargs).items():
@@ -66,6 +66,7 @@ class CaseInsensitiveDict(dict[str, tp.Any]):
         return CaseInsensitiveDict(self.items())
 
 
+CacheDict: tp.Union[type[CaseInsensitiveDict], type[dict]]
 if ON_WINDOWS:
     CacheDict = CaseInsensitiveDict
 else:

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -24,7 +24,7 @@ from xonsh.procs.executables import (
 )
 
 if ON_WINDOWS:
-    from case_insensitive_dict import CaseInsensitiveDict as CacheDict
+    from requests.structures import CaseInsensitiveDict as CacheDict
 else:
     CacheDict = dict
 

--- a/xonsh/commands_cache.py
+++ b/xonsh/commands_cache.py
@@ -24,7 +24,7 @@ from xonsh.procs.executables import (
 )
 
 if ON_WINDOWS:
-    from requests.structures import CaseInsensitiveDict as CacheDict
+    from requests.structures import CaseInsensitiveDict as CacheDict  # type: ignore
 else:
     CacheDict = dict
 


### PR DESCRIPTION
closes #5627 
replaces #5633 

option 1: just import `CaseInsensitiveDict` from `requests.strucures`
pros: 
 - not much typing
cons: 
 - replaces one dependency with another
 - requests is not typed natively so either has to be excluded from mypy, or also import `types-requests` as an additional dependency

Option 2: hard code `CaseInsensitiveDict` by overriding python native dict.  below is a possibility.
pros: behavior is then native in xonsh
cons: more code to maintain
```
class CaseInsensitiveDict(Dict[str, Any]):
    def __init__(self, *args, **kwargs):
        super().__init__()
        self._store = {}
        self.update(*args, **kwargs)

    def __setitem__(self, key, value):
        # Store the key in lowercase but preserve the original case for display
        self._store[key.lower()] = key
        super().__setitem__(key.lower(), value)

    def __getitem__(self, key):
        return super().__getitem__(key.lower())

    def __delitem__(self, key):
        del self._store[key.lower()]
        super().__delitem__(key.lower())

    def __contains__(self, key):
        return key.lower() in self._store

    def get(self, key, default=None):
        return super().get(key.lower(), default)

    def update(self, *args, **kwargs):
        for k, v in dict(*args, **kwargs).items():
            self[k] = v

    def keys(self):
        # Return the original keys with their original casing
        return (self._store[k] for k in self._store)

    def items(self):
        return ((self._store[k], self[k]) for k in self._store)

    def __repr__(self):
        return f"{self.__class__.__name__}({dict(self.items())})"

    def copy(self):
        return CaseInsensitiveDict(self.items())

```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
