### PR TITLE
fix(parser): FIxed ValueError error in typed inline env variables e.g. `$QWE=False xonsh --no-rc`

### DIFF
--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -2578,6 +2578,18 @@ def test_leading_envvar_assignment(check_xonsh_ast):
     check_xonsh_ast({}, "![$FOO='foo' $BAR=2 echo r'$BAR']", False)
 
 
+def test_leading_envvar_assignment_bool(check_xonsh_ast):
+    check_xonsh_ast({}, "![$QWE=False echo 1]", False)
+
+
+def test_leading_envvar_assignment_true(check_xonsh_ast):
+    check_xonsh_ast({}, "![$QWE=True echo 1]", False)
+
+
+def test_leading_envvar_assignment_none(check_xonsh_ast):
+    check_xonsh_ast({}, "![$QWE=None echo 1]", False)
+
+
 def test_echo_comma(check_xonsh_ast):
     check_xonsh_ast({}, "![echo ,]", False)
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2467,12 +2467,23 @@ class BaseParser:
         """
         p[0] = p[1]
 
+    _NAME_CONST_MAP = {"True": True, "False": False, "None": None}
+
     def p_atom_name(self, p):
         """atom : name"""
         p1 = p[1]
-        p[0] = ast.Name(
-            id=p1.value, ctx=ast.Load(), lineno=p1.lineno, col_offset=p1.lexpos
-        )
+        # In subproc mode, True/False/None may arrive as NAME instead of
+        # keyword tokens.  Emit ast.Constant so compile() doesn't reject them.
+        if p1.value in self._NAME_CONST_MAP:
+            p[0] = ast.const_name(
+                value=self._NAME_CONST_MAP[p1.value],
+                lineno=p1.lineno,
+                col_offset=p1.lexpos,
+            )
+        else:
+            p[0] = ast.Name(
+                id=p1.value, ctx=ast.Load(), lineno=p1.lineno, col_offset=p1.lexpos
+            )
 
     def p_atom_ellip(self, p):
         """atom : ellipsis_tok"""


### PR DESCRIPTION
Fixed https://github.com/xonsh/xonsh/issues/5313

### Before

```xsh
$QWE=False xonsh --no-rc
# ValueError: identifier field can't represent 'False' constant
```

### After

```xsh
$QWE=False xonsh --no-rc
$QWE
# 'False'

$AUTO_SUGGEST=True xonsh --no-rc
$AUTO_SUGGEST
# True
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
