### PR TITLE
fix(docs): Update ErrorString import handling in cmdhelp.py

### DIFF
--- a/docs/extensions/cmdhelp.py
+++ b/docs/extensions/cmdhelp.py
@@ -22,7 +22,7 @@ except ImportError:
             # docutils >= 0.22.4
             def ErrorString(exc):
                 return str(exc)
-                
+
 from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 


### PR DESCRIPTION
`docutils.error_reporting` now deleted from docutils

Fix for build docs error:
```xsh
sphinx-build -b html -T -v -d _build/doctrees   . _build/html
Running Sphinx v9.1.0
loading translations [en]... locale_dir /home/runner/work/xonsh/xonsh/docs/locales/en/LC_MESSAGES does not exist
locale_dir /home/runner/work/xonsh/xonsh/docs/locales/en/LC_MESSAGES does not exist
done
Original exception:
Traceback (most recent call last):
  File "/home/runner/work/xonsh/xonsh/docs/extensions/cmdhelp.py", line 17, in <module>
    from docutils.utils.error_reporting import ErrorString  # the new way
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'docutils.utils.error_reporting'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/sphinx/registry.py", line 550, in load_extension
    mod = import_module(extname)
  File "/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/runner/work/xonsh/xonsh/docs/extensions/cmdhelp.py", line 19, in <module>
    from docutils.error_reporting import ErrorString  # the old way
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'docutils.error_reporting'

```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
