### PR TITLE
fix: remove redundant "command not found"

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -861,7 +861,11 @@ def debian_command_not_found(cmd):
         stderr=subprocess.STDOUT,
         shell=True,
     )
-    lines = [line for line in s.rstrip().splitlines() if not line.endswith(": command not found")]
+    lines = [
+        line
+        for line in s.rstrip().splitlines()
+        if not line.endswith(": command not found")
+    ]
     s = "\n".join(lines).strip()
     return s
 


### PR DESCRIPTION
Fixes #4374. Some Linux systems show a "command not found" message at the bottom of their /usr/lib/command-not-found output, and Linux systems don't. Previously, xonsh dropped the last line of command-not-found output, to suppress this message. But this led to useful information being dropped on systems that don't include the redundant line. That led to issue #1180. But the fix caused a regression, #4374.

I believe this new logic works with both cases, by simply filtering out any line with the redundant "command not found".

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
