### PR TITLE
feat: Add `xxonsh` - launches exactly the same ``xonsh`` that was used to start the current session.

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -53,7 +53,7 @@ Xonsh-specific Aliases
 --------------------
 Displays how commands and arguments are evaluated. Use ``-e`` to expand aliases.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ showcmd echo The @('args') @(['list', 'is']) $(echo here) "and" --say="hello" to @([]) you
     ['echo', 'The', 'args', 'list', 'is', 'here', 'and', '--say="hello"', 'to', 'you']
@@ -69,11 +69,15 @@ Manages xonsh configuration information.
 
 .. command-help:: xonsh.xonfig.xonfig_main
 
+``xontrib``
+--------------------
+Manages xonsh extensions. More information is available at :doc:`xontrib`
+
 
 ``xcontext``
 --------------------
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ xcontext
     [Current xonsh session]
@@ -90,17 +94,12 @@ Manages xonsh configuration information.
 Report information about the current xonsh environment, including paths to the Python interpreter, pip, xonsh itself, and relevant environment variables.
 
 
-``xontrib``
---------------------
-Manages xonsh extensions. More information is available at :doc:`xontrib`
-
-
 ``xpip``
 --------------------
 Runs the ``pip`` package manager for xonsh itself. Useful for installations where xonsh is in an
 isolated environment (e.g. conda, mamba, homebrew).
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ which pip
     /usr/bin/pip  # system pip
@@ -117,7 +116,7 @@ isolated environment (e.g. conda, mamba, homebrew).
 
 Alias to the Python interpreter that is currently running xonsh (``sys.executable``). This is useful for running Python modules or scripts in the same environment as the shell itself, especially in complex setups like AppImage.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ python -V
     Python 3.12.10
@@ -129,11 +128,20 @@ Alias to the Python interpreter that is currently running xonsh (``sys.executabl
     /home/snail/.local/xonsh-env/bin/python
 
 
+``xxonsh``
+--------------------
+
+Launches exactly the same ``xonsh`` that was used to start the current session.
+
+See :ref:`xxonsh` for a worked example of using it as a building block to
+launch ``tmux`` with this exact xonsh (the ``xtmux`` recipe).
+
+
 ``xreset``
 --------------------
 Clean the xonsh context. All user variables will be deleted.
 
-.. code-block:: console
+.. code-block:: xonshcon
     @ a=1
     @ a
     1
@@ -167,7 +175,7 @@ raises unconditionally (even inside ``&&``/``||`` chains and even when
 the raise — it also wins over the chain-result check performed by
 ``$XONSH_SUBPROC_RAISE_ERROR``.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ r = !(@error_raise ls nonono)
     subprocess.CalledProcessError: Command '['@error_raise', 'ls', 'nonono']' returned non-zero exit status 1.
@@ -178,7 +186,7 @@ the raise — it also wins over the chain-result check performed by
 -----------------------------
 Use ``@thread`` and ``@unthread`` to run command as threadable or unthreadable e.g to have a result of SSH command:
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ !(@thread ssh host -T "echo 1")
 
@@ -187,7 +195,7 @@ Use ``@thread`` and ``@unthread`` to run command as threadable or unthreadable e
 -----------------------------
 Use ``@path`` and ``@paths`` to get Path object(s) from the command output.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ dir = $(@path echo '/bin')
       dir.exists()
@@ -199,7 +207,7 @@ Use ``@path`` and ``@paths`` to get Path object(s) from the command output.
 -----------
 Return output as list of lines.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ lines = $(@lines cat file)
 
@@ -208,7 +216,7 @@ Return output as list of lines.
 ----------
 Parses JSON and returns a JSON object.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ data = $(@json curl https://example.com/data.json)
 
@@ -217,7 +225,7 @@ Parses JSON and returns a JSON object.
 -----------
 Parses JSON lines and returns a list of JSON objects.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ items = $(@jsonl cat data.jsonl)
 
@@ -226,7 +234,7 @@ Parses JSON lines and returns a list of JSON objects.
 ----------
 Parses YAML and returns a dict.
 
-.. code-block:: console
+.. code-block:: xonshcon
 
     @ config = $(@yaml cat config.yaml)
 

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -136,6 +136,7 @@ Launches exactly the same ``xonsh`` that was used to start the current session.
 See :ref:`xxonsh` for a worked example of using it as a building block to
 launch ``tmux`` with this exact xonsh (the ``xtmux`` recipe).
 
+Mnemonic: think of the initial ‘x’ as ‘c’—xxonsh stands for (c)urrent xonsh.
 
 ``xreset``
 --------------------

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -121,6 +121,26 @@ What each flag does:
 * ``-DXONTRIBS_AUTOLOAD_DISABLED=1`` -- skip loading xontribs.
 
 
+.. _xxonsh:
+
+Launching the Same Xonsh (xxonsh)
+=================================
+
+The built-in ``xxonsh`` alias launches exactly the same ``xonsh`` that was
+used to start the current session — same interpreter, same source tree,
+regardless of the current working directory or whatever is installed in
+``site-packages``.
+
+When another tool needs to spawn xonsh with the same identity as the
+current session, use ``get_xxonsh_alias()`` from ``xonsh.aliases``: it
+always returns a ``list`` so it can be concatenated with any other argv
+list. For example, to start ``tmux`` with exactly this xonsh:
+
+.. code-block:: xonsh
+
+    aliases['xtmux'] = ['tmux', 'new-session'] + @.imp.xonsh.aliases.get_xxonsh_alias()
+
+
 Save and Load Origin Environment
 ================================
 
@@ -148,12 +168,13 @@ and possibly a custom prompt as well.
 After finishing work on that project, you can exit and return to your main environment.
 
 
-Running from a Bash Script
+Running from Another Shell
 ==========================
 
-If you want to run interactive xonsh from a bash script you need to have
-an interactive shebang (i.e. ``#!/bin/bash -i``) to avoid suspending by
-the OS.
+To launch xonsh from another shell, make sure that shell is itself running
+in interactive mode — otherwise the OS will suspend the interactive xonsh
+process. For example, when starting xonsh from a bash script, use an
+interactive shebang (``#!/bin/bash -i``).
 
 
 See also

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -6,7 +6,12 @@ import sys
 
 import pytest
 
-from xonsh.aliases import Aliases, ExecAlias, run_alias_by_params
+from xonsh.aliases import (
+    Aliases,
+    ExecAlias,
+    get_xxonsh_alias,
+    run_alias_by_params,
+)
 
 
 def cd(args, stdin=None):
@@ -331,3 +336,113 @@ def test_env_overlay_thread_isolation(xession):
         assert xession.env["THREAD_VAR"] == "yes"
 
     assert visible_in_other == [False]
+
+
+@pytest.mark.parametrize(
+    "argv0",
+    [
+        "/usr/local/bin/xonsh",
+        "/opt/env/bin/xonsh",
+        "xonsh",
+    ],
+)
+def test_get_xxonsh_alias_entrypoint_returns_single_element_list(monkeypatch, argv0):
+    """When launched via an entry point, the alias is ``[sys.argv[0]]``.
+
+    The result is always a list so that callers can concatenate it with
+    other argv lists without having to special-case the string form.
+    """
+    monkeypatch.setattr(sys, "argv", [argv0])
+    assert get_xxonsh_alias() == [argv0]
+
+
+def test_get_xxonsh_alias_from_source_returns_bootstrap_list(monkeypatch, tmp_path):
+    """
+    When launched via ``python -m xonsh``, the alias must NOT be a plain
+    ``[python, -m, xonsh]``: that would be CWD-dependent and could silently
+    resolve to a different xonsh (site-packages, namespace stub, or error)
+    depending on where the user happens to be.
+
+    Instead the alias must be a ``[python, -c, bootstrap]`` list where the
+    bootstrap prepends the parent of the source ``xonsh`` package to
+    ``sys.path`` and then runs ``xonsh.main.main()``.
+    """
+    fake_src_root = tmp_path / "repo"
+    fake_pkg = fake_src_root / "xonsh"
+    fake_pkg.mkdir(parents=True)
+    fake_main = fake_pkg / "__main__.py"
+    fake_main.write_text("")  # only the basename matters for detection
+
+    monkeypatch.setattr(sys, "argv", [str(fake_main)])
+    monkeypatch.setattr(sys, "executable", "/fake/python")
+
+    alias = get_xxonsh_alias()
+
+    assert isinstance(alias, list)
+    assert len(alias) == 3
+    assert alias[0] == "/fake/python"
+    assert alias[1] == "-c"
+    bootstrap = alias[2]
+    assert "from xonsh.main import main" in bootstrap
+    assert "main()" in bootstrap
+    # The parent of the xonsh/ package dir must be prepended to sys.path
+    # so that ``import xonsh`` resolves to the source tree, not whatever
+    # is currently installed or happens to be in CWD.
+    assert repr(str(fake_src_root)) in bootstrap
+    assert "sys.path.insert(0" in bootstrap
+
+
+def test_get_xxonsh_alias_source_handles_relative_argv0(monkeypatch, tmp_path):
+    """Relative ``sys.argv[0]`` must be resolved against the real CWD."""
+    fake_src_root = tmp_path / "repo"
+    fake_pkg = fake_src_root / "xonsh"
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / "__main__.py").write_text("")
+
+    # Simulate a launch recorded as a relative path
+    monkeypatch.chdir(fake_src_root)
+    monkeypatch.setattr(sys, "argv", ["xonsh/__main__.py"])
+    monkeypatch.setattr(sys, "executable", "/fake/python")
+
+    alias = get_xxonsh_alias()
+    bootstrap = alias[2]
+    # pkg_parent must be the absolute path, not a relative string
+    assert repr(str(fake_src_root)) in bootstrap
+
+
+def test_get_xxonsh_alias_source_bootstrap_runs_from_any_cwd(monkeypatch, tmp_path):
+    """
+    End-to-end: the bootstrap command must actually launch the source
+    xonsh from a CWD that contains no ``xonsh/`` package.
+    """
+    import pathlib
+    import subprocess
+
+    # Resolve the real xonsh source repo from this test file's location
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    real_main = repo_root / "xonsh" / "__main__.py"
+    assert real_main.is_file(), f"expected xonsh/__main__.py at {real_main}"
+
+    # Pretend the current session was launched via python -m xonsh
+    monkeypatch.setattr(sys, "argv", [str(real_main)])
+
+    cmd = get_xxonsh_alias()
+    assert isinstance(cmd, list)
+
+    # Ensure tmp_path truly does not look like a xonsh source tree
+    assert not (tmp_path / "xonsh").exists()
+
+    result = subprocess.run(
+        [*cmd, "--no-rc", "-c", "import xonsh; print(xonsh.__file__)"],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"returncode={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    expected_path = str(repo_root / "xonsh" / "__init__.py")
+    assert expected_path in result.stdout, (
+        f"expected {expected_path} in stdout, got:\n{result.stdout}"
+    )

--- a/xompletions/cd.py
+++ b/xompletions/cd.py
@@ -1,4 +1,5 @@
 """Completion for "cd", includes only valid directory names."""
+
 from xonsh.completers.path import complete_dir
 from xonsh.parsers.completion_context import CommandContext
 

--- a/xompletions/rmdir.py
+++ b/xompletions/rmdir.py
@@ -1,4 +1,5 @@
 """Completion for "rmdir", includes only valid directory names."""
+
 from xonsh.completers.path import complete_dir
 from xonsh.parsers.completion_context import CommandContext
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1280,7 +1280,55 @@ def showcmd(args, stdin=None):
         sys.displayhook(args)
 
 
-def detect_xpip_alias():
+def get_xxonsh_alias():
+    """
+    Determine the correct invocation to launch xonsh the same way the
+    current session was launched.
+
+    Always returns a list, so the result can be concatenated with other
+    argv lists (e.g. ``['tmux', 'new-session'] + get_xxonsh_alias()``).
+
+    For an entry-point launch (e.g. ``/usr/local/bin/xonsh``) the value of
+    ``sys.argv[0]`` is already a runnable absolute path, so the result is
+    a single-element list.
+
+    For a "from source" launch via ``python -m xonsh`` (``sys.argv[0]``
+    basename is ``__main__.py``) a naive ``[sys.executable, "-m", "xonsh"]``
+    would be CWD-dependent: ``python -m xonsh`` resolves the package via
+    ``sys.path``, which has the *current* working directory at position 0.
+    Running ``xxonsh`` from outside the source repo would silently pick
+    whatever ``import xonsh`` resolves to in ``site-packages`` (or raise
+    ``ModuleNotFoundError``), which is almost never what the user wants.
+
+    Instead, compute the parent directory of the source ``xonsh`` package
+    once (from the absolute path of ``__main__.py``) and spawn Python with
+    a ``-c`` bootstrap that prepends that directory to ``sys.path`` before
+    importing ``xonsh.main``. This makes the alias resolve to the same
+    source tree from any CWD, regardless of what is installed in
+    ``site-packages``.
+    """
+    # Local import: xonsh.main pulls in heavy modules (shell, execer,
+    # xontribs), so keep the dependency lazy.
+    from xonsh.main import get_current_xonsh
+
+    current_xonsh = get_current_xonsh()
+    if os.path.basename(current_xonsh) != "__main__.py":
+        # Entry-point case: sys.argv[0] is an absolute path to the xonsh
+        # launcher and is already runnable as-is.
+        return [current_xonsh]
+
+    # Source case: __main__.py lives inside the xonsh/ package, whose
+    # parent directory is the one we need on sys.path for
+    # ``from xonsh.main import main`` to pick up the source version.
+    pkg_parent = os.path.dirname(os.path.dirname(os.path.abspath(current_xonsh)))
+    bootstrap = (
+        f"import sys; sys.path.insert(0, {pkg_parent!r}); "
+        f"from xonsh.main import main; main()"
+    )
+    return [sys.executable, "-c", bootstrap]
+
+
+def get_xpip_alias():
     """
     Determines the correct invocation to get xonsh's pip
     """
@@ -1346,6 +1394,7 @@ def make_default_aliases():
     """Creates a new default aliases dictionary."""
     default_aliases = {
         "cd": cd,
+        "completer": xca.completer_alias,
         "pushd": pushd,
         "popd": popd,
         "dirs": dirs,
@@ -1379,8 +1428,8 @@ def make_default_aliases():
         "which": xxw.which,
         "xcontext": xxt.xcontext,
         "xontrib": xontribs_main,
-        "completer": xca.completer_alias,
-        "xpip": detect_xpip_alias(),
+        "xxonsh": get_xxonsh_alias(),
+        "xpip": get_xpip_alias(),
         "xpython": [XSH.env.get("_", sys.executable)]
         if IN_APPIMAGE
         else [sys.executable],

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -127,6 +127,20 @@ def get_setproctitle():
     return spt
 
 
+def get_current_xonsh():
+    """Return the path used to invoke the current xonsh session.
+
+    This is a thin wrapper around ``sys.argv[0]`` so that callers can share
+    a single source of truth for "how was this xonsh started".
+
+    Examples
+    --------
+    - Entry point: ``/usr/bin/xonsh``.
+    - Source via ``python -m xonsh``: ``/path/to/xonsh/__main__.py``
+    """
+    return sys.argv[0]
+
+
 def path_argument(s):
     """Return a path only if the path is actually legal (file or directory)
 

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -58,18 +58,18 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
 
     # Color tokens: section headers are purple; within a family (xonsh/xxonsh,
     # python/xpython, pip/xpip) both labels go GREEN when the session binary
-    # matches what ``$PATH`` resolves to — otherwise they stay in the "attention"
-    # color (yellow / orange / blue). Printed via print_color, which dispatches
-    # to the active shell's own color renderer.
+    # matches what ``$PATH`` resolves to, otherwise BLUE. Labels outside any
+    # family (pytest, ``[Current environment]`` vars) stay YELLOW. Printed
+    # via print_color, which dispatches to the active shell's own color
+    # renderer.
     PURPLE = "{PURPLE}"
     GREEN = "{GREEN}"
-    ORANGE = "{#ff8800}"
     BLUE = "{BLUE}"
     YELLOW = "{YELLOW}"
     RESET = "{RESET}"
 
-    xonsh_color = GREEN if current_xonsh == path_resolved["xonsh"] else YELLOW
-    python_color = GREEN if xpy == path_resolved["python"] else ORANGE
+    xonsh_color = GREEN if current_xonsh == path_resolved["xonsh"] else BLUE
+    python_color = GREEN if xpy == path_resolved["python"] else BLUE
     pip_color = GREEN if xpip_display == path_resolved["pip"] else BLUE
 
     label_color = {

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -1,11 +1,11 @@
 """The xontext command."""
 
-import shutil
 import sys
 
 from xonsh.built_ins import XSH
 from xonsh.cli_utils import ArgParserAlias
 from xonsh.platform import IN_APPIMAGE
+from xonsh.procs.executables import locate_executable
 from xonsh.tools import print_color
 
 
@@ -34,21 +34,51 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
     xpy = appimage_python if appimage_python else sys.executable
     xpy_ver = _get_version(xpy)
 
-    # Per-label color tokens: python family is orange, pip family is blue,
-    # everything else (xonsh variants, section headers, env vars) is yellow.
-    # Printed via print_color, which dispatches to the active shell's own
-    # color renderer (prompt_toolkit tokens, readline ANSI, etc.).
+    # Pre-resolve the PATH-visible binaries once so we can both display them
+    # in the "commands environment" section and compare them against the
+    # session-specific values (xxonsh/xpython/xpip) to decide coloring.
+    # Uses xonsh's own ``locate_executable`` rather than ``shutil.which``
+    # because the stdlib one is flagged (deprecated for ``PathLike`` args on
+    # Windows < 3.12), and xonsh's version is the recommended replacement.
+    path_resolved = {
+        "xonsh": locate_executable("xonsh"),
+        "python": locate_executable("python"),
+        "pip": locate_executable("pip"),
+        "pytest": locate_executable("pytest"),
+    }
+
+    # xpip alias value as a single string (for display AND for match check).
+    xpip = XSH.aliases.get("xpip")
+    if isinstance(xpip, list) and all(isinstance(x, str) for x in xpip):
+        xpip_display = " ".join(xpip)
+    elif xpip:
+        xpip_display = str(xpip)
+    else:
+        xpip_display = None
+
+    # Color tokens: section headers are purple; within a family (xonsh/xxonsh,
+    # python/xpython, pip/xpip) both labels go GREEN when the session binary
+    # matches what ``$PATH`` resolves to — otherwise they stay in the "attention"
+    # color (yellow / orange / blue). Printed via print_color, which dispatches
+    # to the active shell's own color renderer.
+    PURPLE = "{PURPLE}"
+    GREEN = "{GREEN}"
     ORANGE = "{#ff8800}"
     BLUE = "{BLUE}"
     YELLOW = "{YELLOW}"
     RESET = "{RESET}"
+
+    xonsh_color = GREEN if current_xonsh == path_resolved["xonsh"] else YELLOW
+    python_color = GREEN if xpy == path_resolved["python"] else ORANGE
+    pip_color = GREEN if xpip_display == path_resolved["pip"] else BLUE
+
     label_color = {
-        "xonsh": YELLOW,
-        "xxonsh": YELLOW,
-        "python": ORANGE,
-        "xpython": ORANGE,
-        "pip": BLUE,
-        "xpip": BLUE,
+        "xonsh": xonsh_color,
+        "xxonsh": xonsh_color,
+        "python": python_color,
+        "xpython": python_color,
+        "pip": pip_color,
+        "xpip": pip_color,
         "pytest": YELLOW,
     }
 
@@ -56,26 +86,21 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
         """Return ``{COLOR}name:{RESET}`` for ``print_color`` format strings."""
         return f"{label_color.get(name, YELLOW)}{name}:{RESET}"
 
-    print_color(f"{YELLOW}[Current xonsh session]{RESET}", file=stdout)
+    print_color(f"{PURPLE}[Current xonsh session]{RESET}", file=stdout)
     print_color(f"{_label('xxonsh')} {current_xonsh}", file=stdout)
     print_color(f"{_label('xpython')} {xpy}  # {xpy_ver}", file=stdout)
-
-    xpip = XSH.aliases.get("xpip")
-    if xpip:
-        if isinstance(xpip, list) and all(isinstance(x, str) for x in xpip):
-            print_color(f"{_label('xpip')} {' '.join(xpip)}", file=stdout)
-        else:
-            print_color(f"{_label('xpip')} {xpip}", file=stdout)
+    if xpip_display is not None:
+        print_color(f"{_label('xpip')} {xpip_display}", file=stdout)
     else:
         print_color(f"{_label('xpip')} not found", file=stdout)
 
     print("", file=stdout)
-    print_color(f"{YELLOW}[Current commands environment]{RESET}", file=stdout)
+    print_color(f"{PURPLE}[Current commands environment]{RESET}", file=stdout)
     cmds = ["xonsh", "python", "pip"]
-    if shutil.which("pytest"):
+    if path_resolved["pytest"]:
         cmds.append("pytest")
     for cmd in cmds:
-        path = shutil.which(cmd)
+        path = path_resolved[cmd]
         if path:
             ver = ""
             if cmd == "python":
@@ -84,7 +109,7 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
         else:
             print_color(f"{_label(cmd)} not found", file=stdout)
     print("", file=stdout)
-    print_color(f"{YELLOW}[Current environment]{RESET}", file=stdout)
+    print_color(f"{PURPLE}[Current environment]{RESET}", file=stdout)
     envs = ["CONDA_DEFAULT_ENV", "VIRTUAL_ENV"]
     for ev in envs:
         val = XSH.env.get(ev)

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -6,6 +6,7 @@ import sys
 from xonsh.built_ins import XSH
 from xonsh.cli_utils import ArgParserAlias
 from xonsh.platform import IN_APPIMAGE
+from xonsh.tools import print_color
 
 
 def _get_version(binary, arg_ver="--version"):
@@ -24,27 +25,52 @@ def _get_version(binary, arg_ver="--version"):
 
 def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
     """Report information about the current xonsh environment."""
+    # Local import: xonsh.main pulls in heavy modules, keep the dependency lazy.
+    from xonsh.main import get_current_xonsh
+
     stdout = _stdout or sys.stdout
-    current_xonsh = sys.argv[0]
+    current_xonsh = get_current_xonsh()
     appimage_python = XSH.env.get("_") if IN_APPIMAGE else None
     xpy = appimage_python if appimage_python else sys.executable
     xpy_ver = _get_version(xpy)
 
-    print("[Current xonsh session]", file=stdout)
-    print(f"xonsh: {current_xonsh}", file=stdout)
-    print(f"xpython: {xpy}  # {xpy_ver}", file=stdout)
+    # Per-label color tokens: python family is orange, pip family is blue,
+    # everything else (xonsh variants, section headers, env vars) is yellow.
+    # Printed via print_color, which dispatches to the active shell's own
+    # color renderer (prompt_toolkit tokens, readline ANSI, etc.).
+    ORANGE = "{#ff8800}"
+    BLUE = "{BLUE}"
+    YELLOW = "{YELLOW}"
+    RESET = "{RESET}"
+    label_color = {
+        "xonsh": YELLOW,
+        "xxonsh": YELLOW,
+        "python": ORANGE,
+        "xpython": ORANGE,
+        "pip": BLUE,
+        "xpip": BLUE,
+        "pytest": YELLOW,
+    }
+
+    def _label(name):
+        """Return ``{COLOR}name:{RESET}`` for ``print_color`` format strings."""
+        return f"{label_color.get(name, YELLOW)}{name}:{RESET}"
+
+    print_color(f"{YELLOW}[Current xonsh session]{RESET}", file=stdout)
+    print_color(f"{_label('xxonsh')} {current_xonsh}", file=stdout)
+    print_color(f"{_label('xpython')} {xpy}  # {xpy_ver}", file=stdout)
 
     xpip = XSH.aliases.get("xpip")
     if xpip:
         if isinstance(xpip, list) and all(isinstance(x, str) for x in xpip):
-            print(f"xpip: {' '.join(xpip)}", file=stdout)
+            print_color(f"{_label('xpip')} {' '.join(xpip)}", file=stdout)
         else:
-            print(f"xpip: {xpip}", file=stdout)
+            print_color(f"{_label('xpip')} {xpip}", file=stdout)
     else:
-        print("xpip: not found", file=stdout)
+        print_color(f"{_label('xpip')} not found", file=stdout)
 
     print("", file=stdout)
-    print("[Current commands environment]", file=stdout)
+    print_color(f"{YELLOW}[Current commands environment]{RESET}", file=stdout)
     cmds = ["xonsh", "python", "pip"]
     if shutil.which("pytest"):
         cmds.append("pytest")
@@ -54,17 +80,19 @@ def xcontext_main(_args=None, _stdin=None, _stdout=None, _stderr=None):
             ver = ""
             if cmd == "python":
                 ver = f"  # {_get_version(path)}"
-            print(f"{cmd}: {path}{ver}", file=stdout)
+            print_color(f"{_label(cmd)} {path}{ver}", file=stdout)
         else:
-            print(f"{cmd}: not found", file=stdout)
+            print_color(f"{_label(cmd)} not found", file=stdout)
     print("", file=stdout)
-    print("[Current environment]", file=stdout)
+    print_color(f"{YELLOW}[Current environment]{RESET}", file=stdout)
     envs = ["CONDA_DEFAULT_ENV", "VIRTUAL_ENV"]
     for ev in envs:
         val = XSH.env.get(ev)
         if val:
-            print(f"{ev}: {val}", file=stdout)
+            print_color(f"{_label(ev)} {val}", file=stdout)
     return 0
 
 
-xcontext = ArgParserAlias(func=xcontext_main, has_args=True, prog="xcontext")
+xcontext = ArgParserAlias(
+    func=xcontext_main, has_args=True, prog="xcontext", threadable=False
+)


### PR DESCRIPTION
### Motivation

We already have `xcontext`, `xpip`, `xpython`. It's time to add `xxonsh`.

### Implementation

`xonsh.aliases.get_xxonsh_alias()` logic:
* if xonsh is entry point it returns entrypoint e.g. `~/.local/bin/xonsh`
* if xonsh is from source e.g. `__main__.py` it returns `[sys.executable, "-c", bootstrap]` where bootstrap has guarantee that you will run execatly the same source as used for current session.

### Making aliases with xxonsh

If you want to have `xtmux` for tmux launching or something like this you can add it easily:

```xsh
aliases['xtmux'] = ['tmux', 'new-session'] + @.imp.xonsh.aliases.get_xxonsh_alias()
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**

