### PR TITLE
feat: CommandPipeline: Add `pipecode` and `pipestatus`

### DIFF
--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -926,10 +926,7 @@ class CommandPipeline:
     @property
     def pipestatus(self):
         """Return codes of all commands in the pipeline."""
-        return [
-            None if p is None else p.returncode
-            for p in self.procs
-        ]
+        return [None if p is None else p.returncode for p in self.procs]
 
     @property
     def pipecode(self):


### PR DESCRIPTION
In other shells there is distinction between status of last command and the overall pipe status. So let's implement the same.

```xsh
p = !(false | true | true)
p.end()
p.returncode
# 0
p.pipecode
# 1
p.pipestatus
# [1, 0, 0]
```
```xsh
p = !(false | false | false)
p.end()
p.returncode
# 1
p.pipecode
# 1
p.pipestatus
# [1, 1, 1]
```
```xsh
p = !(true | true | true)
p.end()
p.returncode
# 0
p.pipecode
# 0
p.pipestatus
# [0, 0, 0]
```

cc https://github.com/xonsh/xonsh/issues/4351

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
