### PR TITLE
fix(Windows): Fixed CDLL exception in MSYS2 when running xonsh

### DIFF
--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -577,10 +577,17 @@ def LIBC():
         import ctypes.util
 
         libc = ctypes.CDLL(ctypes.util.find_library("c"))
-    elif ON_CYGWIN:
-        libc = ctypes.CDLL("cygwin1.dll")
-    elif ON_MSYS:
-        libc = ctypes.CDLL("msys-2.0.dll")
+    elif ON_CYGWIN or ON_MSYS:
+        # In MSYS2, sys.platform may report "cygwin" even though the
+        # runtime library is msys-2.0.dll (not cygwin1.dll).  Try both.
+        for _dll in ("msys-2.0.dll", "cygwin1.dll"):
+            try:
+                libc = ctypes.CDLL(_dll)
+                break
+            except OSError:
+                continue
+        else:
+            libc = None
     elif ON_FREEBSD:
         try:
             libc = ctypes.CDLL("libc.so.7")


### PR DESCRIPTION
Fixed exception in https://www.msys2.org/

```xsh
# MSYS2
pacman -S python-pip
pip install --break-system-packages xonsh prompt-toolkit
xonsh
```
```xsh
Traceback (most recent call last):
  File "/usr/bin/xonsh", line 3, in <module>
    from xonsh.main import main
  File "/usr/lib/python3.12/site-packages/xonsh/main.py", line 12, in <module>
    import xonsh.procs.pipelines as xpp
  File "/usr/lib/python3.12/site-packages/xonsh/procs/pipelines.py", line 14, in <module>
    import xonsh.procs.jobs as xj
  File "/usr/lib/python3.12/site-packages/xonsh/procs/jobs.py", line 273, in <module>
    LIBC.pthread_sigmask.restype = ctypes.c_int
    ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/xonsh/lib/lazyasd.py", line 56, in __getattribute__
    obj = self._lazy_obj()
          ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/xonsh/lib/lazyasd.py", line 48, in _lazy_obj
    obj = d["load"]()
          ^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/xonsh/platform.py", line 581, in LIBC
    libc = ctypes.CDLL("cygwin1.dll")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ctypes/__init__.py", line 379, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: No such file or directory

```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
