### PR TITLE
fix(history-sqlite): Set SQLite history journal mode to WAL to avoid I/O error

### DIFF
--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -42,7 +42,9 @@ def _xh_sqlite_create_history_table(cursor):
         it tracks the frequency of the inputs. helps in sorting autocompletion
     """
     if not getattr(XH_SQLITE_CACHE, XH_SQLITE_CREATED_SQL_TBL, False):
-        cursor.execute("PRAGMA journal_mode=WAL;")  # https://github.com/xonsh/xonsh/issues/6096        
+        cursor.execute(
+            "PRAGMA journal_mode=WAL;"
+        )  # https://github.com/xonsh/xonsh/issues/6096
         cursor.execute(
             f"""
             CREATE TABLE IF NOT EXISTS {XH_SQLITE_TABLE_NAME}


### PR DESCRIPTION
Closes #6096

> Write-Ahead Logging (WAL) mode is the most sophisticated journaling method in SQLite. It significantly enhances database read and write performance, especially in environments with high concurrency or where reads are more common than writes. Unlike traditional rollback journal modes that lock the entire database for writing, WAL allows reads and writes to proceed concurrently, eliminating a huge bottleneck.

To show current value for existing xonsh history sqlite file:
```xsh
print((conn := @.imp.sqlite3.connect($XONSH_HISTORY_FILE)).execute("PRAGMA journal_mode;").fetchone()[0])
conn.close()
# delete
```


To switch existing xonsh history sqlite file to WAL:

```xsh
print((conn := @.imp.sqlite3.connect($XONSH_HISTORY_FILE)).execute("PRAGMA journal_mode=wal;").fetchone()[0])
conn.close()
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
