### PR TITLE
Improving SIGINT processing in captured subprocess

### DIFF
--- a/xonsh/procs/posix.py
+++ b/xonsh/procs/posix.py
@@ -83,7 +83,7 @@ class PopenThread(threading.Thread):
         self.old_int_handler = self.old_winch_handler = None
         self.old_tstp_handler = self.old_quit_handler = None
         if xt.on_main_thread():
-            self.old_int_handler = signal.signal(signal.SIGINT, self._signal_int)
+            # self.old_int_handler = signal.signal(signal.SIGINT, self._signal_int)
             if xp.ON_POSIX:
                 self.old_tstp_handler = signal.signal(signal.SIGTSTP, self._signal_tstp)
                 self.old_quit_handler = signal.signal(signal.SIGQUIT, self._signal_quit)


### PR DESCRIPTION
Draft.

### Motivation

Fix #5770

### Before

When you run captured subprocess:
```xsh
p1 = !(sleep 1111); p2 = !(sleep 2222)
jobs
# {'num': 2, 'status': 'running', 'cmd': 'sleep 222', 'pids': [20017]}
# {'num': 1, 'status': 'running', 'cmd': 'sleep 1111', 'pids': [20016]}
```
and then in any case send SIGINT to the main thread:
```xsh
p1
# ^C
```
ALL background processes that were created from captured operator will have SIGINT and stop:
```xsh
jobs
# empty
ps ax | grep 1111
# empty
ps ax | grep 2222
# empty
```
The description of the machinery behind this - https://github.com/xonsh/xonsh/issues/5770#issuecomment-2587877894.

### After

Once we remove the SIGINT signal forwarding to the subprocess, the interaction will become more logical and understandable.

The one way to stop captured subprocess is to do it explicitly:
```xsh
p1 = !(sleep 1111); p2 = !(sleep 2222)
p1  # CommandPipeline is waiting for the ending of the process.
# ^C  # No interrupting of the process.
p1  # CommandPipeline is still waiting for the ending.
# ^C  # It's ok to stop waiting in interactive mode.

jobs  # Processes are still there.
# {'num': 2, 'status': 'running', 'cmd': 'sleep 2222', 'pids': [20017]}
# {'num': 1, 'status': 'running', 'cmd': 'sleep 1111', 'pids': [20016]}

kill 20017
p2
# CommandPipeline(
#   returncode=-15,
#   pid=20017,
#   args=['sleep', '2222'],
#   executed_cmd=['sleep', '2222'],
#   timestamps=[1736842421.792028, 1736842454.662103],
#   input='',
#   output=''
# )

# p1.terminate()  # Sending SIGINT to the process. TODO: it's needed to be implement.
# p1.kill()  # Sending SIGKILL to the process. TODO: it's needed to be implement.
# p1.signal(2)  # Sending any sugnal to the process. TODO: it's needed to be implement.
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
