### PR TITLE
feat(parser): Add correct parsing of `builtin --builtin` to `$XONSH_BUILTINS_TO_CMD`

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -150,6 +150,12 @@ command. Classic collisions: ``id``, ``zip``, ``dir``, ``import``.
 
 Workarounds:
 
+* **Flip the experimental toggle**
+  `$XONSH_BUILTINS_TO_CMD <envvars.html#envvar-XONSH_BUILTINS_TO_CMD>`_ — when
+  set, bare built-in names are run as subprocess commands if a matching
+  alias or executable exists, falling back to the Python built-in
+  otherwise. The same switch is also useful on Windows for ``dir`` (see
+  `platforms.rst <platforms.html#name-space-conflicts>`_).
 * **Change the case**: ``Zip`` or ``ZIP`` — Python names are case-sensitive,
   so ``Zip`` misses the built-in and falls through to a command lookup.
   On case-insensitive filesystems (macOS default, Windows) ``Zip`` then
@@ -160,12 +166,6 @@ Workarounds:
   ``$[id]``, ``$(id)``.
 * **Alias it under a different name**: ``aliases['ids'] = 'id'``.
 * **Use `xontrib-abbrevs`** to auto-expand on space.
-* **Flip the experimental toggle**
-  `$XONSH_BUILTINS_TO_CMD <envvars.html#envvar-XONSH_BUILTINS_TO_CMD>`_ — when
-  set, bare built-in names are run as subprocess commands if a matching
-  alias or executable exists, falling back to the Python built-in
-  otherwise. The same switch is also useful on Windows for ``dir`` (see
-  `platforms.rst <platforms.html#name-space-conflicts>`_).
 
 
 See also: `xonsh-cheatsheet <https://github.com/anki-code/xonsh-cheatsheet>`_

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -2517,6 +2517,73 @@ def test_bare_builtin_becomes_cmd_call(parser, xsh):
     assert call.args[0].value == "zip"
 
 
+def _builtins_ctx():
+    """``dir(__builtins__)`` varies (module vs dict) depending on how the
+    test module is loaded — be explicit so tests are deterministic."""
+    import builtins
+
+    return set(dir(builtins))
+
+
+def test_flag_pattern_becomes_subproc_when_flag_enabled(parser, xsh, monkeypatch):
+    """``zip --help`` / ``id -a`` parse as Python ``BinOp(Sub)`` and would
+    blow up at runtime (``-help`` → ``_Helper.__neg__`` → TypeError). With
+    ``$XONSH_BUILTINS_TO_CMD=True`` and LHS being a known alias/command,
+    the transformer must re-parse the line as subprocess so the user gets
+    the expected behaviour."""
+    import ast as stdlib_ast
+
+    from xonsh.parsers.ast import CtxAwareTransformer
+
+    monkeypatch.setitem(xsh.env, "XONSH_BUILTINS_TO_CMD", True)
+    monkeypatch.setitem(xsh.aliases, "zip", ["zip"])
+    code = "zip --help\n"
+    tree = parser.parse(code, debug_level=0)
+    ctxtr = CtxAwareTransformer(parser)
+    tree = ctxtr.ctxvisit(tree, code, _builtins_ctx())
+    expr_node = tree.body[0]
+    # The original ``BinOp(Sub)`` must be gone — it's now a subprocess call.
+    assert not isinstance(expr_node.value, stdlib_ast.BinOp)
+
+
+def test_flag_pattern_stays_python_when_flag_disabled(parser, xsh, monkeypatch):
+    """With ``$XONSH_BUILTINS_TO_CMD`` off (default), the flag-pattern
+    rewrite must not fire — preserves the legacy behaviour."""
+    import ast as stdlib_ast
+
+    from xonsh.parsers.ast import CtxAwareTransformer
+
+    monkeypatch.setitem(xsh.env, "XONSH_BUILTINS_TO_CMD", False)
+    monkeypatch.setitem(xsh.aliases, "zip", ["zip"])
+    code = "zip --help\n"
+    tree = parser.parse(code, debug_level=0)
+    ctxtr = CtxAwareTransformer(parser)
+    tree = ctxtr.ctxvisit(tree, code, _builtins_ctx())
+    expr_node = tree.body[0]
+    # ``zip`` is a Python builtin so ``is_in_scope`` is True and the node
+    # remains a ``BinOp`` — the old (buggy at runtime) behaviour is kept.
+    assert isinstance(expr_node.value, stdlib_ast.BinOp)
+
+
+def test_flag_pattern_leaves_user_arithmetic_alone(parser, xsh, monkeypatch):
+    """``x - -y`` with user-defined ``x``/``y`` must stay as plain arithmetic,
+    even with ``$XONSH_BUILTINS_TO_CMD`` on and a command of the same name
+    on $PATH."""
+    import ast as stdlib_ast
+
+    from xonsh.parsers.ast import CtxAwareTransformer
+
+    monkeypatch.setitem(xsh.env, "XONSH_BUILTINS_TO_CMD", True)
+    monkeypatch.setitem(xsh.aliases, "ls", ["ls"])
+    code = "ls = 10\nls - -5\n"
+    tree = parser.parse(code, debug_level=0)
+    ctxtr = CtxAwareTransformer(parser)
+    tree = ctxtr.ctxvisit(tree, code, _builtins_ctx())
+    # Second statement must remain a BinOp (the arithmetic), not a subproc.
+    second = tree.body[1]
+    assert isinstance(second.value, stdlib_ast.BinOp)
+
+
 @skip_if_pre_3_8
 def test_walrus_in_assign_ctx(parser, xsh):
     """Walrus operator variable in RHS should be tracked in context."""

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1312,9 +1312,15 @@ class SubprocessSetting(Xettings):
     )
     XONSH_BUILTINS_TO_CMD = Var.with_default(
         False,
-        "If True, bare Python builtin names (e.g. `dir`, `zip`, `type`) "
-        "typed as a standalone expression will be executed as a subprocess command "
-        "if a matching alias or executable exists. "
+        "If True, Python builtin names (e.g. ``dir``, ``zip``, ``type``) "
+        "will be executed as a subprocess command when a matching alias or "
+        "executable exists. Covers two cases that otherwise run as Python "
+        "and may fail or return surprising values: "
+        "(1) a bare builtin name typed as a standalone expression "
+        "(``zip`` → run the ``zip`` command); "
+        "(2) a builtin name followed by flag-looking arguments that also "
+        "parses as a valid Python ``BinOp`` expression "
+        "(``zip --help``, ``id -a``). "
         "Otherwise the Python builtin value is returned as usual.",
     )
     XONSH_SUBPROC_OUTPUT_FORMAT = Var.with_default(

--- a/xonsh/parsers/ast.py
+++ b/xonsh/parsers/ast.py
@@ -546,6 +546,21 @@ class CtxAwareTransformer(NodeTransformer):
                 col=node.col_offset,
             )
             return node
+        if self._looks_like_flag_subproc(node.value):
+            # ``zip --help`` / ``id -v`` parse as Python ``BinOp(Sub)`` (the
+            # LHS name minus ``-flag``). Evaluating that at runtime blows up
+            # when the RHS name is a non-numeric builtin (``help`` →
+            # ``_Helper``) or produces nonsense arithmetic. Since the LHS is
+            # a known alias/command, re-parse the source line as subprocess.
+            newnode = self.try_subproc_toks(node)
+            if not isinstance(newnode, Expr):
+                newnode = Expr(
+                    value=newnode, lineno=node.lineno, col_offset=node.col_offset
+                )
+                if hasattr(node, "max_lineno"):
+                    newnode.max_lineno = node.max_lineno
+                    newnode.max_col = node.max_col
+            return newnode
         if self.is_in_scope(node) or isinstance(node.value, Lambda):
             return node
         else:
@@ -558,6 +573,47 @@ class CtxAwareTransformer(NodeTransformer):
                     newnode.max_lineno = node.max_lineno
                     newnode.max_col = node.max_col
             return newnode
+
+    def _looks_like_flag_subproc(self, node):
+        """Heuristic: does this Python expression look like ``cmd -flag``?
+
+        Matches ``BinOp(Name, Sub, [UnaryOp(USub, …)]*, Name)`` where the LHS
+        name is a known alias, executable on ``$PATH``, or a Python builtin
+        that shadows one — i.e. the user clearly typed a subprocess command
+        with flags but it happened to also be valid Python syntax (e.g.
+        ``zip --help``, ``id -a``). Expressions involving user-defined
+        variables are excluded so legitimate arithmetic stays untouched.
+
+        Gated on ``$XONSH_BUILTINS_TO_CMD``: this is the same experimental
+        "commands win over Python names" switch that already covers the
+        bare-builtin case (``zip`` → run ``zip`` if it exists), so the
+        ``cmd -flag`` behaviour lives under the same opt-in toggle.
+        """
+        env = XSH.env or {}
+        if not env.get("XONSH_BUILTINS_TO_CMD"):
+            return False
+        if not (isinstance(node, BinOp) and isinstance(node.op, Sub)):
+            return False
+        if not isinstance(node.left, Name):
+            return False
+        # Peel off chained unary minuses on the right to handle ``--flag``,
+        # ``---flag``, etc.
+        rhs = node.right
+        while isinstance(rhs, UnaryOp) and isinstance(rhs.op, USub):
+            rhs = rhs.operand
+        if not isinstance(rhs, Name):
+            return False
+        name = node.left.id
+        if name in self._user_names:
+            return False
+        for ctx in self.contexts[1:]:
+            if name in ctx:
+                return False
+        aliases = XSH.aliases or {}
+        if name in aliases:
+            return True
+        cc = XSH.commands_cache
+        return bool(cc and cc.locate_binary(name) is not None)
 
     def _is_bare_builtin(self, node):
         """Check if node is a bare Name referencing a Python builtin, or Ellipsis.


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/6314
* Cc https://github.com/xonsh/xonsh/issues/5802
* Cc https://github.com/xonsh/xonsh/issues/3508
* Cc https://github.com/xonsh/xonsh/issues/3612

**Flip the experimental toggle**
`$XONSH_BUILTINS_TO_CMD <envvars.html#envvar-XONSH_BUILTINS_TO_CMD>`_ — when set, bare built-in names are run as subprocess commands if a matching alias or executable exists, falling back to the Python built-in otherwise. The same switch is also useful on Windows for ``dir`` (see `platforms.rst <platforms.html#name-space-conflicts>`_).

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
