### PR TITLE
fix: filter out empty/whitespace-only completions

### DIFF
--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -44,6 +44,23 @@ def test_sanity(completer, completers_mock):
     )
 
 
+def test_empty_completions_filtered(completer, completers_mock):
+    """Completers returning only empty/whitespace values should be treated as
+    returning no completions (see #5809, #5810)."""
+    # whitespace-only completion:
+    completers_mock["a"] = lambda *a: {" "}
+    assert completer.complete("pre", "", 0, 0) == ((), 0)
+    # empty string completion:
+    completers_mock["a"] = lambda *a: {""}
+    assert completer.complete("pre", "", 0, 0) == ((), 0)
+    # RichCompletion with whitespace-only value:
+    completers_mock["a"] = lambda *a: {RichCompletion(" ", prefix_len=3)}
+    assert completer.complete("pre", "", 0, 0) == ((), 0)
+    # mix of empty and valid completions keeps valid ones:
+    completers_mock["a"] = lambda *a: {"", " ", "valid"}
+    assert completer.complete("pre", "", 0, 0) == (("valid",), 3)
+
+
 def test_cursor_after_closing_quote(completer, completers_mock):
     """See ``Completer.complete`` in ``xonsh/completer.py``"""
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -236,6 +236,12 @@ class Completer:
             if res is None:
                 continue
 
+            # Filter out empty completions (e.g. whitespace-only values)
+            # to prevent them from appearing as valid results (see #5809).
+            res = [c for c in res if str(c).strip()]
+            if not res:
+                continue
+
             items = []
             for comp in res:
                 if (not is_filtered) and (not filter_func(comp, prefix)):


### PR DESCRIPTION
## Summary

Fixes #5810 and #5809.

Completers returning only empty or whitespace-only values (e.g. `{" "}`) now have those values filtered out before processing. If all returned values are empty/whitespace-only, the completer result is treated as `None` (no completions), preventing empty entries from appearing in the tab-completion menu.

## Changes

- **`xonsh/completer.py`**: Added filtering of empty/whitespace-only completion values in `generate_completions()` after the `res is None` check
- **`tests/test_completer.py`**: Added `test_empty_completions_filtered` covering whitespace-only strings, empty strings, `RichCompletion` with whitespace, and mixed valid/empty completions

## Test plan

- [x] All 13 existing `test_completer.py` tests pass
- [x] New `test_empty_completions_filtered` passes with 4 sub-cases
- [ ] Manual verification: `aws s3 cp <tab>` no longer shows empty completion entry

🤖 Generated with [Claude Code](https://claude.ai/claude-code)