### PR TITLE
feat: Added `a>p`, `e>p` to redirect all/stderr to pipe

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -914,10 +914,10 @@ pipe. Both operators require a following pipe.
 
 .. code-block:: xonshcon
 
-    @ cmd a>p | cmd2                 # stdout + stderr into the pipe
+    @ cmd a>p | cmd2                     # stdout + stderr into the pipe
     @ cmd e>p | grep warning             # same — pipe carries both streams
     @ cmd o> out.txt e>p | grep warning  # stdout to file, stderr into the pipe
-    @ cmd all>p | cmd2               # aliases: all>p, err>p, 2>p
+    @ cmd all>p | cmd2                   # aliases: all>p, err>p, 2>p
     @ cmd err>p | cmd2
 
 Redirecting ``stdin`` is also possible to have a command read its input from a file, rather

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -836,43 +836,43 @@ examples.
 .. note:: The target of the redirection should be separated by a space,
           otherwise xonsh will raise a SyntaxError.
 
-Redirecting ``stdout``. All of the following examples will execute ``COMMAND`` and write its regular
+Redirecting ``stdout``. All of the following examples will execute ``cmd`` and write its regular
 output (stdout) to a file called ``output.txt``, creating it if it does not
 exist:
 
 .. code-block:: xonshcon
 
-    @ COMMAND > output.txt
-    @ COMMAND out> output.txt
-    @ COMMAND o> output.txt
-    @ COMMAND 1> output.txt # included for POSIX compatibility
+    @ cmd > output.txt
+    @ cmd out> output.txt
+    @ cmd o> output.txt
+    @ cmd 1> output.txt # included for POSIX compatibility
 
 These can be made to append to ``output.txt`` instead of overwriting its contents
 by replacing ``>`` with ``>>`` (note that ``>>`` will still create the file if it
 does not exist).
 
-Redirecting ``stderr``. All of the following examples will execute ``COMMAND`` and write its error
+Redirecting ``stderr``. All of the following examples will execute ``cmd`` and write its error
 output (stderr) to a file called ``errors.txt``, creating it if it does not
 exist:
 
 .. code-block:: xonshcon
 
-    @ COMMAND err> errors.txt
-    @ COMMAND e> errors.txt
-    @ COMMAND 2> errors.txt # included for POSIX compatibility
+    @ cmd err> errors.txt
+    @ cmd e> errors.txt
+    @ cmd 2> errors.txt # included for POSIX compatibility
 
 As above, replacing ``>`` with ``>>`` will cause the error output to be
 appended to ``errors.txt``, rather than replacing its contents.
 
-Combining streams is possible to send all of ``COMMAND``'s output (both regular output and
+Combining streams is possible to send all of ``cmd``'s output (both regular output and
 error output) to the same location.  All of the following examples accomplish
 that task:
 
 .. code-block:: xonshcon
 
-    @ COMMAND all> combined.txt
-    @ COMMAND a> combined.txt
-    @ COMMAND &> combined.txt # included for POSIX compatibility
+    @ cmd all> combined.txt
+    @ cmd a> combined.txt
+    @ cmd &> combined.txt # included for POSIX compatibility
 
 It is also possible to explicitly merge stderr into stdout so that error
 messages are reported to the same location as regular output.  You can do this
@@ -880,48 +880,62 @@ with the following syntax:
 
 .. code-block:: xonshcon
 
-    @ COMMAND err>out
-    @ COMMAND err>o
-    @ COMMAND e>out
-    @ COMMAND e>o
-    @ COMMAND 2>&1  # included for POSIX compatibility
+    @ cmd err>out
+    @ cmd err>o
+    @ cmd e>out
+    @ cmd e>o
+    @ cmd 2>&1  # included for POSIX compatibility
 
 This merge can be combined with other redirections, including pipes (see the
 section on `Pipes`_ above):
 
 .. code-block:: xonshcon
 
-    @ COMMAND err>out | COMMAND2
-    @ COMMAND e>o > combined.txt
+    @ cmd err>out | cmd2
+    @ cmd e>o > combined.txt
 
-It is worth noting that this last example is equivalent to: ``COMMAND a> combined.txt``
+It is worth noting that this last example is equivalent to: ``cmd a> combined.txt``
 
 Similarly, you can also send stdout to stderr with the following syntax:
 
 .. code-block:: xonshcon
 
-    @ COMMAND out>err
-    @ COMMAND out>e
-    @ COMMAND o>err
-    @ COMMAND o>e
-    @ COMMAND 1>&2  # included for POSIX compatibility
+    @ cmd out>err
+    @ cmd out>e
+    @ cmd o>err
+    @ cmd o>e
+    @ cmd 1>&2  # included for POSIX compatibility
+
+Routing streams into a pipe. ``a>p`` and ``e>p`` both add stderr to the
+following ``|`` pipe. The pipe still carries stdout as usual, unless an
+explicit ``o> file`` diverts stdout elsewhere — which makes ``e>p`` useful
+for pattern: stdout to a file, stderr into the
+pipe. Both operators require a following pipe.
+
+.. code-block:: xonshcon
+
+    @ cmd a>p | cmd2                 # stdout + stderr into the pipe
+    @ cmd e>p | grep warning             # same — pipe carries both streams
+    @ cmd o> out.txt e>p | grep warning  # stdout to file, stderr into the pipe
+    @ cmd all>p | cmd2               # aliases: all>p, err>p, 2>p
+    @ cmd err>p | cmd2
 
 Redirecting ``stdin`` is also possible to have a command read its input from a file, rather
 than from ``stdin``.  The following examples demonstrate two ways to accomplish this:
 
 .. code-block:: xonshcon
 
-    @ COMMAND < input.txt
-    @ < input.txt COMMAND
+    @ cmd < input.txt
+    @ < input.txt cmd
 
 Combining I/O redirects is also possible.  Below is one example of a complicated redirect.
 
 .. code-block:: xonshcon
 
-    @ COMMAND1 e>o < input.txt | COMMAND2 > output.txt e>> errors.txt
+    @ cmd1 e>o < input.txt | cmd2 > output.txt e>> errors.txt
 
-This line will run ``COMMAND1`` with the contents of ``input.txt`` fed in on
-stdin, and will pipe all output (stdout and stderr) to ``COMMAND2``; the
+This line will run ``cmd1`` with the contents of ``input.txt`` fed in on
+stdin, and will pipe all output (stdout and stderr) to ``cmd2``; the
 regular output of this command will be redirected to ``output.txt``, and the
 error output will be appended to ``errors.txt``.
 

--- a/tests/parsers/test_lexer.py
+++ b/tests/parsers/test_lexer.py
@@ -455,6 +455,12 @@ def test_ioredir2(case):
     assert check_tokens_subproc(case, [("IOREDIRECT2", case, 2)], stop=-2)
 
 
+@pytest.mark.parametrize("case", ["a>p", "all>p", "e>p", "err>p", "2>p"])
+def test_ioredir2_pipe(case):
+    """`a>p`/`e>p` and variants are single IOREDIRECT2 tokens."""
+    assert check_tokens_subproc(case, [("IOREDIRECT2", case, 2)], stop=-2)
+
+
 @pytest.mark.parametrize("case", [">", ">>", "<", "e>", "> ", ">>   ", "<  ", "e> "])
 def test_redir_whitespace(case):
     inp = f"![{case}/path/to/file]"

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -3248,6 +3248,17 @@ def test_redirect_output_to_error(r, e, check_xonsh_ast):
     assert check_xonsh_ast({}, f'$[echo "test" {r} {e}> test.txt < input.txt]', False)
 
 
+@pytest.mark.parametrize("r", ["a>p", "all>p"])
+def test_redirect_all_to_pipe_parse(r, check_xonsh_ast):
+    assert check_xonsh_ast({}, f'$[echo "test" {r} | cat]', False)
+
+
+@pytest.mark.parametrize("r", ["e>p", "err>p", "2>p"])
+def test_redirect_err_to_pipe_parse(r, check_xonsh_ast):
+    assert check_xonsh_ast({}, f'$[echo "test" {r} | cat]', False)
+    assert check_xonsh_ast({}, f'$[echo "test" o> out.txt {r} | cat]', False)
+
+
 def test_macro_call_empty(check_xonsh_ast):
     assert check_xonsh_ast({}, "f!()", False)
 

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -951,6 +951,89 @@ def test_redirect_without_left_part(tmpdir):
     assert "subprocess mode: command is empty" in str(expected.value)
 
 
+# -- a>p / e>p pipe-redirects ------------------------------------------------
+
+import subprocess as _subprocess  # noqa: E402
+
+from xonsh.procs.specs import _PIPE_ALL, _PIPE_ERR, _redirect_streams  # noqa: E402
+
+
+@pytest.mark.parametrize("op", ["a>p", "all>p"])
+def test_a2p_redirect_streams_returns_sentinel(op):
+    stdin, stdout, stderr = _redirect_streams(op)
+    assert stdin is None
+    assert stdout is _PIPE_ALL
+    assert stderr is _subprocess.STDOUT
+
+
+@pytest.mark.parametrize("op", ["e>p", "err>p", "2>p"])
+def test_e2p_redirect_streams_returns_sentinel(op):
+    stdin, stdout, stderr = _redirect_streams(op)
+    assert stdin is None
+    assert stdout is None
+    assert stderr is _PIPE_ERR
+
+
+@skip_if_on_windows
+def test_a2p_pipes_both_streams_to_next_spec(xession):
+    cmds = [["echo", "hi", ("a>p",)], "|", ["cat"]]
+    specs = cmds_to_specs(cmds, captured="hiddenobject")
+    assert len(specs) == 2
+    # upstream: stdout wired to pipe write fd, stderr merged via STDOUT flag
+    assert isinstance(specs[0].stdout, int)
+    assert specs[0].stderr is _subprocess.STDOUT
+    # downstream: stdin reads from pipe
+    assert isinstance(specs[1].stdin, int)
+    # sentinel was replaced
+    assert specs[0]._stdout is not _PIPE_ALL
+
+
+@skip_if_on_windows
+def test_e2p_without_stdout_redirect_pipes_both_streams(xession):
+    """`cmd e>p | next` — pipe still carries stdout by default, plus stderr."""
+    cmds = [["echo", "hi", ("e>p",)], "|", ["cat"]]
+    specs = cmds_to_specs(cmds, captured="hiddenobject")
+    assert len(specs) == 2
+    assert isinstance(specs[0].stdout, int)
+    assert isinstance(specs[0].stderr, int)
+    assert specs[0].stdout == specs[0].stderr  # same pipe write fd
+    assert isinstance(specs[1].stdin, int)
+    assert specs[0]._stderr is not _PIPE_ERR
+
+
+@skip_if_on_windows
+def test_e2p_with_stdout_redirect_preserves_file(xession, tmpdir):
+    """`cmd o> file e>p | grep` — stdout to file, stderr through pipe."""
+    outfile = str(tmpdir / "out.txt")
+    cmds = [["echo", "hi", ("o>", outfile), ("e>p",)], "|", ["cat"]]
+    specs = cmds_to_specs(cmds, captured="hiddenobject")
+    # stdout is a file object, stderr is the pipe fd
+    assert getattr(specs[0].stdout, "name", None) == outfile
+    assert isinstance(specs[0].stderr, int)
+    specs[0].stdout.close()
+
+
+@pytest.mark.parametrize("op", ["a>p", "e>p"])
+def test_pipe_redirect_without_pipe_errors(xession, op):
+    cmds = [["echo", "hi", (op,)]]
+    with pytest.raises(XonshError, match=r"requires a following pipe"):
+        cmds_to_specs(cmds, captured="hiddenobject")
+
+
+def test_a2p_conflict_with_o_redirect_errors(xession, tmpdir):
+    outfile = str(tmpdir / "conflict.txt")
+    cmds = [["echo", "hi", ("a>p",), ("o>", outfile)], "|", ["cat"]]
+    with pytest.raises(XonshError, match="Multiple redirections for stdout"):
+        cmds_to_specs(cmds, captured="hiddenobject")
+
+
+def test_e2p_conflict_with_e_redirect_errors(xession, tmpdir):
+    errfile = str(tmpdir / "conflict.txt")
+    cmds = [["echo", "hi", ("e>p",), ("e>", errfile)], "|", ["cat"]]
+    with pytest.raises(XonshError, match="Multiple redirections for stderr"):
+        cmds_to_specs(cmds, captured="hiddenobject")
+
+
 def test_resolve_executable_commands_updates_binary_loc(tmpdir, xession):
     """After resolve_executable_commands wraps a script with an interpreter,
     binary_loc must point to the interpreter, not the script.

--- a/xonsh/parsers/tokenize.py
+++ b/xonsh/parsers/tokenize.py
@@ -358,6 +358,13 @@ _redir_map = (
     "1>e",
     "o>2",
     "1>2",
+    # all streams to the following pipe (merged)
+    "a>p",
+    "all>p",
+    # stderr to the following pipe (stdout untouched)
+    "e>p",
+    "err>p",
+    "2>p",
 )
 IORedirect = group(group(*_redir_map), f"{group(*_redir_names)}>>?")
 

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -216,6 +216,40 @@ def _O2E_MAP():
     return frozenset({f"{o}>{e}" for e in _REDIR_ERR for o in _REDIR_OUT if o != ""})
 
 
+@xl.lazyobject
+def _A2P_MAP():
+    # `a>p` and variants: merge stdout+stderr into the following pipe.
+    # `&` is excluded here: `&>p` would conflict with the background-process
+    # parsing of `&` in subproc redirects.
+    return frozenset({f"{a}>p" for a in _REDIR_ALL if a != "&"})
+
+
+@xl.lazyobject
+def _E2P_MAP():
+    # `e>p` and variants: route stderr into the following pipe
+    return frozenset({f"{e}>p" for e in _REDIR_ERR})
+
+
+class _PipeRedirectSentinel:
+    """Marker put in a spec's stdout/stderr slot by ``_redirect_streams``
+    when the command uses ``a>p`` or ``e>p``. It is replaced by the pipe's
+    write fd later in ``cmds_to_specs``; if it survives to execution, the
+    redirect was used without a subsequent ``|`` pipe.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"<pipe-redirect {self.name}>"
+
+
+_PIPE_ALL = _PipeRedirectSentinel("a>p")
+_PIPE_ERR = _PipeRedirectSentinel("e>p")
+
+
 def safe_open(fname, mode, buffering=-1):
     """Safely attempts to open a file in for xonsh subprocs."""
     # file descriptors
@@ -272,6 +306,12 @@ def _redirect_streams(r, loc=None):
         raise Exception(f"Unsupported redirect: {r!r} {loc!r}")
 
     stdin = stdout = stderr = None
+    # pipe redirects: a>p merges both streams into the following pipe,
+    # e>p routes stderr into the following pipe (stdout left alone).
+    if r in _A2P_MAP:
+        return stdin, _PIPE_ALL, subprocess.STDOUT
+    elif r in _E2P_MAP:
+        return stdin, stdout, _PIPE_ERR
     no_ampersand = r.replace("&", "")
     # special case of redirecting stderr to stdout
     if no_ampersand in _E2O_MAP:
@@ -1186,13 +1226,37 @@ def cmds_to_specs(cmds, captured=False, envs=None, in_boolop=False):
             # these should remain integer file descriptors, and not Python
             # file objects since they connect processes.
             pipe = PipeChannel.from_pipe()
-            specs[i].stdout = pipe.write_fd
+            upstream = specs[i]
+            # `e>p` adds stderr to the pipe; stdout still goes through the
+            # pipe by default, unless the user diverted it with `o>`/`>`.
+            if upstream._stderr is _PIPE_ERR:
+                upstream._stderr = None
+                upstream.stderr = pipe.write_fd
+                # Skip wiring stdout if it is already redirected elsewhere
+                # (e.g. `cmd o> file e>p | grep` — stdout to file, pipe gets
+                # only stderr).
+                skip_stdout = upstream._stdout is not None
+            else:
+                skip_stdout = False
+            # `a>p`: stdout goes to the pipe and stderr is merged into it
+            # (stderr was already set to subprocess.STDOUT by _redirect_streams).
+            if upstream._stdout is _PIPE_ALL:
+                upstream._stdout = None
+            if not skip_stdout:
+                upstream.stdout = pipe.write_fd
             specs[i + 1].stdin = pipe.read_fd
-            specs[i].pipe_channels.append(pipe)
+            upstream.pipe_channels.append(pipe)
         elif redirect == "&" and i == len(redirects) - 1:
             specs[i].background = True
         else:
             raise xt.XonshError(f"unrecognized redirect {redirect!r}")
+    # Any pipe-redirect sentinel still present means `a>p`/`e>p` was used
+    # without a following `|` pipe.
+    for spec in specs:
+        if spec._stdout is _PIPE_ALL or spec._stderr is _PIPE_ERR:
+            raise xt.XonshError(
+                "xonsh: redirect 'a>p'/'e>p' requires a following pipe '|'"
+            )
 
     # Apply boundary conditions
     if not XSH.env.get("XONSH_CAPTURE_ALWAYS"):


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/4494

### Implementation

We already have `o> file`, `o>e`, `e>o`, etc so let's add `a>p`, `e>p`:

```xsh
cmd a>p | cmd2                 # stdout + stderr into the pipe
cmd e>p | grep warning             # same as `a>p` but `e>p` is to next use case
cmd o> out.txt e>p | grep warning  # stdout to file, stderr into the pipe
```
## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
