### PR TITLE
pre-commit: use current 3.13 version of python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_language_version:
     # force all unspecified python hooks to run python3
-    python: python3.10
+    python: python3.13
 
 #ci:
 #  autofix_prs: false


### PR DESCRIPTION
Any reason why pre-commit requires an install of an old python version?

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
