### PR TITLE
Don't append a space if the single available completion ends with a directory separator

### DIFF
--- a/news/subprocess-completions-dir-spaces.rst
+++ b/news/subprocess-completions-dir-spaces.rst
@@ -1,0 +1,7 @@
+**Fixed:**
+
+* Subprocess-based completions like
+  `xontrib-fish-completer <https://github.com/xonsh/xontrib-fish-completer>`_
+  no longer append a space if the single available completion ends with
+  a directory separator. This is consistent with the behavior of the
+  default completer.

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -275,7 +275,7 @@ def complete_from_sub_proc(*args: str, sep=None, filter_prefix=None, **env_vars:
             lines = output.split(sep)
 
         # if there is a single completion candidate then maybe it is over
-        append_space = len(lines) == 1
+        append_space = len(lines) == 1 and not lines[0].rstrip().endswith(os.sep)
         for line in lines:
             if filter_prefix and (not filter_func(line, filter_prefix)):
                 continue


### PR DESCRIPTION
Currently, a space is appended every time there is only a single [suggestion from fish](https://github.com/xonsh/xontrib-fish-completer). This ends with this behavior:

```sh
❯ ls -l .config/ [space]
```

You have to keep removing the spaces to traverse a directory tree. This is inconsistent with the behavior of xonsh itself when `xontrib-fish-completer` is not loaded.

This PR fixes the problem.