### PR TITLE
feat: Allow sourcing files with different extensions

### DIFF
--- a/tests/aliases/test_source.py
+++ b/tests/aliases/test_source.py
@@ -34,15 +34,36 @@ def test_source_files(mockopen, monkeypatch, mocked_execx_checker):
     source_alias_fn([".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"])
     assert mocked_execx_checker == [".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"]
 
+
 def test_source_files_any_ext_exception(mockopen, monkeypatch, mocked_execx_checker):
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
     with pytest.raises(RuntimeError):
         source_alias_fn(["foo.bar", "bar.foo", ".foobar"])
 
+
 def test_source_files_any_ext(mockopen, monkeypatch, mocked_execx_checker):
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
-    source_alias_fn(["foo.bar", "bar.foo", ".foobar", ".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"], ignore_ext=True)
-    assert mocked_execx_checker == ["foo.bar", "bar.foo", ".foobar", ".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"]
+    source_alias_fn(
+        [
+            "foo.bar",
+            "bar.foo",
+            ".foobar",
+            ".xonshrc",
+            "foo.xsh",
+            "bar.xonshrc",
+            "py.py",
+        ],
+        ignore_ext=True,
+    )
+    assert mocked_execx_checker == [
+        "foo.bar",
+        "bar.foo",
+        ".foobar",
+        ".xonshrc",
+        "foo.xsh",
+        "bar.xonshrc",
+        "py.py",
+    ]
 
 
 def test_source_from_env_path(mockopen, mocked_execx_checker, xession):

--- a/tests/aliases/test_source.py
+++ b/tests/aliases/test_source.py
@@ -45,14 +45,14 @@ def test_source_files_any_ext_exception(mockopen, monkeypatch, mocked_execx_chec
 def test_source_files_any_ext(mockopen, monkeypatch, mocked_execx_checker):
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
     files = [
-            "foo.bar",
-            "bar.foo",
-            ".foobar",
-            ".xonshrc",
-            "foo.xsh",
-            "bar.xonshrc",
-            "py.py",
-        ]
+        "foo.bar",
+        "bar.foo",
+        ".foobar",
+        ".xonshrc",
+        "foo.xsh",
+        "bar.xonshrc",
+        "py.py",
+    ]
     source_alias_fn(files, ignore_ext=True)
     assert mocked_execx_checker == files
 

--- a/tests/aliases/test_source.py
+++ b/tests/aliases/test_source.py
@@ -31,8 +31,9 @@ def mocked_execx_checker(xession, monkeypatch):
 
 def test_source_files(mockopen, monkeypatch, mocked_execx_checker):
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
-    source_alias_fn([".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"])
-    assert mocked_execx_checker == [".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"]
+    files = [".xonshrc", "foo.xsh", "bar.xonshrc", "py.py"]
+    source_alias_fn(files)
+    assert mocked_execx_checker == files
 
 
 def test_source_files_any_ext_exception(mockopen, monkeypatch, mocked_execx_checker):
@@ -43,8 +44,7 @@ def test_source_files_any_ext_exception(mockopen, monkeypatch, mocked_execx_chec
 
 def test_source_files_any_ext(mockopen, monkeypatch, mocked_execx_checker):
     monkeypatch.setattr(os.path, "isfile", lambda x: True)
-    source_alias_fn(
-        [
+    files = [
             "foo.bar",
             "bar.foo",
             ".foobar",
@@ -52,18 +52,9 @@ def test_source_files_any_ext(mockopen, monkeypatch, mocked_execx_checker):
             "foo.xsh",
             "bar.xonshrc",
             "py.py",
-        ],
-        ignore_ext=True,
-    )
-    assert mocked_execx_checker == [
-        "foo.bar",
-        "bar.foo",
-        ".foobar",
-        ".xonshrc",
-        "foo.xsh",
-        "bar.xonshrc",
-        "py.py",
-    ]
+        ]
+    source_alias_fn(files, ignore_ext=True)
+    assert mocked_execx_checker == files
 
 
 def test_source_from_env_path(mockopen, mocked_execx_checker, xession):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -763,8 +763,8 @@ def source_alias(args, stdin=None):
     ignore_ext = False
     if "-i" in args or "--ignore-ext" in args:
         args = [a for a in args if a not in {"-i", "--ignore-ext"}]
-        ignore_ext = True 
-    for i, fname in enumerate(args): 
+        ignore_ext = True
+    for i, fname in enumerate(args):
         fpath = fname
         if not os.path.isfile(fpath):
             fpath = locate_file(fname)

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -759,7 +759,11 @@ def source_alias(args, stdin=None):
     env = XSH.env
     encoding = env.get("XONSH_ENCODING")
     errors = env.get("XONSH_ENCODING_ERRORS")
-    for i, fname in enumerate(args):
+    ignore_ext = False
+    if "-i" in args or "--ignore-ext" in args:
+        args = [a for a in args if a not in {"-i", "--ignore-ext"}]
+        ignore_ext = True 
+    for i, fname in enumerate(args): 
         fpath = fname
         if not os.path.isfile(fpath):
             fpath = locate_file(fname)
@@ -772,12 +776,15 @@ def source_alias(args, stdin=None):
                     )
                 break
         _, fext = os.path.splitext(fpath)
-        if fext and fext != ".xsh" and fext != ".py":
+        if fext not in {".xsh", ".py", ".xonshrc"} and not ignore_ext:
             raise RuntimeError(
                 "attempting to source non-xonsh file! If you are "
                 "trying to source a file in another language, "
                 "then please use the appropriate source command. "
-                "For example, source-bash script.sh"
+                "For example, 'source-bash script.sh`. If you want to "
+                "source a xonsh file with a different extension, please "
+                "use the -i / --ingore-ext option."
+                
             )
         with open(fpath, encoding=encoding, errors=errors) as fp:
             src = fp.read()

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -552,7 +552,11 @@ def run_alias_by_params(func: tp.Callable, params: dict[str, tp.Any]):
     if len(kwargs) != len(func_params):
         # There is unknown param. Switch to positional mode.
         kwargs = dict(
-            zip(map(operator.itemgetter(0), func_params), alias_params.values())
+            zip(
+                map(operator.itemgetter(0), func_params),
+                alias_params.values(),
+                strict=False,
+            )
         )
     return func(**kwargs)
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -751,7 +751,6 @@ source_foreign = SourceForeignAlias(
 )
 
 
-@unthreadable
 def source_alias_fn(
     files: Annotated[list[str], Arg(nargs="+")], ignore_ext=False, _stdin=None
 ):
@@ -817,7 +816,7 @@ def source_alias_fn(
                 raise
 
 
-source_alias = ArgParserAlias(func=source_alias_fn, has_args=True, prog="source")
+source_alias = ArgParserAlias(func=source_alias_fn, has_args=True, prog="source", threadable=False)
 
 
 def source_cmd_fn(

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -816,7 +816,9 @@ def source_alias_fn(
                 raise
 
 
-source_alias = ArgParserAlias(func=source_alias_fn, has_args=True, prog="source", threadable=False)
+source_alias = ArgParserAlias(
+    func=source_alias_fn, has_args=True, prog="source", threadable=False
+)
 
 
 def source_cmd_fn(

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -12,8 +12,8 @@ import sys
 import types
 import typing as tp
 from collections import abc as cabc
-from typing import Literal
 from pathlib import Path
+from typing import Literal
 
 import xonsh.completers._aliases as xca
 import xonsh.history.main as xhm
@@ -748,7 +748,9 @@ source_foreign = SourceForeignAlias(
 
 
 @unthreadable
-def source_alias_fn(files: Annotated[list[str], Arg(nargs="+")], ignore_ext=False, _stdin=None):
+def source_alias_fn(
+    files: Annotated[list[str], Arg(nargs="+")], ignore_ext=False, _stdin=None
+):
     """Executes the contents of the provided files in the current context.
     If sourced file isn't found in cwd, search for file along $PATH to source
     instead.
@@ -810,7 +812,9 @@ def source_alias_fn(files: Annotated[list[str], Arg(nargs="+")], ignore_ext=Fals
                 )
                 raise
 
+
 source_alias = ArgParserAlias(func=source_alias_fn, has_args=True, prog="source")
+
 
 def source_cmd_fn(
     files: Annotated[list[str], Arg(nargs="+")],
@@ -957,7 +961,7 @@ def xexec_fn(
     except FileNotFoundError as e:
         return (
             None,
-            f"xonsh: exec: file not found: {e.args[1]}: {command[0]}" "\n",
+            f"xonsh: exec: file not found: {e.args[1]}: {command[0]}\n",
             1,
         )
 
@@ -1137,9 +1141,7 @@ def make_default_aliases():
 
             def sudo(args):
                 if len(args) < 1:
-                    print(
-                        "You need to provide an executable to run as " "Administrator."
-                    )
+                    print("You need to provide an executable to run as Administrator.")
                     return
                 cmd = args[0]
                 if locate_binary(cmd):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -12,6 +12,7 @@ import sys
 import types
 import typing as tp
 from collections import abc as cabc
+from pathlib import Path
 from typing import Literal
 
 import xonsh.completers._aliases as xca
@@ -775,7 +776,14 @@ def source_alias(args, stdin=None):
                         "must source at least one file, " + fname + " does not exist."
                     )
                 break
-        _, fext = os.path.splitext(fpath)
+        # using Path to handle hidden files and extensions since os.path.splitext
+        # does not handle hidden files as we would like it to.
+        fext = Path(fpath).suffix
+        if not fext and (name := Path(fpath).name).startswith("."):
+            fhead = name  # hidden file with no extension
+        if not fext:
+            # file is a hidden file with no extension
+            fext = fhead
         if fext not in {".xsh", ".py", ".xonshrc"} and not ignore_ext:
             raise RuntimeError(
                 "attempting to source non-xonsh file! If you are "
@@ -784,7 +792,6 @@ def source_alias(args, stdin=None):
                 "For example, 'source-bash script.sh`. If you want to "
                 "source a xonsh file with a different extension, please "
                 "use the -i / --ingore-ext option."
-                
             )
         with open(fpath, encoding=encoding, errors=errors) as fp:
             src = fp.read()

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -780,10 +780,7 @@ def source_alias(args, stdin=None):
         # does not handle hidden files as we would like it to.
         fext = Path(fpath).suffix
         if not fext and (name := Path(fpath).name).startswith("."):
-            fhead = name  # hidden file with no extension
-        if not fext:
-            # file is a hidden file with no extension
-            fext = fhead
+            fext = name  # hidden file with no extension
         if fext not in {".xsh", ".py", ".xonshrc"} and not ignore_ext:
             raise RuntimeError(
                 "attempting to source non-xonsh file! If you are "


### PR DESCRIPTION
Resolves #5480 

1. Add `.xonshrc` to the list of acceptable extensions.
2. Add flag `-e --ignore-ext` that disable extension checking.
3. Add info about flag to the error message

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
