### PR TITLE
fix: glob: Remove legacy glob logic that produced issue

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1867,6 +1867,63 @@ def test_iglobpath_dotfiles_recursive(xession):
     assert d + "/bin/.someotherdotfile" in files
 
 
+@pytest.fixture
+def glob_tree(tmp_path):
+    """Create a directory tree for glob tests.
+
+    Structure:
+        tmp/f.ile
+        tmp/.hidden
+        tmp/a/f.ile
+        tmp/a/.hidden
+        tmp/a/b/f.ile
+    """
+    (tmp_path / "a" / "b").mkdir(parents=True)
+    (tmp_path / "f.ile").touch()
+    (tmp_path / ".hidden").touch()
+    (tmp_path / "a" / "f.ile").touch()
+    (tmp_path / "a" / ".hidden").touch()
+    (tmp_path / "a" / "b" / "f.ile").touch()
+    return tmp_path
+
+
+def _glob(glob_tree, pattern, **kwargs):
+    return sorted(iglobpath(str(glob_tree / pattern), **kwargs))
+
+
+def _paths(glob_tree, *relative):
+    return sorted(str(glob_tree / r) for r in relative)
+
+
+class TestIglobpathRecursive:
+    """Tests for ** recursive globbing (issue #4538)."""
+
+    def test_zero_intermediate_dirs(self, glob_tree, xession):
+        """**/f.ile must match f.ile at root (zero intermediate dirs)."""
+        assert _glob(glob_tree, "**/f.ile") == _paths(
+            glob_tree, "a/b/f.ile", "a/f.ile", "f.ile"
+        )
+
+    def test_trailing_doublestar(self, glob_tree, xession):
+        """/** must match all entries recursively."""
+        files = _glob(glob_tree, "**")
+        for expected in ["a", "a/b", "a/b/f.ile", "a/f.ile", "f.ile"]:
+            assert str(glob_tree / expected) in files
+
+    def test_doublestar_with_wildcard(self, glob_tree, xession):
+        """/**/*.ile must also match at root level."""
+        assert _glob(glob_tree, "**/*.ile") == _paths(
+            glob_tree, "a/b/f.ile", "a/f.ile", "f.ile"
+        )
+
+    @skip_if_on_windows
+    def test_dotfiles_zero_intermediate_dirs(self, glob_tree, xession):
+        """**/. pattern with include_dotfiles must match dotfiles at root."""
+        files = _glob(glob_tree, "**/.*", include_dotfiles=True)
+        assert str(glob_tree / ".hidden") in files
+        assert str(glob_tree / "a/.hidden") in files
+
+
 def test_iglobpath_empty_str(monkeypatch, xession):
     # makes sure that iglobpath works, even when os.scandir() and os.listdir()
     # fail to return valid results, like an empty filename

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2492,19 +2492,6 @@ def globpath(
     return o if len(o) != 0 else no_match
 
 
-def _dotglobstr(s):
-    modified = False
-    dotted_s = s
-    if "/*" in dotted_s:
-        dotted_s = dotted_s.replace("/*", "/.*")
-        dotted_s = dotted_s.replace("/.**/.*", "/**/.*")
-        modified = True
-    if dotted_s.startswith("*") and not dotted_s.startswith("**"):
-        dotted_s = "." + dotted_s
-        modified = True
-    return dotted_s, modified
-
-
 def _iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
     s = xsh.expand_path(s)
     if sort_result is None:
@@ -2513,20 +2500,11 @@ def _iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
         include_dotfiles = xsh.env.get("DOTGLOB")
     if ignore_case:
         s = expand_case_matching(s)
-    if "**" in s and "**/*" not in s:
-        s = s.replace("**", "**/*")
-    if include_dotfiles:
-        dotted_s, dotmodified = _dotglobstr(s)
+    kwargs = {"recursive": True, "include_hidden": include_dotfiles or False}
     if sort_result:
-        paths = glob.glob(s, recursive=True)
-        if include_dotfiles and dotmodified:
-            paths.extend(glob.iglob(dotted_s, recursive=True))
-        paths.sort()
-        paths = iter(paths)
+        paths = iter(sorted(glob.glob(s, **kwargs)))
     else:
-        paths = glob.iglob(s, recursive=True)
-        if include_dotfiles and dotmodified:
-            paths = itertools.chain(glob.iglob(dotted_s, recursive=True), paths)
+        paths = glob.iglob(s, **kwargs)
     return paths, s
 
 


### PR DESCRIPTION
### Legacy issue

The `**` → `**/*` replacement in `_iglobpath` and the `_dotglobstr` helper were introduced in PR #734 (2016) when xonsh still supported Python 3.4, which had no `recursive=True` in `glob.glob` — `**` was meaningless to  glob, so the code manually rewrote patterns to emulate recursion. Over time this became the source of issue #4538: the replacement turned `test/**/f.ile` into `test/**/*/f.ile`, requiring at least one intermediate directory and preventing matches at zero depth. Since xonsh now requires Python >= 3.11, both `recursive=True` (3.5+) and `include_hidden=True` (3.11+) are available natively, making the manual pattern rewriting and the `_dotglobstr` workaround unnecessary. Removing them and passing these flags directly to `glob.glob` fixes the bug and simplifies the code.


### Example
```xsh
cd /tmp                                                                                                         
mkdir -p test/a/b                                               
touch test/f.ile test/a/f.ile test/a/b/f.ile                                                                    
touch test/.hidden test/a/.hidden                                                                               
                                                        
g`test/**/f.ile`  # expected: ['test/a/b/f.ile', 'test/a/f.ile', 'test/f.ile']                                                    
g`test/**`        # expected: all files and dirs recursively                      
g`test/**/*.ile`  # # expected: ['test/a/b/f.ile', 'test/a/f.ile', 'test/f.ile']                                                    

$DOTGLOB = True
g`test/**/.*`  # # expected: includes test/.hidden and test/a/.hidden


# ['test/a/b/f.ile', 'test/a/f.ile', 'test/f.ile']
# ['test/', 'test/a', 'test/a/b', 'test/a/b/f.ile', 'test/a/f.ile', 'test/f.ile']
# ['test/a/b/f.ile', 'test/a/f.ile', 'test/f.ile']
# ['test/.hidden', 'test/a/.hidden']
```

Fixed https://github.com/xonsh/xonsh/issues/4538

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
