### PR TITLE
feat(history): Reimplement sqlite history backend `erasedups` and add json history backend support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14"          
+          - "3.14"
     steps:
       - uses: actions/checkout@v6
       - name: setup-python

--- a/appimage/xonsh.appdata.xml
+++ b/appimage/xonsh.appdata.xml
@@ -6,9 +6,9 @@
     <name>Xonsh</name>
     <summary>Xonsh shell on Python {{ python-fullversion }}</summary>
     <description>
-        <p>Xonsh shell, bundled with Python {{ python-fullversion }}. Xonsh (sounds like "consh") is a modern, 
-           full-featured and cross-platform Python-based shell. The language is a superset of Python 3 with 
-           seamless integration of shell functionality and commands. Xonsh is meant for the daily use of experts 
+        <p>Xonsh shell, bundled with Python {{ python-fullversion }}. Xonsh (sounds like "consh") is a modern,
+           full-featured and cross-platform Python-based shell. The language is a superset of Python 3 with
+           seamless integration of shell functionality and commands. Xonsh is meant for the daily use of experts
            and novices.
         </p>
     </description>

--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -425,8 +425,8 @@
       <div class="about-content">
         <h3>Xonsh is Everywhere</h3>
         <p>
-        Xonsh is cross-platform by design, enabling the same workflows to run seamlessly 
-        across macOS, Linux, Windows and WSL, so scripts, aliases, and tools 
+        Xonsh is cross-platform by design, enabling the same workflows to run seamlessly
+        across macOS, Linux, Windows and WSL, so scripts, aliases, and tools
         behave consistently across different environments and package managers.
         </p>
       </div>

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -292,6 +292,17 @@ the overhead of an unfiltered `pull` can be significantly higher.
 Deletes the history from the current session up until this point. Later commands
 will still be saved.
 
+``erasedups`` action
+=====================
+Removes duplicate commands from history, keeping only the latest occurrence of each
+command. Works with both JSON and SQLite backends.
+
+.. code-block:: xonshcon
+
+    @ history erasedups
+    Removed 42 duplicate entries (187 total)
+
+
 ``off`` action
 ================
 Deletes the history from the current session and turns off history saving for the

--- a/tests/history/test_history_json.py
+++ b/tests/history/test_history_json.py
@@ -603,6 +603,30 @@ def test_hist_clear_wipes_file_and_allows_new_commands(hist, xession, tmpdir):
         assert lj["cmds"][0]["inp"] == "echo after"
 
 
+def test_erasedups_command(hist, xession, tmpdir):
+    """Test history erasedups removes duplicates across JSON history."""
+    xession.env.update({"XONSH_DATA_DIR": str(tmpdir)})
+    xession.env["HISTCONTROL"] = set()
+
+    hist.append({"inp": "ls foo", "rtn": 0, "ts": (1, 2)})
+    hist.append({"inp": "ls bar", "rtn": 0, "ts": (3, 4)})
+    hist.append({"inp": "ls foo", "rtn": 0, "ts": (5, 6)})
+    hist.flush(at_exit=True)
+
+    removed, total = hist.erasedups()
+    assert removed == 1
+    assert total == 3
+
+    from xonsh.lib.lazyjson import LazyJSON
+
+    with LazyJSON(hist.filename) as lj:
+        cmds = list(lj["cmds"])
+        inps = [c["inp"] for c in cmds]
+        assert len(inps) == 2
+        assert "ls bar" in inps
+        assert "ls foo" in inps
+
+
 def test_hist_off_cmd(hist, xession, capsys, tmpdir):
     """Verify that the CLI history off command works."""
     xession.env.update({"XONSH_DATA_DIR": str(tmpdir)})

--- a/tests/history/test_history_sqlite.py
+++ b/tests/history/test_history_sqlite.py
@@ -214,27 +214,60 @@ def test_histcontrol(hist, xession):
 
 
 @skipwin311
-def test_histcontrol_erase_dup(hist, xession):
-    """Test HISTCONTROL=erasedups"""
+def test_erasedups_command(hist, xession):
+    """Test history erasedups command removes duplicates."""
 
-    xession.env["HISTCONTROL"] = "erasedups"
+    xession.env["HISTCONTROL"] = set()
     assert len(hist) == 0
 
-    hist.append({"inp": "ls foo", "rtn": 2})
-    hist.append({"inp": "ls foobazz", "rtn": 0})
-    hist.append({"inp": "ls foo", "rtn": 0})
-    hist.append({"inp": "ls foobazz", "rtn": 0})
-    hist.append({"inp": "ls foo", "rtn": 0})
-    assert len(hist) == 2
-    assert len(hist.inps) == 5
+    hist.append({"inp": "ls foo", "rtn": 2, "ts": (1, 2)})
+    hist.append({"inp": "ls foobazz", "rtn": 0, "ts": (3, 4)})
+    hist.append({"inp": "ls foo", "rtn": 0, "ts": (5, 6)})
+    hist.append({"inp": "ls foobazz", "rtn": 0, "ts": (7, 8)})
+    hist.append({"inp": "ls foo", "rtn": 0, "ts": (9, 10)})
+    assert len(hist) == 5
 
-    items = list(hist.items())
-    assert "ls foo" == items[-1]["inp"]
-    assert "ls foobazz" == items[-2]["inp"]
-    assert items[-2]["frequency"] == 2
-    assert items[-1]["frequency"] == 3
+    removed, total = hist.erasedups()
+    assert removed == 3
+    assert total == 5
+
+    items = list(hist.all_items())
+    assert len(items) == 2
+    assert items[0]["inp"] == "ls foobazz"
+    assert items[0]["frequency"] == 2
+    assert items[1]["inp"] == "ls foo"
+    assert items[1]["frequency"] == 3
 
     _clean_up(hist)
+
+
+@skipwin311
+def test_clear_does_not_destroy_other_sessions(tmpdir, xession):
+    """Test that history clear in one session does not lose commands from another.
+    This is the bug described in xonsh/xonsh#5919.
+    """
+    db_file = tmpdir / "xonsh-HISTORY-TEST-CLEAR.sqlite"
+    xession.env["HISTCONTROL"] = set()
+
+    # Session A: type foobar, close session
+    hist_a = SqliteHistory(filename=db_file, gc=False, sessionid="session-a")
+    hist_a.append({"inp": "foobar", "rtn": 0, "ts": (1, 2)})
+
+    # Session B: type foobar and bazbar
+    hist_b = SqliteHistory(filename=db_file, gc=False, sessionid="session-b")
+    hist_b.append({"inp": "foobar", "rtn": 0, "ts": (3, 4)})
+    hist_b.append({"inp": "bazbar", "rtn": 0, "ts": (5, 6)})
+
+    # Session B: history clear
+    hist_b.clear()
+
+    # foobar from session A must still be in history
+    all_items = list(hist_a.all_items())
+    inps = [item["inp"] for item in all_items]
+    assert "foobar" in inps
+    assert "bazbar" not in inps
+
+    _clean_up(hist_a)
 
 
 @skipwin311

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -110,6 +110,26 @@ from xonsh.tools import (
     to_tok_color_dict,
 )
 
+_warned_erasedups = False
+
+
+def histcontrol_csv_to_set(x):
+    """Convert HISTCONTROL value, warning if erasedups is used."""
+    global _warned_erasedups
+    result = csv_to_set(x)
+    if "erasedups" in result and not _warned_erasedups:
+        _warned_erasedups = True
+        import warnings
+
+        warnings.warn(
+            "'erasedups' in $HISTCONTROL is deprecated. "
+            "Use the 'history erasedups' command instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+    return result
+
+
 events.doc(
     "on_envvar_new",
     """
@@ -1897,7 +1917,7 @@ class PromptHistorySetting(Xettings):
     )
     HISTCONTROL = Var(
         is_string_set,
-        csv_to_set,
+        histcontrol_csv_to_set,
         set_to_csv,
         set(),
         "A set of strings (comma-separated list in string form) of options "
@@ -1906,9 +1926,7 @@ class PromptHistorySetting(Xettings):
         "- ``ignoredups`` will not save the command if it matches the previous command\n"
         "- ``ignoreerr`` will cause any commands that fail (i.e. return non-zero "
         "exit status) to not be added to the history list\n"
-        "- ``ignorespace`` will not save the command if it begins with a space\n"
-        "- ``erasedups`` will remove all previous commands that matches and updates the frequency "
-        "(Note: only supported in sqlite backend).",
+        "- ``ignorespace`` will not save the command if it begins with a space\n",
         can_store_as_str=True,
     )
     XONSH_HISTORY_SIZE = Var(

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -825,9 +825,7 @@ class JsonHistory(History):
             try:
                 file_content = json_file.load()
                 cmds = file_content.get("cmds", [])
-                new_cmds = [
-                    cmd for idx, cmd in enumerate(cmds) if (f, idx) in keep_set
-                ]
+                new_cmds = [cmd for idx, cmd in enumerate(cmds) if (f, idx) in keep_set]
                 if len(new_cmds) == len(cmds):
                     continue  # no changes needed
                 file_content["cmds"] = new_cmds

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -778,3 +778,71 @@ class JsonHistory(History):
                 continue
 
         return deleted
+
+    def erasedups(self):
+        """Remove duplicate commands across all history files, keeping the latest."""
+        while self.gc and self.gc.is_alive():
+            time.sleep(0.011)
+
+        # Collect all commands from all files with their source file.
+        # Each entry: (inp, tsb, file_path, index_in_file)
+        entries = []
+        for f in _xhj_get_history_files():
+            try:
+                json_file = xlj.LazyJSON(f, reopen=False)
+            except ValueError:
+                continue
+            try:
+                file_content = json_file.load()
+                for idx, cmd in enumerate(file_content.get("cmds", [])):
+                    inp = cmd.get("inp", "").rstrip()
+                    ts = cmd.get("ts", [0, 0])
+                    tsb = ts[0] if ts else 0
+                    entries.append((inp, tsb, f, idx))
+            except (JSONDecodeError, ValueError):
+                continue
+
+        # Find which entries to keep: for each inp, keep the one with max tsb.
+        keep = {}  # inp -> (tsb, file_path, idx)
+        for inp, tsb, fpath, idx in entries:
+            if inp not in keep or tsb > keep[inp][0]:
+                keep[inp] = (tsb, fpath, idx)
+
+        # Build set of (file_path, idx) to keep.
+        keep_set = {(v[1], v[2]) for v in keep.values()}
+
+        total_before = len(entries)
+        total_after = len(keep_set)
+        if total_before == total_after:
+            return 0, total_before
+
+        # Rewrite each file, removing duplicate entries.
+        for f in _xhj_get_history_files():
+            try:
+                json_file = xlj.LazyJSON(f, reopen=False)
+            except ValueError:
+                continue
+            try:
+                file_content = json_file.load()
+                cmds = file_content.get("cmds", [])
+                new_cmds = [
+                    cmd for idx, cmd in enumerate(cmds) if (f, idx) in keep_set
+                ]
+                if len(new_cmds) == len(cmds):
+                    continue  # no changes needed
+                file_content["cmds"] = new_cmds
+                dirname = os.path.dirname(f)
+                fd, tmpname = tempfile.mkstemp(dir=dirname, suffix=".json.tmp")
+                try:
+                    with os.fdopen(fd, "w", newline="\n", encoding="utf-8") as fp:
+                        xlj.ljdump(file_content, fp)
+                    os.replace(tmpname, f)
+                except Exception:
+                    try:
+                        os.unlink(tmpname)
+                    except OSError:
+                        pass
+            except (JSONDecodeError, ValueError):
+                continue
+
+        return total_before - total_after, total_before

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -824,6 +824,7 @@ class JsonHistory(History):
                 continue
             try:
                 file_content = json_file.load()
+                del json_file  # release file handle before replacing (Windows)
                 cmds = file_content.get("cmds", [])
                 new_cmds = [cmd for idx, cmd in enumerate(cmds) if (f, idx) in keep_set]
                 if len(new_cmds) == len(cmds):

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -404,6 +404,19 @@ class HistoryAlias(xcli.ArgParserAlias):
         print(f"Deleted {deleted} entries from history")
 
     @staticmethod
+    def erasedups():
+        """Remove duplicate commands, keeping only the latest occurrence of each"""
+        hist = XSH.history
+        removed, total = hist.erasedups()
+        if removed:
+            print(
+                f"Removed {removed} duplicate entries ({total} total)",
+                file=sys.stderr,
+            )
+        else:
+            print(f"No duplicates found ({total} total)", file=sys.stderr)
+
+    @staticmethod
     def file(_stdout):
         """Display the current history filename"""
         hist = XSH.history
@@ -530,6 +543,7 @@ class HistoryAlias(xcli.ArgParserAlias):
         parser.add_command(self.on)
         parser.add_command(self.clear)
         parser.add_command(self.delete)
+        parser.add_command(self.erasedups)
         parser.add_command(self.gc)
         parser.add_command(self.transfer)
 

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -37,8 +37,7 @@ def _xh_sqlite_create_history_table(cursor):
 
     Columns:
         info - JSON formatted, reserved for future extension.
-        frequency - in case of HISTCONTROL=erasedups,
-        it tracks the frequency of the inputs. helps in sorting autocompletion
+        frequency - tracks the frequency of the inputs
     """
     if not getattr(XH_SQLITE_CACHE, XH_SQLITE_CREATED_SQL_TBL, False):
         cursor.execute(
@@ -78,7 +77,7 @@ def _xh_sqlite_create_history_table(cursor):
         except sqlite3.OperationalError:
             pass
 
-        # add index on inp. since we query when erasedups is True
+        # add index on inp for faster lookups
         cursor.execute(
             f"""\
 CREATE INDEX IF NOT EXISTS  idx_inp_history
@@ -87,20 +86,6 @@ ON {XH_SQLITE_TABLE_NAME}(inp);"""
 
         # mark that this function ran for this session
         setattr(XH_SQLITE_CACHE, XH_SQLITE_CREATED_SQL_TBL, True)
-
-
-def _xh_sqlite_get_frequency(cursor, input):
-    # type: (sqlite3.Cursor, str) -> int
-    sql = f"SELECT sum(frequency) FROM {XH_SQLITE_TABLE_NAME} WHERE inp=?"
-    cursor.execute(sql, (input,))
-    return cursor.fetchone()[0] or 0
-
-
-def _xh_sqlite_erase_dups(cursor, input):
-    freq = _xh_sqlite_get_frequency(cursor, input)
-    sql = f"DELETE FROM {XH_SQLITE_TABLE_NAME} WHERE inp=?"
-    cursor.execute(sql, (input,))
-    return freq
 
 
 def _sql_insert(cursor, values):
@@ -114,7 +99,7 @@ def _sql_insert(cursor, values):
     )
 
 
-def _xh_sqlite_insert_command(cursor, cmd, sessionid, store_stdout, remove_duplicates):
+def _xh_sqlite_insert_command(cursor, cmd, sessionid, store_stdout):
     tss = cmd.get("ts", [None, None])
     values = collections.OrderedDict(
         [
@@ -132,8 +117,6 @@ def _xh_sqlite_insert_command(cursor, cmd, sessionid, store_stdout, remove_dupli
     if "info" in cmd:
         info = json.dumps(cmd["info"])
         values["info"] = info
-    if remove_duplicates:
-        values["frequency"] = _xh_sqlite_erase_dups(cursor, values["inp"]) + 1
     _sql_insert(cursor, values)
 
 
@@ -176,13 +159,11 @@ def _xh_sqlite_delete_records(cursor, size_to_keep):
     return result.rowcount
 
 
-def xh_sqlite_append_history(
-    cmd, sessionid, store_stdout, filename=None, remove_duplicates=False
-):
+def xh_sqlite_append_history(cmd, sessionid, store_stdout, filename=None):
     with _xh_sqlite_get_conn(filename=filename) as conn:
         c = conn.cursor()
         _xh_sqlite_create_history_table(c)
-        _xh_sqlite_insert_command(c, cmd, sessionid, store_stdout, remove_duplicates)
+        _xh_sqlite_insert_command(c, cmd, sessionid, store_stdout)
         conn.commit()
 
 
@@ -248,6 +229,52 @@ def xh_sqlite_wipe_session(sessionid=None, filename=None):
         c = conn.cursor()
         _xh_sqlite_create_history_table(c)
         c.execute(sql, (str(sessionid),))
+
+
+def xh_sqlite_erasedups(filename=None):
+    """Remove duplicate commands, keeping only the latest occurrence of each."""
+    with _xh_sqlite_get_conn(filename=filename) as conn:
+        c = conn.cursor()
+        _xh_sqlite_create_history_table(c)
+
+        # Count total entries
+        c.execute(f"SELECT COUNT(*) FROM {XH_SQLITE_TABLE_NAME}")
+        total = c.fetchone()[0]
+
+        # Find all inps that have more than one entry
+        c.execute(
+            f"SELECT inp, COUNT(*) as cnt, SUM(frequency) as total_freq "
+            f"FROM {XH_SQLITE_TABLE_NAME} GROUP BY inp HAVING cnt > 1"
+        )
+        dups = c.fetchall()
+
+        removed = 0
+        for inp, _cnt, total_freq in dups:
+            # Keep only the latest entry (by tsb)
+            c.execute(
+                f"SELECT rowid FROM {XH_SQLITE_TABLE_NAME} "
+                f"WHERE inp = ? ORDER BY tsb DESC LIMIT 1",
+                (inp,),
+            )
+            keep_rowid = c.fetchone()[0]
+
+            # Delete all other entries for this inp
+            c.execute(
+                f"DELETE FROM {XH_SQLITE_TABLE_NAME} "
+                f"WHERE inp = ? AND rowid != ?",
+                (inp, keep_rowid),
+            )
+            removed += c.rowcount
+
+            # Update frequency on the kept row
+            c.execute(
+                f"UPDATE {XH_SQLITE_TABLE_NAME} "
+                f"SET frequency = ? WHERE rowid = ?",
+                (total_freq, keep_rowid),
+            )
+
+        conn.commit()
+        return removed, total
 
 
 def xh_sqlite_delete_input_matching(pattern, filename=None):
@@ -373,7 +400,6 @@ class SqliteHistory(History):
                 str(self.sessionid),
                 store_stdout=envs.get("XONSH_STORE_STDOUT", False),
                 filename=self.filename,
-                remove_duplicates=("erasedups" in opts),
             )
         except sqlite3.OperationalError as err:
             print(f"SQLite History Backend Error: {err}")
@@ -448,3 +474,7 @@ class SqliteHistory(History):
         return xh_sqlite_delete_input_matching(
             pattern=re.compile(pattern), filename=self.filename
         )
+
+    def erasedups(self):
+        """Remove duplicate commands, keeping only the latest occurrence."""
+        return xh_sqlite_erasedups(filename=self.filename)

--- a/xonsh/history/sqlite.py
+++ b/xonsh/history/sqlite.py
@@ -260,16 +260,14 @@ def xh_sqlite_erasedups(filename=None):
 
             # Delete all other entries for this inp
             c.execute(
-                f"DELETE FROM {XH_SQLITE_TABLE_NAME} "
-                f"WHERE inp = ? AND rowid != ?",
+                f"DELETE FROM {XH_SQLITE_TABLE_NAME} WHERE inp = ? AND rowid != ?",
                 (inp, keep_rowid),
             )
             removed += c.rowcount
 
             # Update frequency on the kept row
             c.execute(
-                f"UPDATE {XH_SQLITE_TABLE_NAME} "
-                f"SET frequency = ? WHERE rowid = ?",
+                f"UPDATE {XH_SQLITE_TABLE_NAME} SET frequency = ? WHERE rowid = ?",
                 (total_freq, keep_rowid),
             )
 


### PR DESCRIPTION
### Motivation

After reviewing the erasedups option for the SQLite HISTCONTROL, it turned out to have multiple issues, edge cases, and unintended side effects. For example, when combined with history clear, it may result in commands being permanently removed from history.

Moreover, the cleanup routine was triggered on every write to the database, and it was performed synchronously, which caused increasing slowdowns as the history database grew.

The behavior of `erasedups` becomes unpredictable when multiple sessions are running in parallel, especially when combined with `history clear`.

* Fixes https://github.com/xonsh/xonsh/issues/5919

### Implementation

* The `erasedups` option has been removed from HISTCONTROL.
* A dedicated command, `history erasedups`, has been introduced, allowing users to run deduplication explicitly when needed.
* Additionally, `history erasedups` now supports JSON history.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
