### PR TITLE
fix: Highlight: Check and highlight wrong module or variable name

### DIFF
--- a/tests/test_pyghooks.py
+++ b/tests/test_pyghooks.py
@@ -466,6 +466,26 @@ def test_import_module_validation(code, expect_error):
     assert has_error == expect_error, f"{code!r}: tokens={tokens}"
 
 
+@pytest.mark.parametrize(
+    "name, expect_error",
+    [
+        ("len", False),      # builtin
+        ("True", False),     # keyword
+        ("myvar", False),    # in ctx
+        ("undefined", True), # not defined anywhere
+    ],
+)
+def test_at_bracket_name_validation(name, expect_error, xession):
+    """Undefined names inside @() should be highlighted as Error."""
+    from xonsh.pyghooks import XonshLexer
+
+    xession.ctx["myvar"] = 42
+    lexer = XonshLexer()
+    tokens = list(lexer.get_tokens(f"echo @({name})"))
+    has_error = any(t == Token.Error for t, _ in tokens)
+    assert has_error == expect_error, f"@({name}): tokens={tokens}"
+
+
 def test_can_use_xonsh_lexer_without_xession(xession, monkeypatch):
     # When Xonsh is used as a library and simply for its lexer plugin, the
     # xession's env can be unset, so test that it can yield tokens without

--- a/tests/test_pyghooks.py
+++ b/tests/test_pyghooks.py
@@ -444,6 +444,28 @@ def test_pygments_style_no_bg_in_palette():
         assert color != bg_color, f"{token} mapped to background color {bg_color}"
 
 
+@pytest.mark.parametrize(
+    "code, expect_error",
+    [
+        ("import json", False),
+        ("import qweqweqwe", True),
+        ("import os.path", False),
+        ("import os, qweqweqwe", True),
+        ("from os import path", False),
+        ("from qweqweqwe import foo", True),
+        ("from . import something", False),
+    ],
+)
+def test_import_module_validation(code, expect_error):
+    """Non-existent modules in import statements should be highlighted as Error."""
+    from xonsh.pyghooks import XonshLexer
+
+    lexer = XonshLexer()
+    tokens = list(lexer.get_tokens(code))
+    has_error = any(t == Token.Error for t, _ in tokens)
+    assert has_error == expect_error, f"{code!r}: tokens={tokens}"
+
+
 def test_can_use_xonsh_lexer_without_xession(xession, monkeypatch):
     # When Xonsh is used as a library and simply for its lexer plugin, the
     # xession's env can be unset, so test that it can yield tokens without

--- a/tests/test_pyghooks.py
+++ b/tests/test_pyghooks.py
@@ -469,10 +469,10 @@ def test_import_module_validation(code, expect_error):
 @pytest.mark.parametrize(
     "name, expect_error",
     [
-        ("len", False),      # builtin
-        ("True", False),     # keyword
-        ("myvar", False),    # in ctx
-        ("undefined", True), # not defined anywhere
+        ("len", False),  # builtin
+        ("True", False),  # keyword
+        ("myvar", False),  # in ctx
+        ("undefined", True),  # not defined anywhere
     ],
 )
 def test_at_bracket_name_validation(name, expect_error, xession):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -618,7 +618,7 @@ XONSH_BASE_STYLE = LazyObject(
         Name.Attribute: "ansibrightyellow",
         Name.Tag: "bold ansigreen",
         Name.Decorator: "ansibrightmagenta",
-        String: "ansibrightred",
+        String: "ansiyellow",
         String.Doc: "ansicyan",
         String.Interpol: "bold ansimagenta",
         String.Escape: "bold ansiyellow",

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1774,6 +1774,37 @@ def _import_comma_cb(_, match):
     yield match.start(), Punctuation, ","
 
 
+# ---------------------------------------------------------------------------
+# @() Python substitution — highlight undefined names as Error.
+# Only bare names are checked (not attributes like os.path.join).
+# ---------------------------------------------------------------------------
+
+_at_bracket_check: bool = False
+
+
+def _at_bracket_start_cb(_, match):
+    """Enter @() substitution — mark that the first name should be checked."""
+    global _at_bracket_check
+    _at_bracket_check = True
+    yield match.start(), Keyword, match.group(1)
+    yield match.start() + len(match.group(1)), Punctuation, match.group(2)
+
+
+def _at_bracket_name_cb(_, match):
+    """Check first bare name inside @() against session context and builtins."""
+    global _at_bracket_check
+    import builtins
+
+    name = match.group()
+    if _at_bracket_check:
+        _at_bracket_check = False
+        ctx = getattr(XSH, "ctx", None) or {}
+        found = name in ctx or hasattr(builtins, name) or iskeyword(name)
+        yield match.start(), Name if found else Error, name
+    else:
+        yield match.start(), Name, name
+
+
 def subproc_cmd_callback(_, match):
     """Yield Builtin token if match contains valid command,
     otherwise fallback to fallback lexer.
@@ -1820,7 +1851,7 @@ class XonshLexer(Python3Lexer):
         "mode_switch_brackets": [
             (r"(\$)(\{)", bygroups(Keyword, Punctuation), "py_curly_bracket"),
             (r"(@!)(\()", bygroups(Keyword, Punctuation), "py_bracket"),
-            (r"(@)(\()", bygroups(Keyword, Punctuation), "py_bracket"),
+            (r"(@)(\()", _at_bracket_start_cb, "at_py_bracket"),
             (
                 r"([\!\$])(\()",
                 bygroups(Keyword, Punctuation),
@@ -1828,8 +1859,8 @@ class XonshLexer(Python3Lexer):
             ),
             (
                 r"(@\$)(\()",
-                bygroups(Keyword, Punctuation),
-                ("subproc_bracket", "subproc_start"),
+                _at_bracket_start_cb,
+                "at_py_bracket",
             ),
             (
                 r"([\!\$])(\[)",
@@ -1845,6 +1876,11 @@ class XonshLexer(Python3Lexer):
         "subproc_bracket": [(r"\)", Punctuation, "#pop"), include("subproc")],
         "subproc_square_bracket": [(r"\]", Punctuation, "#pop"), include("subproc")],
         "py_bracket": [(r"\)", Punctuation, "#pop"), include("root")],
+        "at_py_bracket": [
+            (r"\)", Punctuation, "#pop"),
+            (r"\w+", _at_bracket_name_cb),
+            include("root"),
+        ],
         "py_curly_bracket": [(r"\}", Punctuation, "#pop"), include("root")],
         "backtick_re": [
             (r"[\.\^\$\*\+\?\[\]\|]", String.Regex),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -599,7 +599,7 @@ def register_custom_pygments_style(
 XONSH_BASE_STYLE = LazyObject(
     lambda: {
         Whitespace: "ansigray",
-        Comment: "underline ansicyan",
+        Comment: "ansicyan",
         Comment.Preproc: "underline ansiyellow",
         Keyword: "bold ansigreen",
         Keyword.Pseudo: "nobold",
@@ -619,7 +619,7 @@ XONSH_BASE_STYLE = LazyObject(
         Name.Tag: "bold ansigreen",
         Name.Decorator: "ansibrightmagenta",
         String: "ansibrightred",
-        String.Doc: "underline",
+        String.Doc: "ansicyan",
         String.Interpol: "bold ansimagenta",
         String.Escape: "bold ansiyellow",
         String.Regex: "ansimagenta",
@@ -1805,6 +1805,22 @@ def _at_bracket_name_cb(_, match):
         yield match.start(), Name, name
 
 
+def _at_bracket_walrus_cb(_, match):
+    """Walrus operator target — it's a definition, skip the check."""
+    global _at_bracket_check
+    _at_bracket_check = False
+    yield match.start(), Name, match.group()
+
+
+def _env_var_cb(_, match):
+    """Check $VAR against the environment."""
+    text = match.group()
+    name = text[1:]  # strip leading $
+    env = getattr(XSH, "env", None)
+    found = env is not None and name in env
+    yield match.start(), Name.Variable if found else Error, text
+
+
 def subproc_cmd_callback(_, match):
     """Yield Builtin token if match contains valid command,
     otherwise fallback to fallback lexer.
@@ -1859,8 +1875,8 @@ class XonshLexer(Python3Lexer):
             ),
             (
                 r"(@\$)(\()",
-                _at_bracket_start_cb,
-                "at_py_bracket",
+                bygroups(Keyword, Punctuation),
+                ("subproc_bracket", "subproc_start"),
             ),
             (
                 r"([\!\$])(\[)",
@@ -1878,6 +1894,7 @@ class XonshLexer(Python3Lexer):
         "py_bracket": [(r"\)", Punctuation, "#pop"), include("root")],
         "at_py_bracket": [
             (r"\)", Punctuation, "#pop"),
+            (r"\w+(?=\s*:=)", _at_bracket_walrus_cb),
             (r"\w+", _at_bracket_name_cb),
             include("root"),
         ],
@@ -1907,7 +1924,7 @@ class XonshLexer(Python3Lexer):
         "root": [
             (r"\?", Keyword),
             (r"(?<=\w)!", Keyword),
-            (r"\$\w+", Name.Variable),
+            (r"\$\w+", _env_var_cb),
             (r"\(", Punctuation, "py_bracket"),
             (r"\{", Punctuation, "py_curly_bracket"),
             (r"(import)((?:\s|\\\s)+)", _import_start_cb, "import"),
@@ -1934,7 +1951,7 @@ class XonshLexer(Python3Lexer):
             (SubprocCommentHighlight, Comment.Single),
             (r'[^=\s\[\]{}()$"\'`<&|;]+', subproc_arg_callback),
             (r"<", Text),
-            (r"\$\w+", Name.Variable),
+            (r"\$\w+", _env_var_cb),
         ],
         "subproc_macro": [
             (r"(\s*)([^\n]+)", bygroups(Whitespace, String)),

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,5 +1,6 @@
 """Hooks for pygments syntax highlighting."""
 
+import importlib.util
 import os
 import re
 import stat
@@ -10,7 +11,7 @@ from collections.abc import MutableMapping
 from keyword import iskeyword
 
 import pygments.util
-from pygments.lexer import bygroups, include, inherit
+from pygments.lexer import bygroups, default, include, inherit
 from pygments.lexers.agile import Python3Lexer
 from pygments.style import Style
 from pygments.token import (
@@ -1734,6 +1735,45 @@ def _run_bg_validation(gen):
             pass
 
 
+# ---------------------------------------------------------------------------
+# Import module validation — highlight non-importable top-level modules
+# as Error.  Only the first name after ``import`` / ``from`` is checked;
+# submodule parts after a dot are left as Name.Namespace.
+# ---------------------------------------------------------------------------
+
+_import_check_next: bool = False
+
+
+def _import_start_cb(_, match):
+    """Intercept ``import``/``from`` keyword — check the next module name."""
+    global _import_check_next
+    _import_check_next = True
+    yield match.start(), Keyword.Namespace, match.group(1)
+    yield match.start() + len(match.group(1)), Text.Whitespace, match.group(2)
+
+
+def _import_module_cb(_, match):
+    """Check only the first identifier after import/from.  Rest pass through."""
+    global _import_check_next
+    name = match.group()
+    if _import_check_next:
+        _import_check_next = False
+        try:
+            found = importlib.util.find_spec(name) is not None
+        except (ModuleNotFoundError, ValueError, AttributeError):
+            found = False
+        yield match.start(), Name.Namespace if found else Error, name
+    else:
+        yield match.start(), Name.Namespace, name
+
+
+def _import_comma_cb(_, match):
+    """Comma separates independent imports — re-enable check for next name."""
+    global _import_check_next
+    _import_check_next = True
+    yield match.start(), Punctuation, ","
+
+
 def subproc_cmd_callback(_, match):
     """Yield Builtin token if match contains valid command,
     otherwise fallback to fallback lexer.
@@ -1813,12 +1853,29 @@ class XonshLexer(Python3Lexer):
             (r"`", String.Backtick, "#pop"),
             (r"[^`\.\^\$\*\+\?\[\]\|]+", String.Backtick),
         ],
+        "import": [
+            (r"(\s+)(as)(\s+)", bygroups(Keyword, Keyword, Text)),
+            (r"\.", Name.Namespace),
+            (r"\w+", _import_module_cb),
+            (r",", _import_comma_cb),
+            (r"\s+", Text.Whitespace),
+            default("#pop"),
+        ],
+        "fromimport": [
+            (r"(\s+)(import)\b", bygroups(Text.Whitespace, Keyword.Namespace), "#pop"),
+            (r"\.", Name.Namespace),
+            (r"None\b", Keyword.Constant, "#pop"),
+            (r"\w+", _import_module_cb),
+            default("#pop"),
+        ],
         "root": [
             (r"\?", Keyword),
             (r"(?<=\w)!", Keyword),
             (r"\$\w+", Name.Variable),
             (r"\(", Punctuation, "py_bracket"),
             (r"\{", Punctuation, "py_curly_bracket"),
+            (r"(import)((?:\s|\\\s)+)", _import_start_cb, "import"),
+            (r"(from)((?:\s|\\\s)+)", _import_start_cb, "fromimport"),
             include("mode_switch_brackets"),
             inherit,
         ],


### PR DESCRIPTION
* FIxes https://github.com/xonsh/xonsh/issues/5927

### Implementation

This is fast minimal support of module highlighting e.g. `import json` vs `import qweqwe`.

### Before

<img width="1094" height="556" alt="image" src="https://github.com/user-attachments/assets/bd776e80-fb03-455c-af1a-22ba120e2f6c" />


### After

<img width="484" height="207" alt="image" src="https://github.com/user-attachments/assets/df8d9582-1b8c-4fa2-9a4f-9688c994b05f" />


### Known limitations

There is no support for complex cases like `from json import qweqwe` or `json.qweqwe`.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
