### PR TITLE
feat: #5745 - send Ctrl+C event on Windows instead of forceful terminate

### DIFF
--- a/xonsh/procs/jobs.py
+++ b/xonsh/procs/jobs.py
@@ -214,6 +214,9 @@ if ON_WINDOWS:
             stderr=subprocess.STDOUT,
         )
 
+    def _ctrl_c(job):
+        os.kill(job["obj"].pid, signal.CTRL_C_EVENT)
+
     _hup = _kill  # there is no equivalent of SIGHUP on Windows
 
     def ignore_sigtstp():
@@ -239,10 +242,7 @@ if ON_WINDOWS:
             except subprocess.TimeoutExpired:
                 pass
             except KeyboardInterrupt:
-                try:
-                    _kill(active_task)
-                except subprocess.CalledProcessError:
-                    pass  # ignore error if process closed before we got here
+                _ctrl_c(active_task)
         return wait_for_active_job(last_task=active_task)
 
 else:

--- a/xonsh/procs/jobs.py
+++ b/xonsh/procs/jobs.py
@@ -234,12 +234,8 @@ if ON_WINDOWS:
         proc = active_task["obj"]
         _continue(active_task)
         while proc.returncode is None:
-            try:
+            with contextlib.suppress(subprocess.TimeoutExpired, KeyboardInterrupt):
                 proc.wait(0.01)
-            except subprocess.TimeoutExpired:
-                pass
-            except KeyboardInterrupt:
-                pass  # No proxying of SIGINT required, Ctrl-C is sent along to the child process.
         return wait_for_active_job(last_task=active_task)
 
 else:

--- a/xonsh/procs/jobs.py
+++ b/xonsh/procs/jobs.py
@@ -239,7 +239,7 @@ if ON_WINDOWS:
             except subprocess.TimeoutExpired:
                 pass
             except KeyboardInterrupt:
-                pass # No proxying of SIGINT required, Ctrl-C is sent along to the child process.
+                pass  # No proxying of SIGINT required, Ctrl-C is sent along to the child process.
         return wait_for_active_job(last_task=active_task)
 
 else:

--- a/xonsh/procs/jobs.py
+++ b/xonsh/procs/jobs.py
@@ -214,9 +214,6 @@ if ON_WINDOWS:
             stderr=subprocess.STDOUT,
         )
 
-    def _ctrl_c(job):
-        os.kill(job["obj"].pid, signal.CTRL_C_EVENT)
-
     _hup = _kill  # there is no equivalent of SIGHUP on Windows
 
     def ignore_sigtstp():
@@ -242,7 +239,7 @@ if ON_WINDOWS:
             except subprocess.TimeoutExpired:
                 pass
             except KeyboardInterrupt:
-                _ctrl_c(active_task)
+                pass # No proxying of SIGINT required, Ctrl-C is sent along to the child process.
         return wait_for_active_job(last_task=active_task)
 
 else:


### PR DESCRIPTION
<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

Resolve #5745. The existing behavior [was introduced in 2015](https://github.com/xonsh/xonsh/commit/3aa37682f9441bb7c8bfb492325c88e0900ed327#diff-75c83180c6250bfa7c142ed214f8c71e7704872f3b0c63b167895cf0ae892989R106-R107) ~~and I suspect was because there was no equivalent to [signal.CTRL_C_EVENT](https://docs.python.org/3/library/signal.html#signal.CTRL_C_EVENT) at the time in Python 2.7, it was introduced in Python 3.2.~~ Xonsh only supported 3.4+ at the time and [signal.CTRL_C_EVENT](https://docs.python.org/3/library/signal.html#signal.CTRL_C_EVENT) was already available; it's unclear why the existing implementation choice was made by @adqm .

# Before behavior:
When pressing Ctrl+C on Windows a forceful terminate was sent using the taskkill command.
```
localhost@ ssh remote
remote$ hello <Press Ctrl+C>
Return 1
localhost@
```
# After behavior:
When pressing Ctrl+C on Windows a [signal.CTRL_C_EVENT](https://docs.python.org/3/library/signal.html#signal.CTRL_C_EVENT) will be sent instead.
```
localhost@ ssh remote
remote$ hello^C
remote$ 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
