### PR TITLE
feat: Add dict support for alias return command and fix env overlay

### DIFF
--- a/docs/callable_aliases.rst
+++ b/docs/callable_aliases.rst
@@ -151,7 +151,7 @@ form below.
     @ @aliases.register
       @aliases.return_command
       def _rca(args):
-          return ['bash', '-c', 'echo hello']
+          return ['xonsh', '-c', 'echo hello']
 
 **2. A dict** with a required ``"cmd"`` key (non-empty list of tokens) and
 an optional ``"env"`` key (dict) — the command tokens plus an env overlay
@@ -163,7 +163,7 @@ that applies **only** to the returned command.
       @aliases.return_command
       def _rca(args):
           return {
-              'cmd': ['bash', '-c', 'echo $RETURNED'],
+              'cmd': ['xonsh', '-c', 'echo $RETURNED'],
               'env': {'RETURNED': 'set_by_dict'},
           }
 
@@ -208,19 +208,19 @@ to the returned command), and the global value that flows through both.
           # ``env`` is the body-scoped overlay (introduced in 0.23.0).
           # Mutating it affects commands the alias runs inline.
           env['LOCAL'] = 1
-          bash -c @('echo g=$GLOBAL l=$LOCAL')
+          xonsh -c @('echo g=$GLOBAL l=$LOCAL')
           # Direct write to the global env — persists after the alias exits.
           $GLOBAL = 2
           return {
-              'cmd': ['bash', '-c', 'echo g=$GLOBAL l=$LOCAL'],
+              'cmd': ['xonsh', '-c', 'echo g=$GLOBAL l=$LOCAL'],
               'env': {'LOCAL': 2},
           }
 
     @ rca
-    g=1 l=1    # bash inside the alias body:
+    g=1 l=1    # xonsh inside the alias body:
                #   g=1  from the global $GLOBAL set before the alias
                #   l=1  from the ``env=`` kwarg overlay (body-scoped)
-    g=2 l=2    # the returned bash command:
+    g=2 l=2    # the returned xonsh command:
                #   g=2  from the direct write ``$GLOBAL = 2`` in the body
                #   l=2  from the dict-return ``"env"`` overlay
 

--- a/docs/callable_aliases.rst
+++ b/docs/callable_aliases.rst
@@ -136,29 +136,100 @@ Return Command Aliases
 ----------------------
 
 The ``@aliases.return_command`` decorator creates aliases that return a new
-command to execute instead of running it themselves. The ``env`` overlay works
-here too — values set in ``env`` are passed to the returned command's
-environment:
+command to execute instead of running it themselves. The body of the alias
+can run its own commands first, then return the command xonsh should execute
+on its behalf.
+
+The alias may return its result in either of two forms:
+
+**1. A non-empty list** — just the command tokens. The returned command has
+no env overlay; if you need to set env vars for it you must use the dict
+form below.
+
+.. code-block:: python
+
+    @ @aliases.register
+      @aliases.return_command
+      def _rca(args):
+          return ['bash', '-c', 'echo hello']
+
+**2. A dict** with a required ``"cmd"`` key (non-empty list of tokens) and
+an optional ``"env"`` key (dict) — the command tokens plus an env overlay
+that applies **only** to the returned command.
+
+.. code-block:: python
+
+    @ @aliases.register
+      @aliases.return_command
+      def _rca(args):
+          return {
+              'cmd': ['bash', '-c', 'echo $RETURNED'],
+              'env': {'RETURNED': 'set_by_dict'},
+          }
+
+    @ rca
+    set_by_dict
+    @ $RETURNED
+    Unknown environment variable: $RETURNED
+
+The ``env=`` kwarg of a ``return_command`` alias behaves exactly like the
+``env=`` kwarg of an ordinary callable alias: it is a **local overlay active
+only during the function body**. Mutating it affects commands the alias runs
+inline (e.g. via ``$[...]``, ``!()``, or subprocess syntax), but it does
+**not** flow to the returned command. To set env for the returned command,
+the alias must use the dict form above.
 
 .. code-block:: python
 
     @ @aliases.register
       @aliases.return_command
       def _rca(args, env=None):
-          env['LOCAL'] = 123
-          $GLOBAL = 321
-          return ['bash', '-c', 'echo $LOCAL']
+          env['BODY_ONLY'] = 'visible_inside'
+          # A subprocess spawned here sees BODY_ONLY=visible_inside
+          $[env | grep BODY_ONLY]
+          # But the returned command does NOT — it has no overlay at all.
+          return ['env']
+
+Direct writes to ``$VAR`` or ``@.env`` still modify the global environment
+and persist after the alias exits, as for any callable alias.
+
+The following example exercises all four env-flow paths of a
+``return_command`` alias in one place: the ``env=`` kwarg overlay (body-only),
+a direct global write (persists), a dict-return ``"env"`` overlay (applies only
+to the returned command), and the global value that flows through both.
+
+.. code-block:: python
+
+    @ $GLOBAL = 1
+
+    @ @aliases.register
+      @aliases.return_command
+      def _rca(env):
+          # ``env`` is the body-scoped overlay (introduced in 0.23.0).
+          # Mutating it affects commands the alias runs inline.
+          env['LOCAL'] = 1
+          bash -c @('echo g=$GLOBAL l=$LOCAL')
+          # Direct write to the global env — persists after the alias exits.
+          $GLOBAL = 2
+          return {
+              'cmd': ['bash', '-c', 'echo g=$GLOBAL l=$LOCAL'],
+              'env': {'LOCAL': 2},
+          }
 
     @ rca
-    123
-    @ $LOCAL
-    Unknown environment variable: $LOCAL
-    @ $GLOBAL
-    321
+    g=1 l=1    # bash inside the alias body:
+               #   g=1  from the global $GLOBAL set before the alias
+               #   l=1  from the ``env=`` kwarg overlay (body-scoped)
+    g=2 l=2    # the returned bash command:
+               #   g=2  from the direct write ``$GLOBAL = 2`` in the body
+               #   l=2  from the dict-return ``"env"`` overlay
 
-The returned command ``bash -c 'echo $LOCAL'`` sees ``LOCAL=123`` in its
-process environment, but ``$LOCAL`` does not exist in the global xonsh env
-after the alias exits. ``$GLOBAL = 321`` was a direct write and persists.
+    @ $LOCAL
+    Unknown environment variable: $LOCAL    # the body overlay is gone,
+                                            # and the dict overlay only
+                                            # applied to the returned command
+    @ $GLOBAL
+    2    # the direct write persisted
 
 
 Return Values

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -696,21 +696,119 @@ def test_alias_env_overlay(xession):
     assert xession.env["GLOBAL"] == "global_write"
 
 
-def test_return_command_alias_env(xession):
-    """return_command alias passes env overlay to the returned command."""
+def test_return_command_alias_env_kwarg_is_body_only(xession):
+    """The ``env=`` kwarg of a return_command alias is a live overlay
+    active only during the function body. It does NOT become the returned
+    command's env overlay, and it does NOT persist after the alias exits.
+    To set env for the returned command, the alias must use dict-return.
+    """
+    captured = {}
 
     @xession.aliases.register("rca")
     @xession.aliases.return_command
     def _rca(args, env=None):
-        env["LOCAL"] = "123"
-        xession.env["GLOBAL"] = "321"
+        env["BODY_ONLY"] = "yes"
+        # While the body runs, the overlay is active. Read via
+        # ``__getitem__`` / ``__contains__`` — those consult the overlay
+        # stack (and so does the ``detype()`` path used for subprocess env).
+        captured["during"] = xession.env["BODY_ONLY"]
+        captured["in_env"] = "BODY_ONLY" in xession.env
+        captured["detype"] = xession.env.detype().get("BODY_ONLY")
+        xession.env["GLOBAL"] = "321"  # direct write persists after exit
         return ["echo", "ok"]
 
     spec = cmds_to_specs([["rca"]], captured="object")[-1]
+    # Overlay was visible to every "normal" read path during the body
+    assert captured["during"] == "yes"
+    assert captured["in_env"] is True
+    assert captured["detype"] == "yes"
+    # Overlay does NOT leak to the returned command's env
+    assert spec.env is None or "BODY_ONLY" not in (spec.env or {})
+    # Overlay does NOT persist in the global env either
+    assert "BODY_ONLY" not in xession.env
+    # A direct write during the body persists normally
+    assert xession.env["GLOBAL"] == "321"
+
+
+def test_return_command_alias_dict_cmd_only(xession):
+    """Dict return with only ``cmd`` is treated like a bare list return."""
+
+    @xession.aliases.register("rcdc")
+    @xession.aliases.return_command
+    def _rcdc(args):
+        return {"cmd": ["echo", "ok"] + args}
+
+    spec = cmds_to_specs([["rcdc", "x"]], captured="object")[-1]
+    assert spec.cmd == ["echo", "ok", "x"]
+    # No env overlay was requested
+    assert spec.env is None or "LOCAL" not in (spec.env or {})
+
+
+def test_return_command_alias_dict_cmd_and_env(xession):
+    """Dict return carries both ``cmd`` and ``env`` overlay in one go."""
+
+    @xession.aliases.register("rcde")
+    @xession.aliases.return_command
+    def _rcde(args):
+        return {"cmd": ["echo", "ok"], "env": {"LOCAL": "123", "FOO": "bar"}}
+
+    spec = cmds_to_specs([["rcde"]], captured="object")[-1]
+    assert spec.cmd == ["echo", "ok"]
     assert spec.env is not None
     assert spec.env.get("LOCAL") == "123"
-    assert xession.env["GLOBAL"] == "321"
+    assert spec.env.get("FOO") == "bar"
+    # env overlay must not leak into the global env
     assert "LOCAL" not in xession.env
+    assert "FOO" not in xession.env
+
+
+def test_return_command_alias_dict_env_independent_of_kwarg_env(xession):
+    """Dict-return ``"env"`` and the ``env=`` kwarg are independent: the
+    kwarg env is only a body-scoped overlay, and the dict env is the only
+    source of the returned command's env overlay."""
+
+    @xession.aliases.register("rcme")
+    @xession.aliases.return_command
+    def _rcme(args, env=None):
+        # These only affect the function body, not the returned command.
+        env["BODY_ONLY_A"] = "body_a"
+        env["BODY_ONLY_B"] = "body_b"
+        return {
+            "cmd": ["echo", "ok"],
+            "env": {"RETURNED": "returned_value"},
+        }
+
+    spec = cmds_to_specs([["rcme"]], captured="object")[-1]
+    assert spec.cmd == ["echo", "ok"]
+    assert spec.env is not None
+    # Dict-return env is on the returned command
+    assert spec.env.get("RETURNED") == "returned_value"
+    # Kwarg env does NOT flow through
+    assert "BODY_ONLY_A" not in spec.env
+    assert "BODY_ONLY_B" not in spec.env
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {},  # no "cmd"
+        {"cmd": []},  # empty cmd
+        {"cmd": None},  # missing cmd
+        {"cmd": "echo"},  # cmd not a list
+        {"cmd": ["echo"], "env": "X=1"},  # env not a dict
+        {"cmd": ["echo"], "env": ["X", "1"]},  # env not a dict
+    ],
+)
+def test_return_command_alias_dict_wrong_return(xession, bad):
+    """Malformed dict returns raise ValueError."""
+
+    @xession.aliases.register("rcwr")
+    @xession.aliases.return_command
+    def _rcwr(args):
+        return bad
+
+    with pytest.raises(ValueError):
+        cmds_to_specs([["rcwr"]], captured="object")[-1]
 
 
 def test_auto_cd(xession, tmpdir):

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -811,6 +811,42 @@ def test_return_command_alias_dict_wrong_return(xession, bad):
         cmds_to_specs([["rcwr"]], captured="object")[-1]
 
 
+def test_return_command_alias_dict_env_through_string_alias_chain(xession):
+    """Chain: a plain string alias points to a return_command alias that
+    dict-returns an env overlay. The overlay must still reach the returned
+    command's spec.env (propagated through eval_alias via env_out).
+
+    Also verifies that the chain's positional args are concatenated with
+    the user's call-site args when both reach the return_command function.
+    """
+    seen_args = []
+
+    @xession.aliases.register("rca")
+    @xession.aliases.return_command
+    def _rca(args):
+        seen_args.append(list(args))
+        return {
+            "cmd": ["echo", "ok"] + args,
+            "env": {"VIA_CHAIN": "yes", "EXTRA": "1"},
+        }
+
+    xession.aliases["hlp"] = "rca X1 X2"
+
+    spec = cmds_to_specs([["hlp", "Y1", "Y2"]], captured="object")[-1]
+
+    # args from the chain ("X1 X2") come first, then args from the user call.
+    assert seen_args == [["X1", "X2", "Y1", "Y2"]]
+    assert spec.cmd == ["echo", "ok", "X1", "X2", "Y1", "Y2"]
+
+    # Dict-return env survived the string-alias chain and lives on spec.env.
+    assert spec.env is not None
+    assert spec.env.get("VIA_CHAIN") == "yes"
+    assert spec.env.get("EXTRA") == "1"
+    # And did not leak into the global env.
+    assert "VIA_CHAIN" not in xession.env
+    assert "EXTRA" not in xession.env
+
+
 def test_auto_cd(xession, tmpdir):
     xession.aliases["cd"] = lambda: "some_cd_alias"
     dir = str(tmpdir)

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -93,6 +93,53 @@ class AliasReturnCommandResult(list):
         self.local_env = local_env or {}
 
 
+def _normalize_return_command_result(val, alias_repr):
+    """Normalize the return value of a ``@return_command`` alias.
+
+    A ``return_command`` alias may return either:
+
+    - a non-empty ``list`` — the resolved command tokens, with **no** env
+      overlay attached to the returned command,
+    - a ``dict`` with a required ``"cmd"`` key (a non-empty list of tokens)
+      and an optional ``"env"`` key (a ``dict``) — the command tokens plus
+      an env overlay that applies **only** to the returned command.
+
+    The ``env=`` kwarg the alias received is a separate concept: it is an
+    overlay active **during the function body** (mutating it affects
+    subprocesses the alias runs inline, just like for an ordinary callable
+    alias). It is independent of the returned command's env — to set env
+    for the returned command, the alias must use dict-return.
+
+    Raises ``ValueError`` on malformed returns, using ``alias_repr`` in the
+    message so the user can tell which alias produced the bad value.
+
+    Returns
+    -------
+    cmd : list
+        The command tokens to execute.
+    returned_env : dict
+        The env overlay for the returned command (empty dict if the alias
+        returned a bare list or a dict without ``"env"``).
+    """
+    returned_env: dict = {}
+    if isinstance(val, dict):
+        env_overlay = val.get("env")
+        if env_overlay is not None:
+            if not isinstance(env_overlay, dict):
+                raise ValueError(
+                    f"return_command alias {alias_repr}: 'env' must be a dict, "
+                    f"got {env_overlay!r}."
+                )
+            returned_env = dict(env_overlay)
+        val = val.get("cmd")
+    if not isinstance(val, list) or not val:
+        raise ValueError(
+            f"return_command alias {alias_repr}: wrong return value {val!r}, "
+            f"expected a non-empty list or dict with 'cmd' (non-empty list)."
+        )
+    return val, returned_env
+
+
 class FuncAlias:
     """Provides a callable alias for xonsh commands."""
 
@@ -351,6 +398,7 @@ class Aliases(cabc.MutableMapping):
         seen_tokens=frozenset(),
         acc_args=(),
         decorators=None,
+        env_out=None,
     ):
         """
         "Evaluates" the alias ``value``, by recursively looking up the leftmost
@@ -361,6 +409,11 @@ class Aliases(cabc.MutableMapping):
         where ``cmd=ls -al`` and ``ls`` is an alias with its value being a
         callable.  The resulting callable will be "partially applied" with
         ``["-al", "arg"]``.
+
+        ``env_out``, if given, is a mutable dict that accumulates the env
+        overlay requested by any ``return_command`` alias encountered while
+        resolving the chain (via dict-return ``"env"`` key). The top-level
+        :meth:`get` caller passes its own collector dict here.
         """
         decorators = decorators if decorators is not None else []
         # Beware of mutability: default values for keyword args are evaluated
@@ -380,15 +433,25 @@ class Aliases(cabc.MutableMapping):
             value = value[i:]
 
         if callable(value) and getattr(value, "return_what", "result") == "command":
-            local_env = {}
+            alias_repr = repr(getattr(value, "__name__", value))
+            # ``kwarg_env`` is a live overlay: while the alias body runs,
+            # mutating it affects commands the alias spawns inline (same
+            # semantics as the ``env=`` kwarg for a normal callable alias).
+            # It does NOT flow to the returned command — for that, the
+            # alias must return a dict with an ``"env"`` key.
+            kwarg_env: dict = {}
             try:
-                value = value(acc_args, decorators=decorators, env=local_env)
+                with XSH.env.swap(overlay=kwarg_env):
+                    value = value(acc_args, decorators=decorators, env=kwarg_env)
                 acc_args = []
             except Exception as e:
-                print_exception(f"Exception inside alias {value}: {e}")
+                print_exception(f"Exception inside alias {alias_repr}: {e}")
                 return None
-            if not len(value):
-                raise ValueError("return_command alias: zero arguments.")
+            value, returned_env = _normalize_return_command_result(
+                value, alias_repr=alias_repr
+            )
+            if env_out is not None and returned_env:
+                env_out.update(returned_env)
 
         if callable(value):
             return [value] + list(acc_args)
@@ -411,6 +474,7 @@ class Aliases(cabc.MutableMapping):
                     seen_tokens,
                     acc_args,
                     decorators=decorators,
+                    env_out=env_out,
                 )
 
     def get(
@@ -437,19 +501,24 @@ class Aliases(cabc.MutableMapping):
         if isinstance(key, list):
             args = key[1:]
             key = key[0]
-        local_env = {}
         val = self._raw.get(key)
+        # Env overlay collected for the RETURNED command — from a dict-return
+        # at any level of the alias chain. Kept strictly separate from the
+        # ``env=`` kwarg, which is a live overlay active only during the body
+        # of a return_command alias.
+        returned_env: dict = {}
         if callable(val) and getattr(val, "return_what", "result") == "command":
+            kwarg_env: dict = {}
             try:
-                val = val(args, decorators=decorators, env=local_env)
+                with XSH.env.swap(overlay=kwarg_env):
+                    val = val(args, decorators=decorators, env=kwarg_env)
                 args = []
             except Exception as e:
                 print_exception(f"Exception inside alias {key!r}: {e}")
                 return None
-            if not isinstance(val, list) or not len(val):
-                raise ValueError(
-                    f"return_command alias {key!r}: wrong return value {val!r}, expected a list."
-                )
+            val, returned_env = _normalize_return_command_result(
+                val, alias_repr=repr(key)
+            )
 
         if val is None:
             return default
@@ -459,9 +528,10 @@ class Aliases(cabc.MutableMapping):
                 seen_tokens={key},
                 decorators=decorators,
                 acc_args=args,
+                env_out=returned_env,
             )
-            if local_env and result is not None:
-                result = AliasReturnCommandResult(result, local_env=local_env)
+            if returned_env and result is not None:
+                result = AliasReturnCommandResult(result, local_env=returned_env)
             return result
         else:
             msg = "alias of {!r} has an inappropriate type: {!r}"


### PR DESCRIPTION
* Complete fixes https://github.com/xonsh/xonsh/issues/5883


```xsh
$GLOBAL = 1

@aliases.register
@aliases.return_command
def _rca(env):  # env is overlay (that introduced in 0.23.0) affect commands in function
    env['LOCAL'] = 1
    bash -c @('echo g=$GLOBAL l=$LOCAL')
    # 1 1
    $GLOBAL = 2
    return {
        "cmd": ['bash','-c', 'echo g=$GLOBAL l=$LOCAL'], 
        "env": {"LOCAL": 2}
    }

rca
# g=1 l=1  # bash in alias: g - set from global, l = set from local env overlay
# g=2 l=2  # returned command: g - set from alias, l - set from return command

$LOCAL
# Unknown environment variable: $LOCAL  # yes because env overlay is only inside alias
$GLOBAL
# 2
```
Returning list is working as before.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
