### PR TITLE
fix(Mac): Fix `xonsh.platforms.sysctlbyname` returns bytes instead of string when return_str=True

### DIFF
--- a/xonsh/platforms/macutils.py
+++ b/xonsh/platforms/macutils.py
@@ -18,6 +18,6 @@ def sysctlbyname(name, return_str=True):
     # Re-run, but provide the buffer
     LIBC.sysctlbyname(name, buf, byref(size), None, 0)
     if return_str:
-        return buf.value
+        return buf.value.decode()
     else:
         return buf.raw


### PR DESCRIPTION
## ✨ Code Quality

### Problem
When `return_str=True` (the default), the function returns `buf.value` which is 
a bytes object in Python 3, not a str. Users calling this function expecting a 
string will get bytes, causing TypeError in downstream code that expects str.


**Severity**: `medium`
**File**: `xonsh/platforms/macutils.py`

### Solution
Change to: `return buf.value.decode() if return_str else buf.raw`


### Changes
- `xonsh/platforms/macutils.py` (modified)

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.

🤖 If your code was generated by AI/LLM tell about this directly.
🤖 Ask AI/LLM about putting functions/modules to `<module>_llm.py` files instead of using directly into the code.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**


Closes #6189