### PR TITLE
fix(environ): NixOS: Added `/nix/store/<hash>-<coreutils>-<version>/bin` to default PATH. 

### DIFF
--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -545,7 +545,11 @@ def PATH_DEFAULT():
             """
             if Path("/nix").exists():
                 path_list = os.environ["PATH"].split(os.pathsep)
-                pd += tuple(path for path in path_list if path.startswith("/nix") and path.endswith("/bin"))
+                pd += tuple(
+                    path
+                    for path in path_list
+                    if path.startswith("/nix") and path.endswith("/bin")
+                )
 
     elif ON_DARWIN:
         pd = ("/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin")


### PR DESCRIPTION
On NixOS the coreutils bin path is versioned in /nix/store, so we need to locate something like: `/nix/store/<hash>-<coreutils>-<version>/bin`.

This fixes:
* `xonsh --no-env`
* tests on nix - https://github.com/NixOS/nixpkgs/pull/497851

Manual test:
```xsh
docker run --rm -it nixos/nix bash
nix-shell -p python3
python3 -m venv venv
source venv/bin/activate
pip install git+https://github.com/anki-code/xonsh@pytest_fix_nix_path
xonsh --no-env
$PATH
# '/nix/store/58wcnwvcyffg0i17jqbi076spkhnijr6-bash-interactive-5.2p37/bin',
# '/nix/store/n0w5n0065pkh0jw9xhqpqlqrfx3my99k-patchelf-0.15.0/bin',
# '/nix/store/sgcywhl3frjxi8j8c1m5f6k4l1qg9gb9-gcc-wrapper-14.3.0/bin',
# '/nix/store/z3ks4zij9d2m4rp5qf4g2ff6f96slmnc-gcc-14.3.0/bin',
# ...
```

Closes #5569
cc https://github.com/NixOS/nixpkgs/pull/497851

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
