### PR TITLE
fix: expand `~`(User's home path) in `xonsh.tools.chdir` function

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -71,6 +71,7 @@ from xonsh.platform import (
 
 @contextmanager
 def chdir(adir, mkdir=False, expanduser=True):
+    """Context manager for switching current directory to another."""
     adir = pathlib.Path(adir)
     old_dir = os.getcwd()
     if expanduser:


### PR DESCRIPTION
### Before
```xsh
with __xonsh__.imp.xonsh.tools.chdir('~'):
  echo 1
# FileNotFoundError: [Errno 2] No such file or directory: '~'
```
### After
```xsh
with __xonsh__.imp.xonsh.tools.chdir('~'):
  echo 1
# 1
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
