### PR TITLE
env: add `PROMPT_TOOLKIT_CURSOR_SHAPE` for configuring `prompt_toolki…

### DIFF
--- a/news/config-cursor-shape.rst
+++ b/news/config-cursor-shape.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* env: add ``$PROMPT_TOOLKIT_CURSOR_SHAPE`` for configuring ``prompt_toolkit`` cursor shape.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -83,6 +83,8 @@ from xonsh.tools import (
     print_exception,
     print_warning,
     ptk2_color_depth_setter,
+    to_ptk_cursor_shape,
+    to_ptk_cursor_shape_display_value,
     seq_to_upper_pathsep,
     set_to_csv,
     str_to_env_path,
@@ -1742,6 +1744,19 @@ class PTKSetting(PromptSetting):  # sub-classing -> sub-group
         "The color depth used by prompt toolkit 2. Possible values are: "
         "``DEPTH_1_BIT``, ``DEPTH_4_BIT``, ``DEPTH_8_BIT``, ``DEPTH_24_BIT`` "
         "colors. Default is an empty string which means that prompt toolkit decide.",
+    )
+    PROMPT_TOOLKIT_CURSOR_SHAPE = Var(
+        always_false,
+        to_ptk_cursor_shape,
+        to_ptk_cursor_shape_display_value,
+        to_ptk_cursor_shape('modal-vi-mode-only'),
+        "The cursor shape used by prompt toolkit. Possible values are: "
+            "``block``, ``beam``, ``underline``, "
+            "``blinking-block``, ``blinking-beam``, ``blinking-underline``, "
+            "``modal``, ``modal-vi-mode-only``, ``never-change``. "
+            "Default value is ``modal-vi-mode-only`` which means "
+            "``modal`` if in vi mode and ``never-change`` if not in vi mode.",
+        doc_default = 'modal-vi-mode-only',
     )
     PTK_STYLE_OVERRIDES = Var(
         is_tok_color_dict,

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -46,13 +46,6 @@ try:
 except ImportError:
     HAVE_SYS_CLIPBOARD = False
 
-try:
-    from prompt_toolkit.cursor_shapes import ModalCursorShapeConfig
-
-    HAVE_CURSOR_SHAPE = True
-except ImportError:
-    HAVE_CURSOR_SHAPE = False
-
 CAPITAL_PATTERN = re.compile(r"([a-z])([A-Z])")
 Token = _TokenType()
 
@@ -377,8 +370,10 @@ class PromptToolkitShell(BaseShell):
             for attr, val in self.get_lazy_ptk_kwargs():
                 prompt_args[attr] = val
 
-        if editing_mode == EditingMode.VI and HAVE_CURSOR_SHAPE:
-            prompt_args["cursor"] = ModalCursorShapeConfig()
+        cursor_shape = env.get("PROMPT_TOOLKIT_CURSOR_SHAPE")
+        if cursor_shape:
+            prompt_args["cursor"] = cursor_shape
+
         events.on_pre_prompt.fire()
         line = self.prompter.prompt(**prompt_args)
         events.on_post_prompt.fire()


### PR DESCRIPTION
Add `$PROMPT_TOOLKIT_CURSOR_SHAPE` for configuring `prompt_toolkit` cursor shape.
Possible values are: `block`, `beam`, `underline`, `blinking-block`, `blinking-beam`, `modal`, `modal-vi-mode-only`, `never-change`.
Default value is `modal-vi-mode-only` which keeps current behavior: `modal` if in vi-mode, `never-change` if not in vi-mode.