### PR TITLE
fix(startup): Fix crash on built-in readline, print compatibility message on uv pythons

### DIFF
--- a/xonsh/shells/readline_shell.py
+++ b/xonsh/shells/readline_shell.py
@@ -96,7 +96,11 @@ def setup_readline():
     uses_libedit = readline.__doc__ and "libedit" in readline.__doc__
     readline.set_completer_delims(" \t\n")
     # Cygwin seems to hang indefinitely when querying the readline lib
-    if (not ON_CYGWIN) and (not ON_MSYS) and (not readline.__file__.endswith(".py")):
+    if (
+        (not ON_CYGWIN)
+        and (not ON_MSYS)
+        and (readline.__spec__.has_location and (not readline.__file__.endswith(".py")))
+    ):
         RL_LIB = lib = ctypes.cdll.LoadLibrary(readline.__file__)
         try:
             RL_COMPLETION_SUPPRESS_APPEND = ctypes.c_int.in_dll(
@@ -129,7 +133,7 @@ def setup_readline():
 
     # handle tab completion differences found in libedit readline compatibility
     # as discussed at http://stackoverflow.com/a/7116997
-    if uses_libedit and ON_DARWIN:
+    if uses_libedit:
         readline.parse_and_bind("bind ^I rl_complete")
         print(
             "\n".join(
@@ -167,7 +171,7 @@ def setup_readline():
         try:
             readline.read_init_file(inputrc_name)
         except Exception:
-            # this seems to fail with libedit
+            # this fails with libedit
             print_exception("xonsh: could not load readline default init file.")
 
     # Protection against paste jacking (issue #1154)


### PR DESCRIPTION
python 3.13+ installed with uv (and maybe others, see source) use a built-in readline which is actually libedit. Therefore, show the compatibility message on all systems, not only `ON_DARWIN`.

Also, don't attempt to load the readline library if it is not a library. Testing against .py does not suffice, as there is a third case where the module is build-in. `Module.__spec__.has_location` is available since python 3.4.

Source:
https://gregoryszorc.com/docs/python-build-standalone/main/quirks.html#use-of-libedit-on-linux

> Python 3.10+ Linux distributions link against libedit (as opposed
> to readline) by default, as libedit is supported on 3.10+ outside of
> macOS.
>
> Most Python builds on Linux will link against readline because
> readline is the dominant library on Linux.

Closes #5693 #6068

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
