### PR TITLE
feat: Support env in on_command_not_found event

### DIFF
--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -556,8 +556,14 @@ def test_on_command_not_found_dict_replacement_with_env(xession):
     def dict_handler(cmd, **kwargs):
         if cmd[0] == "xonshcommandnotfound":
             if ON_WINDOWS:
-                return {"cmd": ["cmd", "/c", "echo", "%XONSH_TEST_VAR%"], "env": {"XONSH_TEST_VAR": "hello_from_env"}}
-            return {"cmd": ["sh", "-c", "echo $XONSH_TEST_VAR"], "env": {"XONSH_TEST_VAR": "hello_from_env"}}
+                return {
+                    "cmd": ["cmd", "/c", "echo", "%XONSH_TEST_VAR%"],
+                    "env": {"XONSH_TEST_VAR": "hello_from_env"},
+                }
+            return {
+                "cmd": ["sh", "-c", "echo $XONSH_TEST_VAR"],
+                "env": {"XONSH_TEST_VAR": "hello_from_env"},
+            }
         return None
 
     xession.builtins.events.on_command_not_found(dict_handler)

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -545,6 +545,63 @@ def test_on_command_not_found_fallback_on_bad_replacement(xession):
     assert "command not found: 'xonshcommandnotfound'" in str(expected.value)
 
 
+def test_on_command_not_found_dict_replacement_with_env(xession):
+    """Test that returning a dict with cmd and env sets the subprocess environment."""
+    xession.env.update(
+        dict(
+            XONSH_INTERACTIVE=True,
+        )
+    )
+
+    def dict_handler(cmd, **kwargs):
+        if cmd[0] == "xonshcommandnotfound":
+            if ON_WINDOWS:
+                return {"cmd": ["cmd", "/c", "echo", "%XONSH_TEST_VAR%"], "env": {"XONSH_TEST_VAR": "hello_from_env"}}
+            return {"cmd": ["sh", "-c", "echo $XONSH_TEST_VAR"], "env": {"XONSH_TEST_VAR": "hello_from_env"}}
+        return None
+
+    xession.builtins.events.on_command_not_found(dict_handler)
+    out = run_subproc([["xonshcommandnotfound"]], captured="stdout")
+    assert "hello_from_env" in out.strip()
+
+
+def test_on_command_not_found_dict_without_env(xession):
+    """Test that returning a dict with only cmd (no env) works."""
+    xession.env.update(
+        dict(
+            XONSH_INTERACTIVE=True,
+        )
+    )
+
+    def dict_no_env_handler(cmd, **kwargs):
+        if cmd[0] == "xonshcommandnotfound":
+            if ON_WINDOWS:
+                return {"cmd": ["cmd", "/c", "echo", "dict_no_env"]}
+            return {"cmd": ["echo", "dict_no_env"]}
+        return None
+
+    xession.builtins.events.on_command_not_found(dict_no_env_handler)
+    out = run_subproc([["xonshcommandnotfound"]], captured="stdout")
+    assert out.strip() == "dict_no_env"
+
+
+def test_on_command_not_found_dict_missing_cmd_ignored(xession):
+    """Test that a dict without 'cmd' key is treated as invalid and ignored."""
+    xession.env.update(
+        dict(
+            XONSH_INTERACTIVE=True,
+        )
+    )
+
+    def bad_dict_handler(cmd, **kwargs):
+        return {"env": {"FOO": "bar"}}  # no 'cmd' key
+
+    xession.builtins.events.on_command_not_found(bad_dict_handler)
+    subproc = SubprocSpec.build(["xonshcommandnotfound"])
+    with pytest.raises(XonshError):
+        subproc.run()
+
+
 def test_redirect_to_substitution(tmpdir):
     file = str(tmpdir / "test_redirect_to_substitution.txt")
     s = SubprocSpec.build(

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -4,13 +4,13 @@ import argparse
 import functools
 import inspect
 import operator
-import textwrap
 import os
 import pathlib
 import re
 import shlex
 import shutil
 import sys
+import textwrap
 import types
 import typing as tp
 from collections import abc as cabc
@@ -1433,8 +1433,8 @@ def get_xpip_alias():
 
             @Aliases.return_command
             def _xpip_user(args):
-                if args and args[0] == 'install':
-                    return basecmd + ['install', '--user'] + args[1:]
+                if args and args[0] == "install":
+                    return basecmd + ["install", "--user"] + args[1:]
                 else:
                     return basecmd + args
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -35,10 +35,10 @@ from xonsh.lib.lazyasd import LazyBool, lazyobject
 from xonsh.platform import (
     BASH_COMPLETIONS_DEFAULT,
     DEFAULT_ENCODING,
+    IN_FLATPAK,
     ON_CYGWIN,
     ON_WINDOWS,
     ON_WSL,
-    IN_FLATPAK,
     PATH_DEFAULT,
     os_environ,
 )

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -788,8 +788,8 @@ def default_xonshrc(env) -> "tuple[str, ...]":
     return dxrc
 
 
-def get_config_paths(env: "Env", name: str):
-    paths = (
+def get_config_paths(env: "Env", name: str) -> tuple[str, ...]:
+    paths: tuple[str, ...] = (
         os.path.join(xonsh_sys_config_dir(env), name),
         os.path.join(xonsh_config_dir(env), name),
     )

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -621,11 +621,24 @@ class SubprocSpec:
                 for replacement in replacements:
                     if replacement is None:
                         continue
+                    # Accept dict with "cmd" and optional "env" keys
+                    # (same convention as @Aliases.return_command).
+                    replacement_env = None
+                    if isinstance(replacement, dict):
+                        replacement_env = replacement.get("env")
+                        replacement = replacement.get("cmd")
                     # Validate replacement format (accept list or tuple)
                     if not isinstance(replacement, (list, tuple)) or not replacement:
                         continue
                     try:
-                        return self.cls(list(replacement), bufsize=bufsize, **kwargs)
+                        kw = {**kwargs}
+                        if replacement_env is not None:
+                            base = kw.get("env") or {}
+                            kw["env"] = {
+                                **base,
+                                **{str(k): str(v) for k, v in replacement_env.items()},
+                            }
+                        return self.cls(list(replacement), bufsize=bufsize, **kw)
                     except (FileNotFoundError, PermissionError):
                         # If replacement also fails, continue to next replacement
                         # or fall through to original error with suggestions

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -80,7 +80,7 @@ Example:
 events.doc(
     "on_command_not_found",
     """
-on_command_not_found(cmd: list[str]) -> list[str] | tuple[str, ...] | None
+on_command_not_found(cmd: list[str]) -> list[str] | tuple[str, ...] | dict | None
 
 Fires if a command is not found (only in interactive sessions).
 
@@ -92,11 +92,14 @@ Returns:
 
 * ``list[str]`` or ``tuple[str, ...]``: A replacement command to execute instead.
   The first valid replacement from any handler will be used.
+* ``dict``: A dict with a required ``"cmd"`` key (list of command tokens) and an
+  optional ``"env"`` key (dict of environment variables to set for the replacement
+  command). Same convention as ``@Aliases.return_command``.
 * ``None``: To let the error be raised normally
 
 Note: If the replacement command also fails, the original error is shown.
 
-Example:
+Examples:
 
 .. code-block:: python
 
@@ -105,6 +108,12 @@ Example:
         '''If vim not found let's try to use vi.'''
         if cmd[0] == 'vim':
             return ['vi'] + cmd[1:]
+
+    @events.on_command_not_found
+    def _node_with_path(cmd, **kwargs):
+        '''Run node with a custom NODE_PATH.'''
+        if cmd[0] == 'mynode':
+            return {"cmd": ["node"] + cmd[1:], "env": {"NODE_PATH": "/opt/libs"}}
 
 """,
 )


### PR DESCRIPTION
### Motivation

We have [on_command_not_found](https://xon.sh/dev/events.html#on-command-not-found) and it returns command. During work on xonsh Flatpak I found that it will be helpful to support env as well as in https://github.com/xonsh/xonsh/pull/6285.

### After

```xsh
@events.on_command_not_found
def _just_echo(cmd, **kwargs):
    return {
        "cmd": ['xonsh', '--no-rc', '-c', 'echo $TERM $VAR'], 
        "env": {"VAR": str(cmd)}
    }

qweqwe
# xterm-256color ['qweqwe']
```




## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
