### PR TITLE
feat(xcontext): Report current xonsh session executable in `xcontext`

### DIFF
--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -30,15 +30,15 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
     """Report information about the current xonsh environment."""
     stdout = _stdout or sys.stdout
     print("[Current xonsh session]", file=stdout)
-    
+
     current_xonsh = sys.argv[0]
     print(f"xonsh: {current_xonsh}", file=stdout)
-    
+
     appimage_python = XSH.env.get("_") if IN_APPIMAGE else None
     xpy = appimage_python if appimage_python else sys.executable
     xpy_ver = _get_version(xpy)
     print(f"xpython: {xpy} # {xpy_ver}", file=stdout)
-    
+
     xpip = XSH.aliases.get("xpip")
     if xpip:
         if isinstance(xpip, list) and all(isinstance(x, str) for x in xpip):
@@ -47,7 +47,7 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
             print(f"xpip: {xpip}", file=stdout)
     else:
         print("xpip: not found", file=stdout)
-        
+
     print("", file=stdout)
     print("[Current commands environment]", file=stdout)
     cmds = ["xonsh", "python", "pip"]


### PR DESCRIPTION
```xsh
xcontext
```
```xsh
[Current xonsh session]
xonsh: /Users/pc/.local/xonsh-env/xbin/xonsh  # ADDED
xpython: /Users/pc/.local/xonsh-env/bin/python
xpip: /Users/pc/.local/xonsh-env/bin/python -m pip

[Current commands environment]
xonsh: /Users/pc/.local/xonsh-env/xbin/xonsh
python: not found
pip: not found
```

cc #6047

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
