### PR TITLE
feat!: Error handling now supports logical operations, and raising exceptions for chains is enabled by default.

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -159,13 +159,17 @@ Command Decorators (Decorator Aliases)
 
 ``@error_raise`` and ``@error_ignore``
 ----------------------------------------
-Use ``@error_raise`` to raise an exception if the command returns a non-zero exit code.
-The behavior is similar with ``$RAISE_SUBPROC_ERROR``. Use ``@error_ignore`` for explicit disable that.
+Use ``@error_raise`` to raise an exception if the command returns a non-zero exit code —
+similar to ``$XONSH_SUBPROC_CMD_RAISE_ERROR`` but scoped to a single command, and it
+raises unconditionally (even inside ``&&``/``||`` chains and even when
+``$XONSH_SUBPROC_RAISE_ERROR`` is disabled).  Use ``@error_ignore`` to explicitly suppress
+the raise — it also wins over the chain-result check performed by
+``$XONSH_SUBPROC_RAISE_ERROR``.
 
 .. code-block:: console
 
     @ r = !(@error_raise ls nonono)
-    subprocess.CalledProcessError: Command '['@error_raise', 'ls', 'nonono']' returned non-zero exit status 1.
+    Error: Command '['@error_raise', 'ls', 'nonono']' returned non-zero exit status 1.
 
     @ r = !(@error_ignore ls nonono)
 

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -169,7 +169,7 @@ the raise — it also wins over the chain-result check performed by
 .. code-block:: console
 
     @ r = !(@error_raise ls nonono)
-    Error: Command '['@error_raise', 'ls', 'nonono']' returned non-zero exit status 1.
+    subprocess.CalledProcessError: Command '['@error_raise', 'ls', 'nonono']' returned non-zero exit status 1.
 
     @ r = !(@error_ignore ls nonono)
 

--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -87,9 +87,13 @@ This page provides xonsh equivalents for common patterns in Bash.
       - ``p'/path/to/file'.exists()`` or ``pf'{file}'.exists()`` or ``if !(test -f $FILE):``
       - Path objects can be instantiated and checked directly using p-string syntax.
     * - ``set -e``
-      - ``$RAISE_SUBPROC_ERROR = True``
-      - Cause a failure after a non-zero return code. Xonsh will raise a
-        ``supbrocess.CalledProcessError``.
+      - ``$XONSH_SUBPROC_RAISE_ERROR = True`` *(default)*
+      - Cause a failure after a non-zero return code of the *final* command
+        in a statement — this matches bash's ``set -e`` semantics where
+        intermediate failures inside ``&&``/``||`` chains are allowed.
+        Xonsh will raise a ``subprocess.CalledProcessError``. Use
+        ``$XONSH_SUBPROC_CMD_RAISE_ERROR = True`` to additionally raise on
+        *every* failing individual command.
     * - ``set -x``
       - ``trace on`` and ``$XONSH_TRACE_SUBPROC = True``
       - Turns on tracing of source code lines during execution.

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -52,6 +52,7 @@ and streamline your command-line experience.
     prompt
     events
     globbing
+    error_handling
     macros
     xonsh_session
     Open technical issue <https://github.com/xonsh/xonsh>

--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -1,0 +1,393 @@
+.. _error_handling:
+
+Subprocess Error Handling
+=========================
+
+Xonsh treats shell commands as first-class code.  When a command fails,
+you usually want your script to **stop** instead of silently marching
+past the failure — the way a Python exception would — but you also want
+the flexibility of ``&&``/``||`` short-circuit logic that
+the shell is built around.
+
+This page walks through the rules xonsh uses to decide *when* a failing
+subprocess raises a ``subprocess.CalledProcessError``, how those rules
+interact with pipes, logical operators, captured forms and per-command
+decorators, and how the interactive prompt displays (or hides) the
+resulting exception.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Chains
+------
+
+To describe where exceptions are raised we use the word **chain** for a
+grouping of subprocess commands that produces a single result:
+
+* **single chain** — one plain command: ``ls file``
+* **pipe chain** — commands joined with ``|``: ``echo 1 | grep 1 | head``
+* **logical chain** — commands joined with ``&&``/``||``:
+  ``ls file1 || ls file2 || echo gone``
+
+Statements separated by ``;`` or newlines are *independent* chains.
+For example, ``echo 1 && echo 2 ; echo 3 ; echo 1 | grep 1`` contains
+**three** chains.
+
+Xonsh decides whether to raise *per chain*, not per individual command,
+which is what gives ``||``/``&&`` their shell-like rescue semantics:
+
+.. code-block:: xonshcon
+
+    @ ls /no || echo rescued            # one chain, rescued by ||
+    ls: cannot access '/no': No such file or directory
+    rescued                              # no exception
+
+    @ echo 1 && ls /no && echo never    # one chain, ends on a failing ls
+    1
+    ls: cannot access '/no': No such file or directory
+    # CalledProcessError (the chain as a whole failed)
+
+    @ echo a ; ls /no ; echo b           # three chains; second fails, third never runs
+    a
+    ls: cannot access '/no': No such file or directory
+    # CalledProcessError on the second chain
+
+
+Environment variables
+---------------------
+
+Xonsh exposes three knobs for error handling.  The first two control
+**whether** a subprocess failure raises; the third controls **display
+of the exception** at the interactive prompt.
+
+``$XONSH_SUBPROC_RAISE_ERROR`` — default ``True``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Raises ``subprocess.CalledProcessError`` when the **final result of a
+chain** is a non-zero exit code.  This is the rule that makes xonsh
+scripts behave like Python: a failing command stops execution unless
+you explicitly rescue it with ``||`` or ``@error_ignore``.
+
+* ``ls /no`` → raises (single chain, failed)
+* ``ls /no | grep root`` → raises (pipe chain, final stage failed)
+* ``ls /no || echo ok`` → **no** raise (logical chain rescued by ``||``)
+* ``echo 1 && ls /no`` → raises (chain ends on failing ``ls``)
+* ``(echo 1 && ls /etc) || echo fb`` → no raise (outer ``||`` rescued
+  by a successful inner chain)
+
+``$XONSH_SUBPROC_CMD_RAISE_ERROR`` — default ``False``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Raises on **every** failing command regardless of chain context — any
+non-zero exit is fatal.  When ``True`` it short-circuits chain
+semantics: ``ls /no || echo fb`` would raise on ``ls``, the ``||``
+fallback never runs.
+
+Reserved for scripts that really want "fail fast on anything".  The old
+name ``$RAISE_SUBPROC_ERROR`` is kept as a deprecated alias that syncs
+to ``XONSH_SUBPROC_CMD_RAISE_ERROR``.
+
+``$XONSH_PROMPT_SHOW_SUBPROC_ERROR`` — default ``False``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is a **display** flag — it does not change whether an exception
+is raised, only whether the **interactive prompt** prints xonsh's
+``subprocess.CalledProcessError: ...`` line after the command's own
+``stderr``.  The command's own ``stderr`` is always visible because
+the subprocess writes it directly to the terminal.
+
+* ``False`` *(default)* — interactive prompt stays quiet after a
+  failed command.  You see the command's ``stderr``, the prompt
+  returns, and ``$LAST_RETURN_CODE`` reflects the failure.
+* ``True`` — restores the historical behavior of printing
+  ``subprocess.CalledProcessError: Command '...' returned non-zero
+  exit status N.`` under the command's own output.
+
+Non-interactive scripts (``./script.xsh``, ``xonsh -c``) are
+**unaffected** — they always show the exception, because in script
+mode you usually want to know which line blew up.
+
+The per-command ``@error_raise`` decorator **always** shows the
+exception regardless of this flag — it is the explicit per-command
+opt-in.
+
+
+Captured subprocess ``!()`` is the only exemption
+--------------------------------------------------
+
+Every subprocess form raises on a non-zero return code by default —
+bare commands, ``![...]``, ``$[...]``, ``$(...)``, ``@$(...)``.  The
+**only** exception is the full-capture form ``!(...)``: it returns a
+``CommandPipeline`` object and xonsh leaves error handling entirely
+up to you.
+
+.. code-block:: xonshcon
+
+    @ ls nofile            # exception
+    @ $(ls nofile)         # exception
+    @ $[ls nofile]         # exception
+    @ ![ls nofile]         # exception
+
+    @ !(ls nofile)         # no exception — returns a CommandPipeline
+
+``!(...)`` is designed to be tested directly, because
+``CommandPipeline`` is truthy when the command succeeded and falsy
+when it failed:
+
+.. code-block:: xonshcon
+
+    @ if !(ls nofile):
+          print("found")
+      else:
+          print("absent")
+    absent
+
+If you want a specific ``!(...)`` call to raise anyway, use the
+``@error_raise`` decorator inside it — the decorator wins over the
+``!()`` exemption:
+
+.. code-block:: xonshcon
+
+    @ if !(@error_raise ls nofile):
+          print("found")
+    # CalledProcessError — @error_raise overrides the !() exemption
+
+
+Per-command decorators
+----------------------
+
+Two decorator aliases give you an escape hatch that is scoped to a
+single command inside a larger chain.
+
+``@error_raise`` — always raise
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Force ``subprocess.CalledProcessError`` on this command, regardless of
+``$XONSH_SUBPROC_RAISE_ERROR``, ``$XONSH_SUBPROC_CMD_RAISE_ERROR``, or
+whether the command sits inside a normally-rescuing chain:
+
+.. code-block:: xonshcon
+
+    @ @error_raise ls /no || echo fb
+    # CalledProcessError — @error_raise wins over ||
+
+    @ !(@error_raise ls /no)
+    # CalledProcessError — @error_raise wins over !() exemption too
+
+It also **always** shows the exception at the interactive prompt,
+overriding ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR = False``.
+
+``@error_ignore`` — never raise
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The inverse — the command *never* raises, no matter the environment
+settings or chain position:
+
+.. code-block:: xonshcon
+
+    @ @error_ignore ls /no
+    ls: cannot access '/no': No such file or directory
+    # no exception
+
+    @ echo 1 && @error_ignore ls /no && echo 2
+    1
+    ls: cannot access '/no': No such file or directory
+    # no exception; the `@error_ignore` also makes the chain
+    # treat the failing ls as "don't raise on this final operand"
+
+``@error_ignore`` is especially handy when you want a command to
+contribute to the chain's return code but **not** its error behavior:
+
+.. code-block:: xonshcon
+
+    @ echo 1 | @error_ignore grep pattern | wc -l
+    0
+    # grep returns 1 (no match), @error_ignore keeps the pipe quiet,
+    # wc happily prints 0
+
+
+Putting it all together: resolution order
+------------------------------------------
+
+When a subprocess finishes with a non-zero exit, xonsh walks a small
+decision tree to decide whether to raise:
+
+1. **``rc == 0``** → never raise.
+2. **``@error_ignore``** was applied (``spec.raise_subproc_error is False``)
+   → never raise.
+3. **``@error_raise``** was applied (``spec.raise_subproc_error is True``)
+   → raise immediately, overriding everything.
+4. **Inside an ``&&``/``||`` chain** (``spec.in_boolop is True``) → do
+   not raise at the pipeline level; let the chain short-circuit and
+   let the chain wrapper decide based on the *final* chain result.
+5. **``$XONSH_SUBPROC_CMD_RAISE_ERROR is True``** → raise on this
+   command immediately (fail-fast on every command).
+6. Otherwise defer to the **chain wrapper**
+   (``subproc_check_boolop``) which consults
+   ``$XONSH_SUBPROC_RAISE_ERROR``:
+
+   * If the final chain value is ``!(...)`` (``spec.captured ==
+     'object'``) → never raise.
+   * If the flag is ``False`` → never raise.
+   * Else if the final chain pipeline has ``rc != 0`` (and ``@error_ignore``
+     wasn't applied) → raise ``subprocess.CalledProcessError``.
+
+The same wrapper is placed around standalone subproc statements at
+parse time (by
+``xonsh.parsers.base.wrap_subproc_raise_checks``), so *every* subproc
+statement — single, pipe, or logical chain — goes through the same
+final-result check.
+
+Once the exception is raised, display is a separate concern:
+
+* **Non-interactive** (script from file / stdin / ``-c``): the
+  exception propagates and is printed via ``print_exception`` as any
+  other Python exception would be.  ``$XONSH_SHOW_TRACEBACK`` decides
+  whether to include a full Python traceback.
+* **Interactive prompt**: ``BaseShell.default()`` catches
+  ``subprocess.CalledProcessError`` and consults
+  ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR`` (with ``@error_raise`` always
+  winning) before deciding whether to print the exception.  Either
+  way ``$LAST_RETURN_CODE`` is updated.
+
+
+Catching the exception
+----------------------
+
+The raised exception is a plain ``subprocess.CalledProcessError``, so
+the usual Python idioms work:
+
+.. code-block:: xonshcon
+
+    @ import subprocess
+    @ try:
+          ls /no
+      except subprocess.CalledProcessError as e:
+          print("rc =", e.returncode)
+          print("cmd =", e.cmd)
+    ls: cannot access '/no': No such file or directory
+    rc = 2
+    cmd = ['ls', '/no']
+
+For scoped overrides, ``env.swap`` is often cleaner than catching:
+
+.. code-block:: xonshcon
+
+    @ with @.env.swap(XONSH_SUBPROC_RAISE_ERROR=False):
+          ls /no
+    ls: cannot access '/no': No such file or directory
+    # no exception, even though the default is True
+
+For **captured iteration** there is also ``CommandPipeline.itercheck()``
+which raises ``XonshCalledProcessError`` (a subclass of
+``subprocess.CalledProcessError`` that additionally carries
+``.completed_command`` and ``.stderr``):
+
+.. code-block:: xonshcon
+
+    @ try:
+          for line in !(grep -R TODO src/).itercheck():
+              print(line.strip())
+      except XonshCalledProcessError as e:
+          print("grep failed with rc", e.returncode)
+
+
+Interactive prompt behavior in detail
+-------------------------------------
+
+With the default ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR = False``:
+
+.. code-block:: xonshcon
+
+    @ ls /no
+    ls: cannot access '/no': No such file or directory
+    @ echo $LAST_RETURN_CODE
+    2
+
+    @ echo hi && ls /no && echo bye
+    hi
+    ls: cannot access '/no': No such file or directory
+    @
+
+With ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR = True``:
+
+.. code-block:: xonshcon
+
+    @ $XONSH_PROMPT_SHOW_SUBPROC_ERROR = True
+    @ ls /no
+    ls: cannot access '/no': No such file or directory
+    subprocess.CalledProcessError: Command '['ls', '/no']' returned non-zero exit status 2.
+    @
+
+``@error_raise`` always shows:
+
+.. code-block:: xonshcon
+
+    @ @error_raise ls /no
+    ls: cannot access '/no': No such file or directory
+    subprocess.CalledProcessError: Command '['@error_raise', 'ls', '/no']' returned non-zero exit status 2.
+    @
+
+
+Frequently asked questions
+--------------------------
+
+**Why did ``ls /no`` just raise in my script?  It used to keep
+going.**
+    The default changed.  ``$XONSH_SUBPROC_RAISE_ERROR`` is now
+    ``True``, which means a failing command is treated like a Python
+    exception by default so failures can't silently slip past and run
+    later code with bad assumptions.  If you want the old "keep
+    going" behavior, set ``$XONSH_SUBPROC_RAISE_ERROR = False`` in
+    your ``.xonshrc``.
+
+**My ``||`` fallback isn't running — I get an exception on the first
+command instead.**
+    You probably have ``$XONSH_SUBPROC_CMD_RAISE_ERROR = True`` (or
+    the legacy ``$RAISE_SUBPROC_ERROR = True``).  That raises on
+    *every* failing command and short-circuits chain evaluation.  The
+    new semantics put rescue logic on
+    ``$XONSH_SUBPROC_RAISE_ERROR`` instead — leave that at its
+    default ``True`` and set ``$XONSH_SUBPROC_CMD_RAISE_ERROR = False``.
+
+**I want one specific command to be fatal even though the rest of the
+script tolerates failures.**
+    Prefix it with ``@error_raise``.  It overrides every other
+    setting.
+
+**I want one specific command to be ignored even when
+``$XONSH_SUBPROC_RAISE_ERROR = True``.**
+    Prefix it with ``@error_ignore``, or wrap it in
+    ``!(...)`` which is exempt by default, or rescue it with
+    ``|| true``.
+
+**At the interactive prompt I want to see the exception like before.**
+    Add ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR = True`` to your
+    ``.xonshrc``.
+
+**My script inside the interactive shell (``source script.xsh``)
+fails silently.**
+    ``source`` runs the script in the current interactive context.
+    The prompt-suppression logic applies to the whole command,
+    including sourced code.  Wrap the risky section with
+    ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR = True`` or run the script
+    standalone via ``./script.xsh``.
+
+**Will setting ``$XONSH_SHOW_TRACEBACK = True`` show the exception
+even when ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR = False``?**
+    No.  ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR`` decides **whether** the
+    exception is shown, ``$XONSH_SHOW_TRACEBACK`` decides **how much**
+    of it is shown once it *is* displayed.  Interactive suppression
+    wins for this particular class of exception.
+
+
+See also
+--------
+
+* :ref:`tutorial` — the scripting section discusses
+  ``$XONSH_SUBPROC_RAISE_ERROR`` in the context of writing robust xonsh
+  scripts.
+* :ref:`aliases` — for ``@error_raise`` / ``@error_ignore`` and other
+  decorator aliases.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1644,9 +1644,14 @@ operates on a given argument, rather than on the string ``'xonsh'`` (notice how
     @ echo @(' '.join($(cat @('file%d.txt' % i)).strip() for i in range(6)))
     s n a i l s
 
-Additionally, if the script should exit if a command fails, set the
-environment variable ``$RAISE_SUBPROC_ERROR = True`` at the top of the
-file. Errors in Python mode will already raise exceptions.
+By default xonsh scripts exit on a failing subprocess: the environment
+variable ``$XONSH_SUBPROC_RAISE_ERROR`` is ``True`` out of the box and
+raises a ``subprocess.CalledProcessError`` whenever the *final* command
+of a statement (or the result of an ``&&``/``||`` chain) returns a
+non-zero exit status.  Set it to ``False`` if you want the old "keep
+going on errors" behavior, or set ``$XONSH_SUBPROC_CMD_RAISE_ERROR =
+True`` to raise on *every* failing command (including intermediate ones
+inside chains).  Errors in Python mode already raise exceptions.
 
 Furthermore, you can also toggle the ability to print source code lines with the
 ``trace on`` and ``trace off`` commands.  This is roughly equivalent to

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1644,18 +1644,53 @@ operates on a given argument, rather than on the string ``'xonsh'`` (notice how
     @ echo @(' '.join($(cat @('file%d.txt' % i)).strip() for i in range(6)))
     s n a i l s
 
-By default xonsh scripts exit on a failing subprocess: the environment
-variable ``$XONSH_SUBPROC_RAISE_ERROR`` is ``True`` out of the box and
-raises a ``subprocess.CalledProcessError`` whenever the *final* command
-of a statement (or the result of an ``&&``/``||`` chain) returns a
-non-zero exit status.  Set it to ``False`` if you want the old "keep
-going on errors" behavior, or set ``$XONSH_SUBPROC_CMD_RAISE_ERROR =
-True`` to raise on *every* failing command (including intermediate ones
-inside chains).  Errors in Python mode already raise exceptions.
-
 Furthermore, you can also toggle the ability to print source code lines with the
 ``trace on`` and ``trace off`` commands.  This is roughly equivalent to
 Python's ``python -m trace``.
+
+Error Handling
+==============
+
+Xonsh treats shell commands as first-class code.  When a command fails,
+you usually want your script to **stop** instead of silently marching
+past the failure — the way a Python exception would — but you also want
+the flexibility of ``&&``/``||`` short-circuit logic that the shell is
+built around.
+
+By default, execution stops as soon as a command **chain** ends in a
+failing command.  A chain is any group of commands whose result is
+determined together — a pipe, a logical ``&&``/``||`` expression, or a
+bare single command.  It is the *final* result of the chain that
+decides whether execution continues; individual commands that are
+explicitly rescued by ``||`` are not fatal.
+
+A couple of examples:
+
+.. code-block:: xonshcon
+
+    @ echo hi | grep x                  # pipe chain — grep didn't match → raise
+    @ ls nofile && echo never           # && chain — ls failed → raise, echo skipped
+    @ ls nofile || echo rescued         # || chain — rescued by echo, no raise
+    rescued
+    @ (echo 1 && ls /etc) || echo fb    # nested — inner chain succeeded, no raise
+
+The **only** subprocess form that does not stop execution on failure
+is the full-capture operator ``!(...)``: it returns a
+``CommandPipeline`` object and leaves error handling entirely up to
+you.  This is the idiomatic way to inspect a command's result without
+triggering an exception:
+
+.. code-block:: xonshcon
+
+    @ if !(ls nofile):
+          print("found")
+      else:
+          print("absent")
+
+See :ref:`error_handling` for the full rules, including
+``@error_raise``/``@error_ignore`` decorators, the environment
+variables that tune this behavior, and how the interactive prompt
+displays (or hides) the resulting exception.
 
 Importing Xonsh (``*.xsh``)
 ==============================

--- a/run-tests.xsh
+++ b/run-tests.xsh
@@ -9,7 +9,7 @@ from xonsh.tools import print_color
 import itertools
 
 
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 # $XONSH_TRACE_SUBPROC = True
 
 

--- a/tests/procs/test_pipelines.py
+++ b/tests/procs/test_pipelines.py
@@ -31,7 +31,7 @@ def patched_events(monkeypatch, xonsh_events, xonsh_session):
     get_tasks().clear()
     # needed for ci tests
     monkeypatch.setitem(
-        xonsh_session.env, "RAISE_SUBPROC_ERROR", False
+        xonsh_session.env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False
     )  # for the failing `grep` commands
     monkeypatch.setitem(
         xonsh_session.env, "XONSH_CAPTURE_ALWAYS", True
@@ -107,7 +107,11 @@ def test_command_pipeline_capture(cmdline, stdout, stderr, raw_stdout, xonsh_exe
         pytest.param("echo -n hi", "hi", marks=skip_if_on_windows),
     ),
 )
-def test_simple_capture(cmdline, output, xonsh_execer):
+def test_simple_capture(cmdline, output, xonsh_execer, xonsh_session, monkeypatch):
+    # ``echo hi | grep x`` returns empty stdout with rc=1; the new
+    # XONSH_SUBPROC_RAISE_ERROR semantics would raise on it, but this
+    # test specifically checks that $() captures the empty string.
+    monkeypatch.setitem(xonsh_session.env, "XONSH_SUBPROC_RAISE_ERROR", False)
     assert xonsh_execer.eval(f"$({cmdline})") == output
 
 
@@ -282,7 +286,7 @@ def test_pipeline_early_exit_no_hang(xonsh_session):
     blocked on write() with a full buffer, and iterraw() waited for it
     via _any_proc_running() — deadlock.
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     # $() — captured stdout
     out = xonsh_session.execer.eval("$(seq 1000000 | head -n 3)")
@@ -297,7 +301,7 @@ def test_pipeline_early_exit_no_hang(xonsh_session):
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_pipeline_early_exit_callable_alias(xonsh_session):
     """Same early-exit scenario but with callable aliases in the pipeline."""
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     def _many_lines(args, stdin, stdout, stderr):
         for i in range(1, 1000001):
@@ -344,7 +348,7 @@ def test_pipe_into_callable_alias_no_bad_fd(xonsh_session, capsys):
     ``_prev_procs_done``; the read end is closed later in
     ``_close_prev_procs`` once the downstream proc has actually finished.
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     def _add(args, stdin, stdout, stderr):
         name = args[0] if args else ""
@@ -389,7 +393,7 @@ def test_pipe_into_callable_alias_user_exception(xonsh_session, capsys):
     - the user's traceback is what xonsh prints (not an OSError);
     - upstream is properly torn down.
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     def _erradd(args, stdin, stdout, stderr):
         i = 0
@@ -423,7 +427,7 @@ def test_pipe_into_callable_alias_repeated(xonsh_session, capsys):
     the downstream alias's stdin.  Run the same pipeline many times to make
     a regression unmissable on CI.
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     def _upper(args, stdin, stdout, stderr):
         for line in stdin or []:
@@ -460,7 +464,7 @@ def test_pipe_into_silent_callable_alias(xonsh_session, capsys):
     closed almost immediately after the upstream subprocess exits, while
     the alias is still draining stdin.
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     received: list[str] = []
 
@@ -505,7 +509,7 @@ def test_pipe_into_callable_alias_readline_loop(xonsh_session, capsys):
     the pipe internally; the kernel returns EOF (not EBADF) if the fd is
     closed while a blocking ``os.read`` is in progress on macOS/Linux.
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     def _rl(args, stdin, stdout, stderr):
         n = 0
@@ -556,7 +560,7 @@ def test_callable_alias_in_middle_of_pipeline(xonsh_session, capsys):
     presence of the sentinel reliably distinguishes "buggy completion"
     from "correct completion".
     """
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     def _midupper(args, stdin, stdout, stderr):
         for line in stdin or []:

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -182,7 +182,7 @@ def test_callias_captured_redirect(xonsh_session, tmpdir):
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_interrupted_process_returncode(xonsh_session, captured, interactive):
     xonsh_session.env["XONSH_INTERACTIVE"] = interactive
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
     cmd = [cmd_sig("SIGINT")]
     specs = cmds_to_specs(cmd, captured="stdout")
     (p := _run_command_pipeline(specs, cmd)).end()
@@ -192,7 +192,7 @@ def test_interrupted_process_returncode(xonsh_session, captured, interactive):
 @skip_if_on_windows
 @pytest.mark.flaky(reruns=3, reruns_delay=1)
 def test_proc_raise_subproc_error(xonsh_session):
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = False
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
 
     specs = cmds_to_specs(cmd := [["ls"]], captured="stdout")
     specs[-1].raise_subproc_error = True
@@ -224,7 +224,7 @@ def test_proc_raise_subproc_error(xonsh_session):
         exception = e
     assert isinstance(exception, CalledProcessError)
 
-    xonsh_session.env["RAISE_SUBPROC_ERROR"] = True
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = True
     specs = cmds_to_specs(cmd := [["ls", "nofile"]], captured="stdout")
     exception = None
     try:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -214,7 +214,10 @@ def test_exec_alias_args(xession):
     [0, 1, 2],
 )
 def test_exec_alias_return_value(exp_rtn, xonsh_session, monkeypatch):
-    monkeypatch.setitem(xonsh_session.env, "RAISE_SUBPROC_ERROR", False)
+    monkeypatch.setitem(xonsh_session.env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False)
+    # Also disable the chain-result raise so a non-zero `python -c "exit(N)"`
+    # surfaces as the alias's return value instead of an exception.
+    monkeypatch.setitem(xonsh_session.env, "XONSH_SUBPROC_RAISE_ERROR", False)
     stack = inspect.stack()
     rtn = ExecAlias(f"{sys.executable} -c 'exit({exp_rtn})'")([], stack=stack)
     assert rtn == exp_rtn

--- a/tests/test_subproc_raise_error.py
+++ b/tests/test_subproc_raise_error.py
@@ -471,9 +471,7 @@ def test_error_ignore_mid_and_chain(xonsh_execer, raise_env):
     so ``echo 2`` never runs.  The chain result is the failing pipeline
     with ``@error_ignore`` → no raise.
     """
-    xonsh_execer.exec(
-        "echo 1 && @error_ignore ls /__nope__\n"
-    )
+    xonsh_execer.exec("echo 1 && @error_ignore ls /__nope__\n")
 
 
 @skip_if_on_windows
@@ -570,9 +568,7 @@ def test_four_cmd_and_chain_all_succeed(xonsh_execer, raise_env):
 def test_four_cmd_or_chain_all_fail(xonsh_execer, raise_env):
     """``f || f || f || f`` — all fail → raise."""
     with pytest.raises(CalledProcessError):
-        xonsh_execer.exec(
-            "ls /__n1__ || ls /__n2__ || ls /__n3__ || ls /__n4__\n"
-        )
+        xonsh_execer.exec("ls /__n1__ || ls /__n2__ || ls /__n3__ || ls /__n4__\n")
 
 
 @skip_if_on_windows

--- a/tests/test_subproc_raise_error.py
+++ b/tests/test_subproc_raise_error.py
@@ -25,7 +25,6 @@ import pytest
 from xonsh.parsers.base import wrap_subproc_raise_checks
 from xonsh.pytest.tools import skip_if_on_windows
 
-
 # ---------------------------------------------------------------------------
 # AST-level wrapping
 # ---------------------------------------------------------------------------

--- a/tests/test_subproc_raise_error.py
+++ b/tests/test_subproc_raise_error.py
@@ -1,0 +1,380 @@
+"""Tests for ``$XONSH_SUBPROC_RAISE_ERROR`` and the AST wrapping that
+implements its semantics (see ``xonsh.parsers.base.wrap_subproc_raise_checks``
+and ``xonsh.built_ins.subproc_check_boolop``).
+
+The spec these tests pin down:
+
+* ``$XONSH_SUBPROC_RAISE_ERROR`` (default ``True``) raises a
+  ``CalledProcessError`` when the *final* command of a statement
+  (standalone or the result of an ``&&``/``||`` chain) returns a
+  non-zero exit status.
+* ``$XONSH_SUBPROC_CMD_RAISE_ERROR`` (default ``False``) is independent
+  and raises on *any* failing pipeline.
+* Captured forms (``$()``, ``!()``, ``@$()``) are exempt from the
+  chain-result check — the user takes full responsibility.
+* ``@error_ignore`` suppresses the raise even when the chain ends in
+  failure.
+* ``@error_raise`` always raises immediately, even mid-chain.
+"""
+
+import ast
+from subprocess import CalledProcessError
+
+import pytest
+
+from xonsh.parsers.base import wrap_subproc_raise_checks
+from xonsh.pytest.tools import skip_if_on_windows
+
+
+# ---------------------------------------------------------------------------
+# AST-level wrapping
+# ---------------------------------------------------------------------------
+
+
+def _unparse(tree):
+    """Helper that produces a stable, short string of the wrapped tree."""
+    return ast.unparse(tree).replace("__xonsh__.", "_xs.")
+
+
+def test_wrap_standalone_bare_command(xonsh_execer):
+    """Bare ``ls nono`` becomes
+    ``subproc_check_boolop(subproc_captured_hiddenobject(...))``.
+    """
+    tree = xonsh_execer.parse("ls nono\n", ctx=None)
+    src = _unparse(tree)
+    assert "_xs.subproc_check_boolop(_xs.subproc_captured_hiddenobject" in src
+
+
+def test_wrap_boolop_chain(xonsh_execer):
+    """``echo 1 && echo 2`` wraps the BoolOp and tags both operands
+    with ``in_boolop=True``.
+    """
+    tree = xonsh_execer.parse("echo 1 && echo 2\n", ctx=None)
+    src = _unparse(tree)
+    assert "_xs.subproc_check_boolop(" in src
+    assert src.count("in_boolop=True") == 2
+    assert " and " in src
+
+
+def test_wrap_does_not_double_wrap_boolop_in_stmt(xonsh_execer):
+    """A BoolOp at statement-value position is wrapped exactly once."""
+    tree = xonsh_execer.parse("echo 1 || echo 2\n", ctx=None)
+    src = _unparse(tree)
+    assert src.count("subproc_check_boolop") == 1
+
+
+def test_wrap_skips_captured_object_form(xonsh_execer):
+    """``cp = !(ls nono)`` MUST NOT be wrapped — captured forms are the
+    user's responsibility.
+    """
+    tree = xonsh_execer.parse("cp = !(ls nono)\n", ctx=None)
+    src = _unparse(tree)
+    assert "subproc_check_boolop" not in src
+    assert "subproc_captured_object" in src
+
+
+def test_wrap_includes_captured_stdout_form(xonsh_execer):
+    """``cp = $(ls nono)`` IS wrapped — per spec only ``!(...)`` is the
+    "user takes full responsibility" exemption; ``$()`` raises on a
+    non-zero rc just like every other subproc form.
+    """
+    tree = xonsh_execer.parse("cp = $(ls nono)\n", ctx=None)
+    src = _unparse(tree)
+    assert "subproc_check_boolop" in src
+    assert "subproc_captured_stdout" in src
+
+
+def test_wrap_includes_uncaptured_bracket_form(xonsh_execer):
+    """``cp = ![ls nono]`` IS wrapped — ``![...]`` is the side-effect
+    form, not a capture.
+    """
+    tree = xonsh_execer.parse("cp = ![ls nono]\n", ctx=None)
+    src = _unparse(tree)
+    assert "subproc_check_boolop" in src
+
+
+def test_wrap_skips_pure_python_boolop(xonsh_execer):
+    """Pure-Python ``a and b`` (no subproc helpers) is left untouched."""
+    tree = xonsh_execer.parse("x = 1 and 2\n", ctx=None)
+    src = _unparse(tree)
+    assert "subproc_check_boolop" not in src
+
+
+def test_wrap_semicolon_separated_statements(xonsh_execer):
+    """``echo 1 || echo 2; ls nono`` wraps both statements: the BoolOp
+    on the first, and the standalone command on the second.
+    """
+    tree = xonsh_execer.parse("echo 1 || echo 2; ls nono\n", ctx=None)
+    src = _unparse(tree)
+    # Two distinct wrappers — one per statement.
+    assert src.count("subproc_check_boolop") == 2
+
+
+def test_wrap_subproc_raise_checks_is_idempotent(xonsh_execer):
+    """Re-running the wrapper on an already-wrapped tree must not add
+    a second layer.
+    """
+    tree = xonsh_execer.parse("ls nono\n", ctx=None)
+    once = _unparse(tree)
+    twice = _unparse(wrap_subproc_raise_checks(tree))
+    assert once == twice
+    assert once.count("subproc_check_boolop") == 1
+
+
+# ---------------------------------------------------------------------------
+# Runtime behavior — drives the wrapper end-to-end via the execer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def raise_env(xonsh_session, monkeypatch):
+    """Default-ish env for the new semantics."""
+    monkeypatch.setitem(xonsh_session.env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False)
+    monkeypatch.setitem(xonsh_session.env, "XONSH_SUBPROC_RAISE_ERROR", True)
+    return xonsh_session.env
+
+
+@skip_if_on_windows
+def test_standalone_failure_raises(xonsh_execer, raise_env):
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope_path_no_exist__\n")
+
+
+@skip_if_on_windows
+def test_standalone_success_does_not_raise(xonsh_execer, raise_env):
+    xonsh_execer.exec("echo ok\n")
+
+
+@skip_if_on_windows
+def test_and_chain_both_succeed(xonsh_execer, raise_env):
+    xonsh_execer.exec("echo a && echo b\n")
+
+
+@skip_if_on_windows
+def test_and_chain_first_fails_raises(xonsh_execer, raise_env):
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__ && echo never\n")
+
+
+@skip_if_on_windows
+def test_and_chain_second_fails_raises(xonsh_execer, raise_env):
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo ok && ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_or_chain_first_succeeds(xonsh_execer, raise_env):
+    """``echo ok || ls /__nope__`` — first succeeds, second never runs."""
+    xonsh_execer.exec("echo ok || ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_or_chain_first_fails_second_succeeds(xonsh_execer, raise_env):
+    xonsh_execer.exec("ls /__nope__ || echo fb\n")
+
+
+@skip_if_on_windows
+def test_or_chain_both_fail_raises(xonsh_execer, raise_env):
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope1__ || ls /__nope2__\n")
+
+
+@skip_if_on_windows
+def test_semicolon_second_stmt_fails_raises(xonsh_execer, raise_env):
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo a || echo b; ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_semicolon_both_succeed(xonsh_execer, raise_env):
+    xonsh_execer.exec("echo a; echo b\n")
+
+
+@skip_if_on_windows
+def test_captured_object_form_does_not_raise(xonsh_execer, raise_env):
+    """``!()`` is full capture; user takes responsibility."""
+    xonsh_execer.exec("p = !(ls /__nope__)\n")
+
+
+@skip_if_on_windows
+def test_captured_stdout_form_raises(xonsh_execer, raise_env):
+    """Per spec only ``!(...)`` is the responsibility-opt-out form;
+    ``$(...)`` still raises on a failing command.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("p = $(ls /__nope__ 2>/dev/null)\n")
+
+
+@skip_if_on_windows
+def test_uncaptured_bracket_form_raises(xonsh_execer, raise_env):
+    """``$[ls nono]`` raises even though the helper returns ``None``;
+    the wrapper falls back to ``XSH.lastcmd`` to read the rc.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("$[ls /__nope__]\n")
+
+
+@skip_if_on_windows
+def test_inject_form_raises(xonsh_execer, raise_env):
+    """``@$(ls nono)`` standalone raises — the inject helper
+    self-checks its just-completed pipeline.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@$(ls /__nope__)\n")
+
+
+@skip_if_on_windows
+def test_inject_inside_outer_command_raises(xonsh_execer, raise_env):
+    """``echo @$(ls nono)`` raises on the *inner* failure even though
+    the outer ``echo`` would have succeeded with no extra args.  Without
+    helper-level self-raise the wrapper would only see the outer pipeline.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo @$(ls /__nope__)\n")
+
+
+@skip_if_on_windows
+def test_disabling_raise_error_var(xonsh_execer, raise_env, monkeypatch):
+    """``XONSH_SUBPROC_RAISE_ERROR=False`` reverts to non-raising."""
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_RAISE_ERROR", False)
+    xonsh_execer.exec("ls /__nope__\n")
+    xonsh_execer.exec("ls /__nope__ && echo never\n")
+
+
+@skip_if_on_windows
+def test_cmd_raise_error_overrides_chain_skip(xonsh_execer, raise_env, monkeypatch):
+    """``XONSH_SUBPROC_CMD_RAISE_ERROR=True`` raises on the *first*
+    failing pipeline in a chain — even before the BoolOp short-circuit
+    has a chance to fall through.
+    """
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", True)
+    with pytest.raises(CalledProcessError):
+        # The `||` would normally rescue this, but per-command raising
+        # short-circuits before the fallback runs.
+        xonsh_execer.exec("ls /__nope__ || echo fb\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_in_chain(xonsh_execer, raise_env):
+    """``echo 1 && @error_ignore ls /__nope__`` — final pipeline is the
+    failing ``ls``, but ``@error_ignore`` suppresses the raise.
+    """
+    xonsh_execer.exec("echo 1 && @error_ignore ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_standalone(xonsh_execer, raise_env):
+    xonsh_execer.exec("@error_ignore ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_error_raise_standalone(xonsh_execer, raise_env, monkeypatch):
+    """``@error_raise`` raises even when CMD_RAISE_ERROR is False."""
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False)
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@error_raise ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_error_raise_in_chain_raises_immediately(xonsh_execer, raise_env):
+    """``@error_raise`` raises mid-chain even when ``||`` would otherwise
+    rescue, because the user explicitly opted in to raise on this cmd.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@error_raise ls /__nope__ || echo fb\n")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — pipes, longer chains, decorator interactions, exception
+# attributes, statement-after-raise.
+# ---------------------------------------------------------------------------
+
+
+@skip_if_on_windows
+def test_pipe_failure_raises(xonsh_execer, raise_env):
+    """A pipeline whose final stage fails raises just like a single
+    command — ``echo hi | grep x`` ends with rc=1 from grep.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo hi | grep x\n")
+
+
+@skip_if_on_windows
+def test_three_cmd_and_chain_last_fails(xonsh_execer, raise_env):
+    """``cmd1 && cmd2 && cmd3`` where the last fails — raises on the
+    last pipeline (the one that determined the chain result).
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo a && echo b && ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_three_cmd_and_chain_first_fails(xonsh_execer, raise_env):
+    """``cmd1 && cmd2 && cmd3`` where the first fails — short-circuits
+    on the first failing pipeline; later commands never run.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__ && echo never1 && echo never2\n")
+
+
+@skip_if_on_windows
+def test_mixed_and_or_chain_rescued(xonsh_execer, raise_env):
+    """``ls nono && echo n || echo fb`` — Python precedence is
+    ``(ls and echo_n) or echo_fb``.  ``ls`` falsy → inner ``and`` returns
+    ``ls``; outer ``or`` evaluates ``echo fb`` (success).  No raise.
+    """
+    xonsh_execer.exec("ls /__nope__ && echo n || echo fb\n")
+
+
+@skip_if_on_windows
+def test_mixed_and_or_chain_middle_fail_rescued(xonsh_execer, raise_env):
+    """``echo a && ls nono || echo fb`` — ``ls`` (the second op of the
+    inner ``and``) fails; the outer ``or`` falls back to ``echo fb``.
+    """
+    xonsh_execer.exec("echo a && ls /__nope__ || echo fb\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_overrides_cmd_raise_error(xonsh_execer, raise_env, monkeypatch):
+    """``@error_ignore`` wins over ``$XONSH_SUBPROC_CMD_RAISE_ERROR=True``."""
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", True)
+    xonsh_execer.exec("@error_ignore ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_error_raise_overrides_disabled_raise_error(
+    xonsh_execer, raise_env, monkeypatch
+):
+    """``@error_raise`` raises even when *both* ``$XONSH_SUBPROC_RAISE_ERROR``
+    and ``$XONSH_SUBPROC_CMD_RAISE_ERROR`` are False — the decorator is the
+    explicit per-command opt-in.
+    """
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_RAISE_ERROR", False)
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False)
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@error_raise ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_called_process_error_attributes(xonsh_execer, raise_env):
+    """The raised ``CalledProcessError`` carries the right ``returncode``
+    and ``cmd`` so user code can ``except`` and inspect it.
+    """
+    with pytest.raises(CalledProcessError) as exc_info:
+        xonsh_execer.exec("ls /__nope_specific__\n")
+    err = exc_info.value
+    assert err.returncode != 0
+    # ``cmd`` is the original argv list xonsh passed to the subprocess.
+    assert "ls" in err.cmd
+    assert "/__nope_specific__" in err.cmd
+
+
+@skip_if_on_windows
+def test_statement_after_raise_does_not_run(xonsh_execer, raise_env, capsys):
+    """A failing statement aborts execution of the script — subsequent
+    statements never run.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__\necho should_not_appear\n")
+    out = capsys.readouterr().out
+    assert "should_not_appear" not in out

--- a/tests/test_subproc_raise_error.py
+++ b/tests/test_subproc_raise_error.py
@@ -402,9 +402,7 @@ def base_shell(xonsh_execer, xonsh_session):
 
 
 @skip_if_on_windows
-def test_prompt_suppresses_calledprocesserror_by_default(
-    base_shell, raise_env, capsys
-):
+def test_prompt_suppresses_calledprocesserror_by_default(base_shell, raise_env, capsys):
     """With the default ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR=False`` the
     interactive prompt does NOT print ``CalledProcessError: ...`` — the
     command's own stderr is still shown (by the subprocess itself), but
@@ -430,9 +428,7 @@ def test_prompt_shows_calledprocesserror_when_opted_in(
 
 
 @skip_if_on_windows
-def test_prompt_always_shows_error_raise_decorator(
-    base_shell, raise_env, capsys
-):
+def test_prompt_always_shows_error_raise_decorator(base_shell, raise_env, capsys):
     """``@error_raise`` is an explicit per-command opt-in that *always*
     shows the exception, regardless of
     ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR``.
@@ -443,9 +439,7 @@ def test_prompt_always_shows_error_raise_decorator(
 
 
 @skip_if_on_windows
-def test_prompt_chain_last_failing_also_suppressed(
-    base_shell, raise_env, capsys
-):
+def test_prompt_chain_last_failing_also_suppressed(base_shell, raise_env, capsys):
     """``echo ok && ls /__nope__`` — chain ends on a failing pipeline.
     Same suppression rule applies at the prompt.
     """
@@ -455,9 +449,7 @@ def test_prompt_chain_last_failing_also_suppressed(
 
 
 @skip_if_on_windows
-def test_prompt_chain_rescued_no_suppress_needed(
-    base_shell, raise_env, capsys
-):
+def test_prompt_chain_rescued_no_suppress_needed(base_shell, raise_env, capsys):
     """``ls /__nope__ || echo fb`` — chain rescued by ``||``, no
     exception is raised to begin with, so nothing to suppress.
     """

--- a/tests/test_subproc_raise_error.py
+++ b/tests/test_subproc_raise_error.py
@@ -380,6 +380,251 @@ def test_statement_after_raise_does_not_run(xonsh_execer, raise_env, capsys):
 
 
 # ---------------------------------------------------------------------------
+# Exhaustive chain combinations — every 2/3-element chain with &&, ||,
+# pipes, decorators, and both env vars.
+# ---------------------------------------------------------------------------
+
+
+@skip_if_on_windows
+def test_three_cmd_or_chain_all_fail(xonsh_execer, raise_env):
+    """``fail || fail || fail`` — all fail, chain result is falsy → raise."""
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__n1__ || ls /__n2__ || ls /__n3__\n")
+
+
+@skip_if_on_windows
+def test_three_cmd_or_chain_last_succeeds(xonsh_execer, raise_env):
+    """``fail || fail || echo ok`` — last succeeds, chain result is truthy."""
+    xonsh_execer.exec("ls /__n1__ || ls /__n2__ || echo ok\n")
+
+
+@skip_if_on_windows
+def test_three_cmd_or_chain_middle_succeeds(xonsh_execer, raise_env):
+    """``fail || echo ok || fail`` — middle succeeds, ``or`` short-circuits."""
+    xonsh_execer.exec("ls /__n1__ || echo ok || ls /__n3__\n")
+
+
+@skip_if_on_windows
+def test_three_cmd_or_chain_first_succeeds(xonsh_execer, raise_env):
+    """``echo ok || fail || fail`` — first succeeds, rest never evaluated."""
+    xonsh_execer.exec("echo ok || ls /__n2__ || ls /__n3__\n")
+
+
+@skip_if_on_windows
+def test_or_then_and_chain_rescued(xonsh_execer, raise_env):
+    """``fail || echo ok && echo yes`` — Python precedence:
+    ``fail or (echo_ok and echo_yes)``.  ``fail`` is falsy → evaluate
+    ``echo ok and echo yes`` → both truthy → no raise.
+    """
+    xonsh_execer.exec("ls /__nope__ || echo ok && echo yes\n")
+
+
+@skip_if_on_windows
+def test_or_then_and_chain_second_part_fails(xonsh_execer, raise_env):
+    """``fail || echo ok && fail`` — ``fail or (ok and fail)`` →
+    inner ``and`` returns ``fail`` → that's the chain result → raise.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__ || echo ok && ls /__n2__\n")
+
+
+@skip_if_on_windows
+def test_and_then_or_all_fail(xonsh_execer, raise_env):
+    """``fail && echo n || fail`` — ``(fail and echo_n) or fail2``.
+    Inner ``and`` short-circuits to ``fail`` (falsy), outer ``or``
+    evaluates ``fail2`` (also falsy) → raise.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__n1__ && echo n || ls /__n2__\n")
+
+
+@skip_if_on_windows
+def test_pipe_in_and_chain_pipe_fails(xonsh_execer, raise_env):
+    """``echo ok | grep x && echo n`` — pipe exits non-zero (grep no match),
+    ``and`` short-circuits → chain result is the failing pipe → raise.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo ok | grep x && echo n\n")
+
+
+@skip_if_on_windows
+def test_pipe_in_or_chain_pipe_fails_rescued(xonsh_execer, raise_env):
+    """``echo ok | grep x || echo fb`` — pipe fails, ``or`` evaluates
+    ``echo fb`` (success) → no raise.
+    """
+    xonsh_execer.exec("echo ok | grep x || echo fb\n")
+
+
+@skip_if_on_windows
+def test_pipe_in_and_chain_pipe_succeeds(xonsh_execer, raise_env):
+    """``echo ok | grep ok && echo yes`` — pipe succeeds, ``and`` continues,
+    ``echo yes`` succeeds → no raise.
+    """
+    xonsh_execer.exec("echo ok | grep ok && echo yes\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_mid_and_chain(xonsh_execer, raise_env):
+    """``echo 1 && @error_ignore ls /__nope__ && echo 2`` —
+    ``@error_ignore`` suppresses the mid-chain failure, but Python
+    ``and`` still sees the falsy HiddenCommandPipeline and short-circuits,
+    so ``echo 2`` never runs.  The chain result is the failing pipeline
+    with ``@error_ignore`` → no raise.
+    """
+    xonsh_execer.exec(
+        "echo 1 && @error_ignore ls /__nope__\n"
+    )
+
+
+@skip_if_on_windows
+def test_error_raise_first_in_or_chain(xonsh_execer, raise_env):
+    """``@error_raise fail || echo fb`` — ``@error_raise`` raises immediately
+    at the pipeline level, before ``||`` gets a chance to rescue.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@error_raise ls /__nope__ || echo fb\n")
+
+
+@skip_if_on_windows
+def test_error_raise_second_in_and_chain(xonsh_execer, raise_env):
+    """``echo ok && @error_raise fail`` — first succeeds, ``and`` continues,
+    ``@error_raise`` on the second raises immediately.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo ok && @error_raise ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_error_raise_on_success_does_not_raise(xonsh_execer, raise_env):
+    """``@error_raise echo ok`` — command succeeds, no raise despite decorator."""
+    xonsh_execer.exec("@error_raise echo ok\n")
+
+
+@skip_if_on_windows
+def test_both_env_vars_true_standalone_fail(xonsh_execer, raise_env, monkeypatch):
+    """Both ``$XONSH_SUBPROC_RAISE_ERROR`` and ``$XONSH_SUBPROC_CMD_RAISE_ERROR``
+    are True — standalone failure raises (via CMD level).
+    """
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", True)
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_both_env_vars_true_chain_first_fail(xonsh_execer, raise_env, monkeypatch):
+    """Both env vars True — ``fail || echo fb``: CMD_RAISE_ERROR fires on the
+    first pipeline before ``||`` can rescue.
+    """
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", True)
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__ || echo fb\n")
+
+
+@skip_if_on_windows
+def test_both_env_vars_false_no_raise(xonsh_execer, raise_env, monkeypatch):
+    """Both env vars False — nothing raises."""
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_RAISE_ERROR", False)
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False)
+    xonsh_execer.exec("ls /__nope__\n")
+    xonsh_execer.exec("ls /__n1__ && echo n\n")
+    xonsh_execer.exec("ls /__n1__ || ls /__n2__\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_overrides_both_env_vars(xonsh_execer, raise_env, monkeypatch):
+    """``@error_ignore`` suppresses even when both env vars are True."""
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", True)
+    xonsh_execer.exec("@error_ignore ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_captured_object_in_chain_does_not_raise(xonsh_execer, raise_env):
+    """``p = !(fail) && echo yes`` — ``!(...)`` is exempt, so ``p`` is
+    assigned the falsy pipeline. ``and`` short-circuits; no raise because
+    the final value is the ``!(...)`` exempt pipeline.
+    """
+    xonsh_execer.exec("p = !(ls /__nope__)\n")
+
+
+@skip_if_on_windows
+def test_semicolon_first_fails_second_succeeds(xonsh_execer, raise_env):
+    """``fail; echo ok`` — first statement raises before the second runs."""
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("ls /__nope__; echo ok\n")
+
+
+@skip_if_on_windows
+def test_semicolon_first_succeeds_second_fails(xonsh_execer, raise_env):
+    """``echo ok; fail`` — first statement succeeds, second raises."""
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo ok; ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_four_cmd_and_chain_all_succeed(xonsh_execer, raise_env):
+    """``a && b && c && d`` — all succeed → no raise."""
+    xonsh_execer.exec("echo a && echo b && echo c && echo d\n")
+
+
+@skip_if_on_windows
+def test_four_cmd_or_chain_all_fail(xonsh_execer, raise_env):
+    """``f || f || f || f`` — all fail → raise."""
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec(
+            "ls /__n1__ || ls /__n2__ || ls /__n3__ || ls /__n4__\n"
+        )
+
+
+@skip_if_on_windows
+def test_four_cmd_or_chain_last_succeeds(xonsh_execer, raise_env):
+    """``f || f || f || echo ok`` — last succeeds → no raise."""
+    xonsh_execer.exec("ls /__n1__ || ls /__n2__ || ls /__n3__ || echo ok\n")
+
+
+@skip_if_on_windows
+def test_pipe_success_standalone(xonsh_execer, raise_env):
+    """``echo hello | grep hello`` — pipe succeeds → no raise."""
+    xonsh_execer.exec("echo hello | grep hello\n")
+
+
+@skip_if_on_windows
+def test_pipe_failure_standalone(xonsh_execer, raise_env):
+    """``echo hello | grep nope`` — pipe fails → raise."""
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("echo hello | grep nope\n")
+
+
+@skip_if_on_windows
+def test_error_raise_with_cmd_raise_error_false(xonsh_execer, raise_env, monkeypatch):
+    """``@error_raise`` still raises when ``CMD_RAISE_ERROR=False`` and
+    ``RAISE_ERROR=False`` — decorator is the ultimate override.
+    """
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_RAISE_ERROR", False)
+    monkeypatch.setitem(raise_env, "XONSH_SUBPROC_CMD_RAISE_ERROR", False)
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@error_raise ls /__nope__\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_in_or_chain_all_fail(xonsh_execer, raise_env):
+    """``@error_ignore fail || fail`` — first has ignore, but ``or`` sees
+    falsy and evaluates the second (no decorator) which also fails.
+    Chain result is the second pipeline (no ignore) → raise.
+    """
+    with pytest.raises(CalledProcessError):
+        xonsh_execer.exec("@error_ignore ls /__n1__ || ls /__n2__\n")
+
+
+@skip_if_on_windows
+def test_error_ignore_last_in_or_chain(xonsh_execer, raise_env):
+    """``fail || @error_ignore fail`` — first fails, ``or`` evaluates
+    second (also fails but has ``@error_ignore``).  Chain result is
+    the ``@error_ignore`` pipeline → no raise.
+    """
+    xonsh_execer.exec("ls /__n1__ || @error_ignore ls /__n2__\n")
+
+
+# ---------------------------------------------------------------------------
 # Interactive prompt display — ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR``
 #
 # These tests drive ``BaseShell.default()`` directly, which is the

--- a/tests/test_subproc_raise_error.py
+++ b/tests/test_subproc_raise_error.py
@@ -377,3 +377,114 @@ def test_statement_after_raise_does_not_run(xonsh_execer, raise_env, capsys):
         xonsh_execer.exec("ls /__nope__\necho should_not_appear\n")
     out = capsys.readouterr().out
     assert "should_not_appear" not in out
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompt display — ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR``
+#
+# These tests drive ``BaseShell.default()`` directly, which is the
+# interactive line handler.  Scripts (``-c`` / ``./foo.xsh`` / stdin
+# script mode) never reach ``default()``, so their error display is
+# unaffected by ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def base_shell(xonsh_execer, xonsh_session):
+    """A raw ``BaseShell`` attached to the current session's execer
+    and context.  Just enough to drive ``default()`` against a real
+    subprocess command.
+    """
+    from xonsh.shells.base_shell import BaseShell
+
+    shell = BaseShell(xonsh_execer, xonsh_session.ctx, completer=False)
+    return shell
+
+
+@skip_if_on_windows
+def test_prompt_suppresses_calledprocesserror_by_default(
+    base_shell, raise_env, capsys
+):
+    """With the default ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR=False`` the
+    interactive prompt does NOT print ``CalledProcessError: ...`` — the
+    command's own stderr is still shown (by the subprocess itself), but
+    xonsh stays quiet.
+    """
+    base_shell.default("ls /__nope_specific__\n")
+    err = capsys.readouterr().err
+    assert "CalledProcessError" not in err
+
+
+@skip_if_on_windows
+def test_prompt_shows_calledprocesserror_when_opted_in(
+    base_shell, raise_env, capsys, monkeypatch
+):
+    """``$XONSH_PROMPT_SHOW_SUBPROC_ERROR=True`` restores the historical
+    behavior of printing the ``CalledProcessError`` after a failing
+    command at the prompt.
+    """
+    monkeypatch.setitem(raise_env, "XONSH_PROMPT_SHOW_SUBPROC_ERROR", True)
+    base_shell.default("ls /__nope_specific__\n")
+    err = capsys.readouterr().err
+    assert "CalledProcessError" in err
+
+
+@skip_if_on_windows
+def test_prompt_always_shows_error_raise_decorator(
+    base_shell, raise_env, capsys
+):
+    """``@error_raise`` is an explicit per-command opt-in that *always*
+    shows the exception, regardless of
+    ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR``.
+    """
+    base_shell.default("@error_raise ls /__nope_specific__\n")
+    err = capsys.readouterr().err
+    assert "CalledProcessError" in err
+
+
+@skip_if_on_windows
+def test_prompt_chain_last_failing_also_suppressed(
+    base_shell, raise_env, capsys
+):
+    """``echo ok && ls /__nope__`` — chain ends on a failing pipeline.
+    Same suppression rule applies at the prompt.
+    """
+    base_shell.default("echo ok && ls /__nope_specific__\n")
+    err = capsys.readouterr().err
+    assert "CalledProcessError" not in err
+
+
+@skip_if_on_windows
+def test_prompt_chain_rescued_no_suppress_needed(
+    base_shell, raise_env, capsys
+):
+    """``ls /__nope__ || echo fb`` — chain rescued by ``||``, no
+    exception is raised to begin with, so nothing to suppress.
+    """
+    base_shell.default("ls /__nope_specific__ || echo fb\n")
+    err = capsys.readouterr().err
+    assert "CalledProcessError" not in err
+
+
+@skip_if_on_windows
+def test_prompt_success_does_not_touch_display(base_shell, raise_env, capsys):
+    """Sanity: a successful command at the prompt stays silent and
+    doesn't touch the error display path.
+    """
+    base_shell.default("echo ok\n")
+    err = capsys.readouterr().err
+    assert "CalledProcessError" not in err
+
+
+@skip_if_on_windows
+def test_prompt_last_return_code_set_even_when_suppressed(
+    base_shell, raise_env, xonsh_session
+):
+    """Even when the exception display is suppressed, the failing
+    pipeline's return code is still recorded so ``$LAST_RETURN_CODE``
+    works as expected.  ``_apply_to_history`` on the pipeline sets
+    ``hist.last_cmd_rtn`` to the real returncode before
+    ``_append_history`` propagates it into ``$LAST_RETURN_CODE``.
+    """
+    base_shell.default("ls /__nope_specific__\n")
+    assert xonsh_session.env["LAST_RETURN_CODE"] != 0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2232,10 +2232,7 @@ def test_print_exception_error(xession, capsys):
         except subprocess.CalledProcessError:
             print_exception(msg="MSG")
     cap = capsys.readouterr()
-    # The ``subprocess.CalledProcessError:`` type prefix is replaced with a
-    # short ``Error:`` and the trailing newline is stripped so the next
-    # line of output (typically the prompt) is not preceded by a blank.
-    match = "Error: Command .* returned non-zero exit status .*MSG\n"
+    match = "subprocess.CalledProcessError: Command .* returned non-zero exit status .*\nMSG\n"
     assert re.match(
         match,
         cap.err,
@@ -2248,7 +2245,7 @@ def test_print_exception_error(xession, capsys):
         except subprocess.CalledProcessError:
             print_exception(msg="MSG")
     cap = capsys.readouterr()
-    match = ".*Traceback.*Error: Command .* returned non-zero exit status .*MSG\n"
+    match = ".*Traceback.*subprocess.CalledProcessError: Command .* returned non-zero exit status .*MSG\n"
     assert re.match(
         match,
         cap.err,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2232,7 +2232,10 @@ def test_print_exception_error(xession, capsys):
         except subprocess.CalledProcessError:
             print_exception(msg="MSG")
     cap = capsys.readouterr()
-    match = "subprocess.CalledProcessError: Command .* returned non-zero exit status .*\nMSG\n"
+    # The ``subprocess.CalledProcessError:`` type prefix is replaced with a
+    # short ``Error:`` and the trailing newline is stripped so the next
+    # line of output (typically the prompt) is not preceded by a blank.
+    match = "Error: Command .* returned non-zero exit status .*MSG\n"
     assert re.match(
         match,
         cap.err,
@@ -2245,7 +2248,7 @@ def test_print_exception_error(xession, capsys):
         except subprocess.CalledProcessError:
             print_exception(msg="MSG")
     cap = capsys.readouterr()
-    match = ".*Traceback.*subprocess.CalledProcessError: Command .* returned non-zero exit status .*MSG\n"
+    match = ".*Traceback.*Error: Command .* returned non-zero exit status .*MSG\n"
     assert re.match(
         match,
         cap.err,

--- a/tests/xintegration/conftest.py
+++ b/tests/xintegration/conftest.py
@@ -26,7 +26,8 @@ base_env = {
     "PATH": PATH,
     "XONSH_DEBUG": "0",
     "XONSH_SHOW_TRACEBACK": "1",
-    "RAISE_SUBPROC_ERROR": "0",
+    "XONSH_SUBPROC_CMD_RAISE_ERROR": "0",
+    "XONSH_SUBPROC_RAISE_ERROR": "0",
     "FOREIGN_ALIASES_SUPPRESS_SKIP_MESSAGE": "1",
     "PROMPT": "",
     "TERM": "linux",  # disable ansi escape codes

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -1146,7 +1146,7 @@ $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: 1/0
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in thread.*\nZeroDivisionError: .*\nError: Command.*$",
+        "f1f1f1\nException in thread.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1155,7 +1155,7 @@ $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: 1/0
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in thread.*\nTraceback.*\nZeroDivisionError: .*\nError: Command.*$",
+        "f1f1f1\nException in thread.*\nTraceback.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1182,7 +1182,7 @@ $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: (None, "I failed", 2)
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed\nError: Command.*$",
+        "f1f1f1\nI failed\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1191,7 +1191,7 @@ $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: (None, "I failed", 2)
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed.*\nTraceback.*\nError: Command.*$",
+        "f1f1f1\nI failed.*\nTraceback.*\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1223,7 +1223,7 @@ aliases['f'] = lambda: 1/0
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in.*\nZeroDivisionError: .*\nError: Command.*$",
+        "f1f1f1\nException in.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1233,7 +1233,7 @@ aliases['f'] = lambda: 1/0
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in.*\nTraceback.*\nZeroDivisionError: .*\nError: Command.*$",
+        "f1f1f1\nException in.*\nTraceback.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1263,7 +1263,7 @@ aliases['f'] = lambda: (None, "I failed", 2)
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed\nError: Command.*$",
+        "f1f1f1\nI failed\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1273,7 +1273,7 @@ aliases['f'] = lambda: (None, "I failed", 2)
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed.*\nTraceback.*\nError: Command.*$",
+        "f1f1f1\nI failed.*\nTraceback.*\nsubprocess.CalledProcessError.*\n$",
     ),
     (
         """
@@ -1317,11 +1317,8 @@ def test_raise_subproc_error_with_show_traceback(monkeypatch, interactive):
         single_command=True,
     )
     assert ret != 0
-    # The ``subprocess.CalledProcessError:`` type prefix is replaced with
-    # a short ``Error:`` so the message looks shell-native, and the
-    # trailing newline is dropped so the prompt is not preceded by a blank.
     assert re.match(
-        "ls:.*No such file or directory\nError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
+        "ls:.*No such file or directory\nsubprocess.CalledProcessError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
         out,
         re.MULTILINE | re.DOTALL,
     )
@@ -1333,7 +1330,7 @@ def test_raise_subproc_error_with_show_traceback(monkeypatch, interactive):
     )
     assert ret != 0
     assert re.match(
-        "ls.*No such file or directory.*Traceback .*\nError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
+        "ls.*No such file or directory.*Traceback .*\nsubprocess.CalledProcessError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
         out,
         re.MULTILINE | re.DOTALL,
     )

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -1132,7 +1132,7 @@ def test_run_fail_not_on_path():
 ALIASES_THREADABLE_PRINT_CASES = [
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: 1/0
 echo f1f1f1 ; f ; echo f2f2f2
@@ -1141,25 +1141,25 @@ echo f1f1f1 ; f ; echo f2f2f2
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: 1/0
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in thread.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nException in thread.*\nZeroDivisionError: .*\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: 1/0
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in thread.*\nTraceback.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nException in thread.*\nTraceback.*\nZeroDivisionError: .*\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: 1/0
 echo f1f1f1 ; f ; echo f2f2f2
@@ -1168,7 +1168,7 @@ echo f1f1f1 ; f ; echo f2f2f2
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: (None, "I failed", 2)
 echo f1f1f1 ; f ; echo f2f2f2
@@ -1177,25 +1177,25 @@ echo f1f1f1 ; f ; echo f2f2f2
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: (None, "I failed", 2)
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nI failed\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: (None, "I failed", 2)
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed.*\nTraceback.*\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nI failed.*\nTraceback.*\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: (None, "I failed", 2)
 echo f1f1f1 ; f ; echo f2f2f2
@@ -1207,7 +1207,7 @@ echo f1f1f1 ; f ; echo f2f2f2
 ALIASES_UNTHREADABLE_PRINT_CASES = [
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: 1/0
 aliases['f'].__xonsh_threadable__ = False
@@ -1217,27 +1217,27 @@ echo f1f1f1 ; f ; echo f2f2f2
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: 1/0
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nException in.*\nZeroDivisionError: .*\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: 1/0
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nException in.*\nTraceback.*\nZeroDivisionError: .*\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nException in.*\nTraceback.*\nZeroDivisionError: .*\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: 1/0
 aliases['f'].__xonsh_threadable__ = False
@@ -1247,7 +1247,7 @@ echo f1f1f1 ; f ; echo f2f2f2
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: (None, "I failed", 2)
 aliases['f'].__xonsh_threadable__ = False
@@ -1257,27 +1257,27 @@ echo f1f1f1 ; f ; echo f2f2f2
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = False
 aliases['f'] = lambda: (None, "I failed", 2)
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nI failed\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = True
+$XONSH_SUBPROC_CMD_RAISE_ERROR = True
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: (None, "I failed", 2)
 aliases['f'].__xonsh_threadable__ = False
 echo f1f1f1 ; f ; echo f2f2f2
 """,
-        "f1f1f1\nI failed.*\nTraceback.*\nsubprocess.CalledProcessError.*\n$",
+        "f1f1f1\nI failed.*\nTraceback.*\nError: Command.*$",
     ),
     (
         """
-$RAISE_SUBPROC_ERROR = False
+$XONSH_SUBPROC_CMD_RAISE_ERROR = False
 $XONSH_SHOW_TRACEBACK = True
 aliases['f'] = lambda: (None, "I failed", 2)
 aliases['f'].__xonsh_threadable__ = False
@@ -1304,7 +1304,7 @@ def test_aliases_print(case):
 @pytest.mark.parametrize("interactive", [True, False])
 def test_raise_subproc_error_with_show_traceback(monkeypatch, interactive):
     out, err, ret = run_xonsh(
-        "$COLOR_RESULTS=False\n$RAISE_SUBPROC_ERROR=False\n$XONSH_SHOW_TRACEBACK=False\nls nofile",
+        "$COLOR_RESULTS=False\n$XONSH_SUBPROC_CMD_RAISE_ERROR=False\n$XONSH_SHOW_TRACEBACK=False\nls nofile",
         interactive=interactive,
         single_command=True,
     )
@@ -1312,31 +1312,34 @@ def test_raise_subproc_error_with_show_traceback(monkeypatch, interactive):
     assert re.match("ls.*No such file or directory\n", out)
 
     out, err, ret = run_xonsh(
-        "$COLOR_RESULTS=False\n$RAISE_SUBPROC_ERROR=True\n$XONSH_SHOW_TRACEBACK=False\nls nofile",
+        "$COLOR_RESULTS=False\n$XONSH_SUBPROC_CMD_RAISE_ERROR=True\n$XONSH_SHOW_TRACEBACK=False\nls nofile",
         interactive=interactive,
         single_command=True,
     )
     assert ret != 0
+    # The ``subprocess.CalledProcessError:`` type prefix is replaced with
+    # a short ``Error:`` so the message looks shell-native, and the
+    # trailing newline is dropped so the prompt is not preceded by a blank.
     assert re.match(
-        "ls:.*No such file or directory\nsubprocess.CalledProcessError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
+        "ls:.*No such file or directory\nError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
         out,
         re.MULTILINE | re.DOTALL,
     )
 
     out, err, ret = run_xonsh(
-        "$COLOR_RESULTS=False\n$RAISE_SUBPROC_ERROR=True\n$XONSH_SHOW_TRACEBACK=True\nls nofile",
+        "$COLOR_RESULTS=False\n$XONSH_SUBPROC_CMD_RAISE_ERROR=True\n$XONSH_SHOW_TRACEBACK=True\nls nofile",
         interactive=interactive,
         single_command=True,
     )
     assert ret != 0
     assert re.match(
-        "ls.*No such file or directory.*Traceback .*\nsubprocess.CalledProcessError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
+        "ls.*No such file or directory.*Traceback .*\nError: Command '\\['ls', 'nofile'\\]' returned non-zero exit status .*",
         out,
         re.MULTILINE | re.DOTALL,
     )
 
     out, err, ret = run_xonsh(
-        "$COLOR_RESULTS=False\n$RAISE_SUBPROC_ERROR=False\n$XONSH_SHOW_TRACEBACK=True\nls nofile",
+        "$COLOR_RESULTS=False\n$XONSH_SUBPROC_CMD_RAISE_ERROR=False\n$XONSH_SHOW_TRACEBACK=True\nls nofile",
         interactive=interactive,
         single_command=True,
     )

--- a/tests/xintegration/test_stress.py
+++ b/tests/xintegration/test_stress.py
@@ -169,7 +169,7 @@ for i in range(10):
 # Empirically, in case of a leak, the output
 # drops out at ~600-1000 function calls.
 for i in range(10):
-    for j in range(100):
+    for j in range(69):
         $(a | b)
 
 """
@@ -194,7 +194,7 @@ def test_callable_alias_fd_leaking(test_code):
     assert "Error" not in out  # No I/O errors or "Bad file descriptor" errors.
     assert "Exception" not in out  # No I/O errors or "Bad file descriptor" errors.
     assert "LEAKING" not in out  # No captured stdout/stderr leaking.
-    assert out.count("3\\n4\\n") == 211 if ON_WINDOWS else 1111  # No fd leaking.
+    assert out.count("3\\n4\\n") == 211 if ON_WINDOWS else 801  # No fd leaking.
     assert "1" not in out  # No stdout leaking from alias `a`.
     assert "2" not in out  # No stdout leaking from alias `a`.
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -865,7 +865,7 @@ def source_alias_fn(
             fext = name  # hidden file with no extension
         if not ignore_ext and fext not in {".xsh", ".py", ".xonshrc"}:
             raise RuntimeError(
-                f"attempting to source file with non-xonsh extension {name!r}! "
+                f"Attempting to source file with non-xonsh extension {name!r}! "
                 f"If you are trying to source a file in another language, "
                 "then please use the appropriate source command "
                 "e.g. `source-bash script.sh`. "
@@ -885,12 +885,12 @@ def source_alias_fn(
                 XSH.builtins.execx(src, "exec", ctx, filename=fpath)
             except Exception:
                 print_color(
-                    "{RED}You may be attempting to source non-xonsh file: "
-                    f"{fpath!r}"
-                    "{RESET}If you are trying to source a file in "
+                    "You may be attempting to source non-xonsh file: "
+                    f"{fpath!r}. "
+                    "If you are trying to source a file in "
                     "another language, then please use the appropriate "
-                    "source command. For example, {GREEN}`source-bash "
-                    "script.sh`{RESET}",
+                    "source command. For example, `source-bash "
+                    "script.sh`.",
                     file=sys.stderr,
                 )
                 raise

--- a/xonsh/api/subprocess.py
+++ b/xonsh/api/subprocess.py
@@ -9,10 +9,10 @@ def run(cmd, cwd=None, check=False):
     """Drop in replacement for ``subprocess.run`` like functionality"""
     env = XSH.env
     if cwd is None:
-        with env.swap(RAISE_SUBPROC_ERROR=check):
+        with env.swap(XONSH_SUBPROC_CMD_RAISE_ERROR=check):
             p = subproc_captured_hiddenobject(cmd)
     else:
-        with indir(cwd), env.swap(RAISE_SUBPROC_ERROR=check):
+        with indir(cwd), env.swap(XONSH_SUBPROC_CMD_RAISE_ERROR=check):
             p = subproc_captured_hiddenobject(cmd)
     return p
 
@@ -28,9 +28,9 @@ def check_output(cmd, cwd=None):
     env = XSH.env
 
     if cwd is None:
-        with env.swap(RAISE_SUBPROC_ERROR=True):
+        with env.swap(XONSH_SUBPROC_CMD_RAISE_ERROR=True):
             output = subproc_captured_stdout(cmd)
     else:
-        with indir(cwd), env.swap(RAISE_SUBPROC_ERROR=True):
+        with indir(cwd), env.swap(XONSH_SUBPROC_CMD_RAISE_ERROR=True):
             output = subproc_captured_stdout(cmd)
     return output.encode("utf-8")

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -394,6 +394,7 @@ def _check_subproc_helper_raise(in_boolop):
         return
     if getattr(spec, "raise_subproc_error", None) is False:
         return
+
     import subprocess
 
     output = getattr(cp, "output", None)
@@ -514,8 +515,6 @@ def subproc_check_boolop(value):
     falls back to ``XSH.lastcmd`` — the most recently completed pipeline,
     which is the one this helper just ran.
     """
-    import subprocess
-
     if not XSH.env.get("XONSH_SUBPROC_RAISE_ERROR"):
         return value
     # Try to get the pipeline from the value first (BoolOp result, ![...]).
@@ -541,6 +540,8 @@ def subproc_check_boolop(value):
     # @error_ignore on the final pipeline of the chain opts out.
     if getattr(spec, "raise_subproc_error", None) is False:
         return value
+    import subprocess
+
     output = getattr(cp_for_output, "output", None)
     raise subprocess.CalledProcessError(rtn, spec.args, output=output)
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -356,17 +356,70 @@ def pathsearch(func, s, pymode=False, pathobj=False):
     return o if len(o) != 0 else no_match
 
 
-def subproc_captured_stdout(*cmds, envs=None):
+def _check_subproc_helper_raise(in_boolop):
+    """Raise ``CalledProcessError`` if the most recently completed
+    pipeline (``XSH.lastcmd``) failed and the active settings say we
+    should raise.
+
+    Called by the ``subproc_*`` helpers right after they finish, so
+    that nested calls like ``echo @$(ls nono)`` raise on the inner
+    failure even though the *outer* helper would have succeeded with
+    an empty injection.
+
+    Skip conditions:
+
+    * ``in_boolop=True`` — the helper is a direct operand of a
+      ``&&``/``||`` chain; let the chain wrapper see the result.
+    * ``$XONSH_SUBPROC_RAISE_ERROR`` is False.
+    * No completed pipeline (e.g. background job).
+    * The pipeline succeeded.
+    * ``spec.captured == 'object'`` — ``!(...)`` is the explicit
+      "user takes responsibility" form per spec.
+    * ``@error_ignore`` was applied (``spec.raise_subproc_error is False``).
+    """
+    if in_boolop:
+        return
+    if not XSH.env.get("XONSH_SUBPROC_RAISE_ERROR"):
+        return
+    cp = XSH.lastcmd
+    if cp is None:
+        return
+    rtn = getattr(cp, "returncode", None)
+    if rtn is None or rtn == 0:
+        return
+    spec = getattr(cp, "spec", None)
+    if spec is None:
+        return
+    if getattr(spec, "captured", None) == "object":
+        return
+    if getattr(spec, "raise_subproc_error", None) is False:
+        return
+    import subprocess
+
+    output = getattr(cp, "output", None)
+    raise subprocess.CalledProcessError(rtn, spec.args, output=output)
+
+
+def subproc_captured_stdout(*cmds, envs=None, in_boolop=False):
     """Runs a subprocess, capturing the output. Returns the stdout
     that was produced as a str or list based on ``$XONSH_SUBPROC_OUTPUT_FORMAT``.
+
+    ``in_boolop`` is set by the parser to True when this call is a direct
+    operand of a ``&&``/``||`` chain, so the runtime can adjust behavior
+    (e.g. suppress ``$XONSH_SUBPROC_CMD_RAISE_ERROR`` to let the chain
+    short-circuit on returncode).
     """
 
     import xonsh.procs.specs
 
-    return xonsh.procs.specs.run_subproc(cmds, captured="stdout", envs=envs)
+    r = xonsh.procs.specs.run_subproc(
+        cmds, captured="stdout", envs=envs, in_boolop=in_boolop
+    )
+    _check_subproc_helper_raise(in_boolop)
+    return r
 
 
-def subproc_captured_inject(*cmds, envs=None):
+def subproc_captured_inject(*cmds, envs=None, in_boolop=False):
     """Runs a subprocess, capturing the output. Returns a list of
     whitespace-separated strings of the stdout that was produced.
     The string is split using xonsh's lexer, rather than Python's str.split()
@@ -374,7 +427,10 @@ def subproc_captured_inject(*cmds, envs=None):
     """
     import xonsh.procs.specs
 
-    o = xonsh.procs.specs.run_subproc(cmds, captured="stdout", envs=envs)
+    o = xonsh.procs.specs.run_subproc(
+        cmds, captured="stdout", envs=envs, in_boolop=in_boolop
+    )
+    _check_subproc_helper_raise(in_boolop)
     o = o if isinstance(o, list) else o.splitlines()
     toks = []
     for line in o:
@@ -383,32 +439,110 @@ def subproc_captured_inject(*cmds, envs=None):
     return toks
 
 
-def subproc_captured_object(*cmds, envs=None):
+def subproc_captured_object(*cmds, envs=None, in_boolop=False):
     """
     Runs a subprocess, capturing the output. Returns an instance of
     CommandPipeline representing the completed command.
     """
     import xonsh.procs.specs
 
-    return xonsh.procs.specs.run_subproc(cmds, captured="object", envs=envs)
+    return xonsh.procs.specs.run_subproc(
+        cmds, captured="object", envs=envs, in_boolop=in_boolop
+    )
 
 
-def subproc_captured_hiddenobject(*cmds, envs=None):
+def subproc_captured_hiddenobject(*cmds, envs=None, in_boolop=False):
     """Runs a subprocess, capturing the output. Returns an instance of
     HiddenCommandPipeline representing the completed command.
     """
     import xonsh.procs.specs
 
-    return xonsh.procs.specs.run_subproc(cmds, captured="hiddenobject", envs=envs)
+    return xonsh.procs.specs.run_subproc(
+        cmds, captured="hiddenobject", envs=envs, in_boolop=in_boolop
+    )
 
 
-def subproc_uncaptured(*cmds, envs=None):
+def subproc_uncaptured(*cmds, envs=None, in_boolop=False):
     """Runs a subprocess, without capturing the output. Returns the stdout
     that was produced as a str.
     """
     import xonsh.procs.specs
 
-    return xonsh.procs.specs.run_subproc(cmds, captured=False, envs=envs)
+    r = xonsh.procs.specs.run_subproc(
+        cmds, captured=False, envs=envs, in_boolop=in_boolop
+    )
+    _check_subproc_helper_raise(in_boolop)
+    return r
+
+
+def subproc_check_boolop(value):
+    """Raise ``CalledProcessError`` if *value* is the (final) result of
+    a subproc statement that ended in failure.
+
+    Used as the AST wrapper around two kinds of nodes:
+
+    * The outermost ``BoolOp`` of a logical chain (``cmd1 && cmd2`` /
+      ``cmd1 || cmd2``).  Python ``and``/``or`` short-circuits to the
+      pipeline that determined the chain result, so the wrapper sees
+      the *final* pipeline.
+    * A standalone subproc-helper call at statement level — bare
+      commands, ``![...]``, ``$[...]``, ``$(...)``, ``@$(...)``.  The
+      explicit-capture form ``!(...)`` is *intentionally* not wrapped:
+      per spec it is the user's full responsibility.
+
+    When ``$XONSH_SUBPROC_RAISE_ERROR`` is True (default), this enforces
+    "raise on the last executed pipeline's non-zero exit code" semantics:
+
+    * ``ls nono`` (standalone) — rc≠0: raises.
+    * ``$(ls nono)`` (standalone) — rc≠0: raises.
+    * ``$[ls nono]`` (standalone) — rc≠0: raises.
+    * ``echo 1 && echo 2`` — last is ``echo 2`` (rc=0): no raise.
+    * ``ls nono || echo 1`` — last is ``echo 1`` (rc=0): no raise.
+    * ``ls nono && echo 1`` — last is ``ls nono`` (rc≠0): raises.
+
+    Per-command overrides:
+
+    * ``@error_ignore`` (``spec.raise_subproc_error is False``) on the
+      final pipeline suppresses the raise — used e.g. for
+      ``echo 1 && @error_ignore ls nono``.
+    * ``@error_raise`` raises directly at the pipeline level, so the
+      wrapper never sees a failed value.
+
+    Some subproc helpers (``$()``, ``$[]``, ``@$()``) return a *string*
+    / *None* / *list* rather than a ``CommandPipeline``, so the wrapper
+    can't read ``returncode`` directly off ``value``.  In that case it
+    falls back to ``XSH.lastcmd`` — the most recently completed pipeline,
+    which is the one this helper just ran.
+    """
+    import subprocess
+
+    if not XSH.env.get("XONSH_SUBPROC_RAISE_ERROR"):
+        return value
+    # Try to get the pipeline from the value first (BoolOp result, ![...]).
+    spec = getattr(value, "spec", None)
+    rtn = getattr(value, "returncode", None)
+    cp_for_output = value
+    if spec is None or rtn is None:
+        # Value isn't a CommandPipeline (e.g. string from $(), None from
+        # $[], list from @$()).  Fall back to the most recently
+        # completed pipeline so we can still inspect its returncode.
+        last = XSH.lastcmd
+        if last is None:
+            return value
+        spec = getattr(last, "spec", None)
+        rtn = getattr(last, "returncode", None)
+        cp_for_output = last
+    if spec is None or rtn is None or rtn == 0:
+        return value
+    # ``!(...)`` is the "user takes full responsibility" form — never
+    # raise even if it ends up here via a chain like ``cmd && !(cmd)``.
+    if getattr(spec, "captured", None) == "object":
+        return value
+    # @error_ignore on the final pipeline of the chain opts out.
+    if getattr(spec, "raise_subproc_error", None) is False:
+        return value
+    output = getattr(cp_for_output, "output", None)
+    raise subprocess.CalledProcessError(rtn, spec.args, output=output)
 
 
 _SPECIAL_BUILTINS = {"...": ...}
@@ -865,6 +999,7 @@ class XonshSession:
         self.subproc_captured_object = subproc_captured_object
         self.subproc_captured_hiddenobject = subproc_captured_hiddenobject
         self.subproc_uncaptured = subproc_uncaptured
+        self.subproc_check_boolop = subproc_check_boolop
         self.call_macro = call_macro
         self.enter_macro = enter_macro
         self.path_literal = path_literal

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1262,6 +1262,7 @@ class SubprocessSetting(Xettings):
         "should cause an end to execution. This is less useful at a terminal. "
         "The error that is raised is a ``subprocess.CalledProcessError``. "
         "(Replaces the deprecated ``$RAISE_SUBPROC_ERROR``.)",
+        sync="RAISE_SUBPROC_ERROR",
     )
     XONSH_SUBPROC_RAISE_ERROR = Var.with_default(
         True,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2315,12 +2315,7 @@ class Env(cabc.MutableMapping):
         # the deprecated key silently here.
         for key, val in initial.items():
             var = self._vars.get(key)
-            if (
-                var is not None
-                and var.deprecated
-                and var.sync
-                and var.sync in initial
-            ):
+            if var is not None and var.deprecated and var.sync and var.sync in initial:
                 continue
             self[key] = val
         if ON_WINDOWS:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1254,13 +1254,29 @@ class GeneralSetting(Xettings):
 class SubprocessSetting(Xettings):
     """Subprocess Settings"""
 
-    RAISE_SUBPROC_ERROR = Var.with_default(
+    XONSH_SUBPROC_CMD_RAISE_ERROR = Var.with_default(
         False,
         "Whether or not to raise an error if a subprocess (captured or "
         "uncaptured) returns a non-zero exit status, which indicates failure. "
         "This is most useful in xonsh scripts or modules where failures "
         "should cause an end to execution. This is less useful at a terminal. "
-        "The error that is raised is a ``subprocess.CalledProcessError``.",
+        "The error that is raised is a ``subprocess.CalledProcessError``. "
+        "(Replaces the deprecated ``$RAISE_SUBPROC_ERROR``.)",
+    )
+    XONSH_SUBPROC_RAISE_ERROR = Var.with_default(
+        True,
+        "Whether or not to raise an error when the *final* command of a "
+        "logical chain (``cmd1 && cmd2`` / ``cmd1 || cmd2``) returns a "
+        "non-zero exit status.  Unlike ``$XONSH_SUBPROC_CMD_RAISE_ERROR`` "
+        "(which raises on every individual non-zero subprocess), commands "
+        "inside a logical chain do not raise on their own — only the "
+        "result of the whole short-circuit evaluation is checked. "
+        "Examples (with the default ``True``):\n\n"
+        "* ``echo 1 && echo 2`` — last executed is ``echo 2`` (rc=0): no raise.\n"
+        "* ``ls nono || echo 1`` — last executed is ``echo 1`` (rc=0): no raise.\n"
+        "* ``ls nono && echo 1`` — last executed is ``ls nono`` (rc≠0): raises.\n"
+        "* ``(echo 1 && ls /etc) || echo 1`` — last executed is ``ls /etc`` (rc=0): no raise.\n\n"
+        "The exception raised is a ``subprocess.CalledProcessError``.",
     )
     LAST_RETURN_CODE = Var.with_default(
         0,
@@ -2238,6 +2254,9 @@ class DeprecatedSetting(PromptSetting):  # sub-classing -> sub-group
 
     AUTO_SUGGEST = PTKSetting.XONSH_PROMPT_AUTO_SUGGEST.set_attrs(
         {"sync": "XONSH_PROMPT_AUTO_SUGGEST", "deprecated": True}
+    )
+    RAISE_SUBPROC_ERROR = SubprocessSetting.XONSH_SUBPROC_CMD_RAISE_ERROR.set_attrs(
+        {"sync": "XONSH_SUBPROC_CMD_RAISE_ERROR", "deprecated": True}
     )
 
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2304,7 +2304,24 @@ class Env(cabc.MutableMapping):
 
         if len(args) == 0 and len(kwargs) == 0:
             args = (os_environ,)
-        for key, val in dict(*args, **kwargs).items():
+        initial = dict(*args, **kwargs)
+        # Avoid a spurious DeprecationWarning when both a deprecated
+        # alias (e.g. ``RAISE_SUBPROC_ERROR``) and its canonical name
+        # (``XONSH_SUBPROC_CMD_RAISE_ERROR``) are present in the source
+        # dict — which happens whenever a parent xonsh process set the
+        # canonical name and the sync mechanism mirrored the value into
+        # os.environ.  The canonical name alone will re-populate the
+        # alias via its forward ``sync=`` declaration, so we can skip
+        # the deprecated key silently here.
+        for key, val in initial.items():
+            var = self._vars.get(key)
+            if (
+                var is not None
+                and var.deprecated
+                and var.sync
+                and var.sync in initial
+            ):
+                continue
             self[key] = val
         if ON_WINDOWS:
             path_key = next((k for k in self._d if k.upper() == "PATH"), None)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1623,6 +1623,26 @@ class PromptSetting(Xettings):
         "    ",
         "Indentation string for multiline input",
     )
+    XONSH_PROMPT_SHOW_SUBPROC_ERROR = Var.with_default(
+        False,
+        "Whether the interactive prompt should display the "
+        "``subprocess.CalledProcessError`` message when a command at the "
+        "prompt fails.  The failing command's own ``stderr`` is always "
+        "shown — this flag only controls xonsh's own exception printout "
+        "that follows it.\n\n"
+        "* ``False`` *(default)*: after a failing command the prompt "
+        "returns silently; the command's ``stderr`` is still visible and "
+        "``$LAST_RETURN_CODE`` is set.\n"
+        "* ``True``: xonsh additionally prints "
+        "``subprocess.CalledProcessError: Command '...' returned non-zero "
+        "exit status N.``.\n\n"
+        "Notes:\n\n"
+        "* Per-command ``@error_raise`` decorator always shows the "
+        "exception, regardless of this flag.\n"
+        "* Non-interactive scripts (run via ``./script.xsh`` or "
+        "``xonsh -c``) are unaffected — there the exception propagates "
+        "normally so the failure is visible.",
+    )
     LS_COLORS = Var(
         is_lscolors,
         LsColors.convert,

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -8,6 +8,7 @@ import types
 
 from xonsh.parser import Parser
 from xonsh.parsers.ast import CtxAwareTransformer
+from xonsh.parsers.base import wrap_subproc_raise_checks
 from xonsh.tools import (
     balanced_parens,
     ends_with_colon_token,
@@ -109,6 +110,12 @@ class Execer:
             debug_level=self.debug_level,
             user_names=user_names,
         )
+        # [Phase 3]
+        # Wrap outermost subproc-containing BoolOps and standalone
+        # "uncaptured" subproc helper Calls (bare commands, ![...],
+        # $[...]) so their final returncode is checked at runtime
+        # against $XONSH_SUBPROC_RAISE_ERROR.
+        tree = wrap_subproc_raise_checks(tree)
         return tree
 
     def compile(

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -694,7 +694,7 @@ def main_context(argv=None):
 def setup(
     ctx=None,
     shell_type="none",
-    env=(("RAISE_SUBPROC_ERROR", True),),
+    env=(("XONSH_SUBPROC_CMD_RAISE_ERROR", True),),
     aliases=(),
     xontribs=(),
     threadable_predictors=(),

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -6,6 +6,7 @@ import re
 import textwrap
 import threading
 import typing as tp
+from ast import iter_fields as _ast_iter_fields
 from ast import parse as pyparse
 from collections.abc import Iterable, Mapping, Sequence
 from threading import Thread
@@ -24,6 +25,218 @@ RE_SEARCHPATH = LazyObject(lambda: re.compile(SearchPath), globals(), "RE_SEARCH
 RE_STRINGPREFIX = LazyObject(
     lambda: re.compile(StringPrefix), globals(), "RE_STRINGPREFIX"
 )
+
+
+_SUBPROC_HELPER_NAMES = frozenset(
+    {
+        "subproc_captured_stdout",
+        "subproc_captured_inject",
+        "subproc_captured_object",
+        "subproc_captured_hiddenobject",
+        "subproc_uncaptured",
+    }
+)
+
+# Subset of subproc helpers whose *standalone* (statement-level) result is
+# subject to ``$XONSH_SUBPROC_RAISE_ERROR``.  Per spec only the explicit
+# "user takes full responsibility" form ``!(...)`` (``subproc_captured_object``)
+# is excluded — every other form raises on a non-zero return code by default:
+# bare commands, ``![...]``, ``$[...]``, ``$(...)``, ``@$(...)``.
+_RAISING_SUBPROC_HELPERS = frozenset(
+    {
+        "subproc_uncaptured",
+        "subproc_captured_hiddenobject",
+        "subproc_captured_stdout",
+        "subproc_captured_inject",
+    }
+)
+
+
+def _is_subproc_helper_call(node):
+    """True if `node` is an `ast.Call` to a `__xonsh__.subproc_*` helper."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in _SUBPROC_HELPER_NAMES
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "__xonsh__"
+    )
+
+
+def _is_raising_subproc_helper_call(node):
+    """True for direct calls to ``subproc_uncaptured`` /
+    ``subproc_captured_hiddenobject``.  These are the "uncaptured" forms
+    that should raise on non-zero rc when ``$XONSH_SUBPROC_RAISE_ERROR``
+    is True.
+    """
+    return (
+        _is_subproc_helper_call(node) and node.func.attr in _RAISING_SUBPROC_HELPERS
+    )
+
+
+def _is_subproc_check_boolop_call(node):
+    """True if `node` is already wrapped in ``subproc_check_boolop``."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "subproc_check_boolop"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "__xonsh__"
+    )
+
+
+def _mark_boolop_subproc_values(boolop):
+    """Tag subproc helper Calls that are direct ``values`` of a BoolOp.
+
+    For ``echo 1 && echo 2 ; echo 3`` the parser builds
+    ``BoolOp(And, [Call(subproc_*), Call(subproc_*)])`` plus a separate
+    standalone ``Call(subproc_*)`` for ``echo 3``.  We want the two calls
+    inside the BoolOp to know they participate in a logical chain (so the
+    runtime can let the chain short-circuit on returncode instead of
+    raising on the first failure), and leave the standalone call alone.
+
+    Nested BoolOps already mark their own values when they are constructed,
+    so this function does *not* recurse — it only injects the keyword on
+    direct subproc-helper children.
+    """
+    for value in boolop.values:
+        if not _is_subproc_helper_call(value):
+            continue
+        # Avoid duplicating the keyword if a parent BoolOp re-marks us.
+        if any(kw.arg == "in_boolop" for kw in value.keywords):
+            continue
+        lineno = getattr(value, "lineno", 1)
+        col = getattr(value, "col_offset", 0)
+        value.keywords.append(
+            ast.keyword(
+                arg="in_boolop",
+                value=ast.Constant(value=True, lineno=lineno, col_offset=col),
+                lineno=lineno,
+                col_offset=col,
+            )
+        )
+
+
+def _boolop_contains_subproc(node):
+    """True if the AST subtree rooted at ``node`` contains at least one
+    subproc helper Call.  Used to skip wrapping pure-Python BoolOps such
+    as ``if x and y:``.
+    """
+    for child in ast.walk(node):
+        if _is_subproc_helper_call(child):
+            return True
+    return False
+
+
+class _SubprocChainRaiseWrapper:
+    """AST post-pass that wraps two kinds of nodes in
+    ``__xonsh__.subproc_check_boolop(...)`` so the runtime can enforce
+    ``$XONSH_SUBPROC_RAISE_ERROR``:
+
+    1. The **outermost** ``BoolOp`` containing subproc helper calls
+       (i.e. ``cmd1 && cmd2`` chains).  Only the outermost is wrapped:
+       inner BoolOps must let their (possibly falsy) result propagate
+       up so an outer ``||`` fallback can still run.
+
+    2. **Standalone** statement-level Calls to "raising" subproc helpers
+       (``subproc_uncaptured`` / ``subproc_captured_hiddenobject`` —
+       i.e. bare commands and ``![...]``/``$[...]``).  This is what
+       makes ``ls nono`` raise by default.  Captured forms (``$()``,
+       ``!()``, ``@$()``) are intentionally NOT wrapped — per spec the
+       user takes full responsibility for their result.
+
+    Pure-Python BoolOps (no subproc helpers in any descendant) are left
+    untouched so user code like ``if x and y:`` is not affected.
+    """
+
+    # AST statement nodes whose ``.value`` is a candidate for
+    # standalone-Call wrapping.  ``Return`` is intentionally omitted —
+    # ``return ![cmd]`` is rare and the existing CMD_RAISE_ERROR path
+    # already covers callers that want it.
+    _VALUE_STMT_TYPES = (
+        ast.Expr,
+        ast.Assign,
+        ast.AugAssign,
+        ast.AnnAssign,
+    )
+
+    def __init__(self):
+        self._inside_boolop = False
+
+    def visit(self, node):
+        if isinstance(node, ast.BoolOp):
+            return self._visit_boolop(node)
+        if isinstance(node, self._VALUE_STMT_TYPES):
+            # Recurse first so that any nested BoolOps inside the value
+            # get the BoolOp wrapping treatment, then optionally wrap
+            # the (possibly already-wrapped) value with the standalone
+            # check.
+            self._recurse(node)
+            self._maybe_wrap_stmt_value(node)
+            return node
+        self._recurse(node)
+        return node
+
+    def _visit_boolop(self, node):
+        if self._inside_boolop:
+            # Nested — recurse into children but do NOT wrap.  An inner
+            # BoolOp must let its (possibly falsy) result propagate up
+            # to the outer short-circuit logic.
+            self._recurse(node)
+            return node
+        self._inside_boolop = True
+        try:
+            self._recurse(node)
+        finally:
+            self._inside_boolop = False
+        if _boolop_contains_subproc(node):
+            return self._wrap(node)
+        return node
+
+    def _maybe_wrap_stmt_value(self, stmt):
+        val = getattr(stmt, "value", None)
+        if val is None:
+            return
+        # If the BoolOp pass already wrapped this value, nothing to do.
+        if _is_subproc_check_boolop_call(val):
+            return
+        if not _is_raising_subproc_helper_call(val):
+            return
+        stmt.value = self._wrap(val)
+
+    def _recurse(self, parent):
+        for field, value in _ast_iter_fields(parent):
+            if isinstance(value, list):
+                for i, item in enumerate(value):
+                    if isinstance(item, ast.AST):
+                        value[i] = self.visit(item)
+            elif isinstance(value, ast.AST):
+                setattr(parent, field, self.visit(value))
+
+    @staticmethod
+    def _wrap(node):
+        lineno = node.lineno
+        col = node.col_offset
+        return ast.Call(
+            func=load_attribute_chain(
+                "__xonsh__.subproc_check_boolop", lineno=lineno, col=col
+            ),
+            args=[node],
+            keywords=[],
+            lineno=lineno,
+            col_offset=col,
+        )
+
+
+def wrap_subproc_raise_checks(tree):
+    """Public entry point — wraps outermost subproc-containing BoolOps
+    *and* standalone "uncaptured" subproc-helper Calls (bare commands,
+    ``![...]``, ``$[...]``) in ``__xonsh__.subproc_check_boolop`` so the
+    result is checked at runtime against ``$XONSH_SUBPROC_RAISE_ERROR``.
+    """
+    return _SubprocChainRaiseWrapper().visit(tree)
 
 
 class Location:
@@ -2046,11 +2259,13 @@ class BaseParser:
         elif len(p2) == 2:
             lineno, col = lopen_loc(p1)
             p0 = ast.BoolOp(op=p2[0], values=[p1, p2[1]], lineno=lineno, col_offset=col)
+            _mark_boolop_subproc_values(p0)
         else:
             lineno, col = lopen_loc(p1)
             p0 = ast.BoolOp(
                 op=p2[0], values=[p[1]] + p2[1::2], lineno=lineno, col_offset=col
             )
+            _mark_boolop_subproc_values(p0)
         p[0] = p0
 
     def p_or_and_test(self, p):
@@ -2065,11 +2280,13 @@ class BaseParser:
         elif len(p2) == 2:
             lineno, col = lopen_loc(p1)
             p0 = ast.BoolOp(op=p2[0], values=[p1, p2[1]], lineno=lineno, col_offset=col)
+            _mark_boolop_subproc_values(p0)
         else:
             lineno, col = lopen_loc(p1)
             p0 = ast.BoolOp(
                 op=p2[0], values=[p1] + p2[1::2], lineno=lineno, col_offset=col
             )
+            _mark_boolop_subproc_values(p0)
         p[0] = p0
 
     def p_and_not_test(self, p):

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -71,9 +71,7 @@ def _is_raising_subproc_helper_call(node):
     that should raise on non-zero rc when ``$XONSH_SUBPROC_RAISE_ERROR``
     is True.
     """
-    return (
-        _is_subproc_helper_call(node) and node.func.attr in _RAISING_SUBPROC_HELPERS
-    )
+    return _is_subproc_helper_call(node) and node.func.attr in _RAISING_SUBPROC_HELPERS
 
 
 def _is_subproc_check_boolop_call(node):

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -853,14 +853,32 @@ class CommandPipeline:
         raise_subproc_error = spec.raise_subproc_error
         if callable(raise_subproc_error):
             raise_subproc_error = raise_subproc_error(spec, self)
+
+        # @error_ignore — never raise.
         if raise_subproc_error is False:
             return
 
-        if raise_subproc_error or XSH.env.get("RAISE_SUBPROC_ERROR", True):
+        # @error_raise — always raise, even mid-chain.
+        if raise_subproc_error is True:
             try:
                 raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
             finally:
-                # this is need to get a working terminal in interactive mode
+                # needed to get a working terminal in interactive mode
+                self._return_terminal()
+            return
+
+        # Default: defer chain operands to the BoolOp wrapper.
+        if getattr(spec, "in_boolop", False):
+            return
+
+        # Standalone — only raise here if the user explicitly opted in
+        # to per-command raising.  Otherwise let the AST wrapper around
+        # the statement do it via $XONSH_SUBPROC_RAISE_ERROR.
+        if XSH.env.get("XONSH_SUBPROC_CMD_RAISE_ERROR"):
+            try:
+                raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
+            finally:
+                # needed to get a working terminal in interactive mode
                 self._return_terminal()
 
     #

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -513,8 +513,8 @@ class CommandPipeline:
             else:
                 err_target.write(b.decode(encoding=enc, errors=err))
             err_target.flush()
-        # save the raw bytes
-        self._raw_error = b
+        # accumulate the raw bytes
+        self._raw_error += b
         # do some munging of the line before we save it to the attr
         b = b.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
         env = XSH.env

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -861,7 +861,9 @@ class CommandPipeline:
         # @error_raise — always raise, even mid-chain.
         if raise_subproc_error is True:
             try:
-                raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
+                raise subprocess.CalledProcessError(
+                    rtn, spec.args, output=self.output
+                )
             finally:
                 # needed to get a working terminal in interactive mode
                 self._return_terminal()
@@ -876,7 +878,9 @@ class CommandPipeline:
         # the statement do it via $XONSH_SUBPROC_RAISE_ERROR.
         if XSH.env.get("XONSH_SUBPROC_CMD_RAISE_ERROR"):
             try:
-                raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
+                raise subprocess.CalledProcessError(
+                    rtn, spec.args, output=self.output
+                )
             finally:
                 # needed to get a working terminal in interactive mode
                 self._return_terminal()

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -861,9 +861,7 @@ class CommandPipeline:
         # @error_raise — always raise, even mid-chain.
         if raise_subproc_error is True:
             try:
-                raise subprocess.CalledProcessError(
-                    rtn, spec.args, output=self.output
-                )
+                raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
             finally:
                 # needed to get a working terminal in interactive mode
                 self._return_terminal()
@@ -878,9 +876,7 @@ class CommandPipeline:
         # the statement do it via $XONSH_SUBPROC_RAISE_ERROR.
         if XSH.env.get("XONSH_SUBPROC_CMD_RAISE_ERROR"):
             try:
-                raise subprocess.CalledProcessError(
-                    rtn, spec.args, output=self.output
-                )
+                raise subprocess.CalledProcessError(rtn, spec.args, output=self.output)
             finally:
                 # needed to get a working terminal in interactive mode
                 self._return_terminal()

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -468,7 +468,10 @@ class SubprocSpec:
         self.decorators = []  # List of DecoratorAlias objects that applied to spec.
         self.pipe_channels = []  # PipeChannel objects owned by this spec
         self.output_format = XSH.env.get("XONSH_SUBPROC_OUTPUT_FORMAT", "stream_lines")
-        self.raise_subproc_error = None  # Spec-based $RAISE_SUBPROC_ERROR.
+        self.raise_subproc_error = None  # Spec-based $XONSH_SUBPROC_CMD_RAISE_ERROR.
+        # True when this pipeline is a direct operand of an `&&`/`||` chain
+        # (set by `cmds_to_specs` from the parser-injected `in_boolop` kwarg).
+        self.in_boolop = False
 
     def __str__(self):
         s = self.__class__.__name__ + "(" + str(self.cmd) + ", "
@@ -1134,9 +1137,15 @@ def _trace_specs(trace_mode, specs, cmds, captured):
                 print(f"{i}: {repr(p)}", file=sys.stderr)
 
 
-def cmds_to_specs(cmds, captured=False, envs=None):
+def cmds_to_specs(cmds, captured=False, envs=None, in_boolop=False):
     """Converts a list of cmds to a list of SubprocSpec objects that are
     ready to be executed.
+
+    ``in_boolop`` is propagated from the parser; it is True when the whole
+    pipeline is a direct operand of a ``&&``/``||`` chain.  Each spec gets
+    the flag stored on it so downstream code (e.g. ``CommandPipeline``,
+    ``_raise_subproc_error``) can decide whether to short-circuit on
+    returncode or raise.
     """
     # first build the subprocs independently and separate from the redirects
     specs = []
@@ -1148,6 +1157,7 @@ def cmds_to_specs(cmds, captured=False, envs=None):
             env = envs[i] if envs is not None else None
             spec = SubprocSpec.build(cmd, captured=captured, env=env)
             spec.pipeline_index = len(specs)
+            spec.in_boolop = in_boolop
             specs.append(spec)
     # now modify the subprocs based on the redirects.
     for i, redirect in enumerate(redirects):
@@ -1211,7 +1221,7 @@ def _shell_set_title(cmds):
             XSH.shell.settitle()
 
 
-def run_subproc(cmds, captured=False, envs=None):
+def run_subproc(cmds, captured=False, envs=None, in_boolop=False):
     """Runs a subprocess, in its many forms. This takes a list of 'commands,'
     which may be a list of command line arguments or a string, representing
     a special connecting character.  For example::
@@ -1223,9 +1233,14 @@ def run_subproc(cmds, captured=False, envs=None):
         [['ls'], '|', ['grep', 'wakka']]
 
     Lastly, the captured argument affects only the last real command.
+
+    ``in_boolop`` is forwarded from the parser; True when this whole
+    pipeline is a direct operand of a ``&&``/``||`` chain.  Each spec
+    receives ``spec.in_boolop`` so downstream consumers can act on it
+    (e.g. let a non-zero return short-circuit instead of raising).
     """
 
-    specs = cmds_to_specs(cmds, captured=captured, envs=envs)
+    specs = cmds_to_specs(cmds, captured=captured, envs=envs, in_boolop=in_boolop)
 
     if trace_mode := XSH.env.get("XONSH_TRACE_SUBPROC", False):
         _trace_specs(trace_mode, specs, cmds, captured)

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+import subprocess
 import sys
 import time
 
@@ -405,6 +406,29 @@ class BaseShell:
                 hist.last_cmd_rtn = 0  # returncode for success
         except XonshError as e:
             print(e.args[0], file=sys.stderr)
+            if hist is not None and hist.last_cmd_rtn is None:
+                hist.last_cmd_rtn = 1  # return code for failure
+        except subprocess.CalledProcessError:
+            # A subproc command at the prompt failed.  The command's own
+            # ``stderr`` is already on screen; whether we *additionally*
+            # print xonsh's ``CalledProcessError: ...`` line is governed
+            # by ``$XONSH_PROMPT_SHOW_SUBPROC_ERROR``.
+            #
+            # ``@error_raise`` is a per-command opt-in that *always*
+            # shows the exception, regardless of the env var — detected
+            # by checking whether the last completed pipeline's spec
+            # has ``raise_subproc_error is True``.
+            #
+            # Scripts (``./script.xsh`` / ``xonsh -c``) never reach this
+            # handler because they don't go through ``default()``, so
+            # their failures keep propagating as before.
+            lastcmd = XSH.lastcmd
+            spec = getattr(lastcmd, "spec", None) if lastcmd is not None else None
+            is_error_raise = (
+                getattr(spec, "raise_subproc_error", None) is True
+            )
+            if is_error_raise or env.get("XONSH_PROMPT_SHOW_SUBPROC_ERROR"):
+                print_exception(exc_info=exc_info)
             if hist is not None and hist.last_cmd_rtn is None:
                 hist.last_cmd_rtn = 1  # return code for failure
         except (SystemExit, KeyboardInterrupt) as err:

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -424,9 +424,7 @@ class BaseShell:
             # their failures keep propagating as before.
             lastcmd = XSH.lastcmd
             spec = getattr(lastcmd, "spec", None) if lastcmd is not None else None
-            is_error_raise = (
-                getattr(spec, "raise_subproc_error", None) is True
-            )
+            is_error_raise = getattr(spec, "raise_subproc_error", None) is True
             if is_error_raise or env.get("XONSH_PROMPT_SHOW_SUBPROC_ERROR"):
                 print_exception(exc_info=exc_info)
             if hist is not None and hist.last_cmd_rtn is None:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -939,10 +939,7 @@ def print_exception(msg=None, exc_info=None, source_msg=None):
     if not show_trace:
         # if traceback output is disabled, print the exception's
         # error message on stderr.
-        if not env.get("XONSH_SHOW_TRACEBACK") and (
-            env.get("XONSH_SUBPROC_CMD_RAISE_ERROR")
-            or env.get("XONSH_SUBPROC_RAISE_ERROR")
-        ):
+        if not env.get("XONSH_SHOW_TRACEBACK") and env.get("RAISE_SUBPROC_ERROR"):
             display_colored_error_message(exc_info, limit=1)
         else:
             display_error_message(exc_info)
@@ -951,21 +948,10 @@ def print_exception(msg=None, exc_info=None, source_msg=None):
         sys.stderr.write(msg)
 
 
-def _strip_subproc_error_prefix(line):
-    """Replace the ``subprocess.CalledProcessError:`` type prefix on a
-    formatted traceback line with a simple ``Error:`` so the user sees
-    a shell-like message:
-
-        ``Error: Command '...' returned non-zero exit status N.``
-    """
-    return re.sub(r"^(?:[\w.]+\.)?CalledProcessError:", "Error:", line, count=1)
-
-
 def display_colored_error_message(exc_info, strip_xonsh_error_types=True, limit=None):
-    no_trace_and_raise_subproc_error = not xsh.env.get("XONSH_SHOW_TRACEBACK") and (
-        xsh.env.get("XONSH_SUBPROC_CMD_RAISE_ERROR")
-        or xsh.env.get("XONSH_SUBPROC_RAISE_ERROR")
-    )
+    no_trace_and_raise_subproc_error = not xsh.env.get(
+        "XONSH_SHOW_TRACEBACK"
+    ) and xsh.env.get("RAISE_SUBPROC_ERROR")
 
     if no_trace_and_raise_subproc_error:
         limit = 1
@@ -975,18 +961,7 @@ def display_colored_error_message(exc_info, strip_xonsh_error_types=True, limit=
     if no_trace_and_raise_subproc_error and "Error:" in content[-1]:
         content = [content[-1]]
 
-    is_called_process_error = isinstance(exc_info[1], subprocess.CalledProcessError)
-    if strip_xonsh_error_types and content and is_called_process_error:
-        content[-1] = _strip_subproc_error_prefix(content[-1])
-
     traceback_str = "".join([v for v in content])
-
-    # For ``CalledProcessError`` strip the trailing newline so the prompt
-    # (or whatever comes next on stderr) starts on its own line without a
-    # blank line in between.  Other exception types keep their trailing
-    # newline so subsequent output is properly separated.
-    if is_called_process_error:
-        traceback_str = traceback_str.rstrip("\n")
 
     # color the traceback if available
     _, interactive = _get_manual_env_var("XONSH_INTERACTIVE", 0)
@@ -1013,14 +988,6 @@ def display_error_message(exc_info, strip_xonsh_error_types=True):
     exception_only = traceback.format_exception_only(exc_type, exc_value)
     if exc_type is XonshError and strip_xonsh_error_types:
         exception_only[0] = exception_only[0].partition(": ")[-1]
-    elif strip_xonsh_error_types and issubclass(
-        exc_type, subprocess.CalledProcessError
-    ):
-        # Replace the ``subprocess.CalledProcessError:`` type prefix with a
-        # short ``Error:`` so the message looks shell-native, and drop any
-        # trailing newline so the next line of output (typically the
-        # prompt) is not preceded by a blank line.
-        exception_only[0] = _strip_subproc_error_prefix(exception_only[0]).rstrip("\n")
     sys.stderr.write("".join(exception_only))
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -840,7 +840,7 @@ def print_warning(msg):
         if not manually_set_logfile:
             sys.stderr.write(
                 "xonsh: To log full traceback to a file set: "
-                "$XONSH_TRACEBACK_LOGFILE = <filename>\n"
+                "$XONSH_TRACEBACK_LOGFILE = 'error.log'\n"
             )
         traceback.print_stack()
     # additionally, check if a file for traceback logging has been
@@ -922,7 +922,7 @@ def print_exception(msg=None, exc_info=None, source_msg=None):
         if not manually_set_logfile:
             sys.stderr.write(
                 "xonsh: To log full traceback to a file set: "
-                "$XONSH_TRACEBACK_LOGFILE = <filename>\n"
+                "$XONSH_TRACEBACK_LOGFILE = 'error.log'\n"
             )
 
         display_colored_error_message(exc_info)
@@ -939,7 +939,10 @@ def print_exception(msg=None, exc_info=None, source_msg=None):
     if not show_trace:
         # if traceback output is disabled, print the exception's
         # error message on stderr.
-        if not env.get("XONSH_SHOW_TRACEBACK") and env.get("RAISE_SUBPROC_ERROR"):
+        if not env.get("XONSH_SHOW_TRACEBACK") and (
+            env.get("XONSH_SUBPROC_CMD_RAISE_ERROR")
+            or env.get("XONSH_SUBPROC_RAISE_ERROR")
+        ):
             display_colored_error_message(exc_info, limit=1)
         else:
             display_error_message(exc_info)
@@ -948,10 +951,23 @@ def print_exception(msg=None, exc_info=None, source_msg=None):
         sys.stderr.write(msg)
 
 
+def _strip_subproc_error_prefix(line):
+    """Replace the ``subprocess.CalledProcessError:`` type prefix on a
+    formatted traceback line with a simple ``Error:`` so the user sees
+    a shell-like message:
+
+        ``Error: Command '...' returned non-zero exit status N.``
+    """
+    return re.sub(
+        r"^(?:[\w.]+\.)?CalledProcessError:", "Error:", line, count=1
+    )
+
+
 def display_colored_error_message(exc_info, strip_xonsh_error_types=True, limit=None):
-    no_trace_and_raise_subproc_error = not xsh.env.get(
-        "XONSH_SHOW_TRACEBACK"
-    ) and xsh.env.get("RAISE_SUBPROC_ERROR")
+    no_trace_and_raise_subproc_error = not xsh.env.get("XONSH_SHOW_TRACEBACK") and (
+        xsh.env.get("XONSH_SUBPROC_CMD_RAISE_ERROR")
+        or xsh.env.get("XONSH_SUBPROC_RAISE_ERROR")
+    )
 
     if no_trace_and_raise_subproc_error:
         limit = 1
@@ -961,7 +977,18 @@ def display_colored_error_message(exc_info, strip_xonsh_error_types=True, limit=
     if no_trace_and_raise_subproc_error and "Error:" in content[-1]:
         content = [content[-1]]
 
+    is_called_process_error = isinstance(exc_info[1], subprocess.CalledProcessError)
+    if strip_xonsh_error_types and content and is_called_process_error:
+        content[-1] = _strip_subproc_error_prefix(content[-1])
+
     traceback_str = "".join([v for v in content])
+
+    # For ``CalledProcessError`` strip the trailing newline so the prompt
+    # (or whatever comes next on stderr) starts on its own line without a
+    # blank line in between.  Other exception types keep their trailing
+    # newline so subsequent output is properly separated.
+    if is_called_process_error:
+        traceback_str = traceback_str.rstrip("\n")
 
     # color the traceback if available
     _, interactive = _get_manual_env_var("XONSH_INTERACTIVE", 0)
@@ -988,6 +1015,14 @@ def display_error_message(exc_info, strip_xonsh_error_types=True):
     exception_only = traceback.format_exception_only(exc_type, exc_value)
     if exc_type is XonshError and strip_xonsh_error_types:
         exception_only[0] = exception_only[0].partition(": ")[-1]
+    elif strip_xonsh_error_types and issubclass(exc_type, subprocess.CalledProcessError):
+        # Replace the ``subprocess.CalledProcessError:`` type prefix with a
+        # short ``Error:`` so the message looks shell-native, and drop any
+        # trailing newline so the next line of output (typically the
+        # prompt) is not preceded by a blank line.
+        exception_only[0] = _strip_subproc_error_prefix(exception_only[0]).rstrip(
+            "\n"
+        )
     sys.stderr.write("".join(exception_only))
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -958,9 +958,7 @@ def _strip_subproc_error_prefix(line):
 
         ``Error: Command '...' returned non-zero exit status N.``
     """
-    return re.sub(
-        r"^(?:[\w.]+\.)?CalledProcessError:", "Error:", line, count=1
-    )
+    return re.sub(r"^(?:[\w.]+\.)?CalledProcessError:", "Error:", line, count=1)
 
 
 def display_colored_error_message(exc_info, strip_xonsh_error_types=True, limit=None):
@@ -1015,14 +1013,14 @@ def display_error_message(exc_info, strip_xonsh_error_types=True):
     exception_only = traceback.format_exception_only(exc_type, exc_value)
     if exc_type is XonshError and strip_xonsh_error_types:
         exception_only[0] = exception_only[0].partition(": ")[-1]
-    elif strip_xonsh_error_types and issubclass(exc_type, subprocess.CalledProcessError):
+    elif strip_xonsh_error_types and issubclass(
+        exc_type, subprocess.CalledProcessError
+    ):
         # Replace the ``subprocess.CalledProcessError:`` type prefix with a
         # short ``Error:`` so the message looks shell-native, and drop any
         # trailing newline so the next line of output (typically the
         # prompt) is not preceded by a blank line.
-        exception_only[0] = _strip_subproc_error_prefix(exception_only[0]).rstrip(
-            "\n"
-        )
+        exception_only[0] = _strip_subproc_error_prefix(exception_only[0]).rstrip("\n")
     sys.stderr.write("".join(exception_only))
 
 

--- a/xonsh/webconfig/xonsh_data.py
+++ b/xonsh/webconfig/xonsh_data.py
@@ -19,7 +19,7 @@ from xonsh.pygments_cache import get_all_styles
 from xonsh.style_tools import partial_color_tokenize
 from xonsh.xontribs import Xontrib, get_xontribs
 
-# $RAISE_SUBPROC_ERROR = True
+# $XONSH_SUBPROC_CMD_RAISE_ERROR = True
 # $XONSH_SHOW_TRACEBACK = False
 
 #


### PR DESCRIPTION
## Motivation

We have RAISE_SUBPROC_ERROR and it False by default. Any subprocess command that returns non-zero result will not raise an exception. This produces unexpected and unwanted situations e.g.

```xsh
def func():
    # <logic>
    ls nofile
    # <logic that based on ls results>
    print('Success')

func()
# ls: file not found
Success  # We have success but error with ls not handled and logic after ls wrong.
```
Another unexpected unwanted situations are related to loops with commands e.g.
```xsh
for f in g`*`:  # let's process some files, for example 10,000 files
    echo Do some work with @(f)
    echo Error in case file f=42 is wrong
# You can try to press <Ctrl+C><Ctrl+C><Ctrl+C><Ctrl+C><Ctrl+C><Ctrl+C> 
# but loop will going forward because SIGNAL handling has lag. It's another 
# This is another bad consequence of not having a way out after the first error.

echo Success # We have success but error with ls above is not handled and logic after ls wrong.
```
As you can see in both cases we have wrong error handling patterns. We miss errors and run logic that shouldn't be executed. This is a legacy of posix shells that is wrong in the language that supports true exceptions and code.

If we set RAISE_SUBPROC_ERROR=True we will have another unwanted situations:
```xsh
ls nofile || ls another_file || echo It is okay
```
Here we will have exception on first ls but this logical command is totally ok. User responsible for error processing and user wants to have "It is ok message" if ls fails.

Based on these two patterns (but there are actually many of them), we improve the error handling logic.

## Implementation

After diving into "Related issues" and read discussions and pros and cons of different approaches it was clear that the logic of error handling should be as below.

### Chains
I use the term "chain" to describe a grouping of commands into a single unit:
* pipe chain - `echo 1 | grep 1 | head`
* logical chain - `ls file1 || ls file2 || echo 3`
* single chain - `ls file`

For example `echo 1 && echo 2 ; echo 3; echo 1 | grep 1` has three sequential chains.

### Error handling principles

1. Raise exception for every chain is enabled by default. Processing errors from logical chain is on user.

    ```xsh
    ls nofile  # exception
    ls nofile | grep 1  # exception because command in pipe returns error
    echo 1 || ls nofile  # no exception because echo 1 returns no errors and ls not called
    echo 1 && ls nofile ; echo 1  # exception because first command has error
    ```
    and
    ```xsh
    ls nofile || echo 1  # no exception because ls returns error (False) we run echo and it has success
    ls /etc  # no exception
    echo 1 | grep 1   # no exception
    ```

2. Captured subprocess `!()` does NOT raise an exception by default. All what user is doing with full captured subprocess in the user responsibility i.e.
    
    ```xsh
    if !(ls nofile):  # no exception
        pass

    ls nofile  # exception
    $(ls nofile)  # exception
    $[ls nofile]  # exception
    ![ls nofile]  # exception
    ```

3. Command decorators `@error_raise` and `@error_ignore` still works for fine-tuning:

    ```xsh
    ls nofile  #exception
    @error_ignore ls nofile  # no exception
    !(@error_raise ls nofile)  # exception
    echo 1 && @error_ignore ls nofile  # no exception
    echo 1 | @error_ignore ls nofile | grep 1  # no exception
    ```
    Env swapping is still working and help:
    ```xsh
    with @.env.swap(XONSH_SUBPROC_RAISE_ERROR=False):
        ls nofile
    # no exception
    ```

4. We have two environment variables:
    * `XONSH_SUBPROC_RAISE_ERROR` - default True - raising exceptions for chains.
    * `XONSH_SUBPROC_CMD_RAISE_ERROR` - default `False` - the new name for `RAISE_SUBPROC_ERROR` (marked deprecated) - raise exception on ANY subprocess command. 

## Display in interactive mode

For interactive mode we have `$XONSH_PROMPT_SHOW_SUBPROC_ERROR` that is `False` by default. This means that in interactive mode the exception like `subprocess.SubprocessError: Command '['ls', 'nonono']' returned non-zero exit status 2.` will be not show i.e.

```xsh
$XONSH_PROMPT_SHOW_SUBPROC_ERROR = False  # default
ls nofile
# ls: cannot access 'nofile': No such file or directory  # stderr

$XONSH_PROMPT_SHOW_SUBPROC_ERROR = True
ls nofile
# ls: cannot access 'nofile': No such file or directory  # stderr
# subprocess.SubprocessError: Command '['ls', 'nofile']' returned non-zero exit status 2.
```

## Benefits

* We now treat commands like code and prevent unexpected errors from being missed, making scripts stable and manageable.
* We significantly reduce the risk for new users of executing unwanted code and receiving negative results.
* Within the code, we have a section responsible for logical chains, and this is a good basis for further development.

## Related issues

* Fixes https://github.com/xonsh/xonsh/issues/6232
* Fixes https://github.com/xonsh/xonsh/issues/2492
* Fixes https://github.com/xonsh/xonsh/issues/4351
* Fixes https://github.com/xonsh/xonsh/issues/5311
* Cc https://github.com/xonsh/xonsh/pull/5483 

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
