### PR TITLE
fix(history): Fix exception when XONSH_HISTORY_FILE has json file but we try to load sqlite

### DIFF
--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -53,7 +53,7 @@ def test_shell_with_sqlite_history(xession, xonsh_execer, tmpdir_factory):
     """
     tempdir = str(tmpdir_factory.mktemp("history"))
 
-    history_file = os.path.join(tempdir, "history.db")
+    history_file = os.path.join(tempdir, "history.sqlite")
     h = SqliteHistory(filename=history_file)
     h.append(
         {

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -307,8 +307,9 @@ class SqliteHistory(History):
 
     def __init__(self, gc=True, filename=None, save_cwd=None, **kwargs):
         super().__init__(**kwargs)
-        if filename is None:
+        if filename is None or not str(filename).endswith(".sqlite"):
             filename = _xh_sqlite_get_file_name()
+            XSH.env["XONSH_HISTORY_FILENAME"] = filename
         self.filename = filename
         self.last_pull_times = {None: time.time()}
         self.gc = SqliteHistoryGC() if gc else None


### PR DESCRIPTION
Fix situation when JSON `$XONSH_HISTORY_FILE` came from previous session to SQLITE.

```xsh
xonsh --no-rc  # json by default
$XONSH_HISTORY_FILE
# PosixPath('~/.local/share/xonsh/xonsh-history.sqlite')

xonsh --no-rc -DXONSH_HISTORY_BACKEND=sqlite
```
```xsh
Traceback (most recent call last):
  File "/Users/pc/micromamba/envs/xonsh-dev/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Users/pc/micromamba/envs/xonsh-dev/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pc/micromamba/envs/xonsh-dev/lib/python3.13/site-packages/prompt_toolkit/history.py", line 190, in _in_load_thread
    for item in self.history.load_history_strings():
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/pc/Documents/git/xonsh/xonsh/shells/ptk_shell/history.py", line 29, in load_history_strings
    for cmd in hist.all_items(newest_first=True):
               ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/pc/Documents/git/xonsh/xonsh/history/sqlite.py", line 382, in all_items
    for inp, ts, rtn, freq, cwd in xh_sqlite_items(
                                   ~~~~~~~~~~~~~~~^
        filename=self.filename, newest_first=newest_first, sessionid=session_id
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/Users/pc/Documents/git/xonsh/xonsh/history/sqlite.py", line 198, in xh_sqlite_items
    _xh_sqlite_create_history_table(c)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/Users/pc/Documents/git/xonsh/xonsh/history/sqlite.py", line 44, in _xh_sqlite_create_history_table
    cursor.execute(
    ~~~~~~~~~~~~~~^
        "PRAGMA journal_mode=WAL;"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )  # https://github.com/xonsh/xonsh/issues/6096
    ^
sqlite3.DatabaseError: file is not a database
```
## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
