### PR TITLE
fix: completer show the exact match on first position

### DIFF
--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -174,6 +174,7 @@ def test_python_only_context(completer, completers_mock):
     assert completer.complete_line("echo @(") != ()
     assert completer.complete("", "echo @(", 0, 0, {}, "echo @(", 7) != ()
 
+
 def test_exact_match(completer, completers_mock):
     @contextual_command_completer
     def comp(context: CommandContext):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -303,7 +303,11 @@ class Completer:
 
             def sortkey(s):
                 """Sort values by prefix position then alphabetically. Exact match should be the first option"""
-                return (s.lower().find(prefix.lower()), not prefix.lower().endswith(s.lower()), s.lower())
+                return (
+                    s.lower().find(prefix.lower()),
+                    not prefix.lower().endswith(s.lower()),
+                    s.lower(),
+                )
         else:
             # Fallback sort.
             sortkey = lambda s: s.lstrip(''''"''').lower()


### PR DESCRIPTION
Sort values by prefix position then alphabetically (refs #6003)
added a check if prefix ends with the completion option => this option will be the first

prefix: "grep -i"

options for example  "i" and "iA" 

since prefix ends with i so "i" will be the first option 

<!---

Thanks for opening a PR on xonsh!

Please do this:

1. Include a news file with your PR (https://xon.sh/devguide.html#changelog).
2. Add the documentation for your feature into `/docs`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `#1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
