### PR TITLE
fix: Parser: fix regress with parsing `a#b;c`

### DIFF
--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -2651,6 +2651,19 @@ def test_comment_only(check_xonsh_ast):
     check_xonsh_ast({}, "# hello")
 
 
+@pytest.mark.parametrize(
+    "inp",
+    [
+        "echo a#b;c",
+        "echo a#b",
+        "echo x#y;z;w",
+    ],
+)
+def test_parse_hash_in_arg_no_hang(inp, xsh):
+    """Regression test for #5976: parser must not hang on '#' inside arguments."""
+    xsh.execer.compile(inp, mode="single", glbs={}, locs={})
+
+
 def test_echo_slash_question(check_xonsh_ast):
     check_xonsh_ast({}, "![echo /?]", False)
 

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -222,6 +222,8 @@ class Execer:
     def _parse_ctx_free(self, input, mode="exec", filename=None, logical_input=False):
         if filename is None:
             filename = self.filename
+        if mode != "eval" and not input.endswith("\n"):
+            input += "\n"
 
         def _try_parse(input, greedy):
             last_error_line = last_error_col = -1

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -297,7 +297,7 @@ def find_next_break(line, mincol=0, lexer=None):
         return None
     maxcol = None
     lparens = []
-    lexer.input(line)
+    lexer.input(line, is_subproc=True)
     for tok in lexer:
         if tok.type in LPARENS:
             lparens.append(tok.type)


### PR DESCRIPTION
Closes #5976
Cc #5941

### Before

Before #5941:
```xsh
echo 1;3
# 1 🟢 
# 3 🟢 

echo 1#2
# 1 🔴 

echo 1#2;3  # comment
# 1 🔴 
```

After #5941:

```xsh
echo 1;3
# 1 🟢 
# 3 🟢 

echo 1#2
# 1#2 🟢 

echo 1#2;3  # regress
# Hanging 🔴 
```


### After

```xsh
echo 1;3
# 1 🟢 
# 3 🟢 

echo 1#2
# 1#2 🟢 

echo 1#2;3
# 1#2 🟢
# 3 🟢
```



## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
