### PR TITLE
Update pyproject.toml: Add prompt-toolkit dependent for Windows platform.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{ name = "Anthony Scopatz" }, { email = "scopatz@gmail.com" }]
 maintainers = [{ name = "Xonsh Community" }, { email = "xonsh@gil.forsyth.dev" }]
 license = { text = "BSD 2-Clause License" }
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["prompt-toolkit; platform_system == 'Windows'"]
 
 [tool.setuptools.dynamic]
 version = {attr = "xonsh.__version__"}


### PR DESCRIPTION
I just added the prompt-toolkit dependent to xonsh.

I didn't even clone it because I think I will just change one file. So I changed online.

If somewhere must be changed but I didn't do it, then help me to change it, thanks.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
