### PR TITLE
Fix PTK shell sometimes not updating auto-suggest when up-arrow is pressed

### DIFF
--- a/news/ptk-history-combining.rst
+++ b/news/ptk-history-combining.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed autosuggest sometimes not updating when up-arrow is pressed.
+
+**Security:**
+
+* <news item>

--- a/tests/shell/test_ptk_shell.py
+++ b/tests/shell/test_ptk_shell.py
@@ -5,9 +5,11 @@ import sys
 import pyte
 import pytest
 
+from prompt_toolkit.history import ThreadedHistory
 from xonsh.platform import minimum_required_ptk_version
 from xonsh.shell import Shell
 from xonsh.shells.ptk_shell import tokenize_ansi
+from xonsh.shells.ptk_shell.history import PromptToolkitHistory
 
 # verify error if ptk not installed or below min
 
@@ -145,3 +147,23 @@ def test_ptk_default_append_history(cmd, exp_append_history, ptk_shell, monkeypa
         assert len(append_history_calls) == 1
     else:
         assert len(append_history_calls) == 0
+
+
+def test_ptk_combine_history(monkeypatch):
+    """Test that consecutive identical history items are combined into a single item
+    when loading xonsh history items into prompt-toolkit history."""
+    def all_items(*args, **kwargs):
+        lines =  [
+            "one two three",
+            "four five six",
+            "four five six",
+            "one two three",
+        ]
+        for line in lines:
+            yield {"inp": line}
+
+    monkeypatch.setattr("xonsh.built_ins.XSH.history.all_items", all_items)
+
+    shell_hist = PromptToolkitHistory()
+    hist_strs = list(shell_hist.load_history_strings())
+    assert len(hist_strs) == 3

--- a/xonsh/shells/ptk_shell/history.py
+++ b/xonsh/shells/ptk_shell/history.py
@@ -25,11 +25,12 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
         hist = XSH.history
         if hist is None:
             return
+        prev_line = None
         for cmd in hist.all_items(newest_first=True):
             line = cmd["inp"].rstrip()
-            strs = self.get_strings()
-            if len(strs) == 0 or line != strs[-1]:
+            if line != prev_line:
                 yield line
+            prev_line = line
 
     def __getitem__(self, index):
         return self.get_strings()[index]


### PR DESCRIPTION
### Current behavior

If you are using the PTK shell and your history contains consecutive duplicate items, then you can encounter a situation where pressing up-parrow does not change the auto-suggest.

### Root cause

It looks like the culprit is in `PromptToolkitHistory.load_history_strings`, specifically [this line(https://github.com/xonsh/xonsh/blob/2cdcd6c97673e53be2ea502c0ca9967566aaa8b1/xonsh/shells/ptk_shell/history.py#L31). It attempts to avoid loading duplicate consecutive history entries, but it turns out that `self.get_strings` just returns `[]` throughout this whole process. I'm not entirely sure why that is, because [it looks like](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/165258d2f3ae594b50f16c7b50ffb06627476269/src/prompt_toolkit/history.py#L190C1-L195C32) the strings should be available more or less as soon as they are yielded, but whatever.

### Fix 

Just track the previous string locally, and compare to that instead.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
