### PR TITLE
fix: missing docstring for argument "verbose" of xontribs_unload and xontribs_reload

### DIFF
--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -269,6 +269,8 @@ def xontribs_unload(
     ----------
     names
         name of xontribs to unload
+    verbose : -v, --verbose
+        verbose output
 
     Notes
     -----
@@ -303,6 +305,8 @@ def xontribs_reload(
     ----------
     names
         name of xontribs to reload
+    verbose : -v, --verbose
+        verbose output
     """
     for name in names:
         if verbose:


### PR DESCRIPTION
This fix this failure to run xontrib command under python 3.14:

```
Exception in {'cls': 'ProcProxy', 'name': None, 'func': <xonsh.xontribs.XontribAlias object at 0x7fef6d368ec0>, 'alias': 'xontrib', 'pid': 16473}
xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = <filename>
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/xonsh/procs/proxies.py", line 784, in wait
    r = run_with_partial_args(
        self.f,
    ...<7 lines>...
        },
    )
  File "/usr/lib/python3.14/site-packages/xonsh/cli_utils.py", line 383, in run_with_partial_args
    return func(**kwargs)
  File "/usr/lib/python3.14/site-packages/xonsh/cli_utils.py", line 652, in __call__
    self.parser,
    ^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/xonsh/cli_utils.py", line 603, in parser
    self._parser = self.build()
                   ~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/xonsh/xontribs.py", line 400, in build
    parser.add_command(xontribs_unload, prog="unload")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/xonsh/cli_utils.py", line 354, in add_command
    add_args(parser, func, allowed_params=args, doc=doc)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/xonsh/cli_utils.py", line 192, in add_args
    action = parser.add_argument(*flags, **kwargs)
  File "/usr/lib64/python3.14/argparse.py", line 1543, in add_argument
    raise ValueError(f'action {action_name!r} is not valid for positional arguments')
ValueError: action 'store_true' is not valid for positional arguments
```