### PR TITLE
feat: Prompt: Added `Ctrl+C` in selection mode to copy selected text

### DIFF
--- a/docs/keyboard_shortcuts.rst
+++ b/docs/keyboard_shortcuts.rst
@@ -15,15 +15,11 @@ Editing
     * - Shortcut
       - Description
     * - ``Ctrl-C``
-      - Cancel the current command entry.
+      - Cancel the current command if nothing is selected.
     * - ``Shift-Left`` or ``Shift-Right``
       - Select one character in either direction.
     * - ``Ctrl-Shift-Left`` or ``Ctrl-Shift-Right``
       - Select one word in either direction.
-    * - ``Ctrl-X + Ctrl-C``
-      - Copy highlighted section.
-    * - ``Ctrl-X + Ctrl-X``
-      - Cut highlighted section.
     * - ``Ctrl-V``
       - Paste clipboard contents.
     * - ``Ctrl-Backspace`` or ``Ctrl-H``
@@ -32,10 +28,15 @@ Editing
       - Open the current buffer in your default text editor.
     * - ``Ctrl-Right``
       - Complete a single auto-suggestion word.
+    * - ``Shift+Enter``
+      - Start new line without execution.
+        Terminal must support xterm modifyOtherKeys mode 1 or Kitty keyboard protocol.
 
 
-Indentation
------------
+Selection Actions
+-----------------
+
+The following shortcuts work when text is selected (e.g. via ``Shift+Arrow`` keys):
 
 .. list-table::
     :widths: 40 60
@@ -43,12 +44,18 @@ Indentation
 
     * - Shortcut
       - Description
-    * - ``Shift+Enter``
-      - Start new line without execution. Terminal need to support xterm modifyOtherKeys mode 1 or Kitty keyboard protocol.
-    * - Selection + ``Tab``
-      - Indentation selected lines.
-    * - Selection + ``Shift+Tab``
-      - Unindentation selected lines.
+    * - ``Ctrl-C``
+      - Copy selected text.
+    * - ``Ctrl-X + Ctrl-C``
+      - Copy selected text (alternative).
+    * - ``Ctrl-X + Ctrl-X``
+      - Cut selected text.
+    * - ``Tab``
+      - Indent selected lines.
+    * - ``Shift+Tab``
+      - Unindent selected lines.
+    * - ``Escape``
+      - Cancel selection.
 
 Execution
 ---------

--- a/xonsh/shells/ptk_shell/key_bindings.py
+++ b/xonsh/shells/ptk_shell/key_bindings.py
@@ -493,6 +493,12 @@ def load_xonsh_bindings(ptk_bindings: KeyBindingsBase) -> KeyBindingsBase:
         data = event.current_buffer.copy_selection()
         event.app.clipboard.set_data(data)
 
+    @handle(Keys.ControlC, filter=has_selection)
+    def _copy_or_sigint(event):
+        """Copy selected text on Ctrl+C if there is a selection."""
+        data = event.current_buffer.copy_selection()
+        event.app.clipboard.set_data(data)
+
     @handle(Keys.ControlV, filter=insert_mode | has_selection)
     def _yank(event):
         """Paste selected text."""


### PR DESCRIPTION
We already have `Ctrl+V` to paste so having `Ctrl+C` in selection mode looks consistent.

cc https://github.com/xonsh/xonsh/issues/6213

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
