### PR TITLE
fix(parser): handle multiline text literals with logical AND/OR operators

### DIFF
--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -270,7 +270,10 @@ class Execer:
                         if error_line_within_logical > 0:
                             # Add lengths of previous lines (including newlines)
                             logical_lines = line.splitlines(keepends=True)
-                            offset = sum(len(l) for l in logical_lines[:error_line_within_logical])
+                            offset = sum(
+                                len(l)
+                                for l in logical_lines[:error_line_within_logical]
+                            )
                             last_error_col += offset
                     if nlogical > 1 and not logical_input:
                         _, sbpline = self._parse_ctx_free(

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -469,15 +469,15 @@ def find_next_break(line, mincol=0, lexer=None):
 
 def _offset_from_prev_lines(line, lineno):
     """Calculate the character offset to the start of a given line number.
-    
+
     Args:
         line: The full string
         lineno: 1-based line number. Returns offset to the start of this line.
-    
+
     Returns:
         The sum of lengths of all lines before lineno.
     """
-    lines = line.splitlines(keepends=True)[:lineno - 1]
+    lines = line.splitlines(keepends=True)[: lineno - 1]
     return sum(map(len, lines))
 
 


### PR DESCRIPTION
<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## Summary

Fix parsing of commands with multiline text literals combined with logical AND (`&&`) or OR (`||`) operators.

**Before:** `echo @("""1\n""") && echo 2` failed with `SyntaxError: ('code: and',)`

**After:** Command parses and executes correctly

## Root Cause
The xonsh lexer produces token positions (`lexpos`) that are **line-relative** (reset to 0 at each newline), not absolute positions in the input string. Several functions in `tools.py` and `execer.py` incorrectly assumed these were absolute positions when working with multiline strings.

## Changes

### `xonsh/tools.py`
- **`_offset_from_prev_lines()`**: Fixed slice logic from `[:last]` to `[:lineno - 1]` to correctly calculate offset to the start of a given line
- **`find_next_break()`**: Added line offset calculation when computing `maxcol` for tokens on lines > 1
- **`subproc_toks()`**: Added absolute position calculation for tokens in multiline strings and fixed `beg_offset` for first tokens not on line 1
- **`get_logical_line()`**: Added backward search for unclosed triple-quoted strings so errors on line 2 of a multiline string correctly identify line 1 as part of the same logical line

### `xonsh/execer.py`
- **`_try_parse()`**: Added conversion of line-relative error columns to absolute positions when processing errors within multiline logical lines

## Testing
All existing tests pass (656 passed)
### Manual Test
<img width="523" height="284" alt="image" src="https://github.com/user-attachments/assets/3539c6b0-873d-436b-bf0b-8bcb32bee802" />

Fixes #6011 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
