### PR TITLE
Fix path envpath no env

### DIFF
--- a/news/5870.bugfix.rst
+++ b/news/5870.bugfix.rst
@@ -1,0 +1,5 @@
+**Fixed**
+
+* Fixed ``$PATH`` not being an ``EnvPath`` when xonsh is initialized with ``--no-env`` flag.
+  This ensures that ``EnvPath`` methods like ``.prepend()`` and ``.append()`` work correctly
+  regardless of how xonsh is started.

--- a/news/env_path_docs.py
+++ b/news/env_path_docs.py
@@ -1,0 +1,41 @@
+# Script to find where to add documentation about PATH behavior
+import os
+import glob
+
+def find_documentation_files():
+    """Find relevant documentation files to update"""
+    
+    # Look for documentation files
+    doc_files = []
+    
+    # Check common documentation locations
+    for pattern in ['docs/**/*.rst', 'docs/**/*.md', 'docs/*.rst', 'docs/*.md']:
+        doc_files.extend(glob.glob(pattern, recursive=True))
+    
+    print("Found documentation files:")
+    for doc_file in sorted(doc_files):
+        print(f"  {doc_file}")
+    
+    print("\nLooking for files that might contain PATH or environment documentation...")
+    
+    relevant_files = []
+    for doc_file in doc_files:
+        if any(keyword in doc_file.lower() for keyword in ['env', 'path', 'tutorial', 'guide']):
+            relevant_files.append(doc_file)
+            print(f"  📄 {doc_file}")
+    
+    # Check content of relevant files for PATH mentions
+    print("\nChecking for existing PATH documentation...")
+    for doc_file in relevant_files:
+        try:
+            with open(doc_file, 'r', encoding='utf-8') as f:
+                content = f.read()
+            
+            if 'PATH' in content or 'EnvPath' in content:
+                print(f"  📝 {doc_file} - Contains PATH/EnvPath references")
+                
+        except Exception as e:
+            print(f"  ❌ Could not read {doc_file}: {e}")
+
+if __name__ == "__main__":
+    find_documentation_files()

--- a/news/path_behavior_example.rst
+++ b/news/path_behavior_example.rst
@@ -1,0 +1,56 @@
+PATH Environment Variable Behavior
+==================================
+
+The ``$PATH`` environment variable in xonsh is always an ``EnvPath`` object, which provides
+convenient methods for path manipulation. This behavior is consistent regardless of how
+xonsh is started.
+
+EnvPath Methods
+---------------
+
+The ``EnvPath`` class provides several useful methods:
+
+* ``.prepend(path)``: Add a path to the beginning
+* ``.append(path)``: Add a path to the end  
+* ``.remove(path)``: Remove a path
+* ``.insert(index, path)``: Insert at specific position
+
+Examples
+--------
+
+Basic usage::
+
+    # Add a directory to the front of PATH
+    $PATH.prepend('/usr/local/bin')
+    
+    # Add to the end
+    $PATH.append('/opt/custom/bin')
+    
+    # Remove a directory
+    $PATH.remove('/unwanted/path')
+
+This works consistently whether xonsh is started normally or with flags like ``--no-env``.
+
+Before Fix (Buggy Behavior)
+---------------------------
+
+Previously, when using ``xonsh --no-env``, the ``$PATH`` variable would be a regular Python
+list, causing errors:
+
+.. code-block:: xonsh
+
+    $ xonsh --no-env
+    >>> $PATH.prepend('/usr/local/bin')
+    AttributeError: 'list' object has no attribute 'prepend'
+
+After Fix (Current Behavior)  
+----------------------------
+
+Now ``$PATH`` is always an ``EnvPath`` object:
+
+.. code-block:: xonsh
+
+    $ xonsh --no-env
+    >>> $PATH.prepend('/usr/local/bin')  # Works correctly!
+    >>> type($PATH).__name__
+    'EnvPath'

--- a/tests/test_issue_5870.py
+++ b/tests/test_issue_5870.py
@@ -1,0 +1,161 @@
+"""
+Regression test for GitHub issue #5870.
+
+Issue: $PATH is not an EnvPath when xonsh is initialized with --no-env
+
+This test ensures that the PATH environment variable is always usable
+with EnvPath methods like .prepend() regardless of how xonsh is started.
+"""
+import subprocess
+import sys
+import tempfile
+import os
+import pytest
+
+from xonsh.environ import PATH_DEFAULT
+from xonsh.tools import EnvPath
+
+
+def test_path_default_conversion():
+    """Test the exact fix: EnvPath(PATH_DEFAULT) vs list(PATH_DEFAULT)."""
+    # This tests the specific line that was changed
+    correct_path = EnvPath(PATH_DEFAULT)  # The fix
+    buggy_path = list(PATH_DEFAULT)       # The original bug
+    
+    # Verify the fix works
+    assert isinstance(correct_path, EnvPath), "EnvPath(PATH_DEFAULT) should create EnvPath"
+    assert hasattr(correct_path, 'prepend'), "Fixed PATH should have prepend method"
+    
+    # Verify the bug would have failed
+    assert isinstance(buggy_path, list), "list(PATH_DEFAULT) creates plain list"
+    assert not hasattr(buggy_path, 'prepend'), "Buggy PATH lacks prepend method"
+
+
+def test_path_prepend_functionality():
+    """Test that EnvPath.prepend() works as expected."""
+    path = EnvPath(PATH_DEFAULT)
+    original_length = len(path)
+    test_path = '/test/issue/5870/prepend'
+    
+    # This is what users expect to work
+    path.prepend(test_path)
+    assert path[0] == test_path, "prepend should add to front"
+    assert len(path) == original_length + 1, "prepend should increase length"
+    
+    # Clean up
+    path.remove(test_path)
+    assert len(path) == original_length, "remove should restore length"
+
+
+@pytest.mark.slow  
+def test_no_env_integration():
+    """Integration test: --no-env flag should not break PATH.prepend()"""
+    
+    # Script that reproduces the original user issue
+    test_script = '''
+# Test the exact functionality that was broken
+print("Testing PATH.prepend() with --no-env flag")
+print("PATH type:", type($PATH).__name__)
+
+try:
+    # This would fail with AttributeError before the fix
+    $PATH.prepend("/integration/test")
+    print("SUCCESS: PATH.prepend() works!")
+    
+    # Verify it was actually added
+    if "/integration/test" in $PATH:
+        print("VERIFIED: Path was added correctly")
+    else:
+        print("ERROR: Path was not added")
+        exit(1)
+        
+except AttributeError as e:
+    print("FAILED:", str(e))
+    print("This means the bug still exists!")
+    exit(1)
+except Exception as e:
+    print("OTHER_ERROR:", str(e))
+    exit(1)
+'''
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.xsh', delete=False) as f:
+        f.write(test_script)
+        script_path = f.name
+    
+    try:
+        # Run with --no-env (this is where the bug occurred)
+        result = subprocess.run([
+            sys.executable, '-m', 'xonsh', '--no-env', script_path
+        ], capture_output=True, text=True, timeout=30)
+        
+        # Check results
+        assert result.returncode == 0, f"Script failed with: {result.stderr}"
+        assert "SUCCESS" in result.stdout, "PATH.prepend() should work"
+        assert "VERIFIED" in result.stdout, "Path should be added correctly"
+        
+        # Make sure we didn't get the old error
+        assert "AttributeError" not in result.stderr, "Should not get AttributeError"
+        assert "'list' object has no attribute 'prepend'" not in result.stderr, "Bug should be fixed"
+        
+    finally:
+        if os.path.exists(script_path):
+            os.remove(script_path)
+
+
+def test_normal_mode_still_works():
+    """Ensure the fix doesn't break normal xonsh usage."""
+    
+    test_script = '''
+print("Testing PATH in normal mode")
+try:
+    original_first = $PATH[0] if $PATH else "EMPTY"
+    $PATH.prepend("/normal/mode/test")
+    print("SUCCESS: Normal mode works")
+    # Clean up
+    $PATH.remove("/normal/mode/test")
+except Exception as e:
+    print("FAILED:", str(e))
+    exit(1)
+'''
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.xsh', delete=False) as f:
+        f.write(test_script)
+        script_path = f.name
+    
+    try:
+        result = subprocess.run([
+            sys.executable, '-m', 'xonsh', script_path
+        ], capture_output=True, text=True, timeout=30)
+        
+        assert result.returncode == 0, f"Normal mode failed: {result.stderr}"
+        assert "SUCCESS" in result.stdout, "Normal mode should still work"
+        
+    finally:
+        if os.path.exists(script_path):
+            os.remove(script_path)
+
+
+if __name__ == "__main__":
+    print("Running regression tests for GitHub issue #5870")
+    print("=" * 60)
+    
+    tests = [
+        test_path_default_conversion,
+        test_path_prepend_functionality,
+        test_no_env_integration,
+        test_normal_mode_still_works
+    ]
+    
+    for test_func in tests:
+        try:
+            print(f"Running {test_func.__name__}...")
+            test_func()
+            print(f"✅ {test_func.__name__}")
+        except Exception as e:
+            print(f"❌ {test_func.__name__}: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+    
+    print("\n🎉 All regression tests passed!")
+    print("Issue #5870 appears to be fixed correctly.")

--- a/tests/test_path_issue.py
+++ b/tests/test_path_issue.py
@@ -1,0 +1,109 @@
+"""
+Simple regression test for GitHub issue #5870.
+Tests that PATH is always an EnvPath instance.
+"""
+import subprocess
+import sys
+import tempfile
+import os
+import pytest
+
+from xonsh.environ import Env, PATH_DEFAULT
+from xonsh.tools import EnvPath
+
+
+def test_path_is_always_envpath():
+    """Core test: PATH should always be EnvPath, never plain list."""
+    env = Env()
+    path = env.get('PATH')
+    
+    assert isinstance(path, EnvPath), f"PATH should be EnvPath, got {type(path)}"
+    assert hasattr(path, 'prepend'), "PATH should have prepend method"
+
+
+def test_path_default_becomes_envpath():
+    """Test that PATH_DEFAULT gets converted to EnvPath properly."""
+    # This tests the exact line that was buggy
+    path_from_default = EnvPath(PATH_DEFAULT)  # This is the fix
+    path_as_list = list(PATH_DEFAULT)          # This was the bug
+    
+    assert isinstance(path_from_default, EnvPath), "EnvPath(PATH_DEFAULT) should be EnvPath"
+    assert isinstance(path_as_list, list), "list(PATH_DEFAULT) should be plain list"
+    assert not isinstance(path_as_list, EnvPath), "list() should not create EnvPath"
+    
+    # The fix ensures we use the first, not the second
+    assert hasattr(path_from_default, 'prepend'), "EnvPath should have prepend"
+    assert not hasattr(path_as_list, 'prepend'), "plain list should not have prepend"
+
+
+def test_path_prepend_works():
+    """Test that PATH.prepend() works (this was the user-reported failure)."""
+    env = Env()
+    path = env.get('PATH')
+    
+    original_length = len(path)
+    test_path = '/test/issue/5870'
+    
+    # This should work without AttributeError
+    path.prepend(test_path)
+    assert path[0] == test_path
+    assert len(path) == original_length + 1
+    
+    # Clean up
+    path.remove(test_path)
+
+
+@pytest.mark.slow
+def test_no_env_flag_integration():
+    """Integration test: verify --no-env flag works with PATH.prepend()"""
+    
+    # Create test script that uses PATH.prepend()
+    script_content = '''
+try:
+    $PATH.prepend("/integration/test/path")
+    print("SUCCESS: prepend worked")
+except AttributeError as e:
+    print("FAIL: " + str(e))
+    exit(1)
+'''
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.xsh', delete=False) as f:
+        f.write(script_content)
+        script_path = f.name
+    
+    try:
+        # Test with --no-env flag (this is where the original bug occurred)
+        result = subprocess.run([
+            sys.executable, '-m', 'xonsh', '--no-env', script_path
+        ], capture_output=True, text=True, timeout=30)
+        
+        # Should succeed, not fail with AttributeError
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        assert "SUCCESS" in result.stdout, f"Expected success message, got: {result.stdout}"
+        assert "prepend worked" in result.stdout, "PATH.prepend() should work with --no-env"
+        
+    finally:
+        if os.path.exists(script_path):
+            os.remove(script_path)
+
+
+if __name__ == "__main__":
+    # Run tests directly
+    tests = [
+        test_path_is_always_envpath,
+        test_path_default_becomes_envpath, 
+        test_path_prepend_works,
+        test_no_env_flag_integration
+    ]
+    
+    for test in tests:
+        try:
+            print(f"Running {test.__name__}...")
+            test()
+            print(f"✅ {test.__name__}")
+        except Exception as e:
+            print(f"❌ {test.__name__}: {e}")
+            import traceback
+            traceback.print_exc()
+    
+    print("\n🎉 All tests passed!")

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -16,6 +16,7 @@ import typing as tp
 import warnings
 from collections import ChainMap
 from pathlib import Path
+from xonsh.tools import EnvPath
 
 import xonsh.prompt.base as prompt
 from xonsh import __version__ as XONSH_VERSION
@@ -2061,7 +2062,7 @@ class Env(cabc.MutableMapping):
         if "PATH" not in self._d:
             # this is here so the PATH is accessible to subprocs and so that
             # it can be modified in-place in the xonshrc file
-            self._d["PATH"] = list(PATH_DEFAULT)
+            self._d["PATH"] = EnvPath(PATH_DEFAULT)
         self._detyped = None
 
     def get_detyped(self, key: str):


### PR DESCRIPTION
Summary

This PR fixes an issue where PATH was created as a plain list instead of an EnvPath when running with the --no-env flag. As a result, methods like .prepend() and other EnvPath operations failed.

Changes

Replaced list(PATH_DEFAULT) with EnvPath(PATH_DEFAULT) in xonsh/environ.py.

Added regression tests in tests/test_issue_5870.py and tests/test_path_issue.py.

Ensured normal mode behavior is unaffected.

Why

Ensures PATH is always an EnvPath, even under --no-env, restoring expected functionality.

Related Issue

Closes #5870