### PR TITLE
fix: Tests: Relax test_loading_correctly path comparison for venv builds

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1112,10 +1112,10 @@ def test_loading_correctly(monkeypatch, interactive):
     )
     assert not err
     assert ret == 0
-    our_xonsh = (
-        xonsh.__file__
-    )  # make sure xonsh didn't fail and fallback to the system shell
-    assert f"AAA {our_xonsh} BBB" in out  # ignore tty warnings/prompt text
+    # make sure xonsh didn't fail and fallback to the system shell
+    # The exact path may differ (e.g. virtualenv vs source tree), so just
+    # check that xonsh's __init__.py was loaded from *some* xonsh package.
+    assert re.search(r"AAA .+xonsh/__init__\.py BBB", out)
 
 
 @skip_if_no_xonsh


### PR DESCRIPTION
This fix is AI generated.

This is necessary to avoid:
```
=================================== FAILURES ===================================
_________________________ test_loading_correctly[True] _________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1aa7be0670>
interactive = True

    @pytest.mark.parametrize("interactive", [True, False])
    def test_loading_correctly(monkeypatch, interactive):
        # Ensure everything loads correctly in interactive mode (e.g. #4289)
        monkeypatch.setenv("SHELL_TYPE", "prompt_toolkit")
        monkeypatch.setenv("XONSH_LOGIN", "1")
        monkeypatch.setenv("XONSH_INTERACTIVE", "1")
        out, err, ret = run_xonsh(
            "import xonsh; echo -n AAA @(xonsh.__file__) BBB",
            interactive=interactive,
            single_command=True,
        )
        assert not err
        assert ret == 0
        our_xonsh = (
            xonsh.__file__
        )  # make sure xonsh didn't fail and fallback to the system shell
>       assert f"AAA {our_xonsh} BBB" in out  # ignore tty warnings/prompt text
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       AssertionError: assert 'AAA /usr/src/RPM/BUILD/python3-module-xonsh-0.22.8/.run_venv/lib64/python3/site-packages/xonsh/__init__.py BBB' in 'AAA /usr/src/RPM/BUILD/python3-module-xonsh-0.22.8/xonsh/__init__.py BBB'

tests/test_integrations.py:1118: AssertionError
________________________ test_loading_correctly[False] _________________________

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f1aaf2642f0>
interactive = False

    @pytest.mark.parametrize("interactive", [True, False])
    def test_loading_correctly(monkeypatch, interactive):
        # Ensure everything loads correctly in interactive mode (e.g. #4289)
        monkeypatch.setenv("SHELL_TYPE", "prompt_toolkit")
        monkeypatch.setenv("XONSH_LOGIN", "1")
        monkeypatch.setenv("XONSH_INTERACTIVE", "1")
        out, err, ret = run_xonsh(
            "import xonsh; echo -n AAA @(xonsh.__file__) BBB",
            interactive=interactive,
            single_command=True,
        )
        assert not err
        assert ret == 0
        our_xonsh = (
            xonsh.__file__
        )  # make sure xonsh didn't fail and fallback to the system shell
>       assert f"AAA {our_xonsh} BBB" in out  # ignore tty warnings/prompt text
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       AssertionError: assert 'AAA /usr/src/RPM/BUILD/python3-module-xonsh-0.22.8/.run_venv/lib64/python3/site-packages/xonsh/__init__.py BBB' in 'AAA /usr/src/RPM/BUILD/python3-module-xonsh-0.22.8/xonsh/__init__.py BBB'

tests/test_integrations.py:1118: AssertionError
```

The test compared the exact xonsh.__file__ path between the pytest process and a subprocess, which fails when pytest runs inside a virtualenv (.run_venv) but the subprocess resolves xonsh from the source tree. Use a regex match instead to verify xonsh loaded from any xonsh package location.

## Fix

Replace the exact path assertion with a regex that verifies xonsh's `__init__.py` was loaded from *some* xonsh package — which is the actual intent of the test (ensuring xonsh didn't fail and fall back to the system shell). 

## Test plan

- [x] Verified fix in RPM build environment (`/usr/bin/python3 -m pyproject_installer run` + hasher chroot)
- [ ] Existing CI should continue to pass since the regex matches any valid xonsh path


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
