### PR TITLE
feat(ptk): make `tempfile_suffix` ".xsh" for `open_in_editor`

### DIFF
--- a/xonsh/shells/ptk_shell/key_bindings.py
+++ b/xonsh/shells/ptk_shell/key_bindings.py
@@ -274,6 +274,7 @@ def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
     @handle(Keys.ControlX, Keys.ControlE, filter=~has_selection)
     def open_editor(event):
         """Open current buffer in editor"""
+        event.current_buffer.tempfile_suffix = ".xsh"
         event.current_buffer.open_in_editor(event.cli)
 
     @handle(Keys.BackTab, filter=insert_mode)


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.

-->

### Before
When using `C-x C-e` (open in editor keybinding), the tempfile would have the file extension `.txt`.

### After
When using `C-x C-e`, the tempfile would have the file extension `.xsh`. 
This is useful because then editors such as neovim can apply the correct syntax highlighting, lsp, etc (instead of manually running `:set ft=xonsh` each time).

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
