### PR TITLE
docs: add RST header and note about author crediting

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,3 +1,7 @@
+=======
+Authors
+=======
+
 All of the people who have made at least one contribution to xonsh.
 Authors are sorted by number of commits.
 
@@ -344,4 +348,10 @@ Authors are sorted by number of commits.
 * Ahmed
 * goodboy
 * Atsushi Morimoto
+
+.. note::
+
+   This list is generated from the ``.authors.yml`` file in the repository.
+   For information about how authors are credited in release notes,
+   see `issue #5950 <https://github.com/xonsh/xonsh/issues/5950>`_.
 * slacksystem


### PR DESCRIPTION
- Added RST document header for proper formatting
- Added note referencing .authors.yml as the source
- Added link to issue #5950 for release note author crediting discussion

Related: xonsh/xonsh#5950

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
