### PR TITLE
feat(main): acquire controlling terminal at startup (terminal handshake)

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -77,6 +77,7 @@ developer tools.
     env
     completers
     xontrib
+    embedding
     api/index
     Create an extension using template <https://github.com/xonsh/xontrib-template>
 

--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -1,0 +1,140 @@
+.. _embedding:
+
+***************************
+Embedding Xonsh in Your App
+***************************
+
+.. warning::
+
+    This page is a **work-in-progress stub**. It currently documents
+    only the controlling-terminal handshake for embedded use cases.
+    A fuller guide — covering :func:`xonsh.main.setup`, custom
+    :class:`~xonsh.shell.Shell` subclasses, teardown, thread safety,
+    and integration patterns for LLM agents / TUI apps / REPLs —
+    will appear in a later release. If you are embedding xonsh and
+    need guidance that is not covered here, please open an issue or
+    discussion on GitHub.
+
+Xonsh exposes itself as a Python library in addition to the standalone
+``xonsh`` command. Third-party projects can create a xonsh session,
+load xontribs and rc files, and drive the execer / shell from their
+own code. The public entry point for this is :func:`xonsh.main.setup`,
+documented in :mod:`xonsh.main`.
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+Controlling Terminal Handshake for Embedded Interactive Shells
+==============================================================
+
+When xonsh runs as the standalone ``xonsh`` command, its entry point
+(:func:`xonsh.main.main`) automatically performs a startup handshake
+that makes xonsh the *foreground process group* of its controlling
+terminal. This avoids a class of startup crashes and hangs in
+environments where the parent process does not arrange TTY ownership
+correctly — Flatpak / Bubblewrap sandboxes, build systems, nested
+containers, ``systemd --user`` services, some IDE terminals.
+
+See :ref:`launch-fg-takeover` for the full rationale, the failure
+modes it fixes (``BlockingIOError`` on asyncio wakeup pipe,
+``termios.error`` EINTR, and related), the three-step signal policy,
+and the ``XONSH_NO_FG_TAKEOVER`` escape hatch.
+
+When the handshake runs
+-----------------------
+
+The handshake is invoked automatically on **both** of these paths:
+
+* :func:`xonsh.main.main` — the default CLI entry point.
+* :func:`xonsh.main.main_xonsh` — the inner entry point used when
+  some code paths bypass ``main``.
+
+It is **not** invoked from :func:`xonsh.main.setup`. That means an
+embedded project that builds its own interactive shell by calling
+``setup()`` (or by instantiating :class:`~xonsh.shell.Shell`,
+:class:`~xonsh.execer.Execer` and :class:`~xonsh.built_ins.XonshSession`
+directly) will **not** get the handshake for free. If your embedded
+xonsh runs in one of the affected environments, you need to invoke
+it yourself.
+
+How to invoke it from embedded code
+-----------------------------------
+
+The helper currently lives in ``xonsh.main`` as a module-private
+function: ``_setup_controlling_terminal``. It is private by
+convention (leading underscore) but the implementation is stable and
+idempotent. A future release is expected to expose a public alias;
+until then, calling the private function directly is the supported
+path.
+
+Call it **before** you start your interactive shell loop — ideally as
+early in your program's startup as possible, so that any xonshrc or
+xontrib code your embedder runs already has foreground ownership:
+
+.. code-block:: python
+
+    # embedded_launcher.py
+    from xonsh.main import setup
+    from xonsh.main import _setup_controlling_terminal
+
+    # Acquire foreground of controlling TTY (idempotent, safe to
+    # call multiple times — only the first call does real work).
+    # No-op on Windows, in non-TTY contexts (pytest, piped input,
+    # redirected stderr), and when XONSH_NO_FG_TAKEOVER=1 is set.
+    _setup_controlling_terminal()
+
+    # Your existing xonsh setup stays unchanged.
+    setup(
+        shell_type="prompt_toolkit",
+        # ... your ctx, env, xontribs, aliases, etc.
+    )
+
+    # Your custom shell / REPL / agent loop starts here.
+
+What the helper does
+--------------------
+
+The call has three possible outcomes, all handled internally:
+
+1. **Fast path** — xonsh is already the foreground process group
+   (standard case when launched from a well-behaved terminal). The
+   function short-circuits, installs a Python no-op handler for
+   ``SIGTTIN`` / ``SIGTTOU`` as a safety net, and returns.
+2. **Full handshake** — xonsh transfers TTY foreground ownership to
+   its own process group via ``setpgid(0, 0)`` plus
+   ``tcsetpgrp(tty, getpgrp())``. Registers an :mod:`atexit`
+   restorer so the previous foreground group is handed back on
+   process exit.
+3. **Sandbox fallback** — if the handshake cannot complete (exotic
+   sandbox, cross-session TTY, missing ``CAP_SYS_ADMIN`` for
+   certain cases), the no-op handler installed in step 1 is
+   *replaced* with ``SIG_IGN`` so that the kernel drops
+   ``SIGTTIN`` / ``SIGTTOU`` at delivery time and they never reach
+   Python's asyncio wakeup pipe.
+
+All outcomes are safe; every error path degrades cleanly. The helper
+never raises under normal use.
+
+When you should *not* call it
+-----------------------------
+
+* **Headless embedding.** If your embedder uses
+  ``setup(shell_type="none")`` (the default) and never starts an
+  interactive prompt, you do not need the handshake. There is no
+  TTY to acquire. Calling the helper in this case is harmless (it
+  will fall into the non-TTY gate and do nothing), but it is also
+  pointless.
+* **You manage TTY / job control yourself.** If your embedder
+  deliberately keeps xonsh in the background of its controlling
+  TTY — for example, you run xonsh under a PTY proxy that
+  multiplexes multiple children — taking foreground ownership will
+  break your design. Set ``XONSH_NO_FG_TAKEOVER=1`` in the
+  environment before starting xonsh, or simply skip the call.
+* **You are running tests.** Most test runners capture stderr, in
+  which case the helper's internal ``isatty`` gate makes the call a
+  no-op. If you use ``pytest -s`` and really want the handshake
+  disabled for tests, export ``XONSH_NO_FG_TAKEOVER=1`` for the
+  test session.
+

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -414,26 +414,3 @@ exactly the behaviour of the historical sandbox wrapper.
 
     # disable the takeover, e.g. when debugging unusual TTY setups
     XONSH_NO_FG_TAKEOVER=1 xonsh
-
-What this does not fix
------------------------
-
-The handshake addresses the *foreground group* part of the problem.
-It does not work around every possible issue that can arise from
-running xonsh in an unusual TTY environment:
-
-* If the TTY belongs to a different session than xonsh (for example
-  a sandbox that calls ``setsid``), ``tcsetpgrp`` fails with
-  ``EPERM`` and the handshake cleanly declines. You are still on
-  the ``SIG_IGN`` fallback in that case.
-* ``termios.tcsetattr`` calls can still be interrupted by signals
-  other than ``SIGTTIN`` / ``SIGTTOU``. In practice a foreground
-  xonsh sees far fewer interruptions — most of the signal volume
-  was the ``SIGTT*`` storm — so the ``EINTR`` race is dramatically
-  less likely, but it is not impossible. If you hit it, wrap your
-  launcher to retry ``tcsetattr`` / ``tcgetattr`` on ``EINTR``.
-* Stealing a controlling terminal from a different session requires
-  ``TIOCSCTTY`` with ``CAP_SYS_ADMIN`` in the init user namespace,
-  which is not available in Flatpak or rootless containers. If you
-  really need a fresh controlling TTY, run xonsh under a PTY proxy
-  such as ``script(1)`` or inside ``tmux``.

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -279,47 +279,71 @@ re-installed.
 What xonsh does now
 -------------------
 
-On POSIX, during ``main_xonsh``, xonsh runs the bash-style handshake
-in :func:`xonsh.main._acquire_controlling_terminal`:
+On POSIX, the **very first thing** :func:`xonsh.main.main` does — before
+argument parsing, xontrib loading or xonshrc execution — is call
+:func:`xonsh.main._setup_controlling_terminal`. That in turn runs the
+bash-style handshake in
+:func:`xonsh.main._acquire_controlling_terminal` and installs matching
+signal handlers. The early placement matters: xonsh's rc files are
+arbitrary user code, and a typical ``~/.xonshrc`` will contain
+``$(...)``/``!(...)`` subprocess captures, possibly including
+interactive programs like ``fzf`` that themselves want to manipulate
+the terminal via ``tcsetattr``. If xonsh is already foreground by the
+time rc runs, every downstream TTY operation is straightforward; if it
+is not, the ``SIG_IGN`` fallback (see below) keeps the asyncio wakeup
+pipe from overflowing while rc executes.
 
-* It uses **stderr** (file descriptor 2) as the TTY handle. This
-  matches :func:`xonsh.procs.jobs.give_terminal_to`, which also uses
-  FD 2 when xonsh later transfers the terminal between pipeline
-  groups.
-* It aborts cleanly — with no side effects — if any precondition
-  fails: Windows, non-TTY stderr, session leader (which cannot
-  ``setpgid`` itself), missing ``pthread_sigmask``, or the escape
-  hatch described below.
-* It blocks ``SIGTTOU``, ``SIGTTIN``, ``SIGTSTP`` and ``SIGCHLD`` in
-  the calling thread with ``pthread_sigmask``. ``SIGTTOU`` is the
-  critical one; without the block, ``tcsetpgrp`` below would send
-  ``SIGTTOU`` to xonsh itself and suspend it immediately.
-* It short-circuits to success if the TTY's foreground group is
-  already our process group — the handshake is not needed and the
-  restorer is *not* registered, so on shutdown we don't race with
-  the parent shell's own ``tcsetpgrp``.
-* Otherwise it calls ``setpgid(0, 0)`` followed by
-  ``tcsetpgrp(tty_fd, getpgrp())``, remembers the previous
-  foreground group, and records the fact that the handshake
-  succeeded.
-* It restores the signal mask in a ``finally`` block so any error
-  path leaves the process in a clean state.
+The handshake itself (``_acquire_controlling_terminal``):
 
-If the handshake succeeds, xonsh then installs a Python-level no-op
-handler for ``SIGTTIN`` and ``SIGTTOU`` — the kernel should not
-deliver those signals any more under normal operation, but a Python
-handler defends against races and, crucially, is **not** inherited
-across ``exec``, so child processes of xonsh see the normal
+* Uses **stderr** (file descriptor 2) as the TTY handle. This matches
+  :func:`xonsh.procs.jobs.give_terminal_to`, which also uses FD 2 when
+  xonsh later transfers the terminal between pipeline groups.
+* Aborts cleanly — with no side effects — if any precondition fails:
+  Windows, session leader (which cannot ``setpgid`` itself), missing
+  ``pthread_sigmask``, or the escape hatch described below.
+* Blocks ``SIGTTOU``, ``SIGTTIN``, ``SIGTSTP`` and ``SIGCHLD`` in the
+  calling thread with ``pthread_sigmask``. ``SIGTTOU`` is the critical
+  one; without the block, ``tcsetpgrp`` below would send ``SIGTTOU``
+  to xonsh itself and suspend it immediately.
+* Short-circuits to success if the TTY's foreground group is already
+  our process group — the handshake is not needed and the restorer is
+  *not* registered, so on shutdown we don't race with the parent
+  shell's own ``tcsetpgrp``.
+* Otherwise calls ``setpgid(0, 0)`` followed by
+  ``tcsetpgrp(tty_fd, getpgrp())``, remembers the previous foreground
+  group, and records the fact that the handshake succeeded.
+* Restores the signal mask in a ``finally`` block so any error path
+  leaves the process in a clean state.
+
+``_setup_controlling_terminal`` wraps the handshake with the signal
+policy decision and an idempotency flag. It only does anything if
+**stderr is a TTY** — script mode, piped input and test runners all
+skip the setup entirely and keep their default POSIX signal
+dispositions. This gate makes the whole feature transparent to
+non-interactive use.
+
+On the success path (either the fast path or a full acquire),
+``_setup_controlling_terminal`` installs a Python-level no-op handler
+for ``SIGTTIN`` and ``SIGTTOU``. Once xonsh is foreground the kernel
+should not deliver those signals any more under normal operation, but
+a Python handler defends against races and, crucially, is **not**
+inherited across ``exec``, so child processes of xonsh see the normal
 ``SIG_DFL`` disposition and their own job control keeps working.
 
-If the handshake fails — as it will in a sandbox where xonsh cannot
-become foreground — xonsh falls back to setting ``SIG_IGN`` for
-``SIGTTIN`` and ``SIGTTOU`` instead of the Python handler. That
-discards the signals at the kernel level, so they never reach
-Python's wakeup pipe and the ``BlockingIOError`` storm cannot happen.
-``SIG_IGN`` *is* inherited across ``exec``, but in a sandbox the
-children have the same TTY ownership problem anyway, so this is the
-right default.
+On the failure path — as will happen in a sandbox where xonsh cannot
+become foreground — ``_setup_controlling_terminal`` installs
+``SIG_IGN`` for ``SIGTTIN`` and ``SIGTTOU`` instead. That discards the
+signals at the kernel level, so they never reach Python's wakeup pipe
+and the ``BlockingIOError`` storm cannot happen. ``SIG_IGN`` *is*
+inherited across ``exec``, but in a sandbox the children have the same
+TTY ownership problem anyway, so this is the right default.
+
+``_setup_controlling_terminal`` is idempotent. It is also called from
+the top of :func:`xonsh.main.main_xonsh`, so callers that enter the
+shell loop without going through ``main`` (tests, programmatic
+launches) still end up with the correct signal setup; the second call
+in a normal ``main → main_xonsh`` flow short-circuits on the
+``_tty_setup_done`` module flag.
 
 Shutdown: handing the TTY back
 -------------------------------
@@ -338,17 +362,23 @@ failed), the restorer is a no-op.
 When the handshake is a no-op
 ------------------------------
 
-The handshake does nothing in any of these situations:
+The setup does nothing in any of these situations:
 
 * **Windows.** POSIX controlling terminals do not apply.
 * **Non-interactive invocations** where stderr is not a TTY:
-  ``xonsh script.xsh``, piped input, redirected stderr, and
-  script-from-stdin mode.
+  ``xonsh script.xsh``, piped input, redirected stderr, script-from-
+  stdin mode, and tests under pytest (which captures stderr via a
+  pipe). In these modes ``_setup_controlling_terminal`` returns
+  before touching signal state — default POSIX dispositions are
+  kept intact.
 * **xonsh is a session leader** (``getsid(0) == getpid()``). A
   session leader cannot change its own process group id, and if it
-  is session leader it almost always already owns the TTY.
+  is session leader it almost always already owns the TTY. The
+  handshake declines and the ``SIG_IGN`` fallback takes over.
 * **xonsh is already the foreground group** — the fast path returns
-  immediately and does not register the atexit restorer.
+  immediately, the Python no-op handler is still installed as a
+  safety net, but the atexit restorer is *not* registered (there is
+  nothing to restore).
 * **Missing** ``pthread_sigmask``, which is POSIX-only and absent on
   exotic builds.
 

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -315,28 +315,41 @@ The handshake itself (``_acquire_controlling_terminal``):
 * Restores the signal mask in a ``finally`` block so any error path
   leaves the process in a clean state.
 
-``_setup_controlling_terminal`` wraps the handshake with the signal
-policy decision and an idempotency flag. It only does anything if
-**stderr is a TTY** — script mode, piped input and test runners all
-skip the setup entirely and keep their default POSIX signal
-dispositions. This gate makes the whole feature transparent to
-non-interactive use.
+``_setup_controlling_terminal`` orchestrates the handshake with a
+three-step signal policy:
 
-On the success path (either the fast path or a full acquire),
-``_setup_controlling_terminal`` installs a Python-level no-op handler
-for ``SIGTTIN`` and ``SIGTTOU``. Once xonsh is foreground the kernel
-should not deliver those signals any more under normal operation, but
-a Python handler defends against races and, crucially, is **not**
-inherited across ``exec``, so child processes of xonsh see the normal
-``SIG_DFL`` disposition and their own job control keeps working.
+**Step 1 — always install Python no-op handlers.** On any POSIX
+invocation — interactive, script mode, piped input, redirected
+stderr, test runner — ``_setup_controlling_terminal`` installs a
+Python-level no-op handler for ``SIGTTIN`` and ``SIGTTOU``. This
+matches xonsh's historical behavior from before the handshake
+existed: script-mode xonsh must not be suspended by default
+``SIG_DFL`` when something indirectly touches the TTY, and a Python
+handler (rather than ``SIG_IGN``) is preferred because it is *not*
+inherited across ``exec``, so subprocess children keep their normal
+job control.
 
-On the failure path — as will happen in a sandbox where xonsh cannot
-become foreground — ``_setup_controlling_terminal`` installs
-``SIG_IGN`` for ``SIGTTIN`` and ``SIGTTOU`` instead. That discards the
-signals at the kernel level, so they never reach Python's wakeup pipe
-and the ``BlockingIOError`` storm cannot happen. ``SIG_IGN`` *is*
-inherited across ``exec``, but in a sandbox the children have the same
-TTY ownership problem anyway, so this is the right default.
+**Step 2 — run the handshake when stderr is a real TTY.** If
+``os.isatty(stderr)`` is true, ``_setup_controlling_terminal`` calls
+:func:`_acquire_controlling_terminal`. Non-TTY callers stop after
+step 1; pytest, script mode, and redirected-stderr invocations all
+bail out here and keep the step-1 handlers.
+
+**Step 3 — branch on handshake result.** If the handshake succeeded
+(either the fast path because we were already foreground, or a full
+acquire), the step-1 Python handlers stay in place and
+``_setup_controlling_terminal`` registers the ``atexit`` restorer —
+but only if we *actually* transferred foreground ownership, so the
+fast path leaves no atexit behind and we never race with the parent
+shell's own ``tcsetpgrp`` on exit. If the handshake failed — typical
+in sandboxes that cannot be made foreground —
+``_setup_controlling_terminal`` **replaces** the step-1 Python
+handlers with ``SIG_IGN``. That is the sandbox fallback: the kernel
+discards ``SIGTTIN`` / ``SIGTTOU`` outright, so they never reach
+Python's asyncio wakeup pipe and the ``BlockingIOError`` storm
+cannot happen. ``SIG_IGN`` *is* inherited across ``exec``, but in a
+sandbox the children have the same TTY ownership problem anyway, so
+this is the right default.
 
 ``_setup_controlling_terminal`` is idempotent. It is also called from
 the top of :func:`xonsh.main.main_xonsh`, so callers that enter the
@@ -362,22 +375,26 @@ failed), the restorer is a no-op.
 When the handshake is a no-op
 ------------------------------
 
-The setup does nothing in any of these situations:
+The *handshake itself* is skipped in these situations (step 1 still
+installs the historical Python no-op handlers):
 
-* **Windows.** POSIX controlling terminals do not apply.
+* **Windows.** POSIX controlling terminals do not apply, and
+  ``_setup_controlling_terminal`` returns immediately after the
+  ``ON_WINDOWS`` check without installing anything.
 * **Non-interactive invocations** where stderr is not a TTY:
   ``xonsh script.xsh``, piped input, redirected stderr, script-from-
   stdin mode, and tests under pytest (which captures stderr via a
-  pipe). In these modes ``_setup_controlling_terminal`` returns
-  before touching signal state — default POSIX dispositions are
-  kept intact.
+  pipe). ``_setup_controlling_terminal`` installs the step-1 Python
+  handlers and returns — no handshake, no atexit. This matches the
+  pre-handshake xonsh behavior for these modes.
 * **xonsh is a session leader** (``getsid(0) == getpid()``). A
   session leader cannot change its own process group id, and if it
   is session leader it almost always already owns the TTY. The
-  handshake declines and the ``SIG_IGN`` fallback takes over.
+  handshake declines and the ``SIG_IGN`` fallback replaces the
+  step-1 handlers.
 * **xonsh is already the foreground group** — the fast path returns
-  immediately, the Python no-op handler is still installed as a
-  safety net, but the atexit restorer is *not* registered (there is
+  immediately, the step-1 Python handlers stay in place as a safety
+  net, and the atexit restorer is *not* registered (there is
   nothing to restore).
 * **Missing** ``pthread_sigmask``, which is POSIX-only and absent on
   exotic builds.

--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -184,3 +184,209 @@ See also
 * :doc:`xonshrc` -- RC file loading and configuration snippets
 * :doc:`env` -- environment variables and type system
 * :doc:`envvars` -- full list of environment variables
+
+
+.. _launch-fg-takeover:
+
+Controlling Terminal and Foreground Process Group
+==================================================
+
+When xonsh starts interactively on a POSIX system it performs a small
+startup handshake to make itself the *foreground process group* of the
+terminal it's attached to. This section explains what that means, why
+xonsh bothers, and how to disable it if it conflicts with something in
+your environment.
+
+Background: foreground process group
+-------------------------------------
+
+Every POSIX terminal has exactly one **foreground process group**.
+Processes in that group are allowed to read from and write control
+operations to the terminal without being suspended. Processes in any
+other group are "in the background" — when they touch the TTY the
+kernel sends them ``SIGTTIN`` (background read) or ``SIGTTOU``
+(background control / write under ``TOSTOP``), and the default
+disposition of those signals is to stop the process, not to let the
+operation proceed.
+
+Interactive shells like bash and zsh install themselves as the
+foreground group at startup. They do it with a short sequence:
+
+1. Find the controlling TTY's file descriptor.
+2. Check whether the current foreground group is already ours.
+3. If not, block the signals that would disrupt step 4.
+4. Call ``setpgid(0, 0)`` to land in a process group of our own.
+5. Call ``tcsetpgrp(tty_fd, getpgrp())`` to install that group as
+   the TTY's foreground group.
+6. Restore the signal mask.
+
+After this, every TTY touch the shell makes is permitted by the
+kernel and the job-control primitives the shell uses to manage
+pipelines (``tcsetpgrp``, ``tcsetattr``, …) work as intended.
+
+Why xonsh needs to do the same
+------------------------------
+
+Historically xonsh skipped this handshake and relied on whatever
+launched it to have arranged things correctly. That assumption holds
+when xonsh is started from a typical terminal via a parent shell
+(bash, zsh, fish, another xonsh, …), because those shells
+``fork + exec + tcsetpgrp`` the child correctly. It breaks in several
+common non-typical environments:
+
+* **Flatpak / Bubblewrap** and similar sandbox launchers: ``bwrap``
+  does not reassign the TTY's foreground group to the sandboxed
+  child. xonsh ends up running as a background process of the TTY.
+* **Build systems, CI runners, IDE integrated terminals** and
+  service managers such as ``systemd --user`` that launch xonsh via
+  ``posix_spawn`` without wiring up job control.
+* **Nested containers** that reuse the outer PTY without reconfiguring
+  foreground ownership.
+
+In all of these, xonsh is technically a background process of the
+TTY. Every terminal operation — ``tcgetattr`` during
+``prompt_toolkit`` initialisation, ``tcsetpgrp`` when launching a
+pipeline, plain reads and writes when ``TOSTOP`` is set — fires
+``SIGTTIN`` or ``SIGTTOU``. There are two failure modes that follow:
+
+1. **asyncio wakeup pipe overflow.** Python routes signals to a
+   non-blocking self-pipe so the main event loop can wake up when
+   one arrives. If signals arrive faster than the loop drains the
+   pipe — which happens instantly under a startup storm — the C-level
+   signal handler's write to the pipe fails and raises::
+
+       BlockingIOError: [Errno 11] Resource temporarily unavailable
+
+   xonsh startup crashes.
+
+2. **termios EINTR.** Even when the storm is under control,
+   low-frequency signals (``SIGCHLD``, ``SIGWINCH``, …) still arrive
+   while ``prompt_toolkit`` calls ``termios.tcsetattr`` to switch the
+   terminal into raw mode. The C call returns ``EINTR``, which
+   ``tcsetattr`` surfaces as::
+
+       termios.error: (4, 'Interrupted system call')
+
+Users in the affected environments used to work around this by
+running xonsh under a wrapper that installed ``SIG_IGN`` for
+``SIGTTIN`` / ``SIGTTOU`` before importing xonsh. That works, but
+it is a workaround: the kernel still considers xonsh background, job
+control is still subtly wrong, ``SIG_IGN`` is inherited through
+``exec`` and affects child processes, and the wakeup-pipe race can
+still bite if a signal storm recurs after the fallback handler is
+re-installed.
+
+What xonsh does now
+-------------------
+
+On POSIX, during ``main_xonsh``, xonsh runs the bash-style handshake
+in :func:`xonsh.main._acquire_controlling_terminal`:
+
+* It uses **stderr** (file descriptor 2) as the TTY handle. This
+  matches :func:`xonsh.procs.jobs.give_terminal_to`, which also uses
+  FD 2 when xonsh later transfers the terminal between pipeline
+  groups.
+* It aborts cleanly — with no side effects — if any precondition
+  fails: Windows, non-TTY stderr, session leader (which cannot
+  ``setpgid`` itself), missing ``pthread_sigmask``, or the escape
+  hatch described below.
+* It blocks ``SIGTTOU``, ``SIGTTIN``, ``SIGTSTP`` and ``SIGCHLD`` in
+  the calling thread with ``pthread_sigmask``. ``SIGTTOU`` is the
+  critical one; without the block, ``tcsetpgrp`` below would send
+  ``SIGTTOU`` to xonsh itself and suspend it immediately.
+* It short-circuits to success if the TTY's foreground group is
+  already our process group — the handshake is not needed and the
+  restorer is *not* registered, so on shutdown we don't race with
+  the parent shell's own ``tcsetpgrp``.
+* Otherwise it calls ``setpgid(0, 0)`` followed by
+  ``tcsetpgrp(tty_fd, getpgrp())``, remembers the previous
+  foreground group, and records the fact that the handshake
+  succeeded.
+* It restores the signal mask in a ``finally`` block so any error
+  path leaves the process in a clean state.
+
+If the handshake succeeds, xonsh then installs a Python-level no-op
+handler for ``SIGTTIN`` and ``SIGTTOU`` — the kernel should not
+deliver those signals any more under normal operation, but a Python
+handler defends against races and, crucially, is **not** inherited
+across ``exec``, so child processes of xonsh see the normal
+``SIG_DFL`` disposition and their own job control keeps working.
+
+If the handshake fails — as it will in a sandbox where xonsh cannot
+become foreground — xonsh falls back to setting ``SIG_IGN`` for
+``SIGTTIN`` and ``SIGTTOU`` instead of the Python handler. That
+discards the signals at the kernel level, so they never reach
+Python's wakeup pipe and the ``BlockingIOError`` storm cannot happen.
+``SIG_IGN`` *is* inherited across ``exec``, but in a sandbox the
+children have the same TTY ownership problem anyway, so this is the
+right default.
+
+Shutdown: handing the TTY back
+-------------------------------
+
+When the handshake actually did change the foreground group, xonsh
+registers :func:`xonsh.main._release_controlling_terminal` with
+:mod:`atexit`. On shutdown this function calls ``tcsetpgrp`` to
+restore the previous foreground group — normally the parent shell —
+with ``SIGTTOU`` blocked during the call. If the parent has already
+reclaimed the TTY, or if the fd is no longer valid, the error is
+swallowed: this runs under ``atexit`` and raising would just make
+shutdown noisy. In every other case (handshake didn't run, handshake
+took the fast path because we were already foreground, handshake
+failed), the restorer is a no-op.
+
+When the handshake is a no-op
+------------------------------
+
+The handshake does nothing in any of these situations:
+
+* **Windows.** POSIX controlling terminals do not apply.
+* **Non-interactive invocations** where stderr is not a TTY:
+  ``xonsh script.xsh``, piped input, redirected stderr, and
+  script-from-stdin mode.
+* **xonsh is a session leader** (``getsid(0) == getpid()``). A
+  session leader cannot change its own process group id, and if it
+  is session leader it almost always already owns the TTY.
+* **xonsh is already the foreground group** — the fast path returns
+  immediately and does not register the atexit restorer.
+* **Missing** ``pthread_sigmask``, which is POSIX-only and absent on
+  exotic builds.
+
+Disabling the handshake
+------------------------
+
+Set ``XONSH_NO_FG_TAKEOVER=1`` in the parent environment (before
+launching xonsh) to skip the handshake entirely. This is an escape
+hatch for rare cases where taking over the foreground group
+conflicts with a parent process that expects xonsh to stay in its
+original process group. When the handshake is disabled, xonsh falls
+back to installing ``SIG_IGN`` for ``SIGTTIN`` / ``SIGTTOU`` —
+exactly the behaviour of the historical sandbox wrapper.
+
+.. code-block:: bash
+
+    # disable the takeover, e.g. when debugging unusual TTY setups
+    XONSH_NO_FG_TAKEOVER=1 xonsh
+
+What this does not fix
+-----------------------
+
+The handshake addresses the *foreground group* part of the problem.
+It does not work around every possible issue that can arise from
+running xonsh in an unusual TTY environment:
+
+* If the TTY belongs to a different session than xonsh (for example
+  a sandbox that calls ``setsid``), ``tcsetpgrp`` fails with
+  ``EPERM`` and the handshake cleanly declines. You are still on
+  the ``SIG_IGN`` fallback in that case.
+* ``termios.tcsetattr`` calls can still be interrupted by signals
+  other than ``SIGTTIN`` / ``SIGTTOU``. In practice a foreground
+  xonsh sees far fewer interruptions — most of the signal volume
+  was the ``SIGTT*`` storm — so the ``EINTR`` race is dramatically
+  less likely, but it is not impossible. If you hit it, wrap your
+  launcher to retry ``tcsetattr`` / ``tcgetattr`` on ``EINTR``.
+* Stealing a controlling terminal from a different session requires
+  ``TIOCSCTTY`` with ``CAP_SYS_ADMIN`` in the init user namespace,
+  which is not available in Flatpak or rootless containers. If you
+  really need a fresh controlling TTY, run xonsh under a PTY proxy
+  such as ``script(1)`` or inside ``tmux``.

--- a/tests/test_main_terminal_llm.py
+++ b/tests/test_main_terminal_llm.py
@@ -391,21 +391,32 @@ def capture_atexit(monkeypatch):
 
 
 @skip_if_on_windows
-def test_setup_is_noop_when_stderr_not_a_tty(
+def test_setup_non_tty_installs_pyhandler_no_handshake(
     monkeypatch, reset_fg_state, capture_signal_signal, capture_atexit
 ):
-    """Non-TTY stderr keeps default POSIX signal dispositions.
+    """Non-TTY stderr skips the handshake but still installs the
+    historical Python no-op handlers for ``SIGTTIN`` / ``SIGTTOU``.
 
-    This is the gate that makes the whole feature safe under pytest
-    and in script/pipe mode: no handlers get installed at all.
+    This matches xonsh's pre-handshake behavior: script mode, piped
+    input, redirected stderr and test runners (pytest captures stderr
+    via a pipe) all land here, and scripts that indirectly touch TTY
+    must not be stopped by default ``SIG_DFL``. The handshake and
+    atexit restorer are *not* invoked.
     """
     monkeypatch.setattr(xonsh.main.os, "isatty", lambda fd: False)
     xonsh.main._setup_controlling_terminal()
-    assert capture_signal_signal == []
+    # Exactly two signal.signal calls — Python no-op handler for each
+    # signal, no SIG_IGN follow-up because the handshake never ran.
+    assert len(capture_signal_signal) == 2
+    installed = {sig for sig, _ in capture_signal_signal}
+    assert installed == {signal.SIGTTIN, signal.SIGTTOU}
+    for _, handler in capture_signal_signal:
+        assert handler is not signal.SIG_IGN
+        assert callable(handler)
     assert capture_atexit == []
-    # Flag stays unset so a later call (e.g. from main_xonsh in a real
-    # interactive run) can still do the setup.
-    assert xonsh.main._tty_setup_done is False
+    # Flag *is* set — we committed to signal handling for this
+    # process, and a second call should be a no-op.
+    assert xonsh.main._tty_setup_done is True
 
 
 @skip_if_on_windows
@@ -436,12 +447,14 @@ def test_setup_installs_pyhandler_on_acquire_success(
 def test_setup_installs_sigign_on_acquire_failure(
     monkeypatch, reset_fg_state, fake_tty, capture_signal_signal, capture_atexit
 ):
-    """Acquire failure → SIG_IGN fallback, no atexit registration.
+    """Acquire failure → SIG_IGN replaces the step-1 Python handlers.
 
-    This is the sandbox path. The handshake fails because e.g. the
-    handshake cannot tcsetpgrp, and we must prevent asyncio from
-    drowning in SIGTT* wakeups — SIG_IGN drops the signals at the
-    kernel boundary.
+    This is the sandbox path. ``_setup_controlling_terminal`` first
+    installs a Python no-op handler (step 1, unconditional) and then
+    *replaces* it with ``SIG_IGN`` when the handshake cannot make
+    xonsh foreground. The replacement is what prevents asyncio from
+    drowning in ``SIGTT*`` wakeups — ``SIG_IGN`` drops the signals at
+    the kernel boundary before they ever reach Python.
     """
     install, _, _ = fake_tty
     monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
@@ -449,11 +462,28 @@ def test_setup_installs_sigign_on_acquire_failure(
     install(fake)
     xonsh.main._setup_controlling_terminal()
     assert xonsh.main._tty_setup_done is True
-    # Both signals are now SIG_IGN.
-    assert len(capture_signal_signal) == 2
-    for sig, handler in capture_signal_signal:
-        assert sig in (signal.SIGTTIN, signal.SIGTTOU)
+    # Four signal.signal calls total: two Python no-op handlers from
+    # step 1, then two SIG_IGN replacements from the failure path.
+    assert len(capture_signal_signal) == 4
+    # Step 1: Python no-op handler for each signal.
+    step1 = capture_signal_signal[:2]
+    step1_sigs = {sig for sig, _ in step1}
+    assert step1_sigs == {signal.SIGTTIN, signal.SIGTTOU}
+    for _, handler in step1:
+        assert handler is not signal.SIG_IGN
+        assert callable(handler)
+    # Step 2: SIG_IGN replacement.
+    step2 = capture_signal_signal[2:]
+    step2_sigs = {sig for sig, _ in step2}
+    assert step2_sigs == {signal.SIGTTIN, signal.SIGTTOU}
+    for _, handler in step2:
         assert handler is signal.SIG_IGN
+    # Final state per signal is SIG_IGN (last write wins).
+    last_per_sig = {}
+    for sig, handler in capture_signal_signal:
+        last_per_sig[sig] = handler
+    assert last_per_sig[signal.SIGTTIN] is signal.SIG_IGN
+    assert last_per_sig[signal.SIGTTOU] is signal.SIG_IGN
     # No atexit — nothing was acquired to release.
     assert capture_atexit == []
 

--- a/tests/test_main_terminal_llm.py
+++ b/tests/test_main_terminal_llm.py
@@ -1,0 +1,513 @@
+"""Tests for the controlling-terminal startup handshake in xonsh.main.
+
+Covers :func:`xonsh.main._acquire_controlling_terminal`,
+:func:`xonsh.main._release_controlling_terminal` and
+:func:`xonsh.main._setup_controlling_terminal`. These manipulate process
+group and TTY state, so most tests patch out the underlying OS primitives
+with a ``FakeOS`` helper instead of exercising them for real — the actual
+syscall behaviour is provided by the kernel and is tested at the libc
+level, we only care about the policy xonsh wraps around them.
+"""
+
+import signal
+import sys
+
+import pytest
+
+import xonsh.main
+from xonsh.pytest.tools import skip_if_on_windows
+
+
+@pytest.fixture
+def reset_fg_state():
+    """Ensure the module-level foreground state is clean around each test.
+
+    The state leaks between tests otherwise because ``_fg_tty_state`` is a
+    plain module-level dict and ``_tty_setup_done`` is a module-level
+    flag for :func:`_setup_controlling_terminal` idempotency.
+    """
+    original = dict(xonsh.main._fg_tty_state)
+    original_done = xonsh.main._tty_setup_done
+    xonsh.main._fg_tty_state["acquired"] = False
+    xonsh.main._fg_tty_state["tty_fd"] = -1
+    xonsh.main._fg_tty_state["old_fg"] = -1
+    xonsh.main._tty_setup_done = False
+    yield
+    xonsh.main._fg_tty_state.clear()
+    xonsh.main._fg_tty_state.update(original)
+    xonsh.main._tty_setup_done = original_done
+
+
+class FakeOS:
+    """A tiny recorder for the OS primitives the handshake touches.
+
+    Tests build a ``FakeOS`` with the desired initial state and then
+    monkeypatch the module-level ``os.*`` calls in :mod:`xonsh.main`
+    to its methods. Each method either returns the stored value,
+    updates state, or raises a configured exception — nothing else.
+    """
+
+    def __init__(
+        self,
+        *,
+        pid=1000,
+        pgid=999,
+        sid=500,
+        fg_pgrp=999,
+        is_tty=True,
+        tcgetpgrp_err=None,
+        setpgid_err=None,
+        tcsetpgrp_err=None,
+        getsid_err=None,
+        isatty_err=None,
+    ):
+        self.pid = pid
+        self.pgid = pgid
+        self.sid = sid
+        self.fg_pgrp = fg_pgrp
+        self.is_tty = is_tty
+        self.tcgetpgrp_err = tcgetpgrp_err
+        self.setpgid_err = setpgid_err
+        self.tcsetpgrp_err = tcsetpgrp_err
+        self.getsid_err = getsid_err
+        self.isatty_err = isatty_err
+        # Call log — tests assert on these to verify the expected
+        # sequence of syscalls happened (or did not happen).
+        self.calls = []
+
+    def getpid(self):
+        return self.pid
+
+    def getpgrp(self):
+        return self.pgid
+
+    def getsid(self, pid):
+        self.calls.append(("getsid", pid))
+        if self.getsid_err is not None:
+            raise self.getsid_err
+        return self.sid
+
+    def isatty(self, fd):
+        self.calls.append(("isatty", fd))
+        if self.isatty_err is not None:
+            raise self.isatty_err
+        return self.is_tty
+
+    def tcgetpgrp(self, fd):
+        self.calls.append(("tcgetpgrp", fd))
+        if self.tcgetpgrp_err is not None:
+            raise self.tcgetpgrp_err
+        return self.fg_pgrp
+
+    def setpgid(self, pid, pgid):
+        self.calls.append(("setpgid", pid, pgid))
+        if self.setpgid_err is not None:
+            raise self.setpgid_err
+        # setpgid(0, 0) means "make me my own leader": pgid := pid.
+        if pid == 0 and pgid == 0:
+            self.pgid = self.pid
+
+    def tcsetpgrp(self, fd, pgid):
+        self.calls.append(("tcsetpgrp", fd, pgid))
+        if self.tcsetpgrp_err is not None:
+            raise self.tcsetpgrp_err
+        self.fg_pgrp = pgid
+
+
+@pytest.fixture
+def fake_tty(monkeypatch):
+    """Wire a ``FakeOS`` into ``xonsh.main`` and yield it.
+
+    Also patches ``signal.pthread_sigmask`` to a recording stub so we can
+    assert that the handshake masks the right signals. We do NOT touch
+    ``sys.stderr`` — pytest already replaces it with a capture fd, and
+    since every ``os.*`` call is mocked, the concrete fd value is
+    irrelevant. The effective fd is exposed as the second element of
+    the yielded tuple so tests can assert against it.
+    """
+    mask_log = []
+
+    def fake_pthread_sigmask(how, signals):
+        mask_log.append((how, set(signals) if signals is not None else None))
+        return set()
+
+    monkeypatch.setattr(xonsh.main.signal, "pthread_sigmask", fake_pthread_sigmask)
+
+    try:
+        expected_fd = sys.stderr.fileno()
+    except (AttributeError, OSError, ValueError):
+        # pytest may wrap stderr with an object whose fileno() errors;
+        # skip the tests in that environment rather than run them on a
+        # bogus fd.
+        pytest.skip("sys.stderr has no usable fileno() under this runner")
+
+    def install(fake):
+        monkeypatch.setattr(xonsh.main.os, "getpid", fake.getpid)
+        monkeypatch.setattr(xonsh.main.os, "getpgrp", fake.getpgrp)
+        monkeypatch.setattr(xonsh.main.os, "getsid", fake.getsid)
+        monkeypatch.setattr(xonsh.main.os, "isatty", fake.isatty)
+        monkeypatch.setattr(xonsh.main.os, "tcgetpgrp", fake.tcgetpgrp)
+        monkeypatch.setattr(xonsh.main.os, "setpgid", fake.setpgid)
+        monkeypatch.setattr(xonsh.main.os, "tcsetpgrp", fake.tcsetpgrp)
+
+    yield install, mask_log, expected_fd
+
+
+@skip_if_on_windows
+def test_acquire_returns_false_when_env_disabled(monkeypatch, reset_fg_state):
+    """``XONSH_NO_FG_TAKEOVER`` short-circuits the whole handshake."""
+    monkeypatch.setenv("XONSH_NO_FG_TAKEOVER", "1")
+    assert xonsh.main._acquire_controlling_terminal() is False
+    assert xonsh.main._fg_tty_state["acquired"] is False
+
+
+@skip_if_on_windows
+def test_acquire_returns_false_when_not_a_tty(monkeypatch, reset_fg_state, fake_tty):
+    """Non-TTY stderr (script mode, piped I/O) is a clean no-op."""
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(is_tty=False)
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is False
+    # isatty must be called; we must NOT touch process group state.
+    kinds = [c[0] for c in fake.calls]
+    assert "isatty" in kinds
+    assert "setpgid" not in kinds
+    assert "tcsetpgrp" not in kinds
+
+
+@skip_if_on_windows
+def test_acquire_returns_false_when_session_leader(
+    monkeypatch, reset_fg_state, fake_tty
+):
+    """A session leader cannot setpgid itself — skip cleanly."""
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, sid=1000)  # sid == pid ⇒ session leader
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is False
+    kinds = [c[0] for c in fake.calls]
+    # Must not try to change pgrp or TTY state.
+    assert "setpgid" not in kinds
+    assert "tcsetpgrp" not in kinds
+
+
+@skip_if_on_windows
+def test_acquire_fast_path_when_already_foreground(
+    monkeypatch, reset_fg_state, fake_tty
+):
+    """If the TTY's fg group is already ours, no work is needed.
+
+    The handshake must not mark state as acquired in this case so the
+    ``atexit`` restorer stays a no-op and we never race with the parent
+    shell's own ``tcsetpgrp`` on exit.
+    """
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, pgid=999, sid=500, fg_pgrp=999)
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is True
+    # State stays unacquired — nothing to release on shutdown.
+    assert xonsh.main._fg_tty_state["acquired"] is False
+    kinds = [c[0] for c in fake.calls]
+    assert "tcgetpgrp" in kinds
+    assert "setpgid" not in kinds
+    assert "tcsetpgrp" not in kinds
+
+
+@skip_if_on_windows
+def test_acquire_full_handshake_success(monkeypatch, reset_fg_state, fake_tty):
+    """Full success path: setpgid then tcsetpgrp, state recorded."""
+    install, mask_log, expected_fd = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, pgid=999, sid=500, fg_pgrp=42)
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is True
+    # State is recorded for the release step.
+    assert xonsh.main._fg_tty_state["acquired"] is True
+    assert xonsh.main._fg_tty_state["tty_fd"] == expected_fd
+    assert xonsh.main._fg_tty_state["old_fg"] == 42
+    # The fake kernel now reports us as the fg group.
+    assert fake.fg_pgrp == 1000
+    assert fake.pgid == 1000
+    # The signal mask was blocked and then restored.
+    assert len(mask_log) == 2
+    assert mask_log[0][0] == signal.SIG_BLOCK
+    assert mask_log[1][0] == signal.SIG_SETMASK
+    blocked = mask_log[0][1]
+    assert signal.SIGTTOU in blocked
+    assert signal.SIGTTIN in blocked
+    assert signal.SIGTSTP in blocked
+    assert signal.SIGCHLD in blocked
+
+
+@skip_if_on_windows
+def test_acquire_returns_false_on_tcgetpgrp_failure(
+    monkeypatch, reset_fg_state, fake_tty
+):
+    """If tcgetpgrp fails, skip without touching setpgid/tcsetpgrp."""
+    install, mask_log, expected_fd = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(tcgetpgrp_err=OSError("ENOTTY"))
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is False
+    kinds = [c[0] for c in fake.calls]
+    assert "setpgid" not in kinds
+    assert "tcsetpgrp" not in kinds
+    # Mask must still be restored.
+    assert len(mask_log) == 2
+    assert mask_log[-1][0] == signal.SIG_SETMASK
+
+
+@skip_if_on_windows
+def test_acquire_returns_false_on_setpgid_failure(
+    monkeypatch, reset_fg_state, fake_tty
+):
+    """A PermissionError from setpgid degrades cleanly."""
+    install, mask_log, expected_fd = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(fg_pgrp=42, setpgid_err=PermissionError("EPERM"))
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is False
+    assert xonsh.main._fg_tty_state["acquired"] is False
+    # Mask restored.
+    assert mask_log[-1][0] == signal.SIG_SETMASK
+
+
+@skip_if_on_windows
+def test_acquire_returns_false_on_tcsetpgrp_failure(
+    monkeypatch, reset_fg_state, fake_tty
+):
+    """If tcsetpgrp fails we leave setpgid's change in place but do
+    not claim success. State is not marked as acquired, so the
+    restorer is a no-op.
+    """
+    install, mask_log, expected_fd = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(fg_pgrp=42, tcsetpgrp_err=OSError("EPERM"))
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is False
+    assert xonsh.main._fg_tty_state["acquired"] is False
+    kinds = [c[0] for c in fake.calls]
+    assert "setpgid" in kinds  # we did get this far
+    assert "tcsetpgrp" in kinds  # and we did try the install
+    assert mask_log[-1][0] == signal.SIG_SETMASK
+
+
+@skip_if_on_windows
+def test_release_is_noop_when_not_acquired(monkeypatch, reset_fg_state, fake_tty):
+    """Releasing before a successful acquire must not touch the TTY."""
+    install, _, _ = fake_tty
+    fake = FakeOS()
+    install(fake)
+    # state is clean from the fixture
+    xonsh.main._release_controlling_terminal()
+    assert fake.calls == []  # no syscalls at all
+
+
+@skip_if_on_windows
+def test_release_restores_previous_foreground(monkeypatch, reset_fg_state, fake_tty):
+    """Full release: tcsetpgrp is called with the old fg pgid."""
+    install, mask_log, expected_fd = fake_tty
+    fake = FakeOS(fg_pgrp=1000)
+    install(fake)
+    xonsh.main._fg_tty_state["acquired"] = True
+    xonsh.main._fg_tty_state["tty_fd"] = expected_fd
+    xonsh.main._fg_tty_state["old_fg"] = 77
+    xonsh.main._release_controlling_terminal()
+    # Old fg is back.
+    assert ("tcsetpgrp", expected_fd, 77) in fake.calls
+    # State was cleared so a second call is a no-op.
+    assert xonsh.main._fg_tty_state["acquired"] is False
+    assert xonsh.main._fg_tty_state["tty_fd"] == -1
+    assert xonsh.main._fg_tty_state["old_fg"] == -1
+    # Mask blocked and restored.
+    assert len(mask_log) == 2
+    assert mask_log[-1][0] == signal.SIG_SETMASK
+
+
+@skip_if_on_windows
+def test_release_swallows_tcsetpgrp_error(monkeypatch, reset_fg_state, fake_tty):
+    """Shutdown must not raise when the parent already reclaimed the TTY."""
+    install, _, expected_fd = fake_tty
+    fake = FakeOS(tcsetpgrp_err=OSError("EPERM"))
+    install(fake)
+    xonsh.main._fg_tty_state["acquired"] = True
+    xonsh.main._fg_tty_state["tty_fd"] = expected_fd
+    xonsh.main._fg_tty_state["old_fg"] = 77
+    # Must not raise despite tcsetpgrp failing.
+    xonsh.main._release_controlling_terminal()
+    # State is still cleared.
+    assert xonsh.main._fg_tty_state["acquired"] is False
+
+
+def test_acquire_returns_false_on_windows(monkeypatch, reset_fg_state):
+    """POSIX concepts don't apply on Windows — fast no-op."""
+    monkeypatch.setattr(xonsh.main, "ON_WINDOWS", True)
+    assert xonsh.main._acquire_controlling_terminal() is False
+
+
+# ---------------------------------------------------------------------------
+# _setup_controlling_terminal — orchestration / signal policy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def capture_signal_signal(monkeypatch):
+    """Record every ``signal.signal`` call made from ``xonsh.main``.
+
+    Returns the list of ``(sig, handler)`` tuples so tests can assert
+    which handlers got installed (Python no-op vs ``SIG_IGN``) without
+    actually mutating the real process signal table.
+    """
+    calls = []
+
+    def fake_signal(sig, handler):
+        calls.append((sig, handler))
+        # Return a stub "previous handler" — the real signal.signal
+        # returns this but callers in xonsh.main don't use it.
+        return signal.SIG_DFL
+
+    monkeypatch.setattr(xonsh.main.signal, "signal", fake_signal)
+    return calls
+
+
+@pytest.fixture
+def capture_atexit(monkeypatch):
+    """Record every ``atexit.register`` call made from ``xonsh.main``.
+
+    Tests use this to verify that the shutdown restorer is registered
+    only in the acquire-success case, and not in the fast-path or
+    failure paths.
+    """
+    registered = []
+
+    def fake_register(func, *args, **kwargs):
+        registered.append(func)
+        return func
+
+    monkeypatch.setattr(xonsh.main.atexit, "register", fake_register)
+    return registered
+
+
+@skip_if_on_windows
+def test_setup_is_noop_when_stderr_not_a_tty(
+    monkeypatch, reset_fg_state, capture_signal_signal, capture_atexit
+):
+    """Non-TTY stderr keeps default POSIX signal dispositions.
+
+    This is the gate that makes the whole feature safe under pytest
+    and in script/pipe mode: no handlers get installed at all.
+    """
+    monkeypatch.setattr(xonsh.main.os, "isatty", lambda fd: False)
+    xonsh.main._setup_controlling_terminal()
+    assert capture_signal_signal == []
+    assert capture_atexit == []
+    # Flag stays unset so a later call (e.g. from main_xonsh in a real
+    # interactive run) can still do the setup.
+    assert xonsh.main._tty_setup_done is False
+
+
+@skip_if_on_windows
+def test_setup_installs_pyhandler_on_acquire_success(
+    monkeypatch, reset_fg_state, fake_tty, capture_signal_signal, capture_atexit
+):
+    """Successful acquire → Python no-op handler + atexit restorer."""
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, pgid=999, sid=500, fg_pgrp=42)
+    install(fake)
+    xonsh.main._setup_controlling_terminal()
+    # Idempotency flag set.
+    assert xonsh.main._tty_setup_done is True
+    # Both signals got a Python callable handler (not SIG_IGN,
+    # because we want children to inherit normal dispositions).
+    assert len(capture_signal_signal) == 2
+    installed_sigs = {sig for sig, _ in capture_signal_signal}
+    assert installed_sigs == {signal.SIGTTIN, signal.SIGTTOU}
+    for _, handler in capture_signal_signal:
+        assert handler is not signal.SIG_IGN
+        assert callable(handler)
+    # Shutdown restorer is registered.
+    assert xonsh.main._release_controlling_terminal in capture_atexit
+
+
+@skip_if_on_windows
+def test_setup_installs_sigign_on_acquire_failure(
+    monkeypatch, reset_fg_state, fake_tty, capture_signal_signal, capture_atexit
+):
+    """Acquire failure → SIG_IGN fallback, no atexit registration.
+
+    This is the sandbox path. The handshake fails because e.g. the
+    handshake cannot tcsetpgrp, and we must prevent asyncio from
+    drowning in SIGTT* wakeups — SIG_IGN drops the signals at the
+    kernel boundary.
+    """
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(fg_pgrp=42, tcsetpgrp_err=OSError("EPERM"))
+    install(fake)
+    xonsh.main._setup_controlling_terminal()
+    assert xonsh.main._tty_setup_done is True
+    # Both signals are now SIG_IGN.
+    assert len(capture_signal_signal) == 2
+    for sig, handler in capture_signal_signal:
+        assert sig in (signal.SIGTTIN, signal.SIGTTOU)
+        assert handler is signal.SIG_IGN
+    # No atexit — nothing was acquired to release.
+    assert capture_atexit == []
+
+
+@skip_if_on_windows
+def test_setup_does_not_register_atexit_on_fast_path(
+    monkeypatch, reset_fg_state, fake_tty, capture_signal_signal, capture_atexit
+):
+    """Already-foreground fast path must not schedule a restorer.
+
+    If xonsh was launched by a well-behaved shell that already put it
+    in the foreground group, the handshake short-circuits. Registering
+    a restorer in that case would race with the parent shell's own
+    ``tcsetpgrp`` on exit and is a bug.
+    """
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, pgid=999, sid=500, fg_pgrp=999)  # already fg
+    install(fake)
+    xonsh.main._setup_controlling_terminal()
+    # Python handler still installed as a safety net.
+    assert len(capture_signal_signal) == 2
+    for _, handler in capture_signal_signal:
+        assert handler is not signal.SIG_IGN
+    # But NO atexit — this is the key distinction from the
+    # acquire-success path.
+    assert capture_atexit == []
+
+
+@skip_if_on_windows
+def test_setup_is_idempotent(
+    monkeypatch, reset_fg_state, fake_tty, capture_signal_signal, capture_atexit
+):
+    """A second call does nothing. This is what makes it safe to call
+    from both :func:`main` and :func:`main_xonsh`."""
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, pgid=999, sid=500, fg_pgrp=42)
+    install(fake)
+    xonsh.main._setup_controlling_terminal()
+    first_call_count = len(capture_signal_signal)
+    first_atexit_count = len(capture_atexit)
+    # Second call
+    xonsh.main._setup_controlling_terminal()
+    assert len(capture_signal_signal) == first_call_count
+    assert len(capture_atexit) == first_atexit_count
+
+
+def test_setup_is_noop_on_windows(
+    monkeypatch, reset_fg_state, capture_signal_signal, capture_atexit
+):
+    """POSIX concepts don't apply on Windows — no handlers installed."""
+    monkeypatch.setattr(xonsh.main, "ON_WINDOWS", True)
+    xonsh.main._setup_controlling_terminal()
+    assert capture_signal_signal == []
+    assert capture_atexit == []
+    assert xonsh.main._tty_setup_done is False

--- a/tests/test_main_terminal_llm.py
+++ b/tests/test_main_terminal_llm.py
@@ -23,19 +23,24 @@ def reset_fg_state():
     """Ensure the module-level foreground state is clean around each test.
 
     The state leaks between tests otherwise because ``_fg_tty_state`` is a
-    plain module-level dict and ``_tty_setup_done`` is a module-level
-    flag for :func:`_setup_controlling_terminal` idempotency.
+    plain module-level dict, ``_tty_setup_done`` is a module-level flag
+    for :func:`_setup_controlling_terminal` idempotency, and
+    ``_ttin_ttou_counter`` is a module-level counter for
+    :func:`_handle_sig_ttin_ttou` livelock escalation.
     """
     original = dict(xonsh.main._fg_tty_state)
     original_done = xonsh.main._tty_setup_done
+    original_counter = xonsh.main._ttin_ttou_counter[0]
     xonsh.main._fg_tty_state["acquired"] = False
     xonsh.main._fg_tty_state["tty_fd"] = -1
     xonsh.main._fg_tty_state["old_fg"] = -1
     xonsh.main._tty_setup_done = False
+    xonsh.main._ttin_ttou_counter[0] = 0
     yield
     xonsh.main._fg_tty_state.clear()
     xonsh.main._fg_tty_state.update(original)
     xonsh.main._tty_setup_done = original_done
+    xonsh.main._ttin_ttou_counter[0] = original_counter
 
 
 class FakeOS:
@@ -388,6 +393,92 @@ def test_acquire_returns_false_on_windows(monkeypatch, reset_fg_state):
     """POSIX concepts don't apply on Windows — fast no-op."""
     monkeypatch.setattr(xonsh.main, "ON_WINDOWS", True)
     assert xonsh.main._acquire_controlling_terminal() is False
+
+
+# ---------------------------------------------------------------------------
+# _handle_sig_ttin_ttou — livelock guard tests
+# ---------------------------------------------------------------------------
+
+
+@skip_if_on_windows
+def test_handle_sig_ttin_ttou_no_op_under_threshold(monkeypatch, reset_fg_state):
+    """Below threshold the handler is a pure no-op: counter increments
+    but no signal disposition change happens.
+
+    Normal operation fires the handler zero times (xonsh is foreground),
+    and legitimate transient bursts — a subprocess briefly stealing
+    foreground during a pipeline, a mis-timed tcsetpgrp — should all
+    recover well below the threshold without triggering the escalation.
+    """
+    calls = []
+
+    def fake_signal(sig, handler):
+        calls.append((sig, handler))
+        return signal.SIG_DFL
+
+    monkeypatch.setattr(xonsh.main.signal, "signal", fake_signal)
+    # Fire the handler many times but below threshold.
+    threshold = xonsh.main._TTIN_TTOU_LIVELOCK_THRESHOLD
+    for _i in range(threshold):
+        xonsh.main._handle_sig_ttin_ttou(signal.SIGTTOU, None)
+    # Counter reflects all invocations.
+    assert xonsh.main._ttin_ttou_counter[0] == threshold
+    # But no escalation — signal.signal was never called.
+    assert calls == []
+
+
+@skip_if_on_windows
+def test_handle_sig_ttin_ttou_escalates_above_threshold(monkeypatch, reset_fg_state):
+    """One firing above threshold → escalate to SIG_IGN.
+
+    This is the livelock guard. If something has been hammering the
+    handler (PEP 475 retry on SIGTTIN, PR #6192 application-level
+    retry on SIGTTOU), we assume xonsh has lost foreground ownership
+    for a reason that won't self-resolve, and we fall back to letting
+    the kernel discard the signals outright so the underlying
+    syscalls can complete on their next retry.
+    """
+    calls = []
+
+    def fake_signal(sig, handler):
+        calls.append((sig, handler))
+        return signal.SIG_DFL
+
+    monkeypatch.setattr(xonsh.main.signal, "signal", fake_signal)
+    # One firing past the threshold triggers escalation.
+    threshold = xonsh.main._TTIN_TTOU_LIVELOCK_THRESHOLD
+    for _i in range(threshold + 1):
+        xonsh.main._handle_sig_ttin_ttou(signal.SIGTTOU, None)
+    # Two signal.signal calls — one for SIGTTIN, one for SIGTTOU.
+    assert len(calls) == 2
+    sigs = {sig for sig, _ in calls}
+    assert sigs == {signal.SIGTTIN, signal.SIGTTOU}
+    for _, handler in calls:
+        assert handler is signal.SIG_IGN
+
+
+@skip_if_on_windows
+def test_handle_sig_ttin_ttou_counter_resets_on_setup(
+    monkeypatch, reset_fg_state, fake_tty, capture_signal_signal, capture_atexit
+):
+    """``_setup_controlling_terminal`` must reset the counter so that
+    a previous run's escalation does not bleed through into a fresh
+    installation.
+
+    Without this reset, a long-lived test process that calls setup
+    twice (first triggering escalation, then resetting state) would
+    start the second run already at threshold, escalating on the
+    first signal instead of providing the full livelock guard.
+    """
+    # Simulate a prior run that left the counter above threshold.
+    xonsh.main._ttin_ttou_counter[0] = xonsh.main._TTIN_TTOU_LIVELOCK_THRESHOLD + 10
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    fake = FakeOS(pid=1000, pgid=999, sid=500, fg_pgrp=42)
+    install(fake)
+    xonsh.main._setup_controlling_terminal()
+    # Counter was reset to 0 by _setup_controlling_terminal.
+    assert xonsh.main._ttin_ttou_counter[0] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main_terminal_llm.py
+++ b/tests/test_main_terminal_llm.py
@@ -216,6 +216,49 @@ def test_acquire_fast_path_when_already_foreground(
 
 
 @skip_if_on_windows
+def test_acquire_pid_namespace_unrepresentable_pgid(
+    monkeypatch, reset_fg_state, fake_tty
+):
+    """PID namespace edge case: ``getpgrp`` and ``tcgetpgrp`` both
+    return 0 because our real pgid is not representable inside the
+    namespace (typical for Flatpak / Bubblewrap / Podman / kubectl
+    exec scenarios). The fast path must NOT treat ``0 == 0`` as
+    "already foreground" — it must fall through to ``setpgid(0, 0)``
+    so we end up with a valid, namespace-visible pgid.
+
+    This reproduces the Flatpak crash where ``tcsetpgrp(fd, 0)``
+    later failed with ESRCH and the TTY foreground ended up
+    orphaned on a dead subprocess group, ultimately raising
+    ``termios.error: (5, 'Input/output error')`` from ptk.
+    """
+    install, _, _ = fake_tty
+    monkeypatch.delenv("XONSH_NO_FG_TAKEOVER", raising=False)
+    # Inside a PID namespace:
+    #   - our visible pid is 2 (namespace-local)
+    #   - our sid is e.g. 500 (some visible session leader)
+    #   - our "real" pgid was inherited from outside the namespace,
+    #     so the kernel reports it as 0 (unrepresentable)
+    #   - the TTY fg pgrp is also 0 (it belongs to a pgrp outside
+    #     the namespace, i.e. the outer bash)
+    fake = FakeOS(pid=2, pgid=0, sid=500, fg_pgrp=0)
+    install(fake)
+    assert xonsh.main._acquire_controlling_terminal() is True
+    # State IS recorded — we really did acquire foreground via
+    # a full setpgid + tcsetpgrp, not via the fast path.
+    assert xonsh.main._fg_tty_state["acquired"] is True
+    assert xonsh.main._fg_tty_state["old_fg"] == 0
+    # setpgid(0, 0) and tcsetpgrp must both have been called.
+    kinds = [c[0] for c in fake.calls]
+    assert "setpgid" in kinds
+    assert "tcsetpgrp" in kinds
+    # After setpgid(0, 0) our FakeOS model sets pgid := pid = 2,
+    # which is representable inside the namespace.
+    assert fake.pgid == 2
+    # And tcsetpgrp installed pgid=2 as the TTY foreground.
+    assert fake.fg_pgrp == 2
+
+
+@skip_if_on_windows
 def test_acquire_full_handshake_success(monkeypatch, reset_fg_state, fake_tty):
     """Full success path: setpgid then tcsetpgrp, state recorded."""
     install, mask_log, expected_fd = fake_tty

--- a/tests/xoreutils/test_xcontext.py
+++ b/tests/xoreutils/test_xcontext.py
@@ -1,0 +1,303 @@
+"""Tests for the xcontext command helpers.
+
+Tests that create real symlinks on the filesystem are skipped on Windows
+(where symlink creation usually requires admin / Developer Mode). The
+code paths they exercise are still cross-platform — on Windows the
+``_has_symlink_cycle`` fallback handles loops that the stdlib
+``os.path.realpath(strict=True)`` reports without a POSIX ``errno.ELOOP``.
+"""
+
+import os
+
+from xonsh.pytest.tools import skip_if_on_windows
+from xonsh.xoreutils.xcontext import (
+    _has_symlink_cycle,
+    _is_executable_file,
+    _resolve_one,
+    _resolve_path,
+)
+
+
+def _make_executable(path):
+    """Write an empty file and give it ``+x`` for the current user."""
+    path.write_text("")
+    path.chmod(0o755)
+
+
+def _make_unexecutable(path):
+    """Write an empty file with no execute permissions."""
+    path.write_text("")
+    path.chmod(0o644)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_one / _resolve_path (string and list values)
+# ---------------------------------------------------------------------------
+
+
+@skip_if_on_windows
+def test_resolve_one_passthrough_when_disabled(tmp_path):
+    """``resolve=False`` never follows symlinks. The accessibility check
+    still runs, so an executable symlink target returns ``bad=False``."""
+    target = tmp_path / "target"
+    _make_executable(target)
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    resolved, bad = _resolve_one(str(link), resolve=False)
+    assert resolved == str(link)  # not resolved
+    assert bad is False  # but still passes the executable check
+
+
+@skip_if_on_windows
+def test_resolve_one_follows_symlink(tmp_path):
+    """A non-cyclic symlink pointing at an executable file is followed to
+    its real target and reported as NOT bad."""
+    target = tmp_path / "target"
+    _make_executable(target)
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    resolved, bad = _resolve_one(str(link), resolve=True)
+    assert resolved == os.path.realpath(str(link))
+    assert resolved == os.path.realpath(str(target))
+    assert bad is False
+
+
+def test_resolve_one_nonexistent_is_bad(tmp_path):
+    """Dangling / missing paths can't be executed — bad=True."""
+    missing = tmp_path / "does_not_exist"
+    resolved, bad = _resolve_one(str(missing), resolve=True)
+    assert resolved == os.path.realpath(str(missing))
+    assert bad is True
+
+
+def test_resolve_one_directory_is_bad(tmp_path):
+    """A directory is not a runnable file — bad=True."""
+    resolved, bad = _resolve_one(str(tmp_path), resolve=True)
+    assert bad is True
+
+
+def test_resolve_one_not_executable_is_bad(tmp_path):
+    """An existing, accessible, but non-``+x`` file is bad."""
+    f = tmp_path / "foo.py"
+    _make_unexecutable(f)
+    resolved, bad = _resolve_one(str(f), resolve=True)
+    assert resolved == os.path.realpath(str(f))
+    assert bad is True
+
+
+def test_resolve_one_main_py_is_not_bad(tmp_path):
+    """``__main__.py`` is exempt from the ``+x`` check — it's a valid
+    ``python -m <pkg>`` entry point that is never marked executable.
+    ``xxonsh`` points at this file when xonsh is launched via
+    ``python -m xonsh``, and it must not be rendered red.
+    """
+    pkg = tmp_path / "somepkg"
+    pkg.mkdir()
+    main = pkg / "__main__.py"
+    _make_unexecutable(main)  # not +x, as __main__.py conventionally is
+
+    resolved, bad = _resolve_one(str(main), resolve=True)
+    assert resolved == os.path.realpath(str(main))
+    assert bad is False
+
+
+def test_resolve_one_missing_main_py_is_bad(tmp_path):
+    """A non-existent ``__main__.py`` is still bad — the ``+x`` exemption
+    only applies when the file actually exists."""
+    missing = tmp_path / "nopkg" / "__main__.py"
+    _, bad = _resolve_one(str(missing), resolve=True)
+    assert bad is True
+
+
+def test_resolve_one_executable_file_is_ok(tmp_path):
+    """An existing, accessible, ``+x`` file is not bad."""
+    f = tmp_path / "runnable"
+    _make_executable(f)
+    resolved, bad = _resolve_one(str(f), resolve=True)
+    assert resolved == os.path.realpath(str(f))
+    assert bad is False
+
+
+def test_resolve_one_not_executable_bad_even_without_resolve(tmp_path):
+    """``resolve=False`` must NOT disable the accessibility / +x check —
+    otherwise ``--no-resolve`` would hide broken entries from the user."""
+    f = tmp_path / "foo.py"
+    _make_unexecutable(f)
+    _, bad = _resolve_one(str(f), resolve=False)
+    assert bad is True
+
+
+@skip_if_on_windows
+def test_resolve_one_dangling_symlink_is_bad(tmp_path):
+    """A symlink whose target doesn't exist is flagged bad (missing)."""
+    target = tmp_path / "does_not_exist"
+    link = tmp_path / "dangling"
+    link.symlink_to(target)
+
+    _, bad = _resolve_one(str(link), resolve=True)
+    assert bad is True
+
+
+@skip_if_on_windows
+def test_resolve_one_detects_cycle(tmp_path):
+    """A symlink pair A → B → A must be flagged bad and leave the
+    original path untouched so the caller can display it."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    resolved, bad = _resolve_one(str(a), resolve=True)
+    assert bad is True
+    assert resolved == str(a)  # original preserved
+
+
+@skip_if_on_windows
+def test_resolve_one_detects_self_cycle(tmp_path):
+    """A self-loop (A → A) is also a cycle."""
+    a = tmp_path / "selfloop"
+    a.symlink_to(a)
+
+    resolved, bad = _resolve_one(str(a), resolve=True)
+    assert bad is True
+    assert resolved == str(a)
+
+
+def test_resolve_path_accepts_none():
+    assert _resolve_path(None, resolve=True) == (None, False)
+
+
+def test_resolve_path_accepts_non_path_list():
+    """A list whose first element is not a string is returned as-is."""
+    value = [object(), "-m", "pip"]
+    assert _resolve_path(value, resolve=True) == (value, False)
+
+
+@skip_if_on_windows
+def test_resolve_path_list_with_cyclic_head(tmp_path):
+    """For list values (e.g. xpip alias), only the first element is resolved.
+    If it cycles, the list is kept and the bad flag is True."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    value = [str(a), "-m", "pip"]
+    resolved, bad = _resolve_path(value, resolve=True)
+    assert bad is True
+    # Original head preserved so the display still works; tail unchanged.
+    assert resolved == [str(a), "-m", "pip"]
+
+
+@skip_if_on_windows
+def test_resolve_path_list_with_good_head(tmp_path):
+    """For list values with an executable head, the head is resolved in
+    place and the tail is kept intact."""
+    target = tmp_path / "real"
+    _make_executable(target)
+    link = tmp_path / "link"
+    link.symlink_to(target)
+
+    value = [str(link), "-m", "pip"]
+    resolved, bad = _resolve_path(value, resolve=True)
+    assert bad is False
+    assert resolved[0] == os.path.realpath(str(link))
+    assert resolved[1:] == ["-m", "pip"]
+
+
+def test_resolve_path_list_with_bad_head_not_executable(tmp_path):
+    """A list whose first element points to a non-``+x`` file is flagged
+    bad (no symlinks involved)."""
+    f = tmp_path / "foo.py"
+    _make_unexecutable(f)
+    value = [str(f), "-m", "pip"]
+    resolved, bad = _resolve_path(value, resolve=True)
+    assert bad is True
+    assert resolved == [os.path.realpath(str(f)), "-m", "pip"]
+
+
+# ---------------------------------------------------------------------------
+# _is_executable_file — direct unit tests for the accessibility check
+# ---------------------------------------------------------------------------
+
+
+def test_is_executable_file_none():
+    assert _is_executable_file(None) is False
+    assert _is_executable_file("") is False
+
+
+def test_is_executable_file_missing(tmp_path):
+    assert _is_executable_file(str(tmp_path / "nope")) is False
+
+
+def test_is_executable_file_directory(tmp_path):
+    assert _is_executable_file(str(tmp_path)) is False
+
+
+def test_is_executable_file_plain_file(tmp_path):
+    f = tmp_path / "plain.txt"
+    _make_unexecutable(f)
+    assert _is_executable_file(str(f)) is False
+
+
+@skip_if_on_windows
+def test_is_executable_file_executable_file(tmp_path):
+    f = tmp_path / "runnable"
+    _make_executable(f)
+    assert _is_executable_file(str(f)) is True
+
+
+def test_is_executable_file_main_py_exempt(tmp_path):
+    """``__main__.py`` is treated as good regardless of ``+x`` bit."""
+    pkg = tmp_path / "somepkg"
+    pkg.mkdir()
+    main = pkg / "__main__.py"
+    _make_unexecutable(main)
+    assert _is_executable_file(str(main)) is True
+
+
+def test_is_executable_file_main_py_missing(tmp_path):
+    """Exemption only applies to files that actually exist."""
+    missing = tmp_path / "nowhere" / "__main__.py"
+    assert _is_executable_file(str(missing)) is False
+
+
+# ---------------------------------------------------------------------------
+# _has_symlink_cycle — direct unit tests for the fallback detector
+# ---------------------------------------------------------------------------
+
+
+@skip_if_on_windows
+def test_has_symlink_cycle_on_cycle(tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+    assert _has_symlink_cycle(str(a)) is True
+    assert _has_symlink_cycle(str(b)) is True
+
+
+@skip_if_on_windows
+def test_has_symlink_cycle_on_valid_chain(tmp_path):
+    """A → B → C (real file) is NOT a cycle."""
+    c = tmp_path / "c"
+    c.write_text("")
+    b = tmp_path / "b"
+    b.symlink_to(c)
+    a = tmp_path / "a"
+    a.symlink_to(b)
+    assert _has_symlink_cycle(str(a)) is False
+
+
+def test_has_symlink_cycle_on_plain_file(tmp_path):
+    f = tmp_path / "plain"
+    f.write_text("")
+    assert _has_symlink_cycle(str(f)) is False
+
+
+def test_has_symlink_cycle_on_nonexistent(tmp_path):
+    """Missing path is not a cycle — we return False and the caller falls
+    back to lenient realpath."""
+    assert _has_symlink_cycle(str(tmp_path / "nope")) is False

--- a/tests/xoreutils/test_xcontext.py
+++ b/tests/xoreutils/test_xcontext.py
@@ -78,8 +78,16 @@ def test_resolve_one_directory_is_bad(tmp_path):
     assert bad is True
 
 
+@skip_if_on_windows
 def test_resolve_one_not_executable_is_bad(tmp_path):
-    """An existing, accessible, but non-``+x`` file is bad."""
+    """An existing, accessible, but non-``+x`` file is bad.
+
+    POSIX-only: Windows has no per-file execute bit. Executability is
+    determined by extension via ``PATHEXT`` and ``os.access(X_OK)`` on
+    Windows is effectively always True for readable files. Windows
+    coverage for the extension-based executable check lives in the
+    dedicated ``_llm`` test module.
+    """
     f = tmp_path / "foo.py"
     _make_unexecutable(f)
     resolved, bad = _resolve_one(str(f), resolve=True)
@@ -120,9 +128,12 @@ def test_resolve_one_executable_file_is_ok(tmp_path):
     assert bad is False
 
 
+@skip_if_on_windows
 def test_resolve_one_not_executable_bad_even_without_resolve(tmp_path):
     """``resolve=False`` must NOT disable the accessibility / +x check —
-    otherwise ``--no-resolve`` would hide broken entries from the user."""
+    otherwise ``--no-resolve`` would hide broken entries from the user.
+    POSIX-only — see :func:`test_resolve_one_not_executable_is_bad`.
+    """
     f = tmp_path / "foo.py"
     _make_unexecutable(f)
     _, bad = _resolve_one(str(f), resolve=False)
@@ -207,9 +218,12 @@ def test_resolve_path_list_with_good_head(tmp_path):
     assert resolved[1:] == ["-m", "pip"]
 
 
+@skip_if_on_windows
 def test_resolve_path_list_with_bad_head_not_executable(tmp_path):
     """A list whose first element points to a non-``+x`` file is flagged
-    bad (no symlinks involved)."""
+    bad (no symlinks involved). POSIX-only — see
+    :func:`test_resolve_one_not_executable_is_bad`.
+    """
     f = tmp_path / "foo.py"
     _make_unexecutable(f)
     value = [str(f), "-m", "pip"]
@@ -236,7 +250,11 @@ def test_is_executable_file_directory(tmp_path):
     assert _is_executable_file(str(tmp_path)) is False
 
 
+@skip_if_on_windows
 def test_is_executable_file_plain_file(tmp_path):
+    """POSIX-only — see :func:`test_resolve_one_not_executable_is_bad`
+    for why the ``+x``-based tests cannot run on Windows.
+    """
     f = tmp_path / "plain.txt"
     _make_unexecutable(f)
     assert _is_executable_file(str(f)) is False

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -1,6 +1,7 @@
 """The main xonsh script."""
 
 import argparse
+import atexit
 import builtins
 import contextlib
 import enum
@@ -152,6 +153,215 @@ def path_argument(s):
         msg = f"{s!r} must be a valid path to a file or directory"
         raise argparse.ArgumentTypeError(msg)
     return s
+
+
+#: Module-level state written by :func:`_acquire_controlling_terminal` and
+#: consumed by :func:`_release_controlling_terminal`. Kept as a dict so that
+#: the atexit restorer is a thin closure without extra globals.
+_fg_tty_state: dict = {"acquired": False, "tty_fd": -1, "old_fg": -1}
+
+
+def _acquire_controlling_terminal():
+    """Put xonsh into the foreground process group of its controlling TTY.
+
+    Background
+    ----------
+    On POSIX systems every terminal has a single *foreground process group*.
+    Only processes belonging to that group may read from or perform control
+    operations on the terminal without being suspended by ``SIGTTIN`` /
+    ``SIGTTOU``. Interactive shells (bash, zsh, …) perform a small startup
+    handshake to make sure they are that foreground group: they put
+    themselves into their own process group and call ``tcsetpgrp`` on the
+    TTY. xonsh historically did not do this — it relied on the launching
+    shell to have arranged things correctly. That assumption breaks in a
+    number of environments:
+
+    * Flatpak / Bubblewrap and similar sandboxes that spawn children
+      without adjusting the TTY's foreground group.
+    * Build systems, CI runners, IDE integrated terminals and service
+      managers (e.g. ``systemd --user``) that don't wire xonsh up as the
+      foreground process of the PTY they attach.
+    * Nested containers that reuse the outer PTY.
+
+    In those cases xonsh is technically a background process. Every TTY
+    touch — ``tcgetattr`` during prompt_toolkit init, ``tcsetpgrp`` when
+    launching a pipeline, plain writes when stdout is line-buffered —
+    raises ``SIGTTIN`` or ``SIGTTOU``. The signals are delivered to
+    Python's asyncio wakeup pipe faster than it can be drained, overflow
+    it, and crash startup with ``BlockingIOError: Resource temporarily
+    unavailable``. Other signals interrupt ``termios`` calls mid-flight
+    and surface as ``termios.error: Interrupted system call``.
+
+    The fix
+    -------
+    Perform the same handshake bash does, very early in xonsh's lifetime:
+
+    1. Find a TTY file descriptor (stderr, same choice xonsh already uses
+       for :func:`xonsh.procs.jobs.give_terminal_to`).
+    2. Compare its current foreground group to our process group. If we
+       are already foreground, record that and exit fast.
+    3. Block ``SIGTTOU``, ``SIGTTIN``, ``SIGTSTP`` and ``SIGCHLD`` in the
+       calling thread so that the handshake cannot suspend us or be
+       reentered by a child's death.
+    4. Call ``setpgid(0, 0)`` to make us a process group of our own.
+    5. Call ``tcsetpgrp(tty_fd, getpgrp())`` to install that group as
+       the foreground group of the TTY.
+    6. Remember the previous foreground group so :func:`_release_controlling_terminal`
+       (registered via ``atexit``) can hand it back on shutdown.
+
+    Every failure mode returns ``False`` cleanly — this is a best-effort
+    upgrade, never a hard requirement. Windows has no concept of
+    controlling terminals in the POSIX sense; the function immediately
+    returns ``False`` there.
+
+    Environment
+    -----------
+    Set ``XONSH_NO_FG_TAKEOVER=1`` in the parent environment to disable
+    the handshake entirely. This is an escape hatch for rare cases where
+    the takeover conflicts with a parent process that expects xonsh to
+    stay in its original process group.
+
+    Returns
+    -------
+    bool
+        ``True`` if xonsh is now (or already was) the foreground process
+        group of its controlling terminal. ``False`` on any failure or
+        when the handshake is not applicable (non-TTY, Windows, session
+        leader, disabled by env var, …).
+    """
+    if ON_WINDOWS:
+        return False
+    if os.environ.get("XONSH_NO_FG_TAKEOVER"):
+        return False
+    # pthread_sigmask is POSIX-only and may be absent on exotic builds.
+    if not hasattr(signal, "pthread_sigmask"):
+        return False
+    # Use stderr as the TTY handle. xonsh already uses FD 2 for
+    # give_terminal_to in pipeline management (xonsh/procs/jobs.py), so
+    # this keeps the choice consistent across subsystems.
+    try:
+        tty_fd = sys.stderr.fileno()
+    except (AttributeError, OSError, ValueError):
+        return False
+    try:
+        if not os.isatty(tty_fd):
+            return False
+    except OSError:
+        return False
+    # A session leader cannot change its own process group id, so the
+    # setpgid(0, 0) call below would fail with EPERM. Detect this up
+    # front and skip cleanly — if we are session leader we almost
+    # certainly already own the TTY anyway.
+    try:
+        if os.getsid(0) == os.getpid():
+            return False
+    except OSError:
+        return False
+    # Block the signals that can disrupt the handshake. SIGTTOU is the
+    # critical one — without this mask, the tcsetpgrp() call below
+    # would send SIGTTOU to our own process group (we are in a
+    # background group at this point) and suspend us. SIGTTIN is
+    # blocked for symmetry; SIGTSTP so that a stray Ctrl+Z cannot
+    # desynchronise state; SIGCHLD so a child reaping does not
+    # interrupt us mid-handshake. The block is thread-local — it
+    # does not affect signal disposition for the rest of the process.
+    block = {signal.SIGTTOU, signal.SIGTTIN, signal.SIGTSTP, signal.SIGCHLD}
+    try:
+        old_mask = signal.pthread_sigmask(signal.SIG_BLOCK, block)
+    except (AttributeError, OSError):
+        return False
+    try:
+        try:
+            current_fg = os.tcgetpgrp(tty_fd)
+        except OSError:
+            return False
+        my_pgid = os.getpgrp()
+        if current_fg == my_pgid:
+            # We are already the foreground group. Nothing to acquire
+            # and nothing to release on shutdown — return success but
+            # do *not* mark state as acquired, so the atexit restorer
+            # stays a no-op and we don't risk racing with the parent
+            # shell's own tcsetpgrp() on exit.
+            return True
+        # Become our own process group leader. If we are already a
+        # leader this is a no-op; if the kernel refuses (EPERM), we
+        # bail out. After this succeeds our pgid == pid.
+        try:
+            os.setpgid(0, 0)
+        except (PermissionError, OSError):
+            return False
+        my_pgid = os.getpgrp()
+        # Install our pgid as the TTY's foreground group. SIGTTOU is
+        # blocked, so this cannot suspend us; it may still fail with
+        # EPERM if the TTY belongs to a different session, or ENOTTY
+        # if the fd lost its TTY-ness between isatty() and now — both
+        # degrade to a clean False return.
+        try:
+            os.tcsetpgrp(tty_fd, my_pgid)
+        except OSError:
+            return False
+        _fg_tty_state["acquired"] = True
+        _fg_tty_state["tty_fd"] = tty_fd
+        _fg_tty_state["old_fg"] = current_fg
+        return True
+    finally:
+        # Always restore the signal mask, even on error paths. We only
+        # changed the mask for this thread, so this call is cheap and
+        # cannot fail in any practical scenario — but guard it anyway.
+        try:
+            signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)
+        except (AttributeError, OSError):
+            pass
+
+
+def _release_controlling_terminal():
+    """Give the controlling TTY's foreground group back to its previous
+    owner on shutdown.
+
+    Registered via :mod:`atexit` when :func:`_acquire_controlling_terminal`
+    actually took over the TTY. A no-op in every other case: if xonsh was
+    already foreground, if the handshake failed, or if there is no TTY.
+
+    Restoring the previous foreground group matters because the parent
+    shell (bash, zsh, another xonsh, …) usually calls ``wait`` on us and
+    then expects to read from the terminal. If xonsh leaves its own pgid
+    installed as foreground, the parent will immediately receive
+    ``SIGTTIN`` on the next read. Robust shells recover from this, but it
+    is much cleaner to hand the TTY back explicitly.
+    """
+    if not _fg_tty_state.get("acquired"):
+        return
+    tty_fd = _fg_tty_state.get("tty_fd", -1)
+    old_fg = _fg_tty_state.get("old_fg", -1)
+    if tty_fd < 0 or old_fg < 0:
+        return
+    if not hasattr(signal, "pthread_sigmask"):
+        return
+    try:
+        old_mask = signal.pthread_sigmask(
+            signal.SIG_BLOCK, {signal.SIGTTOU, signal.SIGTTIN}
+        )
+    except (AttributeError, OSError):
+        return
+    try:
+        try:
+            os.tcsetpgrp(tty_fd, old_fg)
+        except OSError:
+            # Parent may already have reclaimed the TTY, or the fd may
+            # have been closed by shutdown — either way nothing
+            # actionable remains. Swallow silently: this runs inside
+            # atexit and raising here would just make shutdown noisy.
+            pass
+    finally:
+        try:
+            signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)
+        except (AttributeError, OSError):
+            pass
+        # Clear state so a second call (e.g. atexit + explicit shutdown)
+        # is a no-op.
+        _fg_tty_state["acquired"] = False
+        _fg_tty_state["tty_fd"] = -1
+        _fg_tty_state["old_fg"] = -1
 
 
 @lazyobject
@@ -568,12 +778,48 @@ def main(argv=None):
 def main_xonsh(args):
     """Main entry point for xonsh cli."""
     if not ON_WINDOWS:
+        # Try the bash-style startup handshake: make xonsh the
+        # foreground process group of its controlling terminal so that
+        # kernel-delivered SIGTTIN/SIGTTOU do not fire under normal
+        # operation. See :func:`_acquire_controlling_terminal` for
+        # the full rationale.
+        fg_acquired = _acquire_controlling_terminal()
+        if fg_acquired:
+            # Make sure we hand the TTY back to its previous owner
+            # when xonsh exits. Registered only when we actually took
+            # over, so in the common case (xonsh launched from a
+            # well-behaved shell that already installed us as fg) this
+            # is a no-op.
+            if _fg_tty_state.get("acquired"):
+                atexit.register(_release_controlling_terminal)
 
-        def func_sig_ttin_ttou(n, f):
-            pass
+            # Install a Python-level no-op handler as a safety net.
+            # Once we are foreground the kernel should not deliver
+            # these signals any more, but races are possible
+            # (e.g. a child process in our group calling tcsetpgrp
+            # before we reinstall ourselves). A Python handler is
+            # preferred over SIG_IGN here because the latter is
+            # inherited across ``exec`` and would subtly break job
+            # control in child processes that rely on SIGTTIN/SIGTTOU.
+            def func_sig_ttin_ttou(n, f):
+                pass
 
-        signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
-        signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+            signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
+            signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+        else:
+            # We could not become foreground. This is the typical
+            # outcome inside Flatpak/Bubblewrap sandboxes, nested
+            # containers, and some CI runners. In that regime the
+            # kernel *will* keep sending SIGTTIN/SIGTTOU every time
+            # xonsh touches the TTY, and a Python-level handler would
+            # overflow asyncio's signal wakeup pipe with
+            # ``BlockingIOError``. Use SIG_IGN so the kernel discards
+            # the signals outright and never routes them through
+            # Python. This is inherited across ``exec``, but in a
+            # sandbox children have the same TTY ownership problem
+            # anyway, so this is the right default.
+            signal.signal(signal.SIGTTIN, signal.SIG_IGN)
+            signal.signal(signal.SIGTTOU, signal.SIG_IGN)
 
     events.on_post_init.fire()
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -166,6 +166,105 @@ _fg_tty_state: dict = {"acquired": False, "tty_fd": -1, "old_fg": -1}
 #: so tests can reset it between runs.
 _tty_setup_done: bool = False
 
+#: Delivery counter for :func:`_handle_sig_ttin_ttou`. A Python list is
+#: used instead of a plain int so that the handler (a closure / nested
+#: call site) can mutate it in place without a ``global`` declaration.
+#: Exposed so tests can reset it.
+_ttin_ttou_counter: list = [0]
+
+#: Threshold at which :func:`_handle_sig_ttin_ttou` escalates the
+#: ``SIGTTIN`` / ``SIGTTOU`` disposition from the Python no-op handler
+#: to ``SIG_IGN`` as a livelock guard. See the handler's docstring for
+#: the rationale. Chosen conservatively high — normal operation fires
+#: the handler zero times, and legitimate transient bursts (e.g. a
+#: misbehaving subprocess briefly stealing foreground during a
+#: pipeline) should recover well below this bound.
+_TTIN_TTOU_LIVELOCK_THRESHOLD: int = 1000
+
+
+def _handle_sig_ttin_ttou(n, f):
+    """Python no-op handler for ``SIGTTIN`` / ``SIGTTOU`` with a
+    built-in livelock guard.
+
+    Installed by :func:`_setup_controlling_terminal`'s success path.
+    Under normal operation xonsh is the foreground process group of
+    its controlling terminal and this handler never fires — the
+    kernel does not deliver ``SIGTTIN`` / ``SIGTTOU`` to a foreground
+    process. It exists as a safety net for pathological cases where
+    xonsh temporarily loses foreground ownership (unexpected
+    ``tcsetpgrp`` from a subprocess, a PID-namespace race, a buggy
+    xontrib, …) and then tries to touch the TTY.
+
+    Why a plain ``pass`` is a trap
+    ------------------------------
+    There are two independent paths that can turn a ``pass`` no-op
+    handler into a 99%-CPU livelock:
+
+    1. **PEP 475 (``os.read`` retry) — triggered by SIGTTIN.**
+       Since Python 3.5, ``os.read`` is one of the syscalls that
+       Python automatically retries on ``EINTR`` when the signal
+       handler does not raise — see
+       https://peps.python.org/pep-0475/ for the full list. If xonsh
+       is a background process of the TTY and calls ``os.read`` on
+       the TTY fd (directly, or indirectly via ``prompt_toolkit``'s
+       asyncio event loop), the kernel returns ``EINTR`` and sends
+       ``SIGTTIN``. The Python handler runs, does ``pass``, returns.
+       Python retries ``os.read``. The kernel sends ``SIGTTIN``
+       again. Loop — at 99% CPU until the process is killed.
+       ``termios.*`` is **not** in PEP 475's retry list, so
+       ``tcsetattr`` itself does not trigger this path — but
+       ``os.read`` does, and prompt_toolkit reads stdin on every
+       prompt.
+
+    2. **xonsh PR #6192 application-level retry — triggered by
+       SIGTTOU.** The existing outer retry loop in
+       ``xonsh/shells/ptk_shell/__init__.py`` catches any exception
+       with ``args[0] == 4`` (``EINTR``) and calls
+       ``self.prompter.prompt(**prompt_args)`` again. If
+       ``tcsetattr`` inside ``raw_mode`` is what raised (because
+       xonsh is background, so the kernel generates ``SIGTTOU`` and
+       fails the syscall with ``EINTR``), the retry re-enters
+       ``raw_mode`` and re-calls ``tcsetattr``, the kernel re-sends
+       ``SIGTTOU``, the handler passes, the retry fires again —
+       another 99%-CPU loop.
+
+    The fix
+    -------
+    Count deliveries. On the first few thousand we do nothing — that
+    covers every legitimate transient scenario. Above the threshold
+    we **replace the Python handler with ``SIG_IGN``**. POSIX says
+    that if ``SIGTTOU`` / ``SIGTTIN`` are ignored, the underlying
+    operation "shall be allowed to perform" — so the next
+    ``tcsetattr`` / ``read`` succeeds instead of re-entering the
+    loop, and the caller makes progress.
+
+    ``SIG_IGN`` is inherited across ``exec``, so subprocess children
+    launched after escalation see ``SIG_IGN`` for these signals too.
+    That is an acceptable trade-off: we only reach this branch if
+    xonsh is already in a degraded "lost foreground" state, and the
+    alternative is a hard hang.
+
+    References
+    ----------
+    * PEP 475 (Retry system calls failing with EINTR):
+      https://peps.python.org/pep-0475/
+    * ``tcsetattr(3)`` — "the operation shall be allowed to perform"
+      when SIGTTOU is ignored:
+      https://man7.org/linux/man-pages/man3/tcsetattr.3.html
+    * ``read(2)`` — EINTR semantics and PEP 475 coverage:
+      https://man7.org/linux/man-pages/man2/read.2.html
+    * xonsh PR #6192 — the application-level retry loop that
+      provides the SIGTTOU livelock path.
+    """
+    _ttin_ttou_counter[0] += 1
+    if _ttin_ttou_counter[0] > _TTIN_TTOU_LIVELOCK_THRESHOLD:
+        # Escalate: let the kernel drop the signals outright. Future
+        # deliveries will not reach Python at all, and interrupted
+        # syscalls will complete on the next retry (POSIX: "the
+        # operation shall be allowed to perform" when ignored).
+        signal.signal(signal.SIGTTIN, signal.SIG_IGN)
+        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+
 
 def _acquire_controlling_terminal():
     """Put xonsh into the foreground process group of its controlling TTY.
@@ -542,16 +641,19 @@ def _setup_controlling_terminal():
         return
     _tty_setup_done = True
 
-    # Step 1: unconditional Python no-op handlers for SIGTTIN/SIGTTOU.
-    # This matches the pre-handshake xonsh behavior and is what
-    # script-mode / non-TTY callers rely on. The only reason to
-    # deviate from it is the sandbox-failure case below, which
-    # overrides with SIG_IGN to avoid the asyncio wakeup pipe storm.
-    def func_sig_ttin_ttou(n, f):
-        pass
-
-    signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
-    signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+    # Step 1: unconditional Python no-op-with-livelock-guard handler
+    # for SIGTTIN/SIGTTOU. The ``pass`` body of the historical inline
+    # handler is a trap — a background xonsh touching the TTY would
+    # loop forever via PEP 475 retry on ``os.read`` (SIGTTIN path) or
+    # via the application-level retry in
+    # ``xonsh/shells/ptk_shell/__init__.py`` (SIGTTOU path). The
+    # module-level :func:`_handle_sig_ttin_ttou` counts deliveries and
+    # escalates to ``SIG_IGN`` after a high threshold, breaking the
+    # loop while preserving normal job control for typical use (where
+    # the handler never fires at all).
+    _ttin_ttou_counter[0] = 0  # reset any previous-run state
+    signal.signal(signal.SIGTTIN, _handle_sig_ttin_ttou)
+    signal.signal(signal.SIGTTOU, _handle_sig_ttin_ttou)
 
     # Step 2: only attempt the handshake when stderr is a real TTY.
     # Script mode, piped stdin/stdout, and test runners (pytest

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -234,12 +234,61 @@ def _acquire_controlling_terminal():
         group of its controlling terminal. ``False`` on any failure or
         when the handshake is not applicable (non-TTY, Windows, session
         leader, disabled by env var, …).
+
+    References
+    ----------
+    POSIX.1-2017 specifications (https://pubs.opengroup.org/onlinepubs/9699919799/):
+
+    * ``setpgid(2)``: https://man7.org/linux/man-pages/man2/setpgid.2.html
+      — session leader cannot change its own pgid (EPERM); ``setpgid(0, 0)``
+      creates a new pgrp with ``pgid == pid``.
+    * ``tcsetpgrp(3)``: https://man7.org/linux/man-pages/man3/tcsetpgrp.3.html
+      — a background-group caller receives ``SIGTTOU`` unless it is blocked
+      or ignored; fails with ESRCH if the target pgid does not exist.
+    * ``tcgetpgrp(3)``: https://man7.org/linux/man-pages/man3/tcgetpgrp.3.html
+      — reads the controlling terminal's current foreground pgid.
+    * ``tcsetattr(3)``: https://man7.org/linux/man-pages/man3/tcsetattr.3.html
+      — returns EIO when called on an orphaned pgrp's controlling terminal
+      (Linux) rather than sending SIGTTOU, which is the Flatpak crash path.
+    * ``pthread_sigmask(3)``: https://man7.org/linux/man-pages/man3/pthread_sigmask.3.html
+      — per-thread signal mask; used here to block ``SIGTTOU`` across the
+      ``tcsetpgrp`` call without affecting the rest of the process.
+    * ``pid_namespaces(7)``: https://man7.org/linux/man-pages/man7/pid_namespaces.7.html
+      — specifies that ``getpgid``/``getsid`` return 0 for ids not
+      representable inside the namespace; this is the Linux kernel
+      behaviour that the ``my_pgid > 0`` guard in the fast-path exists for.
+    * ``execve(2)``: https://man7.org/linux/man-pages/man2/execve.2.html
+      — specifies signal-disposition inheritance across exec (``SIG_IGN``
+      persists, custom handlers reset to ``SIG_DFL``), which informs the
+      choice between Python no-op handler and ``SIG_IGN`` in
+      :func:`_setup_controlling_terminal`.
+    * ``credentials(7)``: https://man7.org/linux/man-pages/man7/credentials.7.html
+      — general background on sessions and process groups.
+
+    Non-POSIX / Linux-specific:
+
+    * ``signal(7)``: https://man7.org/linux/man-pages/man7/signal.7.html
+      — Linux signal semantics table, including the inheritance rules
+      across ``fork`` and ``exec``.
+
+    Historical prior art:
+
+    * bash ``jobs.c``
+      (https://cgit.git.savannah.gnu.org/cgit/bash.git/tree/jobs.c) —
+      source of the ``setpgid`` + ``tcsetpgrp`` startup pattern, verified
+      for ``start_pipeline``, ``make_child``, ``stop_pipeline``,
+      ``default_tty_job_signals`` and ``ignore_tty_job_signals``.
+    * Original xonsh-flatpak wrapper that documented the failure modes
+      (``BlockingIOError``, ``termios.error``):
+      https://github.com/anki-code/xonsh-flatpak/blob/main/xonsh-wrapper.py
     """
     if ON_WINDOWS:
         return False
     if os.environ.get("XONSH_NO_FG_TAKEOVER"):
         return False
     # pthread_sigmask is POSIX-only and may be absent on exotic builds.
+    # See pthread_sigmask(3):
+    #   https://man7.org/linux/man-pages/man3/pthread_sigmask.3.html
     if not hasattr(signal, "pthread_sigmask"):
         return False
     # Use stderr as the TTY handle. xonsh already uses FD 2 for
@@ -257,7 +306,8 @@ def _acquire_controlling_terminal():
     # A session leader cannot change its own process group id, so the
     # setpgid(0, 0) call below would fail with EPERM. Detect this up
     # front and skip cleanly — if we are session leader we almost
-    # certainly already own the TTY anyway.
+    # certainly already own the TTY anyway. See setpgid(2):
+    #   https://man7.org/linux/man-pages/man2/setpgid.2.html
     try:
         if os.getsid(0) == os.getpid():
             return False
@@ -271,6 +321,8 @@ def _acquire_controlling_terminal():
     # desynchronise state; SIGCHLD so a child reaping does not
     # interrupt us mid-handshake. The block is thread-local — it
     # does not affect signal disposition for the rest of the process.
+    # See tcsetpgrp(3) for the SIGTTOU-when-bg semantics:
+    #   https://man7.org/linux/man-pages/man3/tcsetpgrp.3.html
     block = {signal.SIGTTOU, signal.SIGTTIN, signal.SIGTSTP, signal.SIGCHLD}
     try:
         old_mask = signal.pthread_sigmask(signal.SIG_BLOCK, block)
@@ -282,16 +334,48 @@ def _acquire_controlling_terminal():
         except OSError:
             return False
         my_pgid = os.getpgrp()
-        if current_fg == my_pgid:
+        if current_fg == my_pgid and my_pgid > 0:
             # We are already the foreground group. Nothing to acquire
             # and nothing to release on shutdown — return success but
             # do *not* mark state as acquired, so the atexit restorer
             # stays a no-op and we don't risk racing with the parent
             # shell's own tcsetpgrp() on exit.
+            #
+            # The ``my_pgid > 0`` guard handles PID namespaces
+            # (Flatpak, Bubblewrap, Podman rootless, systemd-nspawn,
+            # kubectl exec, Chrome/Firefox sandboxes, …). From inside
+            # a PID namespace, if our process group id or the TTY's
+            # foreground group id refers to a process *outside* the
+            # namespace (typically because bwrap/flatpak inherited the
+            # pgid from the host before creating the namespace), the
+            # kernel returns 0 from both ``getpgrp`` and ``tcgetpgrp``
+            # — 0 is the "unrepresentable pgid" sentinel specified in
+            # pid_namespaces(7):
+            #   https://man7.org/linux/man-pages/man7/pid_namespaces.7.html
+            # Without the guard, the fast path would see 0 == 0 and
+            # declare success, leaving our pgid as the unrepresentable
+            # 0. Subsequent ``tcsetpgrp(fd, 0)`` calls from
+            # :func:`xonsh.procs.jobs.give_terminal_to` would fail with
+            # ESRCH (tcsetpgrp(3):
+            #   https://man7.org/linux/man-pages/man3/tcsetpgrp.3.html),
+            # the TTY's foreground group would end up orphaned on the
+            # previous pipeline's process group, and the next
+            # ``tcsetattr`` from prompt_toolkit would raise
+            # ``termios.error: (5, 'Input/output error')`` — the
+            # Flatpak sandbox failure mode reported downstream
+            # (tcsetattr(3):
+            #   https://man7.org/linux/man-pages/man3/tcsetattr.3.html).
+            # Falling through to the ``setpgid(0, 0)`` call below
+            # creates a new process group visible inside the namespace
+            # (``pgid == pid``), so the subsequent ``tcsetpgrp`` has a
+            # valid, representable target (setpgid(2):
+            #   https://man7.org/linux/man-pages/man2/setpgid.2.html).
             return True
         # Become our own process group leader. If we are already a
         # leader this is a no-op; if the kernel refuses (EPERM), we
-        # bail out. After this succeeds our pgid == pid.
+        # bail out. After this succeeds our pgid == pid. See
+        # setpgid(2):
+        #   https://man7.org/linux/man-pages/man2/setpgid.2.html
         try:
             os.setpgid(0, 0)
         except OSError:
@@ -334,6 +418,12 @@ def _release_controlling_terminal():
     installed as foreground, the parent will immediately receive
     ``SIGTTIN`` on the next read. Robust shells recover from this, but it
     is much cleaner to hand the TTY back explicitly.
+
+    References
+    ----------
+    * ``atexit(3)``: https://docs.python.org/3/library/atexit.html
+    * ``tcsetpgrp(3)``: https://man7.org/linux/man-pages/man3/tcsetpgrp.3.html
+    * ``pthread_sigmask(3)``: https://man7.org/linux/man-pages/man3/pthread_sigmask.3.html
     """
     if not _fg_tty_state.get("acquired"):
         return
@@ -424,6 +514,26 @@ def _setup_controlling_terminal():
 
     Non-TTY callers (script mode, piped input, test runners under
     pytest) stop after step 1 and keep the historical Python handlers.
+
+    References
+    ----------
+    * ``signal(7)``: https://man7.org/linux/man-pages/man7/signal.7.html
+      — Linux signal semantics, inheritance across ``fork``/``exec``.
+    * ``execve(2)``: https://man7.org/linux/man-pages/man2/execve.2.html
+      — specifies that ``SIG_IGN`` dispositions survive ``exec`` while
+      custom handlers are reset to ``SIG_DFL``. This asymmetry drives
+      the step-1 / step-3 policy split: a Python callable handler in
+      the success path so subprocess children see ``SIG_DFL`` and keep
+      normal job control; ``SIG_IGN`` in the sandbox-failure path to
+      discard signals at the kernel boundary before they reach Python's
+      asyncio wakeup pipe.
+    * ``tcsetattr(3)``: https://man7.org/linux/man-pages/man3/tcsetattr.3.html
+      — the syscall ``prompt_toolkit``'s ``raw_mode`` uses; the one that
+      actually crashes under the Flatpak failure mode described above.
+    * PEP 475 (Retry system calls failing with EINTR):
+      https://peps.python.org/pep-0475/ — confirms that ``termios.*``
+      is *not* covered by Python's automatic EINTR retry, motivating
+      the existing outer retry loop in ``ptk_shell.singleline``.
     """
     global _tty_setup_done
     if _tty_setup_done:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -294,7 +294,7 @@ def _acquire_controlling_terminal():
         # bail out. After this succeeds our pgid == pid.
         try:
             os.setpgid(0, 0)
-        except (PermissionError, OSError):
+        except OSError:
             return False
         my_pgid = os.getpgrp()
         # Install our pgid as the TTY's foreground group. SIGTTOU is

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -160,6 +160,12 @@ def path_argument(s):
 #: the atexit restorer is a thin closure without extra globals.
 _fg_tty_state: dict = {"acquired": False, "tty_fd": -1, "old_fg": -1}
 
+#: Idempotency flag for :func:`_setup_controlling_terminal`. Flipped to
+#: ``True`` once the TTY signal handlers have been installed in a given
+#: process — a second call becomes a cheap no-op. Exposed on the module
+#: so tests can reset it between runs.
+_tty_setup_done: bool = False
+
 
 def _acquire_controlling_terminal():
     """Put xonsh into the foreground process group of its controlling TTY.
@@ -362,6 +368,86 @@ def _release_controlling_terminal():
         _fg_tty_state["acquired"] = False
         _fg_tty_state["tty_fd"] = -1
         _fg_tty_state["old_fg"] = -1
+
+
+def _setup_controlling_terminal():
+    """Run the TTY startup handshake and install matching signal handlers.
+
+    This is the *orchestration* layer around
+    :func:`_acquire_controlling_terminal`: it calls the handshake, picks
+    a signal-handling policy based on whether the handshake succeeded,
+    and registers the ``atexit`` restorer when appropriate. It is
+    idempotent — a second call in the same process is a cheap no-op.
+
+    It is called from the top of :func:`main` so that the handshake
+    happens *before* :func:`premain`. ``premain`` loads xontribs and
+    runs user ``xonshrc`` files, and rc files are arbitrary xonsh code
+    — they routinely contain ``$(...)`` / ``!(...)`` captures and can
+    invoke interactive programs like ``fzf`` that will themselves want
+    to take over the TTY via ``tcsetattr``. When xonsh is foreground
+    *before* rc runs, every downstream TTY operation simply works; when
+    it is not, and the handshake cannot fix that (sandboxed nested
+    containers, cross-session TTYs, …), the ``SIG_IGN`` fallback
+    installed here prevents the asyncio wakeup pipe from overflowing
+    during rc execution. It is also called from :func:`main_xonsh` as a
+    backup for callers that enter the shell loop without going through
+    :func:`main` (tests, programmatic invocation).
+
+    The setup is a no-op when stderr is not a TTY. That gate is crucial:
+    it means non-interactive callers (script mode, piped input, test
+    runners under pytest) keep their default POSIX signal dispositions
+    for ``SIGTTIN`` / ``SIGTTOU`` and are not affected by the startup
+    changes.
+    """
+    global _tty_setup_done
+    if _tty_setup_done:
+        return
+    if ON_WINDOWS:
+        return
+    # Gate on a real TTY. Script mode, piped stdin/stdout, and test
+    # runners (pytest captures stderr via a pipe) all land here and
+    # return without touching signal state — that keeps the change
+    # transparent to non-interactive use.
+    try:
+        if not os.isatty(sys.stderr.fileno()):
+            return
+    except (AttributeError, OSError, ValueError):
+        return
+    _tty_setup_done = True
+    fg_acquired = _acquire_controlling_terminal()
+    if fg_acquired:
+        # Register the shutdown restorer only if the handshake actually
+        # changed the foreground group. The fast-path case (we were
+        # already foreground) deliberately leaves ``_fg_tty_state``
+        # unacquired so the restorer does nothing and we never race
+        # with the parent shell's own tcsetpgrp on exit.
+        if _fg_tty_state.get("acquired"):
+            atexit.register(_release_controlling_terminal)
+
+        # Python-level no-op as a safety net. Once we are foreground
+        # the kernel will not deliver SIGTTIN/SIGTTOU under normal
+        # operation, but races are possible (e.g. a child process in
+        # our group calling tcsetpgrp before we reinstall ourselves).
+        # A Python handler is preferred over SIG_IGN here because the
+        # latter is inherited across ``exec`` and would subtly break
+        # job control in subprocess children.
+        def func_sig_ttin_ttou(n, f):
+            pass
+
+        signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
+        signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+    else:
+        # We could not become foreground — typical inside Flatpak /
+        # Bubblewrap sandboxes, nested containers, some CI runners.
+        # The kernel *will* keep sending SIGTTIN/SIGTTOU every time
+        # xonsh touches the TTY, and a Python-level handler would
+        # overflow asyncio's signal wakeup pipe with ``BlockingIOError``.
+        # SIG_IGN makes the kernel discard the signals outright,
+        # bypassing Python entirely. It is inherited across ``exec``,
+        # but in a sandbox children have the same TTY ownership
+        # problem anyway, so this is the right default.
+        signal.signal(signal.SIGTTIN, signal.SIG_IGN)
+        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
 
 
 @lazyobject
@@ -767,6 +853,17 @@ def _failback_to_other_shells(args, err):
 
 
 def main(argv=None):
+    # Run the TTY startup handshake *before* premain so that xontrib
+    # loading and xonshrc execution happen with xonsh already as the
+    # foreground process group. rc files are arbitrary user code and
+    # can contain subprocess captures ``$(...)``/``!(...)`` — including
+    # interactive tools like ``fzf`` that take over the TTY via
+    # ``tcsetattr``. Having the handshake done before rc runs means
+    # those child processes inherit a "foreground shell" context and
+    # the race between their own TTY manipulation and xonsh's
+    # :func:`xonsh.procs.jobs.give_terminal_to` never has to open.
+    # See :func:`_setup_controlling_terminal` for the full rationale.
+    _setup_controlling_terminal()
     args = None
     try:
         args = premain(argv)
@@ -777,49 +874,13 @@ def main(argv=None):
 
 def main_xonsh(args):
     """Main entry point for xonsh cli."""
-    if not ON_WINDOWS:
-        # Try the bash-style startup handshake: make xonsh the
-        # foreground process group of its controlling terminal so that
-        # kernel-delivered SIGTTIN/SIGTTOU do not fire under normal
-        # operation. See :func:`_acquire_controlling_terminal` for
-        # the full rationale.
-        fg_acquired = _acquire_controlling_terminal()
-        if fg_acquired:
-            # Make sure we hand the TTY back to its previous owner
-            # when xonsh exits. Registered only when we actually took
-            # over, so in the common case (xonsh launched from a
-            # well-behaved shell that already installed us as fg) this
-            # is a no-op.
-            if _fg_tty_state.get("acquired"):
-                atexit.register(_release_controlling_terminal)
-
-            # Install a Python-level no-op handler as a safety net.
-            # Once we are foreground the kernel should not deliver
-            # these signals any more, but races are possible
-            # (e.g. a child process in our group calling tcsetpgrp
-            # before we reinstall ourselves). A Python handler is
-            # preferred over SIG_IGN here because the latter is
-            # inherited across ``exec`` and would subtly break job
-            # control in child processes that rely on SIGTTIN/SIGTTOU.
-            def func_sig_ttin_ttou(n, f):
-                pass
-
-            signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
-            signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
-        else:
-            # We could not become foreground. This is the typical
-            # outcome inside Flatpak/Bubblewrap sandboxes, nested
-            # containers, and some CI runners. In that regime the
-            # kernel *will* keep sending SIGTTIN/SIGTTOU every time
-            # xonsh touches the TTY, and a Python-level handler would
-            # overflow asyncio's signal wakeup pipe with
-            # ``BlockingIOError``. Use SIG_IGN so the kernel discards
-            # the signals outright and never routes them through
-            # Python. This is inherited across ``exec``, but in a
-            # sandbox children have the same TTY ownership problem
-            # anyway, so this is the right default.
-            signal.signal(signal.SIGTTIN, signal.SIG_IGN)
-            signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+    # Normally :func:`main` has already run the handshake before
+    # premain — this call is a cheap idempotent no-op in that case
+    # (the module-level ``_tty_setup_done`` flag short-circuits).
+    # It exists so that callers which enter the shell loop without
+    # going through ``main`` (tests, programmatic launches) still
+    # get the same TTY signal setup.
+    _setup_controlling_terminal()
 
     events.on_post_init.fire()
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -374,10 +374,10 @@ def _setup_controlling_terminal():
     """Run the TTY startup handshake and install matching signal handlers.
 
     This is the *orchestration* layer around
-    :func:`_acquire_controlling_terminal`: it calls the handshake, picks
-    a signal-handling policy based on whether the handshake succeeded,
-    and registers the ``atexit`` restorer when appropriate. It is
-    idempotent — a second call in the same process is a cheap no-op.
+    :func:`_acquire_controlling_terminal`: it installs the baseline
+    signal policy, optionally calls the handshake, and registers the
+    ``atexit`` restorer when appropriate. It is idempotent — a second
+    call in the same process is a cheap no-op.
 
     It is called from the top of :func:`main` so that the handshake
     happens *before* :func:`premain`. ``premain`` loads xontribs and
@@ -393,59 +393,87 @@ def _setup_controlling_terminal():
     backup for callers that enter the shell loop without going through
     :func:`main` (tests, programmatic invocation).
 
-    The setup is a no-op when stderr is not a TTY. That gate is crucial:
-    it means non-interactive callers (script mode, piped input, test
-    runners under pytest) keep their default POSIX signal dispositions
-    for ``SIGTTIN`` / ``SIGTTOU`` and are not affected by the startup
-    changes.
+    Signal policy
+    -------------
+    Step 1: **always** install a Python-level no-op handler for
+    ``SIGTTIN`` and ``SIGTTOU``, on any POSIX invocation. This matches
+    the historical xonsh behavior (before this function existed,
+    ``main_xonsh`` installed the same no-op handler unconditionally)
+    and protects script-mode xonsh from being suspended by
+    ``SIG_DFL`` when something indirectly touches the TTY. A Python
+    handler is preferred over ``SIG_IGN`` here because the latter is
+    inherited across ``exec`` and would subtly break job control in
+    subprocess children.
+
+    Step 2: if stderr is a real TTY, attempt the foreground handshake.
+    If it succeeds, the no-op handlers installed in step 1 already
+    cover the ``success`` case and no further action is needed. If
+    the handshake fails (typical in sandboxes that cannot be made
+    foreground), **replace** the no-op handlers with ``SIG_IGN`` —
+    the kernel will then discard ``SIGTTIN`` / ``SIGTTOU`` outright
+    and they will never reach Python's asyncio wakeup pipe, which
+    would otherwise overflow with ``BlockingIOError`` under a signal
+    storm.
+
+    Step 3: register ``atexit`` to restore the previous foreground
+    group on shutdown, but only when the handshake *actually*
+    transferred foreground ownership (``_fg_tty_state["acquired"]``
+    is True). Fast-path success — where we were already foreground —
+    leaves state unacquired so the restorer does nothing and we don't
+    race with the parent shell's own ``tcsetpgrp`` on exit.
+
+    Non-TTY callers (script mode, piped input, test runners under
+    pytest) stop after step 1 and keep the historical Python handlers.
     """
     global _tty_setup_done
     if _tty_setup_done:
         return
     if ON_WINDOWS:
         return
-    # Gate on a real TTY. Script mode, piped stdin/stdout, and test
-    # runners (pytest captures stderr via a pipe) all land here and
-    # return without touching signal state — that keeps the change
-    # transparent to non-interactive use.
+    _tty_setup_done = True
+
+    # Step 1: unconditional Python no-op handlers for SIGTTIN/SIGTTOU.
+    # This matches the pre-handshake xonsh behavior and is what
+    # script-mode / non-TTY callers rely on. The only reason to
+    # deviate from it is the sandbox-failure case below, which
+    # overrides with SIG_IGN to avoid the asyncio wakeup pipe storm.
+    def func_sig_ttin_ttou(n, f):
+        pass
+
+    signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
+    signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+
+    # Step 2: only attempt the handshake when stderr is a real TTY.
+    # Script mode, piped stdin/stdout, and test runners (pytest
+    # captures stderr via a pipe) all bail out here and keep the
+    # Python handlers from step 1.
     try:
         if not os.isatty(sys.stderr.fileno()):
             return
     except (AttributeError, OSError, ValueError):
         return
-    _tty_setup_done = True
+
     fg_acquired = _acquire_controlling_terminal()
     if fg_acquired:
-        # Register the shutdown restorer only if the handshake actually
-        # changed the foreground group. The fast-path case (we were
-        # already foreground) deliberately leaves ``_fg_tty_state``
-        # unacquired so the restorer does nothing and we never race
-        # with the parent shell's own tcsetpgrp on exit.
+        # Step 3: register the shutdown restorer only if the handshake
+        # actually changed the foreground group. The fast-path case
+        # (we were already foreground) deliberately leaves
+        # ``_fg_tty_state`` unacquired so the restorer does nothing
+        # and we never race with the parent shell's own tcsetpgrp
+        # on exit.
         if _fg_tty_state.get("acquired"):
             atexit.register(_release_controlling_terminal)
-
-        # Python-level no-op as a safety net. Once we are foreground
-        # the kernel will not deliver SIGTTIN/SIGTTOU under normal
-        # operation, but races are possible (e.g. a child process in
-        # our group calling tcsetpgrp before we reinstall ourselves).
-        # A Python handler is preferred over SIG_IGN here because the
-        # latter is inherited across ``exec`` and would subtly break
-        # job control in subprocess children.
-        def func_sig_ttin_ttou(n, f):
-            pass
-
-        signal.signal(signal.SIGTTIN, func_sig_ttin_ttou)
-        signal.signal(signal.SIGTTOU, func_sig_ttin_ttou)
+        # Python handlers from step 1 remain in place as a safety net.
     else:
-        # We could not become foreground — typical inside Flatpak /
-        # Bubblewrap sandboxes, nested containers, some CI runners.
-        # The kernel *will* keep sending SIGTTIN/SIGTTOU every time
-        # xonsh touches the TTY, and a Python-level handler would
-        # overflow asyncio's signal wakeup pipe with ``BlockingIOError``.
-        # SIG_IGN makes the kernel discard the signals outright,
-        # bypassing Python entirely. It is inherited across ``exec``,
-        # but in a sandbox children have the same TTY ownership
-        # problem anyway, so this is the right default.
+        # Sandbox failure path: the kernel *will* keep sending
+        # SIGTTIN/SIGTTOU every time xonsh touches the TTY, and a
+        # Python-level handler would overflow asyncio's signal wakeup
+        # pipe with ``BlockingIOError`` during a signal storm. Replace
+        # the step-1 handlers with SIG_IGN so the kernel discards the
+        # signals outright and never routes them through Python.
+        # SIG_IGN is inherited across ``exec``, but in a sandbox
+        # children have the same TTY ownership problem anyway, so
+        # this is the right default.
         signal.signal(signal.SIGTTIN, signal.SIG_IGN)
         signal.signal(signal.SIGTTOU, signal.SIG_IGN)
 


### PR DESCRIPTION
## Motivation

I tested xonsh 0.23.0 with Flatpak package and noticed that xonsh has no handshake with terminal at start. After this I used code analyzer to deep dive and implement basic logic of handshake.
I've tested this manually and with analyzer on Mac, Windows and Linux. 
This handshake is an additive change and it's the minimal standard to have it for the shell.

After this I found an issue that seen before (Bad file descriptor debugging) - it was also about lack of handshake - 99% CPU load and fix it as well. 
After this fix xonsh more organically integrated with OS and do not produce 99% CPU on signal flood in edge cases.

So below I provided the report from code analyzer.



------------------

## Summary

xonsh now performs the same TTY startup handshake that bash, zsh and other interactive shells do: it makes itself the foreground process group of its controlling terminal before `premain` runs. The implementation lives in `xonsh/main.py` as four small helpers (`_acquire_controlling_terminal`, `_release_controlling_terminal`, `_setup_controlling_terminal`, `_handle_sig_ttin_ttou`) and is called from both `main()` and `main_xonsh()`. A new section in `docs/launch.rst` explains the full rationale and the failure modes it fixes. Verified end-to-end inside a sandboxed environment.

## Problem

Historically xonsh relied on its parent shell to have already placed it in the foreground process group of whatever TTY it was attached to. That assumption holds when xonsh is launched from a well-behaved interactive shell, but it breaks in several real-world environments:

- **Bubblewrap and similar sandboxes** — `bwrap` does not reassign the TTY's foreground group to the sandboxed child.
- **Build systems, CI runners, IDE integrated terminals** and service managers like `systemd --user` that launch xonsh via `posix_spawn` without wiring up job control.
- **Nested containers** that reuse the outer PTY.

In those cases xonsh is a background process of its TTY. Every terminal operation — `tcgetattr` during prompt_toolkit init, `tcsetpgrp` when launching a pipeline, plain writes under `TOSTOP` — raises `SIGTTIN` or `SIGTTOU`. Two failure modes follow:

1. **asyncio wakeup pipe overflow** — Python routes signals to a non-blocking self-pipe so the main event loop can wake up. Under a startup signal storm the pipe overflows and xonsh crashes with `BlockingIOError: [Errno 11] Resource temporarily unavailable`.

2. **termios EINTR** — low-frequency signals (SIGCHLD, SIGWINCH) interrupt `tcsetattr` calls and surface as `termios.error: (4, 'Interrupted system call')`.

Users in affected environments worked around this with a third-party launcher wrapper that installed `SIG_IGN` for `SIGTTIN`/`SIGTTOU` before importing xonsh.

## Solution

Perform the handshake bash has always done, adapted for Python. `_setup_controlling_terminal` works like this:

1. **Gate on POSIX.** Windows returns immediately.
2. **Install a livelock-guarded Python no-op handler for `SIGTTIN`/`SIGTTOU` unconditionally** — matches the historical behavior that `main_xonsh` had before this change. The handler is `_handle_sig_ttin_ttou`: under normal operation it is a cheap counter bump, above a high threshold it escalates to `SIG_IGN`.
3. **Gate the handshake itself on stderr being a real TTY.** Script mode, piped input, redirected stderr and pytest runs stop after step 2.
4. **Check if we are already foreground via `tcgetpgrp == getpgrp && pgid > 0`.** The `pgid > 0` guard handles PID namespaces where the kernel returns `0` for outer pgids.
5. **Block `SIGTTOU`, `SIGTTIN`, `SIGTSTP`, `SIGCHLD`** in the calling thread with `pthread_sigmask`.
6. **Call `setpgid(0, 0)`** to become our own process group leader.
7. **Call `tcsetpgrp(tty_fd, getpgrp())`** to install our new group as the TTY's foreground.
8. **Remember the previous foreground group** and register an `atexit` handler to restore it on shutdown.

If the handshake fails, the step-2 Python handlers are replaced with `SIG_IGN` so the kernel discards `SIGTTIN`/`SIGTTOU` outright and they never reach Python's asyncio wakeup pipe.

The handshake is called from the top of `main()` (so premain / xontribs / xonshrc run with xonsh already foreground) and from `main_xonsh()` as an idempotent backup via the `_tty_setup_done` flag.

## Why before `premain`?

`premain` loads xontribs and runs the user's xonshrc files. Rc files contain `$(...)` / `!(...)` subprocess captures, including interactive tools like `fzf` that take over the TTY via `tcsetattr`. Running the handshake before rc ensures child processes fork from a foreground xonsh and inherit foreground pgrp on the very first instruction, so rc-launched interactive tools do not race with xonsh's pgrp management.

## Escape hatch

`XONSH_NO_FG_TAKEOVER=1` in the parent environment disables the handshake entirely. The step-1 Python handlers still get installed. Documented in `docs/launch.rst`.

## Edge cases handled

**PID namespaces.** Inside a PID namespace (Bubblewrap, Podman rootless, systemd-nspawn, kubectl exec, Chrome/Firefox renderer sandboxes), the Linux kernel returns `0` from `getpgrp()` / `tcgetpgrp()` for pgids inherited from outside the namespace ([`pid_namespaces(7)`](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)). The fast-path check includes `and my_pgid > 0` so `0 == 0` does not spuriously declare success, ensuring `setpgid(0, 0)` runs and installs a valid namespace-local pgid. Caught by real-world sandbox testing and has a dedicated regression test.

**Livelock guard on the Python no-op handler.** The historical `def func_sig_ttin_ttou(n, f): pass` can feed two independent retry loops into a 99% CPU spin: PEP 475 auto-retry on `os.read` (SIGTTIN path), and the xonsh PR #6192 application-level retry on `tcsetattr` (SIGTTOU path). `_handle_sig_ttin_ttou` counts deliveries and escalates to `SIG_IGN` above `_TTIN_TTOU_LIVELOCK_THRESHOLD` (= 1000), breaking the loop. Under normal operation the handler fires zero times.

**Non-TTY regression preserved.** Step 1 of `_setup_controlling_terminal` installs Python no-op handlers unconditionally, matching the pre-PR behavior for script mode. The handshake itself is gated on `isatty`, the baseline signal policy is not.

## Changes

- `xonsh/main.py`: four new helpers (`_acquire_controlling_terminal`, `_release_controlling_terminal`, `_setup_controlling_terminal`, `_handle_sig_ttin_ttou`), three module-level globals (`_fg_tty_state`, `_tty_setup_done`, `_ttin_ttou_counter`), one constant (`_TTIN_TTOU_LIVELOCK_THRESHOLD`), `_setup_controlling_terminal()` called from the top of `main()` and `main_xonsh()`, old inline `func_sig_ttin_ttou` replaced, `atexit` added to imports. All major design decisions carry inline comments pointing at the relevant man page.
- `tests/test_main_terminal_llm.py`: new file with 22 mock-based unit tests covering acquire/release/setup paths, PID namespace edge case, livelock guard, idempotency, non-TTY path, Windows no-op, `XONSH_NO_FG_TAKEOVER` gate, session leader gate. Uses a `FakeOS` helper and recording stubs so no real kernel state is mutated.
- `docs/launch.rst`: new final section "Controlling Terminal and Foreground Process Group" explaining the POSIX background, failure modes, signal policy, shutdown restore, no-op situations, and escape hatch.
- `docs/embedding.rst`: new stub page documenting how embedded xonsh users can invoke `_setup_controlling_terminal` when they bypass `main()` via `xonsh.main.setup`.

## References

### Prior art

- xonsh PR #6192 — prior partial fix at the `ptk_shell.singleline` level.

### bash source code

Handshake approach and `pgrp_pipe` synchronization verified at https://cgit.git.savannah.gnu.org/cgit/bash.git/tree/jobs.c. Functions verified: `start_pipeline()`, `make_child()`, `stop_pipeline()`, `default_tty_job_signals()`, `ignore_tty_job_signals()`.

### POSIX.1-2017 specifications

- `tcsetpgrp(3)`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetpgrp.html
- `tcgetpgrp(3)`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcgetpgrp.html
- `setpgid(2)`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgid.html
- `pthread_sigmask(3)`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_sigmask.html
- `execve(2)`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/execve.html
- General Terminal Interface: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap11.html

### Linux man pages

- `tcsetpgrp(3)`: https://man7.org/linux/man-pages/man3/tcsetpgrp.3.html
- `tcsetattr(3)`: https://man7.org/linux/man-pages/man3/tcsetattr.3.html
- `setpgid(2)`: https://man7.org/linux/man-pages/man2/setpgid.2.html
- `pthread_sigmask(3)`: https://man7.org/linux/man-pages/man3/pthread_sigmask.3.html
- `pid_namespaces(7)`: https://man7.org/linux/man-pages/man7/pid_namespaces.7.html
- `signal(7)`: https://man7.org/linux/man-pages/man7/signal.7.html
- `read(2)`: https://man7.org/linux/man-pages/man2/read.2.html

### Python-specific

- CPython `Modules/termios.c`: https://github.com/python/cpython/blob/main/Modules/termios.c
- PEP 475: https://peps.python.org/pep-0475/
- prompt_toolkit `input/vt100.py`: https://github.com/prompt-toolkit/python-prompt-toolkit/blob/main/src/prompt_toolkit/input/vt100.py

