### PR TITLE
feat: Callable alias Click CLI integration: completer

### DIFF
--- a/docs/callable_aliases.rst
+++ b/docs/callable_aliases.rst
@@ -554,6 +554,15 @@ Use these when a click command needs the underlying xonsh streams or
 environment overlay — for example, ``print(text, file=ctx.stdout)`` writes
 to the alias's captured output the same way a regular callable alias does.
 
+Tab completion is wired up automatically: option flags, ``click.Choice``
+option values, positional ``click.Choice`` arguments, and sub-commands of
+a ``click.Group`` are all suggested without any extra configuration.
+
+.. code-block:: xonshcon
+
+    @ hello --<TAB>
+    --count --help --name
+
 
 String Aliases and ExecAlias
 ----------------------------

--- a/tests/test_aliases_click_completer_llm.py
+++ b/tests/test_aliases_click_completer_llm.py
@@ -1,0 +1,335 @@
+"""Tests for tab-completion of click-based aliases (xonsh/xonsh#6265).
+
+Exercises :func:`xonsh.completers.click.complete_click`, wired up by
+``@aliases.register_click_command``. The completer is looked up by
+``xonsh.completers._aliases.complete_aliases`` via
+``alias.func.xonsh_complete``.
+"""
+
+import pytest
+
+from xonsh.aliases import Aliases
+from xonsh.parsers.completion_context import (
+    CommandArg,
+    CommandContext,
+    CompletionContext,
+)
+
+
+@pytest.fixture
+def click():
+    return pytest.importorskip("click")
+
+
+def _complete(aliases, alias_name, *tokens, prefix=""):
+    """Drive the alias's ``xonsh_complete`` directly and return a set of strs.
+
+    ``tokens`` are the full argument words typed *before* the cursor (not
+    including the alias name itself); ``prefix`` is the partial word at
+    the cursor.
+    """
+    args = (CommandArg(alias_name),) + tuple(CommandArg(t) for t in tokens)
+    ctx = CommandContext(args=args, arg_index=len(args), prefix=prefix)
+    alias = aliases._raw[alias_name]
+    result = alias.func.xonsh_complete(command=ctx, alias=alias)
+    if result is None:
+        return None
+    return {str(r) for r in result}
+
+
+def test_click_complete_options_by_prefix(click):
+    """``hello --nam<TAB>`` offers ``--name``."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--name", default="Anonymous")
+    @aliases.click.option("--count", default=1)
+    def _hello(ctx, name, count):
+        pass
+
+    assert _complete(aliases, "hello", prefix="--nam") == {"--name"}
+
+
+def test_click_complete_all_long_options(click):
+    """``hello --<TAB>`` lists every long option, plus the implicit ``--help``."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--name", default="Anonymous")
+    @aliases.click.option("--count", default=1)
+    def _hello(ctx, name, count):
+        pass
+
+    assert _complete(aliases, "hello", prefix="--") == {
+        "--name",
+        "--count",
+        "--help",
+    }
+
+
+def test_click_complete_short_and_long_options(click):
+    """``cmd -<TAB>`` includes short flags as well as long ones."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("-n", "--name")
+    @aliases.click.option("-v", "--verbose", is_flag=True)
+    def _cmd(ctx, name, verbose):
+        pass
+
+    result = _complete(aliases, "cmd", prefix="-")
+    assert {"-n", "--name", "-v", "--verbose"}.issubset(result)
+
+
+def test_click_complete_flag_pair_secondary_opts(click):
+    """Flag pairs (``--verbose/--quiet``) surface *both* sides."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--verbose/--quiet", default=False)
+    def _cmd(ctx, verbose):
+        pass
+
+    result = _complete(aliases, "cmd", prefix="--")
+    assert {"--verbose", "--quiet"}.issubset(result)
+
+
+def test_click_complete_option_value_choice(click):
+    """``--color <TAB>`` offers the ``click.Choice`` values."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--color", type=click.Choice(["red", "green", "blue"]))
+    def _cmd(ctx, color):
+        pass
+
+    assert _complete(aliases, "cmd", "--color", prefix="") == {
+        "red",
+        "green",
+        "blue",
+    }
+
+
+def test_click_complete_option_value_choice_prefix(click):
+    """Prefix filters the Choice values (``--color r<TAB>`` → only ``red``)."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--color", type=click.Choice(["red", "green", "blue"]))
+    def _cmd(ctx, color):
+        pass
+
+    assert _complete(aliases, "cmd", "--color", prefix="r") == {"red"}
+
+
+def test_click_complete_option_value_opaque_returns_none(click):
+    """``--name <TAB>`` (no Choice type) returns ``None`` so other completers
+    (path/base) can still fire. Flags do NOT count as value-consuming.
+    """
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--name", default="")
+    def _cmd(ctx, name):
+        pass
+
+    assert _complete(aliases, "cmd", "--name", prefix="") is None
+
+
+def test_click_complete_flag_does_not_consume_next_token(click):
+    """After a bare flag, options should complete again — the flag takes no value.
+
+    Regression guard: the completer must distinguish ``is_flag`` / count
+    options from options that take a value.
+    """
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("-v", "--verbose", is_flag=True)
+    @aliases.click.option("--name", default="")
+    def _cmd(ctx, verbose, name):
+        pass
+
+    # After "-v ", "--<TAB>" should still offer --name (we're not waiting
+    # for -v's value).
+    assert _complete(aliases, "cmd", "-v", prefix="--") == {
+        "--name",
+        "--verbose",
+        "--help",
+    }
+
+
+def test_click_complete_group_subcommands(click):
+    """``grp <TAB>`` lists sub-commands of a ``click.Group``."""
+    aliases = Aliases()
+
+    @click.group()
+    def _grp():
+        pass
+
+    @_grp.command(short_help="run the server")
+    def serve():
+        pass
+
+    @_grp.command()
+    def status():
+        pass
+
+    aliases.register_click_command(_grp)
+    assert _complete(aliases, "grp", prefix="") == {"serve", "status"}
+
+
+def test_click_complete_group_subcommand_prefix(click):
+    """Prefix filters sub-command names."""
+    aliases = Aliases()
+
+    @click.group()
+    def _grp():
+        pass
+
+    @_grp.command()
+    def serve():
+        pass
+
+    @_grp.command()
+    def status():
+        pass
+
+    aliases.register_click_command(_grp)
+    assert _complete(aliases, "grp", prefix="se") == {"serve"}
+
+
+def test_click_complete_subcommand_options(click):
+    """Inside a sub-command, ``--<TAB>`` completes *the sub-command's* options."""
+    aliases = Aliases()
+
+    @click.group()
+    def _grp():
+        pass
+
+    @_grp.command()
+    @click.option("--port", default=8080)
+    def serve(port):
+        pass
+
+    aliases.register_click_command(_grp)
+    result = _complete(aliases, "grp", "serve", prefix="--")
+    assert result == {"--port", "--help"}
+
+
+def test_click_complete_group_flag_before_subcommand(click):
+    """A group-level flag between ``grp`` and the sub-command doesn't
+    derail sub-command resolution.
+    """
+    aliases = Aliases()
+
+    @click.group()
+    @click.option("--debug", is_flag=True)
+    def _grp(debug):
+        pass
+
+    @_grp.command()
+    @click.option("--port", default=8080)
+    def serve(port):
+        pass
+
+    aliases.register_click_command(_grp)
+    assert _complete(aliases, "grp", "--debug", "serve", prefix="--") == {
+        "--port",
+        "--help",
+    }
+
+
+def test_click_complete_positional_argument_choice(click):
+    """``click.Argument`` with a Choice type completes its values."""
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.argument("target", type=click.Choice(["prod", "staging", "dev"]))
+    def _deploy(ctx, target):
+        pass
+
+    assert _complete(aliases, "deploy", prefix="") == {"prod", "staging", "dev"}
+    assert _complete(aliases, "deploy", prefix="p") == {"prod"}
+
+
+def test_click_complete_custom_alias_name(click):
+    """Completion works even when the alias is registered under a custom name."""
+    aliases = Aliases()
+
+    @aliases.register_click_command("hi")
+    @aliases.click.option("--name", default="Anonymous")
+    def _hello(ctx, name):
+        pass
+
+    assert "hi" in aliases
+    assert _complete(aliases, "hi", prefix="--nam") == {"--name"}
+
+
+def test_click_complete_via_complete_aliases(click, xession):
+    """Smoke test: the full ``complete_aliases`` pipeline picks up our
+    ``xonsh_complete`` attribute and produces the same completions.
+    """
+    from xonsh.completers._aliases import complete_aliases
+
+    @xession.aliases.register_click_command
+    @xession.aliases.click.option("--name", default="World")
+    @xession.aliases.click.option("--count", default=1)
+    def _hello_click_alias_for_test(ctx, name, count):
+        pass
+
+    try:
+        full = CompletionContext(
+            command=CommandContext(
+                args=(CommandArg("hello-click-alias-for-test"),),
+                arg_index=1,
+                prefix="--nam",
+            )
+        )
+        comps, _extra = complete_aliases(full)
+        assert {str(c) for c in comps} == {"--name"}
+    finally:
+        del xession.aliases["hello-click-alias-for-test"]
+
+
+def test_click_complete_option_help_text_in_description(click):
+    """Options surface their ``help=`` text as the RichCompletion description —
+    keeps the behaviour parity with argparse-based aliases.
+    """
+    from xonsh.completers.tools import RichCompletion
+
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    @aliases.click.option("--name", default="Anon", help="Who to greet")
+    def _hello(ctx, name):
+        pass
+
+    alias = aliases._raw["hello"]
+    ctx = CommandContext(args=(CommandArg("hello"),), arg_index=1, prefix="--nam")
+    result = alias.func.xonsh_complete(command=ctx, alias=alias)
+    comps = {c: c for c in result if isinstance(c, RichCompletion)}
+    assert any(c.description == "Who to greet" for c in comps)
+
+
+def test_click_complete_unknown_subcommand_stops_walk(click):
+    """An unknown sub-command token halts traversal and falls back to the
+    current group — we still complete the group's options.
+    """
+    aliases = Aliases()
+
+    @click.group()
+    @click.option("--debug", is_flag=True)
+    def _grp(debug):
+        pass
+
+    @_grp.command()
+    def serve():
+        pass
+
+    aliases.register_click_command(_grp)
+    # "nonexistent" isn't a real sub-command; completer should still work
+    # against the root group and offer its options.
+    result = _complete(aliases, "grp", "nonexistent", prefix="--")
+    assert "--debug" in result
+    assert "--help" in result

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -762,6 +762,14 @@ def _click_command_alias(func_or_name=None, *, _aliases):
             ]
         )
 
+        # Tab-completion: ``complete_aliases`` picks this up via
+        # ``alias.func.xonsh_complete``. Bound to the live click.Command so
+        # the completer always reflects the current option/argument set —
+        # even if the user mutates ``cmd.params`` after registration.
+        from xonsh.completers.click import complete_click
+
+        _wrapper.xonsh_complete = functools.partial(complete_click, cmd)
+
         _aliases.register(registered_name, dash_case=False)(_wrapper)
         return _wrapper
 

--- a/xonsh/completers/click.py
+++ b/xonsh/completers/click.py
@@ -1,0 +1,206 @@
+"""Tab-completion for click-based aliases registered via
+:func:`xonsh.aliases.Aliases.register_click_command`.
+
+The entry point is :func:`complete_click`, bound per-alias through
+``functools.partial(complete_click, click_cmd)`` and attached to the
+alias wrapper as ``xonsh_complete``. The stock alias completer
+(``xonsh.completers._aliases.complete_aliases``) then picks it up from
+``alias.func.xonsh_complete`` during normal tab completion.
+
+The ``click`` package is imported lazily — this module is only
+exercised once a click alias has been registered, which itself requires
+click to be installed.
+"""
+
+from xonsh.completers.tools import RichCompletion
+
+
+def option_all_opts(param):
+    """Every flag string declared on a ``click.Option`` — primary +
+    secondary. ``secondary_opts`` holds the off-switch of flag pairs
+    like ``--verbose/--quiet``.
+    """
+    return list(param.opts) + list(param.secondary_opts)
+
+
+def option_takes_value(param):
+    """``True`` if the option consumes a separate argument as its value.
+    Flags (``--verbose``) and count options (``-vvv``) do not.
+    """
+    return not (getattr(param, "is_flag", False) or getattr(param, "count", False))
+
+
+def resolve_subcommand(root_cmd, args):
+    """Walk ``click.Group`` → sub-command chain consuming positional tokens.
+
+    Returns ``(current_cmd, remaining_args)`` where ``remaining_args`` is
+    the slice of ``args`` belonging to ``current_cmd`` (i.e. everything
+    after the last recognised sub-command name).
+
+    Options are skipped when they appear before the sub-command name —
+    the few that take a separate value consume the next token as well.
+    An unknown sub-command stops the walk, so the completer can still
+    offer ``--`` options on the outermost unresolved command.
+    """
+    import click
+
+    current = root_cmd
+    remaining = list(args)
+    while isinstance(current, click.Group) and remaining:
+        i = 0
+        # Skip leading options belonging to the group.
+        while i < len(remaining) and remaining[i].startswith("-"):
+            opt = remaining[i]
+            i += 1
+            if "=" not in opt and i < len(remaining):
+                for p in current.params:
+                    if isinstance(p, click.Option) and opt in option_all_opts(p):
+                        if option_takes_value(p):
+                            i += 1
+                        break
+        if i >= len(remaining):
+            break
+        sub_name = remaining[i]
+        sub = current.get_command(click.Context(current), sub_name)
+        if sub is None:
+            # Unknown sub-command — stop here so caller can still complete
+            # against the current group's options.
+            break
+        current = sub
+        remaining = remaining[i + 1 :]
+    return current, remaining
+
+
+def previous_option_waiting_value(current_cmd, args_after_cmd):
+    """If the last token is an option expecting a value, return that
+    ``click.Option``; otherwise ``None``. Used to drive Choice completion
+    after things like ``--color <TAB>``.
+    """
+    import click
+
+    if not args_after_cmd:
+        return None
+    prev = args_after_cmd[-1]
+    if not prev.startswith("-") or "=" in prev:
+        return None
+    for param in current_cmd.params:
+        if isinstance(param, click.Option) and prev in option_all_opts(param):
+            if option_takes_value(param):
+                return param
+            return None
+    return None
+
+
+def positional_index(current_cmd, args_after_cmd):
+    """Count how many positional arguments have been supplied to
+    ``current_cmd`` so far, skipping options and their values. Used to
+    pick which ``click.Argument`` slot we're completing into.
+    """
+    import click
+
+    idx = 0
+    j = 0
+    while j < len(args_after_cmd):
+        arg = args_after_cmd[j]
+        if arg.startswith("-"):
+            if "=" in arg:
+                j += 1
+                continue
+            takes_value = False
+            for param in current_cmd.params:
+                if isinstance(param, click.Option) and arg in option_all_opts(param):
+                    takes_value = option_takes_value(param)
+                    break
+            j += 2 if takes_value else 1
+        else:
+            idx += 1
+            j += 1
+    return idx
+
+
+def complete_click(click_cmd, command, alias=None, **_):
+    """Tab-completer for click-based aliases.
+
+    Yields completions for, in priority order:
+
+    1. Option values when the preceding token is an option with a
+       ``click.Choice`` type (``--color <TAB>`` → ``red green blue``).
+    2. Option flags when the prefix starts with ``-``
+       (``--nam<TAB>`` → ``--name``).
+    3. Sub-command names when the current command is a ``click.Group``.
+    4. Positional arguments with a ``click.Choice`` type.
+
+    Bound per-alias via :func:`functools.partial` in
+    :func:`xonsh.aliases._click_command_alias`, so each wrapper captures
+    its own ``click.Command`` instance.
+    """
+    import click
+
+    # Descend click.Group chain to find the command we're completing into.
+    args_after_cmd = [a.value for a in command.args[1:]]
+    current_cmd, args_after_cmd = resolve_subcommand(click_cmd, args_after_cmd)
+
+    prefix = command.prefix
+
+    # 1. Value for an option that takes one (only Choice is predictable).
+    pending = previous_option_waiting_value(current_cmd, args_after_cmd)
+    if pending is not None:
+        if isinstance(pending.type, click.Choice):
+            return {
+                RichCompletion(choice, append_space=True)
+                for choice in pending.type.choices
+                if choice.startswith(prefix)
+            }
+        # Opaque type (str, int, path, ...) — no suggestions from us; let
+        # other completers (path, etc.) try.
+        return None
+
+    # 2. Option flag.
+    if prefix.startswith("-"):
+        results = set()
+        for param in current_cmd.params:
+            if isinstance(param, click.Option):
+                for opt in option_all_opts(param):
+                    if opt.startswith(prefix):
+                        results.add(
+                            RichCompletion(
+                                opt,
+                                description=(param.help or "").strip(),
+                            )
+                        )
+        if getattr(current_cmd, "add_help_option", False) and "--help".startswith(
+            prefix
+        ):
+            results.add(
+                RichCompletion("--help", description="Show this message and exit.")
+            )
+        return results
+
+    # 3. Sub-command name for a click.Group.
+    if isinstance(current_cmd, click.Group):
+        ctx = click.Context(current_cmd)
+        results = set()
+        for sub_name in current_cmd.list_commands(ctx):
+            if sub_name.startswith(prefix):
+                sub = current_cmd.get_command(ctx, sub_name)
+                desc = (
+                    getattr(sub, "short_help", None) or getattr(sub, "help", None) or ""
+                ).strip()
+                results.add(
+                    RichCompletion(sub_name, description=desc, append_space=True)
+                )
+        return results
+
+    # 4. Positional arg with a Choice type.
+    click_arguments = [p for p in current_cmd.params if isinstance(p, click.Argument)]
+    pos_idx = positional_index(current_cmd, args_after_cmd)
+    if pos_idx < len(click_arguments):
+        arg_param = click_arguments[pos_idx]
+        if isinstance(arg_param.type, click.Choice):
+            return {
+                RichCompletion(choice, append_space=True)
+                for choice in arg_param.type.choices
+                if choice.startswith(prefix)
+            }
+
+    return None


### PR DESCRIPTION
Final stage of https://github.com/xonsh/xonsh/pull/6265

### After

```xsh
@aliases.register_click_command
@aliases.click.option('--count', default=1, help='Number of greetings.')
@aliases.click.option('--name', help='The person to greet.')
def _hello(ctx, count, name):
    """Simple program that greets NAME for a total of COUNT times."""
    for i in range(count):
        print(name, file=ctx.stdout)

hello --na
# --name - The person to greet.
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
