### PR TITLE
fix(Parser): Fix parsing path with num in case `cd /tmp/123 && ...`

### DIFF
--- a/tests/parsers/test_ast.py
+++ b/tests/parsers/test_ast.py
@@ -126,6 +126,29 @@ def test_whitespace_subproc(test_input, xonsh_execer_parse):
 
 
 @pytest.mark.parametrize(
+    "test_input",
+    [
+        "cd /tmp/123 && ls\n",
+        "echo /tmp/123 && echo done\n",
+        "cd /tmp/123 || ls\n",
+    ],
+)
+def test_subproc_with_numeric_path_and_boolop(test_input, xonsh_execer_parse):
+    """Paths with numeric components like /tmp/123 must not be parsed as Python division.
+
+    See https://github.com/xonsh/xonsh/issues/5253
+    """
+    tree = xonsh_execer_parse(test_input)
+    assert tree is not None
+    # The AST should NOT contain BinOp(Div) — that would mean /tmp/123 was parsed as division
+    for node in pyast.walk(tree):
+        if isinstance(node, pyast.BinOp) and isinstance(node.op, pyast.Div):
+            pytest.fail(
+                f"Path with numeric component was incorrectly parsed as Python division: {test_input!r}"
+            )
+
+
+@pytest.mark.parametrize(
     "inp,exp",
     [
         ("1+1", True),

--- a/xonsh/parsers/ast.py
+++ b/xonsh/parsers/ast.py
@@ -256,14 +256,17 @@ def max_col(node):
 
 
 def node_len(node):
-    """The length of a node as a string"""
+    """The length of a node as a string
+    (This may need to be added to for more nodes as more cases are found.)
+    """
     val = 0
     for n in walk(node):
         if isinstance(n, Name):
             val += len(n.id)
+        elif isinstance(n, Constant) and n.value is not None:  # Case #5253
+            val += len(repr(n.value))
         elif isinstance(n, Attribute):
             val += 1 + (len(n.attr) if isinstance(n.attr, str) else 0)
-        # this may need to be added to for more nodes as more cases are found
     return val
 
 


### PR DESCRIPTION
Fixes https://github.com/xonsh/xonsh/issues/5253

### Before
```xsh
cd /tmp/123 && ls
# NameError: name 'cd' is not define
echo / 123 && ls
# NameError: name 'echo' is not define
```

### After
```xsh
cd /tmp/123 && ls
# <cd and ls result>
echo / 123 && ls
# / 123
# <ls result>
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
