### PR TITLE
test: Test fixing the case when last proc in the pipe closed without waiting previous processes

### DIFF
--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -307,7 +307,7 @@ class CommandPipeline:
         # GNU Parallel, which has a long startup time.
         first_read = True
 
-        while first_read or (proc.poll() is None and self._any_proc_running()):
+        while proc.poll() is None or first_read or self._any_proc_running():
             first_read = False
             if getattr(proc, "suspended", False) or self._procs_suspended() is not None:
                 self.suspended = True
@@ -549,7 +549,7 @@ class CommandPipeline:
         """Boolean for if all previous processes have completed. If there
         is only a single process in the pipeline, this returns False.
         """
-        for s, p in zip(self.specs, self.procs, strict=False):
+        for p in self.procs:
             if p.poll() is None:
                 return True
         return False


### PR DESCRIPTION
Fixed https://github.com/xonsh/xonsh/issues/5631#issuecomment-4010217740:
```xsh
@aliases.register
def _a1(args, stdin, stdout):
    @.imp.time.sleep(0.05)
    print(1)

@aliases.register
def _a2(args, stdin, stdout):
    print(2)
            
a1 | a2  # a2 will be ended before a1

for i in range(100):
    a1 | a2
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
