### PR TITLE
Refactor.

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -509,7 +509,8 @@ def main(argv=None):
     args = None
     try:
         args = premain(argv)
-        sys.exit(main_xonsh(args))
+        exit_status = main_xonsh(args)
+        sys.exit(exit_status)
     except Exception as err:
         _failback_to_other_shells(args, err)
 


### PR DESCRIPTION
Hello,

I am just starting a discussion whether it is good to code in this way:

```python
a = b(c(...))
```

I am opting for this instead:

```python
d = c(...)
a = b(d)
```

The former one is easier to edit and more readable.
The earlier one is uses less variables.