### PR TITLE
fix(import): Fixed CPython sys_path_init requrement to have current directory in sys path for executed script

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -862,6 +862,25 @@ def test_single_command_no_windows(cmd, fmt, exp):
 
 
 @skip_if_no_xonsh
+def test_script_local_import(tmp_path):
+    """xonsh script-file should add script dir to sys.path like CPython does."""
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "mod.py").write_text("X = 42\n")
+    script = tmp_path / "run.py"
+    script.write_text("import pkg.mod\nprint(pkg.mod.X)\n")
+    out, err, rtn = run_xonsh(
+        None,
+        stdin=None,
+        args=["--no-rc", str(script)],
+        stderr=sp.PIPE,
+    )
+    assert rtn == 0, f"stderr: {err}"
+    assert out.strip() == "42"
+
+
+@skip_if_no_xonsh
 def test_eof_syntax_error():
     """Ensures syntax errors for EOF appear on last line."""
     script = "x = 1\na = (1, 0\n"

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -618,9 +618,14 @@ def main_xonsh(args):
                 env.update(make_args_env())  # $ARGS is not sys.argv
                 env["XONSH_SOURCE"] = path
                 shell.ctx.update({"__file__": args.file, "__name__": "__main__"})
+                # Add script directory to sys.path[0], matching CPython behavior.
+                # See https://docs.python.org/3/library/sys_path_init.html
+                script_dir = os.path.dirname(path)
+                sys.path.insert(0, script_dir)
                 exc_info = run_script_with_cache(
                     args.file, shell.execer, glb=shell.ctx, loc=None, mode="exec"
                 )
+                sys.path.remove(script_dir)
             else:
                 print(f"xonsh: {args.file}: No such file.")
                 exit_code = 1


### PR DESCRIPTION
### Requirement

CPython — https://docs.python.org/3/library/sys_path_init.html:

>The first entry in the module search path is the directory that contains the input script, if there is one.

### Before

```xsh
mkdir -p /tmp/123
cd /tmp/123
mkdir -p pkg

echo "print('hello')" > pkg/importme.py
echo "import pkg.importme" > run.py

python run.py
# hello 🟢 

xonsh run.py
# ModuleNotFoundError: No module named 'pkg' 🔴 
```

### After

```xsh
python run.py
# hello 🟢 

xonsh run.py
# hello 🟢 
```

Fixed https://github.com/xonsh/xonsh/issues/5291

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
