### PR TITLE
fix(prompt-toolkit): Support retry on EINTR (errno 4) in ptk. Fixed exceptions when xonsh run as a child process.

### DIFF
--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -399,7 +399,19 @@ class PromptToolkitShell(BaseShell):
             prompt_args["cursor"] = cursor_shape
 
         events.on_pre_prompt.fire()
-        line = self.prompter.prompt(**prompt_args)
+        while True:
+            try:
+                line = self.prompter.prompt(**prompt_args)
+                break
+            except Exception as e:
+                # Retry on EINTR (errno 4) — tcsetattr in prompt_toolkit's
+                # raw_mode() is not automatically retried by Python (PEP 475
+                # doesn't cover termios).  This happens when a signal (e.g.
+                # SIGCHLD from a process launcher like `uv run`) arrives
+                # during terminal setup.
+                if getattr(e, "args", (None,))[0] == 4:
+                    continue
+                raise
         events.on_post_prompt.fire()
         return line
 


### PR DESCRIPTION
It's just a fix that allows to reduce exception and doing things right and partially related to https://github.com/xonsh/xonsh/issues/5791 but the case with `uv run xonsh` is a user error.

I will do self-merge because it's minor edge case.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
