### PR TITLE
Fix for completer issue with file name containing backslash

### DIFF
--- a/xonsh/shells/ptk_shell/completer.py
+++ b/xonsh/shells/ptk_shell/completer.py
@@ -85,7 +85,7 @@ class PromptToolkitCompleter(Completer):
         elif len(os.path.commonprefix(completions)) <= len(prefix):
             self.reserve_space()
         # Find common prefix (strip quoting)
-        c_prefix = os.path.commonprefix([a.strip("'\"") for a in completions])
+        c_prefix = os.path.commonprefix([a.strip("r'\"") for a in completions])
         # Find last split symbol, do not trim the last part
         while c_prefix:
             if c_prefix[-1] in r"/\.:@,":
@@ -108,14 +108,14 @@ class PromptToolkitCompleter(Completer):
                 yield Completion(
                     comp,
                     -comp.prefix_len if comp.prefix_len is not None else -plen,
-                    display=comp.display or comp[pre:].strip("'\""),
+                    display=comp.display or comp[pre:].strip("r'\""),
                     display_meta=desc,
                     style=comp.style or "",
                 )
             elif isinstance(comp, Completion):
                 yield comp
             else:
-                disp = comp[pre:].strip("'\"")
+                disp = comp[pre:].strip("r'\"")
                 yield Completion(comp, -plen, display=disp)
 
     def suggestion_completion(self, document, line):


### PR DESCRIPTION
<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->
Fix for Case 1 in https://github.com/xonsh/xonsh/issues/3914

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
