### PR TITLE
fix: Ignore empty strings in completion fallback chain (Fixes #5810)

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -238,6 +238,9 @@ class Completer:
 
             items = []
             for comp in res:
+                if not comp or not str(comp).strip():
+                    continue
+                
                 if (not is_filtered) and (not filter_func(comp, prefix)):
                     continue
                 comp = Completer._format_completion(

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -240,7 +240,7 @@ class Completer:
             for comp in res:
                 if not comp or not str(comp).strip():
                     continue
-                
+
                 if (not is_filtered) and (not filter_func(comp, prefix)):
                     continue
                 comp = Completer._format_completion(


### PR DESCRIPTION
My solution was line 239, when getting the items of completion. Before adding a completion, I skip it if its empty or just consisting of spaces or /t.

cc https://github.com/xonsh/xonsh/issues/5810

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
