### PR TITLE
feat: make event handlers reload-safe by keying on module+qualname instead of id

### DIFF
--- a/tests/test_events_llm.py
+++ b/tests/test_events_llm.py
@@ -1,0 +1,256 @@
+"""Tests for reload-safe event handler uniqueness (xonsh/xonsh#3276)."""
+
+import pytest
+
+from xonsh.events import Event, EventManager, LoadEvent, _handler_key
+
+
+@pytest.fixture
+def events():
+    return EventManager()
+
+
+# --- _handler_key ---
+
+
+def _module_level_handler(**kw):
+    pass
+
+
+def test_handler_key_named_function():
+    """Named module-level functions use (module, qualname) as key."""
+    key = _handler_key(_module_level_handler)
+    assert key == (
+        _module_level_handler.__module__,
+        _module_level_handler.__qualname__,
+    )
+    assert "<" not in _module_level_handler.__qualname__
+
+
+def test_handler_key_closure():
+    """Closures (with '<locals>' in qualname) fall back to id()."""
+
+    def make():
+        def inner(**kw):
+            pass
+
+        return inner
+
+    h = make()
+    assert "<" in h.__qualname__
+    assert _handler_key(h) == id(h)
+
+
+def test_handler_key_lambda():
+    """Lambdas fall back to id()."""
+    h = lambda **kw: None  # noqa: E731
+    assert "<" in h.__qualname__
+    assert _handler_key(h) == id(h)
+
+
+def test_handler_key_bound_method():
+    """Bound methods fall back to id()."""
+
+    class C:
+        def method(self, **kw):
+            pass
+
+    m = C().method
+    assert _handler_key(m) == id(m)
+
+
+def test_handler_key_two_bound_methods_differ():
+    """Two bound methods from different instances are distinct."""
+
+    class C:
+        def method(self, **kw):
+            pass
+
+    assert _handler_key(C().method) != _handler_key(C().method)
+
+
+# --- Event reload-safety ---
+
+
+def test_named_handler_replaced_on_reregister(events):
+    """Re-registering a handler with the same module+qualname replaces it."""
+
+    def handler(**kw):
+        return "old"
+
+    handler.__module__ = "my_mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    def handler(**kw):  # noqa: F811
+        return "new"
+
+    handler.__module__ = "my_mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    assert len(events.on_test) == 1
+    assert events.on_test.fire() == ["new"]
+
+
+def test_closures_not_collapsed(events):
+    """Two closures registered on the same event stay separate."""
+
+    def make(val):
+        def inner(**kw):
+            return val
+
+        return inner
+
+    events.on_test(make("a"))
+    events.on_test(make("b"))
+
+    assert len(events.on_test) == 2
+    assert set(events.on_test.fire()) == {"a", "b"}
+
+
+def test_discard_by_qualname(events):
+    """Discard finds the handler by key, not by identity."""
+
+    def handler(**kw):
+        pass
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+    assert len(events.on_test) == 1
+
+    # New object, same key
+    def handler(**kw):  # noqa: F811
+        pass
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test.discard(handler)
+    assert len(events.on_test) == 0
+
+
+def test_contains_by_qualname(events):
+    """__contains__ matches by key, not by identity."""
+
+    def handler(**kw):
+        pass
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    # Different object, same key
+    def handler2(**kw):
+        pass
+
+    handler2.__module__ = "mod"
+    handler2.__qualname__ = "handler"
+    assert handler2 in events.on_test
+
+
+# --- LoadEvent reload-safety ---
+
+
+def test_load_event_replaces_on_reregister(events):
+    """LoadEvent also replaces handlers with the same key."""
+    events.transmogrify("on_test", LoadEvent)
+
+    def handler(**kw):
+        return "old"
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    def handler(**kw):  # noqa: F811
+        return "new"
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    assert len(events.on_test) == 1
+
+
+def test_load_event_fires_replaced_handler(events):
+    """After replace + fire, only the new handler runs."""
+    events.transmogrify("on_test", LoadEvent)
+    called = []
+
+    def handler(**kw):
+        called.append("old")
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    def handler(**kw):  # noqa: F811
+        called.append("new")
+
+    handler.__module__ = "mod"
+    handler.__qualname__ = "handler"
+    events.on_test(handler)
+
+    events.on_test.fire()
+    assert called == ["new"]
+
+
+# --- Delayed add/discard during fire ---
+
+
+def test_delayed_add_replaces_during_fire(events):
+    """Handler added during fire replaces by key on next fire."""
+
+    def adder(**kw):
+        # Registering a handler with the same key as 'target' during fire
+        def target(**kw):
+            return "replaced"
+
+        target.__module__ = "mod"
+        target.__qualname__ = "target"
+        events.on_test(target)
+
+    def target(**kw):
+        return "original"
+
+    target.__module__ = "mod"
+    target.__qualname__ = "target"
+
+    events.on_test(adder)
+    events.on_test(target)
+
+    events.on_test.fire()  # adder runs, schedules replacement
+    vals = events.on_test.fire()
+    assert "replaced" in vals
+    assert "original" not in vals
+
+
+def test_delayed_discard_by_key_during_fire(events):
+    """Discard during fire uses key matching."""
+    removed = False
+
+    def remover(**kw):
+        nonlocal removed
+        if not removed:
+            removed = True
+            # Create a new object with same key to discard
+            def target(**kw):
+                pass
+
+            target.__module__ = "mod"
+            target.__qualname__ = "target"
+            events.on_test.discard(target)
+
+    def target(**kw):
+        return "target"
+
+    target.__module__ = "mod"
+    target.__qualname__ = "target"
+
+    events.on_test(remover)
+    events.on_test(target)
+
+    events.on_test.fire()  # remover schedules discard
+    vals = events.on_test.fire()
+    assert "target" not in vals

--- a/tests/test_events_llm.py
+++ b/tests/test_events_llm.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from xonsh.events import Event, EventManager, LoadEvent, _handler_key
+from xonsh.events import EventManager, LoadEvent, _handler_key
 
 
 @pytest.fixture
@@ -234,6 +234,7 @@ def test_delayed_discard_by_key_during_fire(events):
         nonlocal removed
         if not removed:
             removed = True
+
             # Create a new object with same key to discard
             def target(**kw):
                 pass

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -28,12 +28,7 @@ def _handler_key(handler):
     """
     module = getattr(handler, "__module__", None)
     qualname = getattr(handler, "__qualname__", None)
-    if (
-        module
-        and qualname
-        and "<" not in qualname
-        and not hasattr(handler, "__self__")
-    ):
+    if module and qualname and "<" not in qualname and not hasattr(handler, "__self__"):
         return (module, qualname)
     return id(handler)
 

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -16,6 +16,28 @@ from xonsh.built_ins import XSH
 from xonsh.tools import print_exception
 
 
+def _handler_key(handler):
+    """Return a uniqueness key for an event handler.
+
+    Named module-level functions use ``(__module__, __qualname__)`` so that
+    re-registering the same function after a module reload *replaces* the
+    old handler instead of duplicating it.
+
+    Closures / lambdas (``'<' in __qualname__``) and bound methods fall back
+    to ``id()`` so that distinct dynamic handlers are never collapsed.
+    """
+    module = getattr(handler, "__module__", None)
+    qualname = getattr(handler, "__qualname__", None)
+    if (
+        module
+        and qualname
+        and "<" not in qualname
+        and not hasattr(handler, "__self__")
+    ):
+        return (module, qualname)
+    return id(handler)
+
+
 def has_kwargs(func):
     return any(
         p.kind == p.VAR_KEYWORD for p in inspect.signature(func).parameters.values()
@@ -123,9 +145,8 @@ class Event(AbstractEvent):
     An event species for notify and scatter-gather events.
     """
 
-    # Wish I could just pull from set...
     def __init__(self):
-        self._handlers = set()
+        self._handlers: dict = {}  # _handler_key -> handler
         self._firing_depth = 0
         self._delayed_adds = None
         self._delayed_discards = None
@@ -134,23 +155,24 @@ class Event(AbstractEvent):
         return len(self._handlers)
 
     def __contains__(self, item):
-        return item in self._handlers
+        return _handler_key(item) in self._handlers
 
     def __iter__(self):
-        yield from self._handlers
+        yield from self._handlers.values()
 
     def add(self, item):
         """
         Add an element to a set.
 
-        This has no effect if the element is already present.
+        If a handler with the same key is already present, it is replaced.
         """
+        key = _handler_key(item)
         if self._firing_depth:
             if self._delayed_adds is None:
-                self._delayed_adds = set()
-            self._delayed_adds.add(item)
+                self._delayed_adds = {}
+            self._delayed_adds[key] = item
         else:
-            self._handlers.add(item)
+            self._handlers[key] = item
 
     def discard(self, item):
         """
@@ -158,12 +180,13 @@ class Event(AbstractEvent):
 
         If the element is not a member, do nothing.
         """
+        key = _handler_key(item)
         if self._firing_depth:
             if self._delayed_discards is None:
                 self._delayed_discards = set()
-            self._delayed_discards.add(item)
+            self._delayed_discards.add(key)
         else:
-            self._handlers.discard(item)
+            self._handlers.pop(key, None)
 
     def fire(self, **kwargs):
         """
@@ -186,7 +209,7 @@ class Event(AbstractEvent):
         vals = []
         self._firing_depth += 1
         try:
-            for handler in self._filterhandlers(self._handlers, **kwargs):
+            for handler in self._filterhandlers(self._handlers.values(), **kwargs):
                 try:
                     rv = handler(**kwargs)
                 except Exception:
@@ -200,7 +223,8 @@ class Event(AbstractEvent):
                     self._handlers.update(self._delayed_adds)
                     self._delayed_adds = None
                 if self._delayed_discards is not None:
-                    self._handlers.difference_update(self._delayed_discards)
+                    for key in self._delayed_discards:
+                        self._handlers.pop(key, None)
                     self._delayed_discards = None
         return vals
 
@@ -218,31 +242,33 @@ class LoadEvent(AbstractEvent):
     """
 
     def __init__(self):
-        self._fired = set()
-        self._unfired = set()
+        self._fired: dict = {}  # _handler_key -> handler
+        self._unfired: dict = {}  # _handler_key -> handler
         self._hasfired = False
 
     def __len__(self):
         return len(self._fired) + len(self._unfired)
 
     def __contains__(self, item):
-        return item in self._fired or item in self._unfired
+        key = _handler_key(item)
+        return key in self._fired or key in self._unfired
 
     def __iter__(self):
-        yield from self._fired
-        yield from self._unfired
+        yield from self._fired.values()
+        yield from self._unfired.values()
 
     def add(self, item):
         """
         Add an element to a set.
 
-        This has no effect if the element is already present.
+        If a handler with the same key is already present, it is replaced.
         """
+        key = _handler_key(item)
         if self._hasfired:
             self._call(item)
-            self._fired.add(item)
+            self._fired[key] = item
         else:
-            self._unfired.add(item)
+            self._unfired[key] = item
 
     def discard(self, item):
         """
@@ -250,8 +276,9 @@ class LoadEvent(AbstractEvent):
 
         If the element is not a member, do nothing.
         """
-        self._fired.discard(item)
-        self._unfired.discard(item)
+        key = _handler_key(item)
+        self._fired.pop(key, None)
+        self._unfired.pop(key, None)
 
     def _call(self, handler):
         try:
@@ -264,9 +291,9 @@ class LoadEvent(AbstractEvent):
             return
         self._kwargs = kwargs
         while self._unfired:
-            handler = self._unfired.pop()
+            key, handler = self._unfired.popitem()
             self._call(handler)
-            self._fired.add(handler)
+            self._fired[key] = handler
         self._hasfired = True
         return ()  # Entirely for API compatibility
 


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/3276

Event handlers now use `(__module__, __qualname__)` as uniqueness key instead of `id()`. This means re-registering a handler with the same module and qualified name replaces the old one instead of creating a duplicate. Closures, lambdas, and bound methods fall back to `id()` so distinct dynamic handlers are never collapsed.

Reload-safe scenarios: `source ~/.xonshrc` with top-level `@events.on_*` decorators, `xontribs reload` for xontribs that register handlers at module level, `importlib.reload()` of any module with module-level event handlers. In all these cases the old handler is replaced by the new one, no duplicates accumulate.

Not reload-safe: handlers registered as closures inside `_load_xontrib_()` or any other function scope (`<locals>` in qualname). These still use `id()` and will duplicate on reload. For such xontribs the existing `_unload_xontrib_` contract is the correct cleanup mechanism.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
