### PR TITLE
feat: Allow specifying special files as scripts

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -573,7 +573,10 @@ def main_xonsh(args):
         elif args.mode == XonshMode.script_from_file:
             # run a script contained in a file
             path = os.path.abspath(os.path.expanduser(args.file))
-            if os.path.isfile(path):
+            if os.path.isdir(path):
+                print(f"xonsh: {args.file}: Is a directory.")
+                exit_code = 1
+            elif os.path.exists(path):
                 sys.argv = [args.file] + args.args
                 env.update(make_args_env())  # $ARGS is not sys.argv
                 env["XONSH_SOURCE"] = path
@@ -582,7 +585,7 @@ def main_xonsh(args):
                     args.file, shell.execer, glb=shell.ctx, loc=None, mode="exec"
                 )
             else:
-                print(f"xonsh: {args.file}: No such file or directory.")
+                print(f"xonsh: {args.file}: No such file.")
                 exit_code = 1
         elif args.mode == XonshMode.script_from_stdin:
             # run a script given on stdin


### PR DESCRIPTION
Allows specifying any existing non-directory path as a script to run. Primarily I intend for this to allow running scripts out of named pipes (FIFOs). Examples here use bash, but the principal is not tied to any shell, see the unit tests for how this can be done in python.
Before:
```console
$ xonsh <(echo "print('Hello')")
xonsh: /dev/fd/63: No such file or directory.
```
After:
```console
$ xonsh <(echo "print('Hello')")
Hello
```

This type of script specification is supported by many interpreters including python and bash:
```console
$ python3 <(echo "print('Hello')")
Hello
$ bash <(echo "echo Hello")
Hello
```

### Comparisons to other redirection methods

#### Reading the script from stdin

You could accomplish something similar using `echo "print('Hello')" | xonsh` or `xonsh < <(echo "print('Hello')")` however that prevents reading from stdin as part of your script.

#### Use -c and specify the script as an argument

You could also do `xonsh -c "$(echo "print('Hello')")"` but that leaks the contents of the script as an argument, is pretty noisy to look at in process lists, and imposes a maximum size on the script (see [this StackExchange answer](https://unix.stackexchange.com/a/120842) for a good explanation).

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
