### PR TITLE
fix: Rename XONSH_TRACE_SUBPROC to XONSH_SUBPROC_TRACE and remove XONSH_TRACE_SUBPROC_FUNC

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue.md
+++ b/.github/ISSUE_TEMPLATE/new-issue.md
@@ -11,7 +11,7 @@ assignees: ''
 <!---
 For general xonsh issues, please try to replicate the failure using `xonsh --no-rc --no-env`.
 Short, reproducible code snippets are highly appreciated.
-You can use `$XONSH_SHOW_TRACEBACK=1`, `$XONSH_TRACE_SUBPROC=2`, or `$XONSH_DEBUG=1`
+You can use `$XONSH_SHOW_TRACEBACK=1`, `$XONSH_SUBPROC_TRACE=2`, or `$XONSH_DEBUG=1`
 to collect more information about the failure.
 -->
 

--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -94,7 +94,7 @@ This page provides xonsh equivalents for common patterns in Bash.
         ``$XONSH_SUBPROC_CMD_RAISE_ERROR = True`` to additionally raise on
         *every* failing individual command.
     * - ``set -x``
-      - ``trace on`` and ``$XONSH_TRACE_SUBPROC = True``
+      - ``trace on`` and ``$XONSH_SUBPROC_TRACE = True``
       - Turns on tracing of source code lines during execution.
     * - ``&&``
       - ``&&`` or ``and``
@@ -144,11 +144,11 @@ This page provides xonsh equivalents for common patterns in Bash.
       - ``exit 1`` or ``exit(1)``
       - Exiting from the current script.
 
-To understand how xonsh executes the subprocess commands try ``showcmd`` or set :ref:`$XONSH_TRACE_SUBPROC <xonsh_trace_subproc>` to ``True``:
+To understand how xonsh executes the subprocess commands try ``showcmd`` or set :ref:`$XONSH_SUBPROC_TRACE <xonsh_subproc_trace>` to ``True``:
 
 .. code-block:: xonshcon
 
-    @ $XONSH_TRACE_SUBPROC = True
+    @ $XONSH_SUBPROC_TRACE = True
     @ echo $(echo @('hello')) @('wor' + 'ld') | grep hello
     TRACE SUBPROC: (['echo', 'hello'],)
     TRACE SUBPROC: (['echo', 'hello\n', 'world'], '|', ['grep', 'hello'])

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -735,11 +735,11 @@ With great power, and so forth...
           inside of them.
 
 To understand how xonsh executes the subprocess commands try
-to set :ref:`$XONSH_TRACE_SUBPROC <xonsh_trace_subproc>` to ``True``:
+to set :ref:`$XONSH_SUBPROC_TRACE <xonsh_subproc_trace>` to ``True``:
 
 .. code-block:: xonshcon
 
-    @ $XONSH_TRACE_SUBPROC = True
+    @ $XONSH_SUBPROC_TRACE = True
     @ $[@$(which @($(echo ls).strip())) @('-' + $(printf 'l'))]
     TRACE SUBPROC: (['echo', 'ls'],)
     TRACE SUBPROC: (['which', 'ls'],)

--- a/run-tests.xsh
+++ b/run-tests.xsh
@@ -10,7 +10,7 @@ import itertools
 
 
 $XONSH_SUBPROC_CMD_RAISE_ERROR = True
-# $XONSH_TRACE_SUBPROC = True
+# $XONSH_SUBPROC_TRACE = True
 
 
 def colored_tracer(cmds, **_):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1371,25 +1371,27 @@ class SubprocessSetting(Xettings):
         "xonsh process threads sleep for while running command pipelines. "
         "The value has units of seconds [s].",
     )
-    XONSH_TRACE_SUBPROC = Var(
+    XONSH_SUBPROC_TRACE = Var(
         default=False,
-        validate=is_bool_or_int,
-        convert=to_bool_or_int,
+        validate=lambda x: callable(x) or is_bool_or_int(x),
+        convert=lambda x: x if callable(x) else to_bool_or_int(x),
         doc="Set to ``True`` or ``1`` to show arguments list of every executed subprocess command. "
-        "Use ``2`` to have a specification. Use ``3`` to have full specification.",
-    )
-    XONSH_TRACE_SUBPROC_FUNC = Var.with_default(
-        None,
-        doc=(
-            "A callback function used to format the trace output shown when ``$XONSH_TRACE_SUBPROC=True``."
-        ),
+        "Use ``2`` to have a specification. Use ``3`` to have full specification. "
+        "Alternatively assign a callable ``f(cmds, captured=..., specs=...)`` to format "
+        "the trace output yourself — it is invoked instead of the default printer. "
+        "``specs`` is the list of :class:`SubprocSpec` objects about to be executed; "
+        "``CommandPipeline`` is not yet built at this point.",
         doc_default="""\
     By default it just prints ``cmds`` like below.
 
     .. code-block:: python
 
-        def tracer(cmds: list, captured: Union[bool, str]):
+        def _tracer(cmds, captured, specs):
+            # ``specs`` is a list of SubprocSpec — use e.g. ``s.args``,
+            # ``s.alias``, ``s.binary_loc``, ``s.threadable`` for details.
             print(f"TRACE SUBPROC: {cmds}, captured={captured}", file=sys.stderr)
+
+        $XONSH_SUBPROC_TRACE = _tracer
     """,
     )
 

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -1106,48 +1106,56 @@ def _update_proc_alias_captured(proc):
     proc.captured = getattr(proc.alias, "__xonsh_capturable__", proc.captured)
 
 
-def _trace_specs(trace_mode, specs, cmds, captured):
-    """Show information about specs."""
-    tracer = XSH.env.get("XONSH_TRACE_SUBPROC_FUNC", None)
-    if callable(tracer):
-        tracer(cmds, captured=captured)
-    else:
-        r = {"cmds": cmds, "captured": captured}
-        print(f"Trace run_subproc({repr(r)})", file=sys.stderr)
-        if trace_mode >= 2:
-            for i, s in enumerate(specs):
-                pcls = s.cls.__module__ + "." + s.cls.__name__
-                pcmd = (
-                    [s.args[0].__name__] + s.args[1:] if callable(s.args[0]) else s.args
-                )
-                p = {
-                    "cmd": pcmd,
-                    "cls": pcls,
-                }
+def _trace_specs(trace, specs, cmds, captured):
+    """Show information about specs.
+
+    ``trace`` is the value of ``$XONSH_SUBPROC_TRACE``. If it's a
+    callable, it's used as the formatter — called as
+    ``trace(cmds, captured=<str|bool>, specs=<list[SubprocSpec]>)``.
+    ``specs`` exposes per-command ``args``, ``alias``, ``binary_loc``,
+    ``threadable`` and friends. ``CommandPipeline`` is *not* available
+    at this point — it's built later, during ``_run_specs``.
+
+    Otherwise ``trace`` is a verbosity int (1/2/3) for the default
+    printer.
+    """
+    if callable(trace):
+        trace(cmds, captured=captured, specs=specs)
+        return
+    r = {"cmds": cmds, "captured": captured}
+    print(f"Trace run_subproc({repr(r)})", file=sys.stderr)
+    if trace >= 2:
+        for i, s in enumerate(specs):
+            pcls = s.cls.__module__ + "." + s.cls.__name__
+            pcmd = [s.args[0].__name__] + s.args[1:] if callable(s.args[0]) else s.args
+            p = {
+                "cmd": pcmd,
+                "cls": pcls,
+            }
+            p |= {
+                a: getattr(s, a, None)
+                for a in [
+                    "alias_name",
+                    "alias",
+                    "binary_loc",
+                    "threadable",
+                    "background",
+                ]
+            }
+            if trace == 3:
                 p |= {
                     a: getattr(s, a, None)
                     for a in [
-                        "alias_name",
-                        "alias",
-                        "binary_loc",
-                        "threadable",
-                        "background",
+                        "stdin",
+                        "stdout",
+                        "stderr",
+                        "captured",
+                        "captured_stdout",
+                        "captured_stderr",
                     ]
                 }
-                if trace_mode == 3:
-                    p |= {
-                        a: getattr(s, a, None)
-                        for a in [
-                            "stdin",
-                            "stdout",
-                            "stderr",
-                            "captured",
-                            "captured_stdout",
-                            "captured_stderr",
-                        ]
-                    }
-                p = {k: v for k, v in p.items() if v is not None}
-                print(f"{i}: {repr(p)}", file=sys.stderr)
+            p = {k: v for k, v in p.items() if v is not None}
+            print(f"{i}: {repr(p)}", file=sys.stderr)
 
 
 def cmds_to_specs(cmds, captured=False, envs=None, in_boolop=False):
@@ -1256,8 +1264,8 @@ def run_subproc(cmds, captured=False, envs=None, in_boolop=False):
 
     specs = cmds_to_specs(cmds, captured=captured, envs=envs, in_boolop=in_boolop)
 
-    if trace_mode := XSH.env.get("XONSH_TRACE_SUBPROC", False):
-        _trace_specs(trace_mode, specs, cmds, captured)
+    if trace := XSH.env.get("XONSH_SUBPROC_TRACE", False):
+        _trace_specs(trace, specs, cmds, captured)
 
     cmds = [
         _flatten_cmd_redirects(cmd) if isinstance(cmd, list) else cmd for cmd in cmds


### PR DESCRIPTION
### Motivation

We have a convention `XONSH_<COMPONENT>_<SETTING>` so it's fix of this.
Trace func is also redundant and we can assign function to the main env var.

### Implementation

Changes are reflected to the docs and code.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
