### PR TITLE
feat: Add `$XONSH_SUBPROC_ARG_EXPANDUSER` to ability to switch expanding off

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1733,6 +1733,24 @@ def test_expand_path(expand_user, inp, expand_env_vars, exp_end, xession):
         assert path == "~" + exp_end
 
 
+@pytest.mark.parametrize(
+    "inp, exp_expanded, exp_literal",
+    [
+        ("~/docs", os.path.expanduser("~") + "/docs", "~/docs"),
+        ("~", os.path.expanduser("~"), "~"),
+        ("x=~/path", "x=" + os.path.expanduser("~") + "/path", "x=~/path"),
+        ("no-tilde", "no-tilde", "no-tilde"),
+    ],
+)
+def test_expand_path_expanduser_toggle(inp, exp_expanded, exp_literal, xession):
+    """$XONSH_SUBPROC_ARG_EXPANDUSER controls ~ expansion in subprocess args."""
+    xession.env["XONSH_SUBPROC_ARG_EXPANDUSER"] = True
+    assert expand_path(inp) == exp_expanded
+
+    xession.env["XONSH_SUBPROC_ARG_EXPANDUSER"] = False
+    assert expand_path(inp) == exp_literal
+
+
 def test_swap_values():
     orig = {"x": 1}
     updates = {"x": 42, "y": 43}

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1508,6 +1508,13 @@ class InterpreterSetting(Xettings):
         "Toggles whether environment variables are expanded inside of strings "
         "in subprocess mode.",
     )
+    XONSH_SUBPROC_ARG_EXPANDUSER = Var.with_default(
+        True,
+        "If True, ``~`` and ``~user`` in subprocess arguments are expanded to "
+        "home directories (e.g. ``~/docs`` → ``/home/user/docs``, "
+        "``~bob/docs`` → ``/home/bob/docs``). "
+        "Set to False to pass ``~`` through as a literal character.",
+    )
     FOREIGN_ALIASES_SUPPRESS_SKIP_MESSAGE = Var.with_default(
         False,
         "Whether or not foreign aliases should suppress the message "

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -139,7 +139,7 @@ def expand_path(s, expand_user=True):
     env = xsh.env or os_environ
     if env.get("EXPAND_ENV_VARS", False):
         s = expandvars(s)
-    if expand_user:
+    if expand_user and env.get("XONSH_SUBPROC_ARG_EXPANDUSER", True):
         # expand ~ according to Bash unquoted rules "Each variable assignment is
         # checked for unquoted tilde-prefixes immediately following a ':' or the
         # first '='". See the following for more details.


### PR DESCRIPTION
Related to https://github.com/xonsh/xonsh/issues/5970

We have a behavior that was implemented based on POISX shells logic:  expand `~` and `~username` to `/home/username` implicitly. Those shells, unlike xonsh, there are huge amount of implicit logic that we love like differences `QWE=~asd`, `QWE='~asd'`, `echo $QWE`, `echo "$QWE"`, etc.

I think "user expanding" is another feature that was made to please traditional command shells.
In this PR I introduced XONSH_SUBPROC_ARG_EXPANDUSER to make this shit visible and we will think what to do with this later.

------------------------------------

Yes, I think it was made to support things like `cmd VAR=~/dir`. But my current thoughts are about this should work explicit in the future so if you have direct intention to use expansion you can have an ability to write `cmd e"VAR=~/dir"` or something like this. 

The main thougt that I'm staying here: in xonsh we must have an ability to write things totally explicit. For example we need to have an ability to write:

```xsh
$XONSH_SUBPROC_ARG_EXPANDUSER = False
from xonsh.tools import expanduser as exp

cmd ~args
cmd @(exp("ARG=~user/VAR"))
cmd ~args
```
And this PR is the step to this world.

cc 
* https://github.com/xonsh/xonsh/issues/4654

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
