### PR TITLE
fix(completer): Do not propagate empty lines from completers and add tracer

### DIFF
--- a/docs/completers.rst
+++ b/docs/completers.rst
@@ -173,18 +173,126 @@ xonsh actually uses, in the ``xonsh.completers`` module.
             return {'snail'}, len('lou ') + len(command.prefix)
 
 To understand how xonsh uses completers and their return values try
-to set :ref:`$XONSH_TRACE_COMPLETIONS <xonsh_trace_completions>` to ``True``:
+to set :ref:`$XONSH_COMPLETER_TRACE <xonsh_completer_trace>` to ``True``:
 
 .. code-block:: xonshcon
 
-    @ $XONSH_TRACE_COMPLETIONS = True
+    @ $XONSH_COMPLETER_TRACE = True
     @ pip c<TAB>
     TRACE COMPLETIONS: Getting completions with context:
     CompletionContext(command=CommandContext(args=(CommandArg(value='pip', opening_quote='', closing_quote=''),), arg_index=1, prefix='c', suffix='', opening_quote='', closing_quote='', is_after_closing_quote=False, subcmd_opening=''), python=PythonContext('pip c', 5, is_sub_expression=False))
-    TRACE COMPLETIONS: Got 3 results from exclusive completer 'pip':
-    {RichCompletion('cache', append_space=True),
-     RichCompletion('check', append_space=True),
-     RichCompletion('config', append_space=True)}
+    TRACE COMPLETIONS: Got 3 from exclusive 'pip' for 'c':
+    'cache': src=pip, type=exclusive, prefix_len=1, append_space=True
+    'check': src=pip, type=exclusive, prefix_len=1, append_space=True
+    'config': src=pip, type=exclusive, prefix_len=1, append_space=True
+
+The header reads as ``Got <N> from <type> '<name>' for '<prefix>'`` —
+showing the number of results, the completer's exclusivity, its name,
+and the prefix the completer tried to match. Each body line shows the
+completion value, the ``src`` (completer that produced it), the
+completer ``type`` (``exclusive`` or ``non-exclusive``), and any
+non-default ``RichCompletion`` attributes (``prefix_len``, ``display``,
+``description``, ``append_space``, ``close_quote`` — short for
+``append_closing_quote`` — ``style``, ``pvd`` — short for ``provider``).
+The format is grep-friendly, so you can filter by source or type,
+e.g. ``... | grep 'src=pip'`` or ``... | grep 'type=non-exclusive'``.
+
+Fine-grained origin via ``provider``
+------------------------------------
+
+A completer may set a ``provider`` tag on each ``RichCompletion`` to
+identify the sub-source inside the completer. This is trace-only
+metadata and does not affect the completion UX.
+
+For example, the ``base`` completer runs a union of Python names,
+``$PATH`` executables, aliases, and file paths. When you type the first
+argument and hit ``<TAB>``, the trace distinguishes them:
+
+.. code-block:: xonshcon
+
+    @ aliases['qwe-xonsh'] = 'echo'
+    @ xonsh<TAB>
+    TRACE COMPLETIONS: Got 2 from exclusive 'base' for 'xonsh':
+    'qwe-xonsh ': src=base, pvd='alias', type=exclusive, prefix_len=5, append_space=True
+    'xonsh ': src=base, pvd='command', type=exclusive, prefix_len=5, append_space=True
+
+Completers that are invoked but return no usable matches are also
+reported, so you can see the full decision path:
+
+.. code-block:: text
+
+    TRACE COMPLETIONS: Got 0 from non-exclusive 'environment_vars' for 'xonsh'.
+    TRACE COMPLETIONS: Got 0 from exclusive 'bash' for 'xonsh'.
+    TRACE COMPLETIONS: Got 3 from exclusive 'path' for './do':
+    ...
+
+This way you can see immediately that ``qwe-xonsh`` comes from an alias
+while ``xonsh`` is a real executable on ``$PATH``. Built-in providers:
+``alias``, ``command``, ``python``, ``path``, plus the xompletion module
+name (e.g. ``pip``, ``gh``) for completions produced by the ``xompleter``.
+Custom completers may set any string they like.
+
+Setting ``provider`` in your own completer
+------------------------------------------
+
+There are two ways to tag your completions, depending on whether you
+want per-item control or want to label the whole result at once.
+
+**Per-item**: pass ``provider=...`` directly to each ``RichCompletion``.
+This is most useful when a single completer has internal branches and
+you want to distinguish them in trace:
+
+.. code-block:: python
+
+    from xonsh.completers.tools import (
+        RichCompletion,
+        contextual_command_completer_for,
+    )
+
+    @contextual_command_completer_for("deploy")
+    def complete_deploy(command):
+        """Complete ``deploy <env>`` with fast- and slow-paths tagged."""
+        cached = {"prod", "staging"}       # e.g. loaded from a local cache
+        remote = {"dev-42", "dev-43"}      # e.g. hit an HTTP endpoint
+
+        for env in cached:
+            if env.startswith(command.prefix):
+                yield RichCompletion(env, provider="deploy:cache")
+        for env in remote:
+            if env.startswith(command.prefix):
+                yield RichCompletion(env, provider="deploy:remote")
+
+After ``completer add deploy complete_deploy`` the trace will show:
+
+.. code-block:: text
+
+    TRACE COMPLETIONS: Got 3 from exclusive 'deploy' for 'd':
+    'dev-42': src=deploy, pvd='deploy:remote', type=exclusive, prefix_len=1
+    'dev-43': src=deploy, pvd='deploy:remote', type=exclusive, prefix_len=1
+    'staging': src=deploy, pvd='deploy:cache', type=exclusive, prefix_len=1
+
+**Whole-result**: wrap the completer's return value with
+``tag_provider``. This preserves the return shape (``None``, iterable,
+or ``(comps, lprefix)`` tuple) and only tags completions that do not
+already carry their own ``provider``:
+
+.. code-block:: python
+
+    from xonsh.completers.tools import (
+        contextual_command_completer_for,
+        tag_provider,
+    )
+
+    @contextual_command_completer_for("mycmd")
+    def complete_mycmd(command):
+        """Completer whose entire output is tagged ``provider='mycmd'``."""
+        results = {"start", "stop", "status"}
+        return tag_provider(results, "mycmd")
+
+``tag_provider`` is also what the built-in ``xompleter`` uses under the
+hood to label each xompletion module's output — so any ``RichCompletion``
+that *already* specifies its own ``provider`` is kept intact and won't
+be overwritten by the outer tag.
 
 
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -232,3 +232,210 @@ def test_deduplicate_trailing_space(completer, completers_mock):
 def test_python_only_context(completer, completers_mock):
     assert completer.complete_line("echo @(") != ()
     assert completer.complete("", "echo @(", 0, 0, {}, "echo @(", 7) != ()
+
+
+def test_trace_completions_is_per_line_with_source(
+    completer, completers_mock, xession, monkeypatch, capsys
+):
+    """``$XONSH_COMPLETER_TRACE`` should print one line per completion,
+    each tagged with ``source=<completer-name>`` and non-default
+    ``RichCompletion`` attrs. See user request in conversation.
+    """
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+
+    completers_mock["commands"] = lambda *a: {
+        RichCompletion("ls", append_space=True),
+        "lsof",
+    }
+
+    completer.complete("l", "l", 0, 1, {}, multiline_text="l", cursor_index=1)
+    captured = capsys.readouterr().out
+
+    # Header still present — now compact form with prefix echoed back.
+    assert "Got 2 from exclusive 'commands' for 'l':" in captured
+    # Per-line source for every completion (shortened label ``src``).
+    assert captured.count("src=commands") == 2
+    # type= tag on every line.
+    assert captured.count("type=exclusive") == 2
+    # RichCompletion attribute shown.
+    assert "append_space=True" in captured
+    # Plain str shows the pipeline lprefix after ``type=``.
+    assert "'lsof': src=commands, type=exclusive, prefix_len=1" in captured
+    # No pprint-style dump of a set/list object.
+    assert "RichCompletion(" not in captured
+    # No two-space indent before completion lines.
+    assert "\n  'ls " not in captured and "\n  'lsof'" not in captured
+
+
+def test_trace_completions_non_exclusive_type(
+    completer, completers_mock, xession, monkeypatch, capsys
+):
+    """Trace lines from a non-exclusive completer must show ``type=non-exclusive``."""
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+
+    completers_mock["env"] = non_exclusive_completer(lambda *a: {"$FOO"})
+    completers_mock["cmd"] = lambda *a: {"ls"}
+
+    completer.complete("", "", 0, 0, {}, multiline_text="", cursor_index=0)
+    captured = capsys.readouterr().out
+
+    assert "'$FOO': src=env, type=non-exclusive" in captured
+    assert "'ls': src=cmd, type=exclusive" in captured
+
+
+def test_trace_completions_shows_provider(
+    completer, completers_mock, xession, monkeypatch, capsys
+):
+    """Completions with a ``provider`` tag must surface it in trace output.
+
+    Verifies the user-facing goal: telling that ``qwe-xonsh`` from the
+    ``base`` completer came from aliases rather than $PATH. We mock the
+    ``base`` completer directly so the test doesn't depend on the real
+    commands_cache/filesystem.
+    """
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+
+    completers_mock["base"] = lambda *a: {
+        RichCompletion("qwe-xonsh ", append_space=True, provider="alias"),
+        RichCompletion("xonsh-real ", append_space=True, provider="command"),
+    }
+
+    completer.complete(
+        "xonsh", "xonsh", 0, 5, {}, multiline_text="xonsh", cursor_index=5
+    )
+    captured = capsys.readouterr().out
+
+    # pvd sits immediately after src, before type.
+    assert "src=base, pvd='alias', type=exclusive" in captured
+    assert "src=base, pvd='command', type=exclusive" in captured
+
+
+def test_tag_provider_preserves_return_shapes():
+    """``tag_provider`` must accept None / iterable / (iter, extra) tuple."""
+    from xonsh.completers.tools import tag_provider
+
+    # None passthrough
+    assert tag_provider(None, "x") is None
+
+    # bare iterable
+    out = list(tag_provider(["a", RichCompletion("b")], "pip"))
+    assert all(c.provider == "pip" for c in out)
+    assert [str(c) for c in out] == ["a", "b"]
+
+    # (iterable, extra) tuple — extra preserved, comps tagged
+    gen, extra = tag_provider((["a"], 3), "gh")
+    assert extra == 3
+    assert [c.provider for c in gen] == ["gh"]
+
+
+def test_tag_provider_does_not_overwrite_existing():
+    """A completion with an existing ``provider`` keeps its own tag."""
+    from xonsh.completers.tools import tag_provider
+
+    out = list(tag_provider([RichCompletion("x", provider="inner"), "y"], "outer"))
+    assert out[0].provider == "inner"
+    assert out[1].provider == "outer"
+
+
+def test_xompleter_tags_with_module_basename():
+    """``CommandCompleter`` must tag xompletion results with module basename.
+
+    Verifies that ``xompletions.<name>.xonsh_complete`` output is wrapped
+    so the trace shows ``provider=<name>`` — the ``xompleter`` bridging
+    layer discussed in the user conversation.
+    """
+    from types import SimpleNamespace
+
+    from xonsh.completers.commands import CommandCompleter
+    from xonsh.parsers.completion_context import (
+        CommandArg,
+        CommandContext,
+        CompletionContext,
+    )
+
+    fake_module = SimpleNamespace(
+        __name__="xompletions.fake_pip",
+        xonsh_complete=lambda ctx: {RichCompletion("install"), "freeze"},
+    )
+    cc = CommandCompleter()
+    cc._matcher = SimpleNamespace(
+        get_module=lambda name: fake_module,
+        search_completer=lambda name, cleaned=False: None,
+    )
+
+    full_ctx = CompletionContext(
+        command=CommandContext(args=(CommandArg("fake_pip"),), arg_index=1, prefix="")
+    )
+    result = list(cc(full_ctx))
+    assert {str(c) for c in result} == {"install", "freeze"}
+    assert all(c.provider == "fake_pip" for c in result)
+
+
+def test_xompleter_passes_through_none():
+    """If the xompletion module returns ``None`` (no match), ``CommandCompleter``
+    must still pass ``None`` through so the pipeline falls to the next completer.
+    """
+    from types import SimpleNamespace
+
+    from xonsh.completers.commands import CommandCompleter
+    from xonsh.parsers.completion_context import (
+        CommandArg,
+        CommandContext,
+        CompletionContext,
+    )
+
+    fake_module = SimpleNamespace(
+        __name__="xompletions.fake_pip",
+        xonsh_complete=lambda ctx: None,
+    )
+    cc = CommandCompleter()
+    cc._matcher = SimpleNamespace(
+        get_module=lambda name: fake_module,
+        search_completer=lambda name, cleaned=False: None,
+    )
+
+    full_ctx = CompletionContext(
+        command=CommandContext(args=(CommandArg("fake_pip"),), arg_index=1, prefix="")
+    )
+    assert cc(full_ctx) is None
+
+
+def test_trace_completions_uses_close_quote_alias(
+    completer, completers_mock, xession, monkeypatch, capsys
+):
+    """``append_closing_quote=False`` should surface as ``close_quote=False``."""
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+
+    completers_mock["a"] = lambda *a: {
+        RichCompletion("foo", append_closing_quote=False)
+    }
+
+    completer.complete("f", "f", 0, 1, {}, multiline_text="f", cursor_index=1)
+    captured = capsys.readouterr().out
+
+    assert "close_quote=False" in captured
+    assert "append_closing_quote" not in captured
+
+
+def test_trace_completions_reports_zero_results(
+    completer, completers_mock, xession, monkeypatch, capsys
+):
+    """A completer that is invoked but returns nothing still gets a header.
+
+    Lets the user see which completers ran even when they produce no
+    matches. Non-exclusive completers with 0 results must also be shown.
+    """
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+
+    completers_mock["first"] = non_exclusive_completer(lambda *a: None)
+    completers_mock["second"] = lambda *a: set()
+    completers_mock["third"] = lambda *a: {"real"}
+
+    completer.complete("pre", "", 0, 0)
+    captured = capsys.readouterr().out
+
+    assert "TRACE COMPLETIONS: Got 0 from non-exclusive 'first' for 'pre'." in captured
+    assert "TRACE COMPLETIONS: Got 0 from exclusive 'second' for 'pre'." in captured
+    assert "TRACE COMPLETIONS: Got 1 from exclusive 'third' for 'pre':" in captured
+    # 0-result header ends with "." and has no body lines.
+    assert "from non-exclusive 'first' for 'pre'.\n" in captured

--- a/tests/test_completer_empty_llm.py
+++ b/tests/test_completer_empty_llm.py
@@ -1,0 +1,101 @@
+"""Tests for empty-completion fallthrough in ``xonsh.completer``.
+
+See https://github.com/xonsh/xonsh/issues/5810 and the related
+https://github.com/xonsh/xonsh/issues/5809 — an exclusive completer that
+returns only empty or whitespace-only items must not short-circuit the
+completer pipeline, so that fallback completers (``python``, ``path``,
+etc.) still get a chance to run.
+"""
+
+import pytest
+
+from xonsh.completer import Completer
+from xonsh.completers.tools import (
+    RichCompletion,
+    complete_from_sub_proc,
+    completion_from_cmd_output,
+    non_exclusive_completer,
+)
+
+
+@pytest.fixture(scope="session")
+def completer():
+    return Completer()
+
+
+@pytest.fixture
+def completers_mock(xession, monkeypatch):
+    completers = {}
+    monkeypatch.setattr(xession, "_completers", completers)
+    return completers
+
+
+@pytest.mark.parametrize(
+    "bad_result",
+    (
+        {""},
+        {" "},
+        {"  ", "\t"},
+        {"\n"},
+    ),
+)
+def test_empty_completer_falls_through_to_next(completer, completers_mock, bad_result):
+    """An exclusive completer returning only blanks must not block the chain."""
+    completers_mock["bad"] = lambda *a: bad_result
+    completers_mock["good"] = lambda *a: {"real"}
+
+    assert completer.complete("pre", "", 0, 0) == (("real",), 3)
+
+
+def test_mixed_valid_and_empty_filters_empty(completer, completers_mock):
+    """Blank items are filtered, but valid ones keep the completer exclusive."""
+    completers_mock["mixed"] = lambda *a: {"real1", "", "real2", "  "}
+    completers_mock["fallback"] = lambda *a: {"fallback"}
+
+    comps, _ = completer.complete("pre", "", 0, 0)
+    # Empties are dropped; the valid items remain and fallback is NOT reached.
+    assert set(comps) == {"real1", "real2"}
+
+
+def test_rich_completion_with_empty_value_is_skipped(completer, completers_mock):
+    """``RichCompletion`` with an empty value must be skipped just like ``''``."""
+    completers_mock["bad"] = lambda *a: {RichCompletion("", display="hint")}
+    completers_mock["good"] = lambda *a: {"real"}
+
+    comps, _ = completer.complete("pre", "", 0, 0)
+    assert "real" in comps
+    assert "" not in (str(c) for c in comps)
+
+
+def test_non_exclusive_empty_still_yields_to_others(completer, completers_mock):
+    """Even a non-exclusive completer's blanks should not leak into results."""
+    completers_mock["a"] = non_exclusive_completer(lambda *a: {"", " "})
+    completers_mock["b"] = lambda *a: {"real"}
+
+    comps, _ = completer.complete("pre", "", 0, 0)
+    assert set(comps) == {"real"}
+
+
+def test_complete_from_sub_proc_skips_blank_lines(fake_process, xession):
+    """``complete_from_sub_proc`` must not emit empty RichCompletion objects.
+
+    Simulates a subprocess whose stdout has interleaved blank lines — a common
+    symptom of the original #5809 ``aws s3 cp`` issue at the helper layer.
+    """
+    fake_process.register_subprocess(
+        command=["somecmd", fake_process.any()],
+        stdout=b"good1\n\n  \n\ngood2\n",
+    )
+
+    results = list(complete_from_sub_proc("somecmd", "arg"))
+    values = [str(r) for r in results]
+    assert values == ["good1", "good2"]
+    # ``completion_from_cmd_output`` uses ``append_space=True`` only when
+    # there is a single candidate; two here means no trailing space.
+    assert all(not v.endswith(" ") for v in values)
+
+
+def test_completion_from_cmd_output_strips_whitespace():
+    """Sanity: the helper still trims whitespace on non-blank input."""
+    comp = completion_from_cmd_output("  hello  ")
+    assert str(comp) == "hello"

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -6,6 +6,7 @@ import typing as tp
 
 from xonsh.built_ins import XSH
 from xonsh.completers.tools import (
+    RICH_COMPLETION_DEFAULTS,
     Completion,
     RichCompletion,
     apply_lprefix,
@@ -175,6 +176,44 @@ class Completer:
 
         return completion, lprefix
 
+    # Renames applied to ``RichCompletion`` attribute names in trace
+    # output only; the Python attributes themselves are unchanged.
+    _TRACE_ATTR_ALIASES = {
+        "append_closing_quote": "close_quote",
+    }
+
+    @staticmethod
+    def _format_trace_item(comp, lprefix, source: str, exclusive: bool) -> str:
+        """Render one completion as a single ``$XONSH_COMPLETER_TRACE`` line.
+
+        Format::
+
+            "value": src=<completer>, pvd=<sub-source>, type=<exclusive|non-exclusive>, <non-default RichCompletion attrs>
+
+        ``pvd`` (provider) is placed right after ``src`` (source) when
+        set, so the two origin fields stay visually adjacent. Other
+        non-default ``RichCompletion`` fields (``prefix_len``,
+        ``display``, ``description``, ``append_space``, ``close_quote``
+        — short for ``append_closing_quote`` — and ``style``) are
+        appended afterwards. Plain ``str`` completions fall back to
+        showing the pipeline's ``lprefix``.
+        """
+        parts = [f"src={source}"]
+        if isinstance(comp, RichCompletion) and comp.provider is not None:
+            parts.append(f"pvd={comp.provider!r}")
+        parts.append(f"type={'exclusive' if exclusive else 'non-exclusive'}")
+        if isinstance(comp, RichCompletion):
+            for name, default in RICH_COMPLETION_DEFAULTS:
+                if name == "provider":
+                    continue  # already placed right after ``src``
+                val = getattr(comp, name)
+                if val != default:
+                    label = Completer._TRACE_ATTR_ALIASES.get(name, name)
+                    parts.append(f"{label}={val!r}")
+        else:
+            parts.append(f"prefix_len={lprefix}")
+        return f"{str(comp)!r}: {', '.join(parts)}"
+
     @staticmethod
     def generate_completions(
         completion_context, old_completer_args, trace: bool
@@ -233,47 +272,68 @@ class Completer:
             else:
                 res = out
 
-            if res is None:
-                continue
+            # Completer was invoked (didn't raise, wasn't skipped by the
+            # contextual gate). Process its output into ``items``; note
+            # that ``res is None`` is valid — it just yields an empty
+            # ``items``, and trace will report ``Got 0 results``.
+            items: list = []
+            if res is not None:
+                for comp in res:
+                    if (not is_filtered) and (not filter_func(comp, prefix)):
+                        continue
+                    # Skip empty or whitespace-only completions as if the
+                    # completer had not returned them. Without this an
+                    # exclusive completer that yields only blanks (e.g. a
+                    # subprocess-based completer returning spurious empty
+                    # lines) would short-circuit the pipeline and hide
+                    # the fallback ``python``/``path`` completers. See #5810.
+                    if not str(comp).strip():
+                        continue
+                    comp = Completer._format_completion(
+                        comp,
+                        completion_context,
+                        completing_contextual_command,
+                        lprefix or 0,
+                        custom_lprefix,
+                    )
+                    items.append(comp)
+                    yield comp
 
-            items = []
-            for comp in res:
-                if (not is_filtered) and (not filter_func(comp, prefix)):
-                    continue
-                # Skip empty or whitespace-only completions as if the
-                # completer had not returned them. Without this an
-                # exclusive completer that yields only blanks (e.g. a
-                # subprocess-based completer returning spurious empty
-                # lines) would short-circuit the pipeline and hide the
-                # fallback ``python``/``path`` completers. See #5810.
-                if not str(comp).strip():
-                    continue
-                comp = Completer._format_completion(
-                    comp,
-                    completion_context,
-                    completing_contextual_command,
-                    lprefix or 0,
-                    custom_lprefix,
-                )
-                items.append(comp)
-                yield comp
+            exclusive = is_exclusive_completer(func)
+
+            if trace:
+                exclusivity = "exclusive" if exclusive else "non-exclusive"
+                if not items:
+                    # Completer was invoked but produced nothing usable —
+                    # still report it so the user can see which completers
+                    # ran. Trailing ``.`` since no list follows.
+                    print(
+                        f"TRACE COMPLETIONS: Got 0"
+                        f" from {exclusivity} '{name}'"
+                        f" for {prefix!r}."
+                    )
+                else:
+                    print(
+                        f"TRACE COMPLETIONS: Got {len(items)}"
+                        f" from {exclusivity} '{name}'"
+                        f" for {prefix!r}:"
+                    )
+                    for item_comp, item_lprefix in items:
+                        print(
+                            Completer._format_trace_item(
+                                item_comp, item_lprefix, name, exclusive
+                            )
+                        )
 
             if not items:  # empty completion
                 continue
 
-            if trace:
-                print(
-                    f"TRACE COMPLETIONS: Got {len(items)} results"
-                    f" from {'' if is_exclusive_completer(func) else 'non-'}exclusive completer '{name}':"
-                )
-                sys.displayhook(items)
-
-            if is_exclusive_completer(func):
+            if exclusive:
                 # we got completions for an exclusive completer
                 break
 
     def complete_from_context(self, completion_context, old_completer_args=None):
-        trace = XSH.env.get("XONSH_TRACE_COMPLETIONS")
+        trace = XSH.env.get("XONSH_COMPLETER_TRACE")
         if trace:
             print("\nTRACE COMPLETIONS: Getting completions with context:")
             sys.displayhook(completion_context)

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -240,6 +240,14 @@ class Completer:
             for comp in res:
                 if (not is_filtered) and (not filter_func(comp, prefix)):
                     continue
+                # Skip empty or whitespace-only completions as if the
+                # completer had not returned them. Without this an
+                # exclusive completer that yields only blanks (e.g. a
+                # subprocess-based completer returning spurious empty
+                # lines) would short-circuit the pipeline and hide the
+                # fallback ``python``/``path`` completers. See #5810.
+                if not str(comp).strip():
+                    continue
                 comp = Completer._format_completion(
                     comp,
                     completion_context,

--- a/xonsh/completers/base.py
+++ b/xonsh/completers/base.py
@@ -5,7 +5,7 @@ import collections.abc as cabc
 from xonsh.completers.commands import complete_command
 from xonsh.completers.path import contextual_complete_path
 from xonsh.completers.python import complete_python
-from xonsh.completers.tools import apply_lprefix, contextual_completer
+from xonsh.completers.tools import apply_lprefix, contextual_completer, tag_provider
 from xonsh.parsers.completion_context import CompletionContext
 
 
@@ -22,11 +22,11 @@ def complete_base(context: CompletionContext):
     python_comps = complete_python(context) or set()
     if isinstance(python_comps, cabc.Sequence):
         python_comps, python_comps_len = python_comps  # type: ignore
-        yield from apply_lprefix(python_comps, python_comps_len)
+        yield from tag_provider(apply_lprefix(python_comps, python_comps_len), "python")
     else:
-        yield from python_comps
+        yield from tag_provider(python_comps, "python")
 
-    # add command completions
+    # add command completions (they tag themselves with alias/command)
     yield from complete_command(context.command)
 
     # add paths, if needed
@@ -34,4 +34,4 @@ def complete_base(context: CompletionContext):
         path_comps, path_comp_len = contextual_complete_path(
             context.command, cdpath=False
         )
-        yield from apply_lprefix(path_comps, path_comp_len)
+        yield from tag_provider(apply_lprefix(path_comps, path_comp_len), "path")

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -12,6 +12,7 @@ from xonsh.completers.tools import (
     contextual_command_completer,
     get_filter_function,
     non_exclusive_completer,
+    tag_provider,
 )
 from xonsh.lib.modules import ModuleFinder
 from xonsh.parsers.completion_context import CommandContext, CompletionContext
@@ -33,16 +34,21 @@ def complete_command(command: CommandContext):
             kwargs = {}
             if show_desc:
                 kwargs["description"] = "Alias" if is_alias else path
-            yield RichCompletion(s, append_space=True, **kwargs)  # type: ignore
+            yield RichCompletion(
+                s,
+                append_space=True,
+                provider="alias" if is_alias else "command",
+                **kwargs,
+            )  # type: ignore
     if xp.ON_WINDOWS:
         for i in executables_in("."):
             if get_filter_function()(i, cmd):
-                yield RichCompletion(i, append_space=True)
+                yield RichCompletion(i, append_space=True, provider="command")
     base = os.path.basename(cmd)
     if os.path.isdir(base):
         for i in executables_in(base):
             if get_filter_function()(i, cmd):
-                yield RichCompletion(os.path.join(base, i))
+                yield RichCompletion(os.path.join(base, i), provider="command")
 
 
 @contextual_command_completer
@@ -194,7 +200,12 @@ class CommandCompleter:
 
         if hasattr(module, "xonsh_complete"):
             func = module.xonsh_complete
-            return func(ctx)
+            # Tag results with the xompletion module's short name
+            # (``xompletions.pip`` → ``pip``) so ``$XONSH_COMPLETER_TRACE``
+            # can tell which concrete module produced each completion
+            # under the generic ``source=xompleter`` umbrella.
+            provider = module.__name__.rsplit(".", 1)[-1]
+            return tag_provider(func(ctx), provider)
 
 
 complete_xompletions = CommandCompleter()

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -31,15 +31,13 @@ def complete_command(command: CommandContext):
     show_desc = (XSH.env or {}).get("CMD_COMPLETIONS_SHOW_DESC", False)
     for s, (path, is_alias) in XSH.commands_cache.iter_commands():
         if get_filter_function()(s, cmd):
-            kwargs = {}
-            if show_desc:
-                kwargs["description"] = "Alias" if is_alias else path
+            description = ("Alias" if is_alias else path) if show_desc else ""
             yield RichCompletion(
                 s,
                 append_space=True,
                 provider="alias" if is_alias else "command",
-                **kwargs,
-            )  # type: ignore
+                description=description,
+            )
     if xp.ON_WINDOWS:
         for i in executables_in("."):
             if get_filter_function()(i, cmd):

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -268,6 +268,11 @@ def complete_from_sub_proc(*args: str, sep=None, filter_prefix=None, **env_vars:
         else:
             lines = output.split(sep)
 
+        # Drop blank lines before counting / yielding so that a subprocess
+        # emitting trailing/extra whitespace doesn't produce empty
+        # RichCompletion objects (see #5810).
+        lines = [ln for ln in lines if ln.strip()]
+
         # if there is a single completion candidate then maybe it is over
         append_space = len(lines) == 1 and not lines[0].rstrip().endswith(os.sep)
         for line in lines:

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -64,6 +64,7 @@ class RichCompletion(str):
         style: str = "",
         append_closing_quote: bool = True,
         append_space: bool = False,
+        provider: str | None = None,
     ):
         """
         Parameters
@@ -88,6 +89,13 @@ class RichCompletion(str):
             This is intended to work with ``appending_closing_quote``, so the space will be added correctly **after** the closing quote.
             This is used in ``Completer.complete``.
             An extra bonus is that the space won't show up in the ``display`` attribute.
+        provider :
+            Optional, debug-only tag identifying the sub-source inside the
+            completer that produced this completion (e.g. ``"alias"``,
+            ``"command"``, ``"python"``, ``"path"``). Surfaced by
+            ``$XONSH_COMPLETER_TRACE`` so users can tell whether a match
+            came from, say, an alias vs. a ``$PATH`` executable inside the
+            same ``base`` completer. Does not affect UX.
         """
         super().__init__()
         self.prefix_len = prefix_len
@@ -96,6 +104,7 @@ class RichCompletion(str):
         self.style = style
         self.append_closing_quote = append_closing_quote
         self.append_space = append_space
+        self.provider = provider
 
     @property
     def value(self):
@@ -209,6 +218,40 @@ def apply_lprefix(comps, lprefix):
                 yield comp
         else:
             yield RichCompletion(comp, prefix_len=lprefix)
+
+
+def _tag_each(comps, provider: str):
+    """Yield completions with ``provider`` set, promoting ``str`` to
+    ``RichCompletion``. A completion that already has a ``provider`` keeps
+    its own — lets a nested completer override the outer tag.
+    """
+    for comp in comps:
+        if isinstance(comp, RichCompletion):
+            if comp.provider is None:
+                yield comp.replace(provider=provider)
+            else:
+                yield comp
+        else:
+            yield RichCompletion(comp, provider=provider)
+
+
+def tag_provider(result, provider: str):
+    """Tag completer output with ``provider`` for ``$XONSH_COMPLETER_TRACE``.
+
+    Accepts any of the three standard completer return shapes and
+    preserves the shape so downstream pipeline logic (exclusivity,
+    filtering, lprefix) is unaffected:
+
+    - ``None`` → returned unchanged.
+    - ``(comps, extra)`` 2-tuple → ``(tagged_generator, extra)``.
+    - Any other iterable → generator of tagged completions.
+    """
+    if result is None:
+        return None
+    if isinstance(result, tuple) and len(result) == 2:
+        comps, extra = result
+        return _tag_each(comps, provider), extra
+    return _tag_each(result, provider)
 
 
 def completion_from_cmd_output(line: str, append_space=False):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2194,9 +2194,11 @@ The file should contain a function with the signature
         "Set to ``':::'`` to enable, then type ``:::<TAB>`` or ``:::arrow<TAB>`` to search. "
         "Default is ``None`` (disabled).",
     )
-    XONSH_TRACE_COMPLETIONS = Var.with_default(
+    XONSH_COMPLETER_TRACE = Var.with_default(
         False,
-        "Set to ``True`` to show completers invoked and their return values.",
+        "Set to ``True`` to show completers invoked and their return values. "
+        "Each completion is printed on its own line with its ``source`` "
+        "completer and any non-default ``RichCompletion`` attributes.",
     )
 
 


### PR DESCRIPTION

* Fixes https://github.com/xonsh/xonsh/issues/5810
* Fixes https://github.com/xonsh/xonsh/issues/6292

### Implementation

* Skip empty completion results
* Reimplemented tracing
* Added docs

### Before

```xsh
$XONSH_TRACE_COMPLETIONS=1
# The list of completions without source
```

### After

```xsh
/private/tmp @ $XONSH_COMPLETER_TRACE=1
/private/tmp @ aliases['qwe-xonsh']='echo'
/private/tmp @ xon
TRACE COMPLETIONS: Getting completions with context:
TRACE COMPLETIONS: Got 0 from non-exclusive 'end_proc_tokens' for 'xon'.
TRACE COMPLETIONS: Got 0 from non-exclusive 'end_proc_keywords' for 'xon'.
TRACE COMPLETIONS: Got 0 from non-exclusive 'environment_vars' for 'xon'.
TRACE COMPLETIONS: Got 13 from exclusive 'base' for 'xon':
'__xonsh__': src=base, pvd='python', type=exclusive, prefix_len=3
'XonshCalledProcessError': src=base, pvd='python', type=exclusive, prefix_len=3
'XonshError': src=base, pvd='python', type=exclusive, prefix_len=3
'xonsh-uname ': src=base, pvd='command', type=exclusive, prefix_len=3, append_space=True
'rust-xonsh ': src=base, pvd='command', type=exclusive, prefix_len=3, append_space=True
'xonsh-uptime ': src=base, pvd='command', type=exclusive, prefix_len=3, append_space=True
'xonsh-cat ': src=base, pvd='command', type=exclusive, prefix_len=3, append_space=True
'xonsh ': src=base, pvd='command', type=exclusive, prefix_len=3, append_space=True
'xbin-xonsh ': src=base, pvd='command', type=exclusive, prefix_len=3, append_space=True
'xonfig ': src=base, pvd='alias', type=exclusive, prefix_len=3, append_space=True
'xontrib ': src=base, pvd='alias', type=exclusive, prefix_len=3, append_space=True
'xxonsh ': src=base, pvd='alias', type=exclusive, prefix_len=3, append_space=True
'qwe-xonsh ': src=base, pvd='alias', type=exclusive, prefix_len=3, append_space=True 🟢 

CompletionContext(command=CommandContext(args=(), arg_index=0, prefix='xon', suffix='', opening_quote='', closing_quote='', is_after_closing_quote=False, subcmd_opening=''), python=PythonContext('xon', 3, is_sub_expression=False))

```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
