### PR TITLE
fix(completion): strip quotes correctly in PTK completer display

### DIFF
--- a/tests/shell/test_ptk_completer.py
+++ b/tests/shell/test_ptk_completer.py
@@ -23,6 +23,26 @@ from xonsh.shells.ptk_shell.completer import PromptToolkitCompleter
         ),
         (RichCompletion("x"), 5, PTKCompletion(RichCompletion("x"), -5, "x")),
         ("x", 5, PTKCompletion("x", -5, "x")),
+        ("rrr", 5, PTKCompletion("rrr", -5, "rrr")),
+        (
+            RichCompletion('r"with\\backslash"'),
+            0,
+            PTKCompletion(RichCompletion('r"with\\backslash"'), 0, "with\\backslash"),
+        ),
+        (
+            RichCompletion("'with space'"),
+            0,
+            PTKCompletion(RichCompletion("'with space'"), 0, "with space"),
+        ),
+        (
+            RichCompletion("r'./hello/world with space'"),
+            2,
+            PTKCompletion(
+                RichCompletion("r'./hello/world with space'"),
+                -2,
+                "hello/world with space",
+            ),
+        ),
     ],
 )
 def test_rich_completion(completion, lprefix, ptk_completion, monkeypatch, xession):
@@ -35,8 +55,8 @@ def test_rich_completion(completion, lprefix, ptk_completion, monkeypatch, xessi
 
     document_mock = MagicMock()
     document_mock.text = ""
-    document_mock.current_line = ""
-    document_mock.cursor_position_col = 0
+    document_mock.current_line = "x" * lprefix
+    document_mock.cursor_position_col = lprefix
 
     monkeypatch.setattr(xession.commands_cache, "aliases", Aliases())
 


### PR DESCRIPTION
https://github.com/xonsh/xonsh/pull/5816 introduced a funny bug that letter 'r' in the beginning or ending of file names are stripped. e.g. in a folder with file "release", typing `ls <TAB>` would suggest "elease".

The stripping behavior in PTK completer also had some other issues. Example:

<img width="576" height="323" alt="Screenshot 2025-12-28 at 15 55 19" src="https://github.com/user-attachments/assets/55326e01-2d4f-4d71-a2d8-388608d58741" />

<img width="431" height="114" alt="Screenshot 2025-12-28 at 15 55 24" src="https://github.com/user-attachments/assets/8531ea00-25bb-41ff-83f7-0d39d3b9b082" />

<img width="222" height="58" alt="Screenshot 2025-12-28 at 15 55 36" src="https://github.com/user-attachments/assets/55a76503-d75b-47f1-ad67-136a3e42c95e" />


This PR tries to improve this a bit. After this PR:


<img width="286" height="97" alt="Screenshot 2025-12-28 at 15 55 45" src="https://github.com/user-attachments/assets/86b12e3d-bf3e-4542-a230-ce74931d83fd" />
<img width="192" height="61" alt="Screenshot 2025-12-28 at 15 55 51" src="https://github.com/user-attachments/assets/6545c382-20d7-4173-bb54-eccec0333d67" />

Also adds unit tests.

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
