### PR TITLE
fix(history): The subproc cmd from prompt field is affecting the history rtn value of the python command 

### DIFF
--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -285,7 +285,9 @@ def test_reset_clears_dependent_field(live_fields, formatter, xession):
     """
     xession.shell.prompt_formatter = formatter
 
-    live_fields["modified_title"] = lambda: live_fields.pick_val("current_job") or "xonsh"
+    live_fields["modified_title"] = lambda: (
+        live_fields.pick_val("current_job") or "xonsh"
+    )
 
     # first render — no job running, modified_title caches "xonsh"
     assert formatter("{modified_title}", fields=live_fields) == "xonsh"

--- a/tests/shell/test_base_shell.py
+++ b/tests/shell/test_base_shell.py
@@ -90,6 +90,25 @@ def test_default_append_history(cmd, exp_append_history, xonsh_session, monkeypa
         assert len(append_history_calls) == 0
 
 
+def test_prompt_subproc_does_not_leak_rtn(xonsh_session):
+    """A subprocess run during prompt rendering must not pollute
+    hist.last_cmd_rtn for the next pure-Python command.
+
+    Regression test for #4912.
+    """
+    hist = xonsh_session.history
+
+    # Simulate a prompt field that ran a failing subprocess:
+    # CommandPipeline._apply_to_history() would have done this.
+    hist.last_cmd_rtn = 222
+
+    # Now the user executes a pure-Python expression.
+    xonsh_session.shell.default("2+2")
+
+    # The env var must reflect success, not the prompt field's code.
+    assert xonsh_session.env["LAST_RETURN_CODE"] == 0
+
+
 def test_precmd_does_not_strip(xession, xonsh_execer):
     """precmd() must preserve leading whitespace."""
     shell = BaseShell(xonsh_execer, None)

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -397,6 +397,28 @@ class BaseShell:
         tee = Tee(encoding=enc, errors=err)
         ts0 = time.time()
         exc_info = (None, None, None)
+        if hist is not None:
+            # Reset so the ``is None`` guard below can distinguish
+            # "no subprocess ran" from "a subprocess already reported
+            # its return code".
+            #
+            # Flow:
+            #   1. Prompt fields may run subprocesses (e.g. ``$(cmd)``
+            #      inside a lambda) whose pipelines call
+            #      ``CommandPipeline._apply_to_history()`` and set
+            #      ``hist.last_cmd_rtn`` to *their* exit code.
+            #   2. ``run_compiled_code()`` executes the user's command.
+            #      - Subprocess commands (``echo 1``, ``!(cmd)``,
+            #        ``$(cmd)``) again go through ``_apply_to_history()``
+            #        and set ``hist.last_cmd_rtn`` to the real exit code.
+            #      - Pure-Python expressions (``2+2``) never touch it.
+            #   3. The ``if hist.last_cmd_rtn is None`` guard then sets 0
+            #      for success — but only fires when no subprocess has
+            #      already reported a code.
+            #
+            # Without this reset, a stale code from step 1 survives into
+            # step 3 and is mistaken for the user command's result.  #4912
+            hist.last_cmd_rtn = None
         try:
             exc_info = run_compiled_code(code, self.ctx, None, "single")
             if exc_info != (None, None, None):


### PR DESCRIPTION
* Fixed https://github.com/xonsh/xonsh/issues/4912

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
