### PR TITLE
chore: update bash_completion.py

### DIFF
--- a/news/update_bash_completion.rst
+++ b/news/update_bash_completion.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Updated ``bash_completion.py`` from archived xonsh/py-bash-completion repo
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -110,7 +110,7 @@ def _get_bash_completions_source(paths=None):
         paths = _BASH_COMPLETIONS_PATHS_DEFAULT
     for path in map(pathlib.Path, paths):
         if path.is_file():
-            return 'source "{}"'.format(path.as_posix())
+            return f'source "{path.as_posix()}"'
     return None
 
 

--- a/xonsh/completers/bash_completion.py
+++ b/xonsh/completers/bash_completion.py
@@ -99,7 +99,7 @@ def _bash_completion_paths_default():
     return bcd
 
 
-_BASH_COMPLETIONS_PATHS_DEFAULT: tp.Tuple[str, ...] = ()
+_BASH_COMPLETIONS_PATHS_DEFAULT: tuple[str, ...] = ()
 
 
 def _get_bash_completions_source(paths=None):


### PR DESCRIPTION
Copied from xonsh/py-bash-completion.

I've also archived that repository and left a link in the README to point to this file.

I think we can (and should) keep this file as actionless on import so that it can still be used as a standalone tool, but we don't need to deal with multiple repositories anymore.
