### PR TITLE
feat(completer): show per-item completion source in trace output

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -164,7 +164,6 @@ class Completer:
                     completion = completion + closing_quote
 
         completion = list(apply_lprefix([completion], lprefix))[0]
-
         if (
             isinstance(completion, RichCompletion)
             and completion.append_space
@@ -258,7 +257,10 @@ class Completer:
                     f"TRACE COMPLETIONS: Got {len(items)} results"
                     f" from {'' if is_exclusive_completer(func) else 'non-'}exclusive completer '{name}':"
                 )
-                sys.displayhook(items)
+                for completion, _ in items:
+                    shown = getattr(completion, "display", None) or str(completion)
+                    source = getattr(completion, "source", None) or name
+                    print(f"# {shown} <- {source}")
 
             if is_exclusive_completer(func):
                 # we got completions for an exclusive completer

--- a/xonsh/completers/base.py
+++ b/xonsh/completers/base.py
@@ -32,7 +32,6 @@ def _with_source(completions, source):
                 source=source,
             )
 
-
 @contextual_completer
 def complete_base(context: CompletionContext):
     """If the line is empty, complete based on valid commands, python names, and paths."""

--- a/xonsh/completers/base.py
+++ b/xonsh/completers/base.py
@@ -32,6 +32,7 @@ def _with_source(completions, source):
                 source=source,
             )
 
+
 @contextual_completer
 def complete_base(context: CompletionContext):
     """If the line is empty, complete based on valid commands, python names, and paths."""

--- a/xonsh/completers/base.py
+++ b/xonsh/completers/base.py
@@ -5,8 +5,32 @@ import collections.abc as cabc
 from xonsh.completers.commands import complete_command
 from xonsh.completers.path import contextual_complete_path
 from xonsh.completers.python import complete_python
-from xonsh.completers.tools import apply_lprefix, contextual_completer
+from xonsh.completers.tools import (
+    RichCompletion,
+    apply_lprefix,
+    contextual_completer,
+)
 from xonsh.parsers.completion_context import CompletionContext
+
+
+def _with_source(completions, source):
+    for comp in completions:
+        if isinstance(comp, RichCompletion):
+            yield RichCompletion(
+                str(comp),
+                prefix_len=comp.prefix_len,
+                display=comp.display,
+                description=comp.description,
+                style=comp.style,
+                append_closing_quote=comp.append_closing_quote,
+                append_space=comp.append_space,
+                source=getattr(comp, "source", None) or source,
+            )
+        else:
+            yield RichCompletion(
+                str(comp),
+                source=source,
+            )
 
 
 @contextual_completer
@@ -22,9 +46,12 @@ def complete_base(context: CompletionContext):
     python_comps = complete_python(context) or set()
     if isinstance(python_comps, cabc.Sequence):
         python_comps, python_comps_len = python_comps  # type: ignore
-        yield from apply_lprefix(python_comps, python_comps_len)
+        yield from _with_source(
+            apply_lprefix(python_comps, python_comps_len),
+            "python",
+        )
     else:
-        yield from python_comps
+        yield from _with_source(python_comps, "python")
 
     # add command completions
     yield from complete_command(context.command)
@@ -34,4 +61,7 @@ def complete_base(context: CompletionContext):
         path_comps, path_comp_len = contextual_complete_path(
             context.command, cdpath=False
         )
-        yield from apply_lprefix(path_comps, path_comp_len)
+        yield from _with_source(
+            apply_lprefix(path_comps, path_comp_len),
+            "path",
+        )

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -28,21 +28,31 @@ def complete_command(command: CommandContext):
 
     cmd = command.prefix
     show_desc = (XSH.env or {}).get("CMD_COMPLETIONS_SHOW_DESC", False)
+
     for s, (path, is_alias) in XSH.commands_cache.iter_commands():
         if get_filter_function()(s, cmd):
-            kwargs = {}
+            kwargs = {
+                "append_space": True,
+                "source": "aliases" if is_alias else "commands_cache",
+            }
             if show_desc:
                 kwargs["description"] = "Alias" if is_alias else path
-            yield RichCompletion(s, append_space=True, **kwargs)  # type: ignore
+            yield RichCompletion(s, **kwargs)  # type: ignore
+
     if xp.ON_WINDOWS:
         for i in executables_in("."):
             if get_filter_function()(i, cmd):
-                yield RichCompletion(i, append_space=True)
+                yield RichCompletion(i, source="cwd")
+
     base = os.path.basename(cmd)
     if os.path.isdir(base):
         for i in executables_in(base):
             if get_filter_function()(i, cmd):
-                yield RichCompletion(os.path.join(base, i))
+                yield RichCompletion(
+                    os.path.join(base, i),
+                    append_space=True,
+                    source="path",
+                )
 
 
 @contextual_command_completer

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -42,7 +42,7 @@ def complete_command(command: CommandContext):
     if xp.ON_WINDOWS:
         for i in executables_in("."):
             if get_filter_function()(i, cmd):
-                yield RichCompletion(i, source="cwd")
+                yield RichCompletion(i, append_space=True, source="cwd")
 
     base = os.path.basename(cmd)
     if os.path.isdir(base):
@@ -50,7 +50,6 @@ def complete_command(command: CommandContext):
             if get_filter_function()(i, cmd):
                 yield RichCompletion(
                     os.path.join(base, i),
-                    append_space=True,
                     source="path",
                 )
 

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -272,7 +272,6 @@ def _complete_python(prefix, context: PythonContext):
             if filt(s, dp):
                 obj = getattr(builtins, s, None)
                 rtn.add(_rich_with_source("@" + s, _python_source_from_obj(obj)))
-
     return rtn
 
 

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -231,26 +231,74 @@ def _complete_python(prefix, context: PythonContext):
     ctx = context.ctx
     filt = get_filter_function()
     rtn = set()
+    _sentinel = object()
     if ctx is not None:
         if "." in prefix:
             rtn |= attr_complete(prefix, ctx, filt)
         args = python_signature_complete(prefix, line, end, ctx, filt)
-        rtn |= args
-        rtn |= {s for s in ctx if filt(s, prefix)}
+        for s in args:
+            rtn.add(_rich_with_source(s, "function_arg"))
+
+        for s in ctx:
+            if isinstance(s, str) and filt(s, prefix):
+                obj = ctx.get(s, _sentinel) if hasattr(ctx, "get") else _sentinel
+                source = None if obj is _sentinel else _python_source_from_obj(obj)
+                rtn.add(_rich_with_source(s, source))
     else:
         args = ()
     if len(args) == 0:
-        # not in a function call, so we can add non-expression tokens
-        rtn |= {s for s in XONSH_TOKENS if filt(s, prefix)}
+        for s in XONSH_TOKENS:
+            if filt(s, prefix):
+                rtn.add(_rich_with_source(s, "keyword"))
     else:
-        rtn |= {s for s in XONSH_EXPR_TOKENS if filt(s, prefix)}
-    rtn |= {s for s in dir(builtins) if filt(s, prefix)}
+        for s in XONSH_EXPR_TOKENS:
+            if filt(s, prefix):
+                rtn.add(_rich_with_source(s, "keyword"))
+
+    for s in dir(builtins):
+        if filt(s, prefix):
+            obj = getattr(builtins, s, None)
+            rtn.add(_rich_with_source(s, _python_source_from_obj(obj)))
+
     if prefix.startswith("@"):
         dp = prefix[1:]
         if ctx is not None:
-            rtn |= {"@" + s for s in ctx if filt(s, dp)}
-        rtn |= {"@" + s for s in dir(builtins) if filt(s, dp)}
+            for s in ctx:
+                if isinstance(s, str) and filt(s, dp):
+                    obj = ctx.get(s, _sentinel) if hasattr(ctx, "get") else _sentinel
+                    source = None if obj is _sentinel else _python_source_from_obj(obj)
+                    rtn.add(_rich_with_source("@" + s, source))
+        for s in dir(builtins):
+            if filt(s, dp):
+                obj = getattr(builtins, s, None)
+                rtn.add(_rich_with_source("@" + s, _python_source_from_obj(obj)))
+
     return rtn
+
+
+def _python_source_from_obj(obj):
+    if inspect.isbuiltin(obj) or inspect.isfunction(obj) or inspect.ismethod(obj):
+        return "function"
+    if inspect.isclass(obj):
+        return "class"
+    if inspect.ismodule(obj):
+        return "module"
+    return "python"
+
+
+def _rich_with_source(value, source, **kwargs):
+    if isinstance(value, RichCompletion):
+        return RichCompletion(
+            str(value),
+            prefix_len=value.prefix_len,
+            display=value.display,
+            description=value.description,
+            style=value.style,
+            append_closing_quote=value.append_closing_quote,
+            append_space=value.append_space,
+            source=getattr(value, "source", None) or source,
+        )
+    return RichCompletion(str(value), source=source, **kwargs)
 
 
 def _turn_off_warning(func):
@@ -283,6 +331,20 @@ def _safe_eval(expr, ctx):
     return val, _ctx
 
 
+def _attr_source(obj):
+    if inspect.isbuiltin(obj) or inspect.isfunction(obj) or inspect.ismethod(obj):
+        return "function"
+    if inspect.isclass(obj):
+        return "class"
+    if inspect.ismodule(obj):
+        return "module"
+    if isinstance(obj, cabc.Mapping):
+        return "mapping"
+    if isinstance(obj, cabc.Sequence) and not isinstance(obj, str):
+        return "sequence"
+    return "attribute"
+
+
 @_turn_off_warning
 def attr_complete(prefix, ctx, filter_func):
     """Complete attributes of an object."""
@@ -308,47 +370,44 @@ def attr_complete(prefix, ctx, filter_func):
     might_block = isinstance(val, CommandPipeline)
     prelen = len(prefix)
     for opt in opts:
-        # check whether these options actually work (e.g., disallow 7.imag)
         _expr = f"{expr}.{opt}"
-        # skip properties marked as blocking (e.g. CommandPipeline.returncode)
         if might_block:
             static_attr = inspect.getattr_static(val, opt, None)
             if isinstance(static_attr, blocking_property):
-                attrs.add(prefix[: prelen - len(attr)] + opt)
+                comp = prefix[: prelen - len(attr)] + opt
+                attrs.add(RichCompletion(comp, source="attribute"))
                 continue
         _val_, _ctx_ = _safe_eval(_expr, _ctx)
         if _val_ is None and _ctx_ is None:
             continue
-        a = getattr(val, opt)
+
+        source = _attr_source(_val_)
         if XSH.env["COMPLETIONS_BRACKETS"]:
-            if callable(a):
-                # Determine if this callable has useful attributes (class/module/namespace)
+            if callable(_val_):
                 has_useful_attrs = (
-                    inspect.isclass(a)
-                    or inspect.ismodule(a)
-                    or any(not attr.startswith("_") for attr in dir(a))
+                    inspect.isclass(_val_)
+                    or inspect.ismodule(_val_)
+                    or any(not name.startswith("_") for name in dir(_val_))
                 )
 
                 base_comp = prefix[: prelen - len(attr)] + opt
 
                 if has_useful_attrs:
-                    # Show plain name for attribute access (e.g., classes, modules)
-                    attrs.add(base_comp)
+                    attrs.add(RichCompletion(base_comp, source=source))
                 else:
-                    # Show with ( for calling (e.g., simple functions, methods)
-                    attrs.add(base_comp + "(")
-            elif isinstance(a, cabc.Sequence | cabc.Mapping):
+                    attrs.add(RichCompletion(base_comp + "(", source=source))
+            elif isinstance(_val_, cabc.Sequence | cabc.Mapping):
                 rpl = opt + "["
                 comp = prefix[: prelen - len(attr)] + rpl
-                attrs.add(comp)
+                attrs.add(RichCompletion(comp, source=source))
             else:
                 rpl = opt
                 comp = prefix[: prelen - len(attr)] + rpl
-                attrs.add(comp)
+                attrs.add(RichCompletion(comp, source=source))
         else:
             rpl = opt
             comp = prefix[: prelen - len(attr)] + rpl
-            attrs.add(comp)
+            attrs.add(RichCompletion(comp, source=source))
     return attrs
 
 

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -64,6 +64,7 @@ class RichCompletion(str):
         style: str = "",
         append_closing_quote: bool = True,
         append_space: bool = False,
+        source: str | None = None,
     ):
         """
         Parameters
@@ -88,6 +89,9 @@ class RichCompletion(str):
             This is intended to work with ``appending_closing_quote``, so the space will be added correctly **after** the closing quote.
             This is used in ``Completer.complete``.
             An extra bonus is that the space won't show up in the ``display`` attribute.
+        source :
+            Optional label describing where this completion came from.
+            This is primarily intended for debugging and trace output, such as ``XONSH_TRACE_COMPLETIONS``, and does not affect normal completion behavior.
         """
         super().__init__()
         self.prefix_len = prefix_len
@@ -96,6 +100,7 @@ class RichCompletion(str):
         self.style = style
         self.append_closing_quote = append_closing_quote
         self.append_space = append_space
+        self.source = source
 
     @property
     def value(self):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1932,73 +1932,25 @@ class XonshLexer(Python3Lexer):
             include("mode_switch_brackets"),
             # xonsh path-string literals (p prefix)
             # raw formatted path strings
-            (
-                '([fF][rR]p)(""")',
-                bygroups(String.Affix, String.Double),
-                combined("rfstringescape", "tdqf"),
-            ),
-            (
-                "([fF][rR]p)(''')",
-                bygroups(String.Affix, String.Single),
-                combined("rfstringescape", "tsqf"),
-            ),
-            (
-                '([fF][rR]p)(")',
-                bygroups(String.Affix, String.Double),
-                combined("rfstringescape", "dqf"),
-            ),
-            (
-                "([fF][rR]p)(')",
-                bygroups(String.Affix, String.Single),
-                combined("rfstringescape", "sqf"),
-            ),
+            ('([fF][rR]p)(""")', bygroups(String.Affix, String.Double), combined('rfstringescape', 'tdqf')),
+            ("([fF][rR]p)(''')", bygroups(String.Affix, String.Single), combined('rfstringescape', 'tsqf')),
+            ('([fF][rR]p)(")', bygroups(String.Affix, String.Double), combined('rfstringescape', 'dqf')),
+            ("([fF][rR]p)(')", bygroups(String.Affix, String.Single), combined('rfstringescape', 'sqf')),
             # formatted path strings
-            (
-                '(p[fF]|[fF]p)(""")',
-                bygroups(String.Affix, String.Double),
-                combined("fstringescape", "tdqf"),
-            ),
-            (
-                "(p[fF]|[fF]p)(''')",
-                bygroups(String.Affix, String.Single),
-                combined("fstringescape", "tsqf"),
-            ),
-            (
-                '(p[fF]|[fF]p)(")',
-                bygroups(String.Affix, String.Double),
-                combined("fstringescape", "dqf"),
-            ),
-            (
-                "(p[fF]|[fF]p)(')",
-                bygroups(String.Affix, String.Single),
-                combined("fstringescape", "sqf"),
-            ),
+            ('(p[fF]|[fF]p)(""")', bygroups(String.Affix, String.Double), combined('fstringescape', 'tdqf')),
+            ("(p[fF]|[fF]p)(''')", bygroups(String.Affix, String.Single), combined('fstringescape', 'tsqf')),
+            ('(p[fF]|[fF]p)(")', bygroups(String.Affix, String.Double), combined('fstringescape', 'dqf')),
+            ("(p[fF]|[fF]p)(')", bygroups(String.Affix, String.Single), combined('fstringescape', 'sqf')),
             # raw path strings
-            ('(p[rR]|[rR]p)(""")', bygroups(String.Affix, String.Double), "tdqs"),
-            ("(p[rR]|[rR]p)(''')", bygroups(String.Affix, String.Single), "tsqs"),
-            ('(p[rR]|[rR]p)(")', bygroups(String.Affix, String.Double), "dqs"),
-            ("(p[rR]|[rR]p)(')", bygroups(String.Affix, String.Single), "sqs"),
+            ('(p[rR]|[rR]p)(""")', bygroups(String.Affix, String.Double), 'tdqs'),
+            ("(p[rR]|[rR]p)(''')", bygroups(String.Affix, String.Single), 'tsqs'),
+            ('(p[rR]|[rR]p)(")', bygroups(String.Affix, String.Double), 'dqs'),
+            ("(p[rR]|[rR]p)(')", bygroups(String.Affix, String.Single), 'sqs'),
             # plain path strings
-            (
-                '(p)(""")',
-                bygroups(String.Affix, String.Double),
-                combined("stringescape", "tdqs"),
-            ),
-            (
-                "(p)(''')",
-                bygroups(String.Affix, String.Single),
-                combined("stringescape", "tsqs"),
-            ),
-            (
-                '(p)(")',
-                bygroups(String.Affix, String.Double),
-                combined("stringescape", "dqs"),
-            ),
-            (
-                "(p)(')",
-                bygroups(String.Affix, String.Single),
-                combined("stringescape", "sqs"),
-            ),
+            ('(p)(""")', bygroups(String.Affix, String.Double), combined('stringescape', 'tdqs')),
+            ("(p)(''')", bygroups(String.Affix, String.Single), combined('stringescape', 'tsqs')),
+            ('(p)(")', bygroups(String.Affix, String.Double), combined('stringescape', 'dqs')),
+            ("(p)(')", bygroups(String.Affix, String.Single), combined('stringescape', 'sqs')),
             inherit,
         ],
         "subproc_start": [

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1932,25 +1932,73 @@ class XonshLexer(Python3Lexer):
             include("mode_switch_brackets"),
             # xonsh path-string literals (p prefix)
             # raw formatted path strings
-            ('([fF][rR]p)(""")', bygroups(String.Affix, String.Double), combined('rfstringescape', 'tdqf')),
-            ("([fF][rR]p)(''')", bygroups(String.Affix, String.Single), combined('rfstringescape', 'tsqf')),
-            ('([fF][rR]p)(")', bygroups(String.Affix, String.Double), combined('rfstringescape', 'dqf')),
-            ("([fF][rR]p)(')", bygroups(String.Affix, String.Single), combined('rfstringescape', 'sqf')),
+            (
+                '([fF][rR]p)(""")',
+                bygroups(String.Affix, String.Double),
+                combined("rfstringescape", "tdqf"),
+            ),
+            (
+                "([fF][rR]p)(''')",
+                bygroups(String.Affix, String.Single),
+                combined("rfstringescape", "tsqf"),
+            ),
+            (
+                '([fF][rR]p)(")',
+                bygroups(String.Affix, String.Double),
+                combined("rfstringescape", "dqf"),
+            ),
+            (
+                "([fF][rR]p)(')",
+                bygroups(String.Affix, String.Single),
+                combined("rfstringescape", "sqf"),
+            ),
             # formatted path strings
-            ('(p[fF]|[fF]p)(""")', bygroups(String.Affix, String.Double), combined('fstringescape', 'tdqf')),
-            ("(p[fF]|[fF]p)(''')", bygroups(String.Affix, String.Single), combined('fstringescape', 'tsqf')),
-            ('(p[fF]|[fF]p)(")', bygroups(String.Affix, String.Double), combined('fstringescape', 'dqf')),
-            ("(p[fF]|[fF]p)(')", bygroups(String.Affix, String.Single), combined('fstringescape', 'sqf')),
+            (
+                '(p[fF]|[fF]p)(""")',
+                bygroups(String.Affix, String.Double),
+                combined("fstringescape", "tdqf"),
+            ),
+            (
+                "(p[fF]|[fF]p)(''')",
+                bygroups(String.Affix, String.Single),
+                combined("fstringescape", "tsqf"),
+            ),
+            (
+                '(p[fF]|[fF]p)(")',
+                bygroups(String.Affix, String.Double),
+                combined("fstringescape", "dqf"),
+            ),
+            (
+                "(p[fF]|[fF]p)(')",
+                bygroups(String.Affix, String.Single),
+                combined("fstringescape", "sqf"),
+            ),
             # raw path strings
-            ('(p[rR]|[rR]p)(""")', bygroups(String.Affix, String.Double), 'tdqs'),
-            ("(p[rR]|[rR]p)(''')", bygroups(String.Affix, String.Single), 'tsqs'),
-            ('(p[rR]|[rR]p)(")', bygroups(String.Affix, String.Double), 'dqs'),
-            ("(p[rR]|[rR]p)(')", bygroups(String.Affix, String.Single), 'sqs'),
+            ('(p[rR]|[rR]p)(""")', bygroups(String.Affix, String.Double), "tdqs"),
+            ("(p[rR]|[rR]p)(''')", bygroups(String.Affix, String.Single), "tsqs"),
+            ('(p[rR]|[rR]p)(")', bygroups(String.Affix, String.Double), "dqs"),
+            ("(p[rR]|[rR]p)(')", bygroups(String.Affix, String.Single), "sqs"),
             # plain path strings
-            ('(p)(""")', bygroups(String.Affix, String.Double), combined('stringescape', 'tdqs')),
-            ("(p)(''')", bygroups(String.Affix, String.Single), combined('stringescape', 'tsqs')),
-            ('(p)(")', bygroups(String.Affix, String.Double), combined('stringescape', 'dqs')),
-            ("(p)(')", bygroups(String.Affix, String.Single), combined('stringescape', 'sqs')),
+            (
+                '(p)(""")',
+                bygroups(String.Affix, String.Double),
+                combined("stringescape", "tdqs"),
+            ),
+            (
+                "(p)(''')",
+                bygroups(String.Affix, String.Single),
+                combined("stringescape", "tsqs"),
+            ),
+            (
+                '(p)(")',
+                bygroups(String.Affix, String.Double),
+                combined("stringescape", "dqs"),
+            ),
+            (
+                "(p)(')",
+                bygroups(String.Affix, String.Single),
+                combined("stringescape", "sqs"),
+            ),
             inherit,
         ],
         "subproc_start": [


### PR DESCRIPTION

# Summary

This improves `XONSH_TRACE_COMPLETIONS` by showing per-item completion sources in trace output.

## What changed

* added `source` metadata to `RichCompletion`
* updated trace output to print `item <- source`
* preserved more specific sources when completions are wrapped by higher-level completers
* added finer-grained sources for command and Python completions where available

## Before

Trace mode reported which completer produced a batch of results, but did not show the source for each individual completion item.

## After

Trace mode now shows per-item sources, for example:

```text id="5vdj0i"
TRACE COMPLETIONS: Got 30 results from exclusive completer 'base':
# os.path <- module
# os.PathLike <- class
# os.posix_spawnp( <- function
# dirmode <- aliases
# lsusb <- command
```

## Notes

* this only affects trace/debug output
* normal completion behavior is unchanged
* when a completion does not provide a more specific source, trace output falls back to the completer name

Closes #6292

LLM assistance was used during development for patch planning, debugging, and drafting code changes. The final code was reviewed and edited manually.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
