### PR TITLE
Fix #6129: Question mark support for env variables

### DIFF
--- a/tests/completers/test_environment_completer.py
+++ b/tests/completers/test_environment_completer.py
@@ -28,7 +28,7 @@ def test_simple(cmd, xession, monkeypatch, parser):
         assert lprefix == 5
     else:
         assert lprefix == 4
-    assert set(comps) == {"$WOWZER"}
+    assert set(comps) == {"$WOWZER", "$WOWZER?"}
 
 
 def test_rich_completions(xession, monkeypatch, parser):
@@ -39,3 +39,29 @@ def test_rich_completions(xession, monkeypatch, parser):
     completion = next(complete_environment_vars(context)[0])
     assert completion.display == "$WOWZER [int]"
     assert completion.description == "Nice Docs!"
+
+
+def test_question_mark_completions(xession, monkeypatch, parser):
+    """$VAR? completions should include type and default in description."""
+    xession.env.update({"WOWZER": 1})
+    xession.env.register("WOWZER", type=int, doc="Nice Docs!")
+
+    context = parser.parse("$WOW", 4)
+    comps = list(complete_environment_vars(context)[0])
+    help_comp = next(c for c in comps if str(c) == "$WOWZER?")
+    assert help_comp.display == "$WOWZER? [int]"
+    assert "Nice Docs!" in help_comp.description
+    assert "int" in help_comp.description
+
+
+def test_question_mark_prefix(xession, monkeypatch, parser):
+    """Typing $VAR? as prefix should complete to $VAR (and $VAR?)."""
+    xession.env.update({"WOWZER": 1})
+    xession.env.register("WOWZER", type=int, doc="Nice Docs!")
+
+    context = parser.parse("$WOWZER?", 8)
+    result = complete_environment_vars(context)
+    assert result is not None
+    comps, lprefix = result
+    comp_set = set(comps)
+    assert "$WOWZER" in comp_set

--- a/xonsh/completers/environment.py
+++ b/xonsh/completers/environment.py
@@ -28,12 +28,29 @@ def complete_environment_vars(context: CompletionContext):
         lprefix += 1
     env = XSH.env
 
-    vars = [k for k, v in env.items() if key.lower() in k.lower()]
-    return (
-        RichCompletion(
-            "$" + k,
-            display=f"${k} [{type(env[k]).__name__}]",
-            description=env.get_docs(k).doc,
-        )
-        for k in vars
-    ), lprefix
+    # Strip trailing '?' to support "$VAR?" help completions
+    help_query = key.endswith("?")
+    search_key = key[:-1] if help_query else key
+
+    vars = [k for k, v in env.items() if search_key.lower() in k.lower()]
+
+    def _completions():
+        for k in vars:
+            vd = env.get_docs(k)
+            type_name = type(env[k]).__name__
+            yield RichCompletion(
+                "$" + k,
+                display=f"${k} [{type_name}]",
+                description=vd.doc,
+            )
+            if not help_query:
+                doc_str = vd.doc
+                default_str = vd.doc_default
+                desc = f"{doc_str} | Type: {type_name} | Default: {default_str}"
+                yield RichCompletion(
+                    "$" + k + "?",
+                    display=f"${k}? [{type_name}]",
+                    description=desc,
+                )
+
+    return _completions(), lprefix


### PR DESCRIPTION
Closes #6129

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.

🤖 If your code was generated by AI/LLM tell about this directly.
🤖 Ask AI/LLM about putting functions/modules to `<module>_llm.py` files instead of using directly into the code.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**

## What this does

Adds `$VAR?` completions to the environment variable completer (`xonsh/completers/environment.py`). When tab-completing an environment variable, the completer now yields two entries per match:

- `$VAR` — existing behavior, with `[type]` display and `.doc` description
- `$VAR?` — new help-query completion, with `[type]` display and a richer description combining doc string, type name, and default value (e.g. `Nice Docs! | Type: int | Default: 0`)

Also handles the case where the user has already typed `$VAR?` as a prefix: the trailing `?` is stripped before the key search (`search_key = key[:-1] if help_query else key`), so matching still works and `$VAR` appears in the completion list.

## Before / After

**Before:**
```
$ $WOW<Tab>
$WOWZER
```

**After:**
```
$ $WOW<Tab>
$WOWZER        # display: $WOWZER [int]  | description: Nice Docs!
$WOWZER?       # display: $WOWZER? [int] | description: Nice Docs! | Type: int | Default: 0
```

## Changes

- `xonsh/completers/environment.py`: Refactored `complete_environment_vars` to use an inner generator `_completions()`. Added `help_query` detection, `search_key` stripping, and conditional `$VAR?` `RichCompletion` emission using `vd.doc`, `vd.doc_default`, and `type(env[k]).__name__`.
- `tests/completers/test_environment_completer.py`: Updated `test_simple` expected set to include `$WOWZER?`. Added `test_question_mark_completions` (verifies display and description content for `$WOWZER?`) and `test_question_mark_prefix` (verifies that typing `$WOWZER?` as a prefix still returns `$WOWZER` in completions).

🤖 This PR was generated with AI assistance.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*