### PR TITLE
fix: Stability: Handle broken pygments plugins in cache discovery

### DIFF
--- a/xonsh/pygments_cache.py
+++ b/xonsh/pygments_cache.py
@@ -39,6 +39,25 @@ def _print_duplicate_message(duplicates):
         print(msg, file=sys.stderr)
 
 
+def _safe_iter(gen):
+    """Iterate a generator, catching exceptions from broken pygments plugins.
+
+    Pygments discovers plugin lexers/formatters/styles via entry points.
+    If a third-party package registers a broken entry point (e.g. voltron
+    trying to import gdb internals outside of a gdb session), the generator
+    dies on the first error.  Built-in entries are yielded before plugins,
+    so we lose at most some plugin entries.
+    """
+    it = iter(gen)
+    while True:
+        try:
+            yield next(it)
+        except StopIteration:
+            return
+        except Exception:
+            return
+
+
 def _discover_lexers():
     import inspect
 
@@ -110,10 +129,13 @@ def _discover_lexers():
         from collections import defaultdict
 
         duplicates = defaultdict(set)
-    for longname, _, filenames, _ in get_all_lexers():
-        cls = find_lexer_class(longname)
-        mod = inspect.getmodule(cls)
-        val = (mod.__name__, cls.__name__)
+    for longname, _, filenames, _ in _safe_iter(get_all_lexers()):
+        try:
+            cls = find_lexer_class(longname)
+            mod = inspect.getmodule(cls)
+            val = (mod.__name__, cls.__name__)
+        except Exception:
+            continue
         for filename in filenames:
             if filename.startswith("*."):
                 filename = filename[1:]
@@ -152,7 +174,7 @@ def _discover_formatters():
         from collections import defaultdict
 
         duplicates = defaultdict(set)
-    for cls in get_all_formatters():
+    for cls in _safe_iter(get_all_formatters()):
         mod = inspect.getmodule(cls)
         val = (mod.__name__, cls.__name__)
         # add extentions
@@ -204,7 +226,7 @@ def _discover_styles():
         from collections import defaultdict
 
         duplicates = defaultdict(set)
-    for name in get_all_styles():
+    for name in _safe_iter(get_all_styles()):
         cls = get_style_by_name(name)
         mod = inspect.getmodule(cls)
         val = (mod.__name__, cls.__name__)
@@ -233,7 +255,7 @@ def _discover_filters():
         from collections import defaultdict
 
         duplicates = defaultdict(set)
-    for name in get_all_filters():
+    for name in _safe_iter(get_all_filters()):
         filter = get_filter_by_name(name)
         cls = type(filter)
         mod = inspect.getmodule(cls)


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/5110

Added _safe_iter() wrapper around pygments generator iteration. A broken plugin entry point (e.g. voltron importing gdb internals) killed the generator and crashed xonfig web. Built-in entries are  yielded before plugins, so only broken plugin entries are lost.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
