### PR TITLE
fix: MULTILINE_PROMPT now supports ansi escape codes

### DIFF
--- a/docs/prompt.rst
+++ b/docs/prompt.rst
@@ -192,6 +192,62 @@ ordinary format string. What we're doing here is equivalent to this expression:
     " [{}]".format(curr_branch()) if curr_branch() is not None else ""
 
 
+Multiline Prompt
+================
+
+When you enter a multi-line statement (``for`` loop, ``if`` block, etc.),
+xonsh displays a continuation prompt on each subsequent line.  The pattern
+is controlled by ``$MULTILINE_PROMPT`` (default ``" "``).
+
+The value is **repeated** to fill the width of the main prompt.  It can be a
+plain string, a string with color markup, or a callable:
+
+.. code-block:: xonshcon
+
+    @ $MULTILINE_PROMPT = '   |'
+    @ for i in range(3):
+       |    print(i)
+       |
+
+Both xonsh color keywords (``{RED}``) and ANSI escape codes (``\033[31m``)
+are supported:
+
+.. code-block:: python
+
+    $MULTILINE_PROMPT = '{CYAN}   |{RESET} '
+
+Callable with ``line_number`` and ``width``
+-------------------------------------------
+
+When ``$MULTILINE_PROMPT`` is a callable, it receives two keyword arguments:
+
+* ``line_number`` — the line number of the continuation line.
+  The main prompt is line 1, so the first continuation is ``line_number=2``.
+* ``width`` — the visible width (in columns) of the main prompt.
+
+This lets you render unique content per line, for example line numbers:
+
+.. code-block:: python
+
+    _ml_colors = ['{CYAN}', '{GREEN}', '{YELLOW}', '{BLUE}', '{PURPLE}', '{RED}']
+
+    def _multiline(line_number, width):
+        c = _ml_colors[line_number % len(_ml_colors)]
+        return f'{c}{line_number:>{width - 2}}|{{RESET}} '
+
+    $MULTILINE_PROMPT = _multiline
+
+Result (each line is a different color)::
+
+    prompt @
+          2|    for i in range(5):
+          3|        if i > 2:
+          4|            print(i)
+          5|
+
+Existing callables that accept no arguments continue to work.
+
+
 Custom Keybindings
 ==================
 

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -562,15 +562,17 @@ class PromptToolkitShell(BaseShell):
             # [('class:pygments.color.reset',''), ('[ZeroWidthEscape]','\x1b]133;P;k=c\x07')]
             # [('class:pygments.color.reset',''), ('[ZeroWidthEscape]','\x1b]133;B\x07')]
 
-        basetoks = self.format_color(dots)
+        # Resolve both xonsh colors ({RED}) and ANSI escapes (\033[31m)
+        # so baselen counts only visible characters.  See #5898.
+        basetoks = tokenize_ansi(PygmentsTokens(self.format_color(dots)))
         baselen = sum(len(t[1]) for t in basetoks)
         if baselen == 0:
-            toks = [(Token, " " * width)]
-            if is_affix:  # to convert ↓ classes to str to allow +
-                return prefixtoks + to_formatted_text(PygmentsTokens(toks)) + suffixtoks
+            toks = [("", " " * width)]
+            if is_affix:
+                return prefixtoks + toks + suffixtoks
             else:
-                return PygmentsTokens(toks)
-        toks = basetoks * (width // baselen)
+                return toks
+        toks = list(basetoks) * (width // baselen)
         n = width % baselen
         count = 0
         for tok in basetoks:
@@ -586,9 +588,9 @@ class PromptToolkitShell(BaseShell):
             if n <= count:
                 break
         if is_affix:
-            return prefixtoks + to_formatted_text(PygmentsTokens(toks)) + suffixtoks
+            return prefixtoks + toks + suffixtoks
         else:
-            return PygmentsTokens(toks)
+            return toks
 
     def format_color(self, string, hide=False, force_string=False, **kwargs):
         """Formats a color string using Pygments. This, therefore, returns

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -546,7 +546,13 @@ class PromptToolkitShell(BaseShell):
         if is_soft_wrap:
             return ""
         dots = XSH.env.get("MULTILINE_PROMPT")
-        dots = dots() if callable(dots) else dots
+        if callable(dots):
+            try:
+                # prompt_toolkit passes 1 for the first continuation,
+                # but the main prompt is line 1, so shift by 1.
+                dots = dots(line_number=line_number + 1, width=width)
+            except TypeError:
+                dots = dots()
         if not dots:
             return ""
         prefix = XSH.env.get(


### PR DESCRIPTION
* FIxes https://github.com/xonsh/xonsh/issues/5898

### Changes
* ANSI codes support
* Added line_number, width to multiline callable

### After

```xsh
_ml_colors = ['{BLUE}', '{PURPLE}']                                                                                               
                                                                                                                                                                              
def _multiline(line_number, width):                                                                                                                                         
    c = _ml_colors[line_number % len(_ml_colors)]                                                                                                                           
    return f'{c}{line_number:>{width - 2}}|{{RESET}}'                                                                                                                       
                                                                                                                                                                            
$MULTILINE_PROMPT = _multiline
```

<img width="505" height="195" alt="image" src="https://github.com/user-attachments/assets/bb8d7b6d-d042-4b97-a92e-b1cf13cec09a" />


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
