### PR TITLE
fix: Fixed RESET in XONSH_STDERR_POSTFIX to colorize stderr properly

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2188,26 +2188,35 @@ def format_std_prepost(template, env=None):
         return ""
     env = xsh.env if env is None else env
     invis = "\001\002"
-    from xonsh.ansi_colors import ansi_partial_color_format
-
     if xsh.shell is None:
         # shell hasn't fully started up (probably still in xonshrc)
+        from xonsh.ansi_colors import ansi_partial_color_format
         from xonsh.prompt.base import PromptFormatter
 
         pf = PromptFormatter()
         s = pf(template)
+        style = env.get("XONSH_COLOR_STYLE")
+        s = ansi_partial_color_format(invis + s + invis, hide=False, style=style)
     else:
+        # shell has fully started. do the normal thing
         shell = xsh.shell.shell
         try:
             s = shell.prompt_formatter(template)
         except Exception:
             print_exception()
-    # Use ansi_partial_color_format directly instead of shell.format_color
-    # because PTK's partial_color_tokenize starts with Color.RESET,
-    # making {RESET} a no-op that produces an empty string.
-    style = env.get("XONSH_COLOR_STYLE")
-    s = ansi_partial_color_format(invis + s + invis, hide=False, style=style)
+        # \001\002 is there to fool pygments into not returning an empty string
+        # for potentially empty input. This happens when the template is just a
+        # color code with no visible text.
+        s = shell.format_color(invis + s + invis, force_string=True)
     s = s.replace(invis, "")
+    if not s and template:
+        # PTK's pygments formatter produces no ANSI for Color.RESET tokens
+        # (it treats RESET as "no style").  Fall back to direct ANSI conversion.
+        from xonsh.ansi_colors import ansi_partial_color_format
+
+        style = env.get("XONSH_COLOR_STYLE")
+        s = ansi_partial_color_format(invis + template + invis, hide=False, style=style)
+        s = s.replace(invis, "")
     return s
 
 


### PR DESCRIPTION
Fixed #5489

PTK shell's format_color uses partial_color_tokenize (from style_tools.py) which starts with color = Color.RESET. When the template is just {RESET}, the tokenizer sees no color change (RESET → RESET), produces no ANSI escape code, and returns an empty string — so the postfix is silently dropped. We need to use ansi_partial_color_format for RESET.

### Before

```xsh
$XONSH_CAPTURE_ALWAYS = True
$XONSH_STDERR_PREFIX = "{YELLOW}"
$XONSH_STDERR_POSTFIX = "{RESET}"  
```

<img width="1196" height="370" alt="image" src="https://github.com/user-attachments/assets/bc821c33-beca-4da0-bc44-7761f5733d5a" />

### After

<img width="596" height="157" alt="image" src="https://github.com/user-attachments/assets/3163b8a9-02bd-4ce8-95b1-cafcc72be873" />


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
