### PR TITLE
fix(main): Respect xontribs autoload disabled in RC files

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -539,6 +539,7 @@ def test_xonsh_no_file_returncode(shell, monkeypatch, monkeypatch_stderr):
 
 
 def test_auto_loading_xontribs(xession, shell, mocker):
+    # GIVEN a xontrib is installed
     from importlib.metadata import EntryPoint
 
     group = "xonsh.xontribs"
@@ -551,6 +552,54 @@ def test_auto_loading_xontribs(xession, shell, mocker):
         },
     )
     xontribs_load = mocker.patch("xonsh.xontribs.xontribs_load")
+
+    # AND auto-loading xontribs is enabled by default
+    assert xession.env["XONTRIBS_AUTOLOAD_DISABLED"] is False
+
+    # WHEN xonsh is initialized
     xonsh.main.premain([])
+
+    # THEN auto-loading xontribs is still enabled
+    assert xession.env["XONTRIBS_AUTOLOAD_DISABLED"] is False
+
+    # AND installed xontrib should be auto-loaded
     assert xession.builtins.autoloaded_xontribs == {"test": "test.module"}
     xontribs_load.assert_called()
+
+
+def test_xontribs_autoload_disabled_in_custom_rc(xession, shell, mocker, tmpdir):
+    """As a Xonsh user, if I set `$XONTRIBS_AUTOLOAD_DISABLED = True`
+    in my RC file, then Xontribs should not be auto-loaded.
+
+    https://github.com/xonsh/xonsh/issues/5872
+    """
+    # GIVEN a xontrib is installed
+    from importlib.metadata import EntryPoint
+
+    group = "xonsh.xontribs"
+    mocker.patch(
+        "importlib.metadata.entry_points",
+        autospec=True,
+        return_value={
+            group: [EntryPoint(name="test", group=group, value="test.module")]
+        },
+    )
+    xontribs_load = mocker.patch("xonsh.xontribs.xontribs_load")
+
+    # AND auto-loading xontribs is disabled in a custom RC file
+    f = tmpdir.join("wakkawakka")
+    f.write("$XONTRIBS_AUTOLOAD_DISABLED = True\n")
+
+    # AND auto-loading xontribs is not explicitly disabled
+    assert xession.env["XONTRIBS_AUTOLOAD_DISABLED"] is False
+
+    # WHEN xonsh is initialized
+    xonsh.main.premain(["--rc", f.strpath])
+
+    # THEN custom RC file should have been processed
+    assert f.strpath in xession.rc_files
+    assert xession.env["XONTRIBS_AUTOLOAD_DISABLED"] is True
+
+    # AND installed xontrib should not be auto-loaded
+    assert not hasattr(xession.builtins, "autoloaded_xontribs")
+    xontribs_load.assert_not_called()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -372,9 +372,9 @@ def start_services(shell_kwargs, args, pre_env=None):
     for k, v in pre_env.items():
         env[k] = v
 
+    _load_rc_files(shell_kwargs, args, env, execer, ctx)
     if not shell_kwargs.get("norc"):
         _autoload_xontribs(env)
-    _load_rc_files(shell_kwargs, args, env, execer, ctx)
     # create shell
     XSH.shell = Shell(execer=execer, **shell_kwargs)
     ctx["__name__"] = "__main__"


### PR DESCRIPTION
<!---

Thanks for opening a PR on xonsh!

Please do this:

- [x] ~~Include a news file with your PR (https://xon.sh/devguide.html#changelog).~~ https://github.com/xonsh/xonsh/blob/main/CONTRIBUTING.rst#changelog
- [x] Add the documentation for your feature into `/docs`.
- [x] Add the example of usage or before-after behavior.
- [x] Mention the issue that this PR is addressing e.g. `#1234`.

-->

## Changes

Addresses https://github.com/xonsh/xonsh/issues/5872:

- 79036030 fix(main): Respect xontribs autoload disabled in RC file
- 20e7fc8a test(main): Setup failing test to disable xontrib auto-loading in RC file

### Example: `$XONTRIBS_AUTOLOAD_DISABLED = False`

1. Launch a clean Docker environment
2. `$XONTRIBS_AUTOLOAD_DISABLED = False` by default
3. Install contrib that supports auto-loading (eg, `pip install coconut`)
4. Run xonsh to auto-load xontrib
5. Verify xontrib is loaded (eg, `"hello, world" |> print`)

<details>

```xsh
uv run python xonsh-in-docker.py 
Building and running Xonsh
Using python  3.11
Using prompt-toolkit  3.0.47
[+] Building 1.5s (12/12) FINISHED                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                  0.0s
 => => transferring dockerfile: 217B                                                                  0.0s
 => WARN: ConsistentInstructionCasing: Command 'from' should match the case of the command majority   0.0s
 => [internal] load metadata for docker.io/library/python:3.11                                        1.1s
 => [auth] library/python:pull token for registry-1.docker.io                                         0.0s
 => [internal] load .dockerignore                                                                     0.0s
 => => transferring context: 2B                                                                       0.0s
 => [1/6] FROM docker.io/library/python:3.11@sha256:ca0b6467f5accb0c39c154a5e242df36348d9afb009a58b4  0.0s
 => [internal] load build context                                                                     0.4s
 => => transferring context: 909.22kB                                                                 0.4s
 => CACHED [2/6] RUN pip install --upgrade pip && pip install   prompt-toolkit==3.0.47      pygments  0.0s
 => CACHED [3/6] RUN mkdir /xonsh                                                                     0.0s
 => CACHED [4/6] WORKDIR /xonsh                                                                       0.0s
 => CACHED [5/6] ADD ./ ./                                                                            0.0s
 => CACHED [6/6] RUN python setup.py install                                                          0.0s
 => exporting to image                                                                                0.0s
 => => exporting layers                                                                               0.0s
 => => writing image sha256:cbc383b73652a57ea8e0992706048539b604d21224353ba9a5c1fdb89e5630e2          0.0s
 => => naming to docker.io/library/xonsh                                                              0.0s

 1 warning found (use docker --debug to expand):
 - ConsistentInstructionCasing: Command 'from' should match the case of the command majority (uppercase) (l
ine 2)

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/t4z1ufeamcdlfcho9xx97viea

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 

                                Welcome to the xonsh shell 0.19.9.dev5.dev5                                

                                      ~ Conches for the xonsh god! ~                                       

-----------------------------------------------------------------------------------------------------------

               Create ~/.xonshrc file manually or use xonfig to suppress the welcome message               

Start from commands:
  xonfig web         # Run the configuration tool in the browser to create ~/.xonshrc 
  xonfig tutorial    # Open the xonsh tutorial in the browser

-----------------------------------------------------------------------------------------------------------

root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# $XONTRIBS_AUTOLOAD_DISABLED
False
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# pip install coconut
Collecting coconut
  Downloading coconut-3.1.2-py2.py3-none-any.whl.metadata (28 kB)
Requirement already satisfied: setuptools>=44 in /usr/local/lib/python3.11/site-packages (from coconut) (65
.5.1)
Collecting cPyparsing<2.4.7.2.5,>=2.4.7.2.4.0 (from coconut)
  Downloading cpyparsing-2.4.7.2.4.1.tar.gz (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 7.7 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting psutil>=6 (from coconut)
  Downloading psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (22 kB)
Requirement already satisfied: prompt-toolkit>=1 in /usr/local/lib/python3.11/site-packages (from coconut) 
(3.0.47)
Collecting async-generator>=1.10 (from coconut)
  Downloading async_generator-1.10-py3-none-any.whl.metadata (4.9 kB)
Collecting anyio>=3 (from coconut)
  Downloading anyio-4.9.0-py3-none-any.whl.metadata (4.7 kB)
Collecting typing-extensions>=4.12 (from coconut)
  Downloading typing_extensions-4.14.1-py3-none-any.whl.metadata (3.0 kB)
Requirement already satisfied: pygments>=2.18 in /usr/local/lib/python3.11/site-packages (from coconut) (2.
19.2)
Collecting idna>=2.8 (from anyio>=3->coconut)
  Downloading idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting sniffio>=1.1 (from anyio>=3->coconut)
  Downloading sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)
Requirement already satisfied: wcwidth in /usr/local/lib/python3.11/site-packages (from prompt-toolkit>=1->
coconut) (0.2.13)
Downloading coconut-3.1.2-py2.py3-none-any.whl (325 kB)
Downloading anyio-4.9.0-py3-none-any.whl (100 kB)
Downloading async_generator-1.10-py3-none-any.whl (18 kB)
Downloading idna-3.10-py3-none-any.whl (70 kB)
Downloading psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (279 kB)
Downloading sniffio-1.3.1-py3-none-any.whl (10 kB)
Downloading typing_extensions-4.14.1-py3-none-any.whl (43 kB)
Building wheels for collected packages: cPyparsing
  Building wheel for cPyparsing (pyproject.toml) ... done
  Created wheel for cPyparsing: filename=cpyparsing-2.4.7.2.4.1-cp311-cp311-linux_aarch64.whl size=5960170 
sha256=e3577091266efa52d9cbd14a0c1a94ddb6a12a6270c0ff84246f7c66b421bf93
  Stored in directory: /root/.cache/pip/wheels/2f/3c/a7/848f46b41e89a32443e969754473035d9d1a877b47801678e2
Successfully built cPyparsing
Installing collected packages: cPyparsing, typing-extensions, sniffio, psutil, idna, async-generator, anyio
, coconut
Successfully installed anyio-4.9.0 async-generator-1.10 cPyparsing-2.4.7.2.4.1 coconut-3.1.2 idna-3.10 psut
il-7.0.0 sniffio-1.3.1 typing-extensions-4.14.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the
 system package manager, possibly rendering your system unusable. It is recommended to use a virtual enviro
nment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you ar
e doing and want to suppress this warning.
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# "hello, world" |> print
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
IndexError: list index out of range
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs [1] @# xonsh

                                Welcome to the xonsh shell 0.19.9.dev5.dev5                                

                                         ~ The xonsh is a symbol ~                                         

-----------------------------------------------------------------------------------------------------------

               Create ~/.xonshrc file manually or use xonfig to suppress the welcome message               

Start from commands:
  xonfig web         # Run the configuration tool in the browser to create ~/.xonshrc 
  xonfig tutorial    # Open the xonsh tutorial in the browser

-----------------------------------------------------------------------------------------------------------

root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs [1] @# "hello,world" |> print
hello,world
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @#
```

</details>


### Example: `$XONTRIBS_AUTOLOAD_DISABLED = True`

1. Launch a clean Docker environment
2. Set `$XONTRIBS_AUTOLOAD_DISABLED = True` in RC file (eg, `echo @('$XONTRIBS_AUTOLOAD_DISABLED = True') > ~/.xonshrc`)
3. Install contrib that supports auto-loading (eg, `pip install coconut`)
4. Run xonsh, which **should not** auto-load xontrib
5. Verify xontrib is **not** loaded (eg, `"hello, world" |> print`)

<details>

```xsh
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs [1] @# echo @('$XONTRIBS_AUTOLOAD_DISABLED = True') >
 ~/.xonshrc
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# $XONTRIBS_AUTOLOAD_DISABLED
False
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# xonsh
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# $XONTRIBS_AUTOLOAD_DISABLED
True
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs @# "hello, world" |> print
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
IndexError: list index out of range
root@55b5f8e85715 /xonsh issue-5872/autoload-xontribs [1] @#
```

</details>

##

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
