### PR TITLE
fix: allow sourcing files with any extension

### DIFF
--- a/tests/aliases/test_source.py
+++ b/tests/aliases/test_source.py
@@ -44,6 +44,13 @@ def test_source_path(mockopen, mocked_execx_checker, xession):
     assert mocked_execx_checker[1].endswith(path_bar)
 
 
+def test_source_non_xsh_extension(mockopen, monkeypatch, mocked_execx_checker):
+    """Test that files with non-.xsh extensions can be sourced"""
+    monkeypatch.setattr(os.path, "isfile", lambda x: True)
+    source_alias(["file.xonshrc", "script.config"])
+    assert mocked_execx_checker == ["file.xonshrc", "script.config"]
+
+
 @pytest.mark.parametrize(
     "alias",
     [

--- a/tests/prompt/test_vc.py
+++ b/tests/prompt/test_vc.py
@@ -33,7 +33,7 @@ def repo(request, tmpdir_factory):
     # Skip early if the VCS executable is not available
     if not shutil.which(vc):
         pytest.skip(f"cannot find {vc} executable")
-    
+
     temp_dir = Path(tmpdir_factory.mktemp("dir"))
     os.chdir(temp_dir)
     try:

--- a/tests/prompt/test_vc.py
+++ b/tests/prompt/test_vc.py
@@ -47,8 +47,6 @@ def repo(request, tmpdir_factory):
 
 
 def _init_git_repository(temp_dir):
-    # This function should only be called when git is available
-    # since it's called from the repo fixture which already checks
     git_config = temp_dir / ".git/config"
     git_config.write_text(
         textwrap.dedent(
@@ -63,11 +61,8 @@ def _init_git_repository(temp_dir):
     )
     # git needs at least one commit
     Path("test-file").touch()
-    try:
-        sp.call(["git", "add", "test-file"])
-        sp.call(["git", "commit", "-m", "test commit"])
-    except FileNotFoundError:
-        pytest.skip("cannot find git executable")
+    sp.call(["git", "add", "test-file"])
+    sp.call(["git", "commit", "-m", "test commit"])
 
 
 @pytest.fixture
@@ -136,10 +131,7 @@ def test_dirty_working_directory(repo, set_xenv):
     Path("second-test-file").touch()
     assert not getattr(vc, get_dwd)()
 
-    try:
-        sp.call([repo["vc"], "add", "second-test-file"])
-    except FileNotFoundError:
-        pytest.skip(f"cannot find {repo['vc']} executable")
+    sp.call([repo["vc"], "add", "second-test-file"])
     assert getattr(vc, get_dwd)()
 
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -767,14 +767,7 @@ def source_alias(args, stdin=None):
                         "must source at least one file, " + fname + " does not exist."
                     )
                 break
-        _, fext = os.path.splitext(fpath)
-        if fext and fext != ".xsh" and fext != ".py":
-            raise RuntimeError(
-                "attempting to source non-xonsh file! If you are "
-                "trying to source a file in another language, "
-                "then please use the appropriate source command. "
-                "For example, source-bash script.sh"
-            )
+        # Allow sourcing any file - the execx will handle validation
         with open(fpath, encoding=encoding, errors=errors) as fp:
             src = fp.read()
         if not src.endswith("\n"):


### PR DESCRIPTION
Remove restrictive file extension check in source_alias() to allow sourcing files regardless of extension (.xonshrc, .config, etc.) while maintaining safety through existing execx error handling.

Fixes #5480

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
