### PR TITLE
Forward SIGHUP to child processes

### DIFF
--- a/news/hup-propagation.rst
+++ b/news/hup-propagation.rst
@@ -1,0 +1,10 @@
+**Added:**
+
+* SIGHUP will now be forwarded to child processes when received by the main xonsh process.
+This matches the behavior of other shells (e.g. Bash, documented
+[here](https://www.gnu.org/software/bash/manual/bash.html#Signals))
+* Documented the fact that the `on_postcommand` event only fires in interactive mode.
+
+**Fixed:**
+
+* Running a subcommand in an event handler will no longer block xonsh from exiting.

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -58,6 +58,13 @@ def resetting_signal_handle(sig, f):
     def new_signal_handler(s=None, frame=None):
         f(s, frame)
         signal.signal(sig, prev_signal_handler)
+        if sig == signal.SIGHUP:
+            """
+            SIGHUP means the controlling terminal has been lost. This should be
+            propagated to child processes so that they can decide what to do about it.
+            """
+            import xonsh.procs.jobs as xj
+            xj.hup_all_jobs()
         if sig != 0:
             """
             There is no immediate exiting here.

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -267,7 +267,10 @@ class CommandPipeline:
             # we get here if the process is not threadable or the
             # class is the real Popen
             PrevProcCloser(pipeline=self)
-            task = xj.wait_for_active_job()
+            task = None
+            if not isinstance(sys.exception(), SystemExit):
+                task = xj.wait_for_active_job()
+
             if task is None or task["status"] != "stopped":
                 proc.wait()
                 self._endtime()

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -46,6 +46,7 @@ events.doc(
 on_postcommand(cmd: str, rtn: int, out: str or None, ts: list) -> None
 
 Fires just after a command is executed. The arguments are the same as history.
+This event only fires in interactive mode.
 
 Parameters:
 

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -406,14 +406,17 @@ class BaseShell:
         finally:
             ts1 = ts1 or time.time()
             tee_out = tee.getvalue()
-            self._append_history(
+            info = self._append_history(
                 inp=src,
                 ts=[ts0, ts1],
                 spc=self.src_starts_with_space,
                 tee_out=tee_out,
                 cwd=self.precwd,
             )
-            self.accumulated_inputs += src
+            if not isinstance(exc_info[1], SystemExit):
+                events.on_postcommand.fire(
+                    cmd=info["inp"], rtn=info["rtn"], out=info.get("out", None), ts=info["ts"]
+                )
             if (
                 tee_out
                 and env.get("XONSH_APPEND_NEWLINE")
@@ -444,12 +447,10 @@ class BaseShell:
             info["out"] = last_out
         else:
             info["out"] = tee_out + "\n" + last_out
-        events.on_postcommand.fire(
-            cmd=info["inp"], rtn=info["rtn"], out=info.get("out", None), ts=info["ts"]
-        )
         if hist is not None:
             hist.append(info)
             hist.last_cmd_rtn = hist.last_cmd_out = None
+        return info
 
     def _fix_cwd(self):
         """Check if the cwd changed out from under us."""


### PR DESCRIPTION
Fixes #5784. A few points for discussion:

1. I ended up not using the approach modeled [here](https://github.com/jfmontanaro/xonsh/commit/6d78ed32c41e3b137684fd5c02bf8b61e0b5aaf3), because it caused problems when there were multiple tasks happening concurrently. The issue was that signal handlers are global state, so if e.g. two `PopenThread`s happening at once, then only one of them would get the SIGHUP. Also, it would prevent the main application from shutting down.  
Maybe it's possible to solve these issues, but it seemed much simpler to me to just call `hup_all_jobs` directly in the main signal handler. This seems to work well for both regular `Popen` jobs and `PopenThread` jobs. `ProcProxyThread` jobs are different, but more on that later.

2. I moved the invocation of `events.on_postcommand` out of `_append_history` as discussed, and added a check to skip it if we are currently processing a `SystemExit` exception. However, I realized that if another event handler (such as `on_post_cmdloop`) were to run a subprocess command, it could have the exact same issue. So I added a separate check in `iterraw` that skips calling `wait_for_active_job` if there is an active `SystemExit` exception.

3. `ProcProxyThread` commands (which is only used for callable aliases I think?) can still block xonsh from shutting down, because they are threads, and that's just how non-daemon threads work in Python. I don't think we need to solve this right now, and in fact I don't even know if there's a good way to solve it ever. In theory we could do something like add a check right at the end of the shutdown process that checks for any still-running non-daemon threads and then calls `os.kill` with `SIGKILL` or something, but that seems like a separate discussion.

4. I checked the behavior of Bash when a subprocess does not respond to `SIGHUP` by exiting: Bash just exits anyway and lets the child continue. As of now, that is what xonsh does as well, so I think we're ok on that front.

5. I haven't added any tests. Should I do that? Is it even possible to test this kind of behavior that's all about global state like signal handlers and SystemExit exceptions?

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
