### PR TITLE
feat(prompt): Improve dedent and fix `# \` issue

### DIFF
--- a/tests/shell/test_base_shell.py
+++ b/tests/shell/test_base_shell.py
@@ -163,8 +163,11 @@ def test_on_precommand_preserves_leading_whitespace(prefix, xonsh_session):
     assert fired[0].startswith(prefix + "print")
 
 
-def test_on_postcommand_preserves_leading_whitespace(xonsh_session):
-    """on_postcommand must also receive the command with original whitespace."""
+def test_on_postcommand_receives_dedented_command(xonsh_session):
+    """on_postcommand must receive the command in the form that was executed:
+    post-transform and post-dedent — i.e. what was actually compiled and run.
+    This is the counterpart to on_precommand, which sees the original input.
+    """
     fired = []
 
     @xonsh_session.builtins.events.on_postcommand
@@ -173,7 +176,24 @@ def test_on_postcommand_preserves_leading_whitespace(xonsh_session):
 
     xonsh_session.shell.default("  print('test')")
     assert len(fired) == 1
-    assert fired[0].startswith("  print")
+    assert fired[0].startswith("print")
+
+
+def test_on_postcommand_dedents_block_with_comment_backslash(xonsh_session):
+    """on_postcommand must see the dedented block even when a line ends with a
+    ``\\`` *inside a comment*. The backslash in a comment is not a line
+    continuation, so the whole ``if``-block compiles as one unit and the
+    dedented form reaches the event.
+    """
+    fired = []
+
+    @xonsh_session.builtins.events.on_postcommand
+    def capture(cmd, **_):
+        fired.append(cmd)
+
+    xonsh_session.shell.default("   if 1: # \\\n     echo 1")
+    assert len(fired) == 1
+    assert fired[0] == "if 1: # \\\n  echo 1\n"
 
 
 def test_on_transform_command_receives_leading_whitespace(xonsh_session):

--- a/tests/shell/test_base_shell.py
+++ b/tests/shell/test_base_shell.py
@@ -5,8 +5,37 @@ import os
 
 import pytest
 
-from xonsh.shell import transform_command
+from xonsh.shell import deindent, transform_command
 from xonsh.shells.base_shell import BaseShell, _TeeStdBuf
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        # single-line indented input
+        ("  echo 1\n", "echo 1\n"),
+        ("\techo 1\n", "echo 1\n"),
+        # no leading whitespace - untouched
+        ("echo 1\n", "echo 1\n"),
+        # multi-line block with common leading indent (Python paste case)
+        (
+            "    if True:\n        x = 1\n    print(x)\n",
+            "if True:\n    x = 1\nprint(x)\n",
+        ),
+        # multi-line subproc with common leading indent
+        ("  echo 1\n  echo 2\n", "echo 1\necho 2\n"),
+        # first line deeper than continuation -- line-continuation subproc
+        # paste: dedent alone leaves line 1 indented, so lstrip kicks in
+        ("        echo 1 \\\n    2\n", "echo 1 \\\n2\n"),
+        # first line deeper but no continuation -- lstrip does NOT fire,
+        # so the (already-broken) indent structure is preserved as-is
+        ("        echo 1\n    echo 2\n", "    echo 1\necho 2\n"),
+        # empty string
+        ("", ""),
+    ],
+)
+def test_deindent(src, expected):
+    assert deindent(src) == expected
 
 
 def test_pwd_tracks_cwd(xession, xonsh_execer, tmpdir_factory, monkeypatch):

--- a/tests/shell/test_base_shell.py
+++ b/tests/shell/test_base_shell.py
@@ -179,6 +179,39 @@ def test_on_postcommand_receives_dedented_command(xonsh_session):
     assert fired[0].startswith("print")
 
 
+def test_event_chain_transform_precommand_dedent_postcommand(xonsh_session):
+    """The full command chain: ``on_transform_command`` (may modify) →
+    ``on_precommand`` (reacts to the transformed input, whitespace preserved)
+    → dedent + execute → ``on_postcommand`` (sees what was actually run).
+    Each stage receives a different, correctly-progressed form of the command.
+    """
+    transformed = []
+    precommand = []
+    postcommand = []
+
+    @xonsh_session.builtins.events.on_transform_command
+    def transform(cmd, **_):
+        transformed.append(cmd)
+        return cmd.replace("echo 1", "echo 2")
+
+    @xonsh_session.builtins.events.on_precommand
+    def precmd(cmd, **_):
+        precommand.append(cmd)
+
+    @xonsh_session.builtins.events.on_postcommand
+    def postcmd(cmd, **_):
+        postcommand.append(cmd)
+
+    xonsh_session.shell.default("   echo 1")
+
+    # on_transform_command sees the raw input on its first firing
+    assert transformed[0] == "   echo 1\n"
+    # on_precommand sees the post-transform command with leading whitespace
+    assert precommand == ["   echo 2\n"]
+    # on_postcommand sees the dedented form that was actually executed
+    assert postcommand == ["echo 2\n"]
+
+
 def test_on_postcommand_dedents_block_with_comment_backslash(xonsh_session):
     """on_postcommand must see the dedented block even when a line ends with a
     ``\\`` *inside a comment*. The backslash in a comment is not a line

--- a/tests/shell/test_ptk_shell.py
+++ b/tests/shell/test_ptk_shell.py
@@ -148,6 +148,50 @@ def test_ptk_default_append_history(cmd, exp_append_history, ptk_shell, monkeypa
         assert len(append_history_calls) == 0
 
 
+@pytest.mark.parametrize(
+    "prefix",
+    ["  ", "\t", " \t "],
+)
+def test_ptk_push_compiles_indented_input(prefix, ptk_shell):
+    """``_push`` must lstrip before compile so leading whitespace from the
+    user's input doesn't turn ``echo 1`` into a ``SyntaxError: unexpected
+    indent``. The returned ``src`` still carries the original whitespace so
+    events like ``on_precommand`` see it unmodified.
+    """
+    _, _, shell = ptk_shell
+    src, code = shell.push(prefix + "print('test')\n")
+    assert code is not None
+    assert src.startswith(prefix)
+
+
+def test_ptk_default_executes_indented_input(ptk_shell, xession):
+    """Regression for #6294 follow-up: ``  echo 1`` in ptk shell must run
+    without raising ``SyntaxError: unexpected indent``.
+    """
+    _, _, shell = ptk_shell
+    fired = []
+
+    @xession.builtins.events.on_precommand
+    def capture(cmd, **_):
+        fired.append(cmd)
+
+    shell.default("  print('test')")
+    assert len(fired) == 1
+    assert fired[0].startswith("  print")
+
+
+def test_ptk_push_compiles_multiline_indented_block(ptk_shell):
+    """A multi-line paste with a common leading indent must compile —
+    ``lstrip()`` would only strip the first line and break inner
+    indentation, so the fix must use ``textwrap.dedent``.
+    """
+    _, _, shell = ptk_shell
+    block = "    if True:\n        x = 1\n    y = 2\n"
+    src, code = shell.push(block)
+    assert code is not None
+    assert src == block  # event-visible src is unchanged
+
+
 def test_ptk_combine_history(monkeypatch):
     """Test that consecutive identical history items are combined into a single item
     when loading xonsh history items into prompt-toolkit history."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -539,6 +539,28 @@ def test_get_logical_line(src, idx, exp_line, exp_n, xession):
     assert exp_n == n
 
 
+@pytest.mark.parametrize(
+    "src, idx, exp_line, exp_n",
+    [
+        # A ``\`` inside a comment is NOT a line continuation -- the
+        # next physical line stands on its own. Regression for #6294
+        # follow-up where a comment ending in ``\`` would swallow the
+        # subproc line below it and produce ``no further code``.
+        ("# \\\necho 1", 1, "echo 1", 1),
+        ("if 1: # \\\n  echo 1", 1, "  echo 1", 1),
+        ("a = 1 # \\\necho 1", 1, "echo 1", 1),
+        # A ``#`` inside a string must not be confused with a comment,
+        # so the real continuation still fires.
+        ('x = "# in str" + \\\n    "y"', 0, 'x = "# in str" +     "y"', 2),
+    ],
+)
+def test_get_logical_line_comment_continuation(src, idx, exp_line, exp_n, xession):
+    lines = src.splitlines()
+    line, n, start = get_logical_line(lines, idx)
+    assert exp_line == line
+    assert exp_n == n
+
+
 @pytest.mark.parametrize("src, idx, exp_line, exp_n", LOGICAL_LINE_CASES)
 def test_replace_logical_line(src, idx, exp_line, exp_n, xession):
     lines = src.splitlines()

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2316,10 +2316,18 @@ class DeprecatedSetting(Xettings):  # sub-classing -> sub-group
     """Deprecated settings."""
 
     AUTO_SUGGEST = PTKSetting.XONSH_PROMPT_AUTO_SUGGEST.set_attrs(
-        {"sync": "XONSH_PROMPT_AUTO_SUGGEST", "deprecated": True, "doc": "Deprecated. Use XONSH_PROMPT_AUTO_SUGGEST."}
+        {
+            "sync": "XONSH_PROMPT_AUTO_SUGGEST",
+            "deprecated": True,
+            "doc": "Deprecated. Use XONSH_PROMPT_AUTO_SUGGEST.",
+        }
     )
     RAISE_SUBPROC_ERROR = SubprocessSetting.XONSH_SUBPROC_CMD_RAISE_ERROR.set_attrs(
-        {"sync": "XONSH_SUBPROC_CMD_RAISE_ERROR", "deprecated": True, "doc": "Deprecated. Use XONSH_SUBPROC_CMD_RAISE_ERROR."}
+        {
+            "sync": "XONSH_SUBPROC_CMD_RAISE_ERROR",
+            "deprecated": True,
+            "doc": "Deprecated. Use XONSH_SUBPROC_CMD_RAISE_ERROR.",
+        }
     )
 
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -2,6 +2,7 @@
 
 import difflib
 import sys
+import textwrap
 import time
 import warnings
 
@@ -146,6 +147,27 @@ on_post_prompt() -> None
 Fires just after the prompt returns
 """,
 )
+
+
+def deindent(src):
+    """Remove leading indentation from ``src`` before compilation.
+
+    Applies ``textwrap.dedent`` to strip the common leading whitespace
+    from every line. If the first line ends with a line-continuation
+    backslash and still begins with whitespace after dedent (paste of a
+    subproc command where line 1 was indented deeper than the
+    continuation line), also ``lstrip`` the source so the first line is
+    flush-left.
+    """
+    src = textwrap.dedent(src)
+    first_line = src.split("\n", 1)[0]
+    if (
+        first_line
+        and first_line[0].isspace()
+        and first_line.rstrip().endswith("\\")
+    ):
+        src = src.lstrip()
+    return src
 
 
 def transform_command(src, show_diff=True):

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -62,7 +62,10 @@ This event only fires in interactive mode.
 
 Parameters:
 
-* ``cmd``: The command that was executed (after transformation)
+* ``cmd``: The command that was executed — the final form after transformation
+  and dedent, i.e. exactly what was compiled and run (and what is stored in
+  history). This may differ from the ``cmd`` seen by ``on_precommand``, which
+  preserves the original leading whitespace.
 * ``rtn``: The result of the command executed (``0`` for success)
 * ``out``: If xonsh stores command output, this is the output
 * ``ts``: Timestamps, in the order of ``[starting, ending]``

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -48,7 +48,24 @@ events.doc(
     """
 on_precommand(cmd: str) -> None
 
-Fires just before a command is executed.
+Fires just before a command is executed, after ``on_transform_command`` has
+produced its final form. Handlers cannot modify the command — use
+``on_transform_command`` if you need to change the source before it runs.
+This event only fires in interactive mode.
+
+Parameters:
+
+* ``cmd``: The command about to be executed.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_precommand
+    def _audit(cmd, **kw):
+        '''Log each command to a file right before execution.'''
+        with open('/tmp/xonsh_audit.log', 'a') as f:
+            f.write(cmd)
 """,
 )
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -80,9 +80,7 @@ This event only fires in interactive mode.
 Parameters:
 
 * ``cmd``: The command that was executed — the final form after transformation
-  and dedent, i.e. exactly what was compiled and run (and what is stored in
-  history). This may differ from the ``cmd`` seen by ``on_precommand``, which
-  preserves the original leading whitespace.
+  and dedent.
 * ``rtn``: The result of the command executed (``0`` for success)
 * ``out``: If xonsh stores command output, this is the output
 * ``ts``: Timestamps, in the order of ``[starting, ending]``

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -161,11 +161,7 @@ def deindent(src):
     """
     src = textwrap.dedent(src)
     first_line = src.split("\n", 1)[0]
-    if (
-        first_line
-        and first_line[0].isspace()
-        and first_line.rstrip().endswith("\\")
-    ):
+    if first_line and first_line[0].isspace() and first_line.rstrip().endswith("\\"):
         src = src.lstrip()
     return src
 

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -21,7 +21,7 @@ from xonsh.events import events
 from xonsh.lib.lazyimps import pyghooks, pygments
 from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.prompt.base import PromptFormatter, multiline_prompt
-from xonsh.shell import transform_command
+from xonsh.shell import deindent, transform_command
 from xonsh.tools import (
     DefaultNotGiven,
     XonshError,
@@ -461,7 +461,7 @@ class BaseShell:
             ts1 = ts1 or time.time()
             tee_out = tee.getvalue()
             info = self._append_history(
-                inp=src.lstrip(),
+                inp=deindent(src),
                 ts=[ts0, ts1],
                 spc=self.src_starts_with_space,
                 tee_out=tee_out,
@@ -550,7 +550,7 @@ class BaseShell:
             return None, None
         src = "".join(self.buffer)
         src = transform_command(src)
-        _, code = self.compile(src.lstrip())
+        _, code = self.compile(deindent(src))
         return src, code
 
     def compile(self, src):

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -469,7 +469,7 @@ class BaseShell:
             )
             if not isinstance(exc_info[1], SystemExit):
                 events.on_postcommand.fire(
-                    cmd=src,
+                    cmd=info["inp"],
                     rtn=info["rtn"],
                     out=info.get("out", None),
                     ts=info["ts"],

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -30,7 +30,7 @@ from xonsh.events import events
 from xonsh.lib.lazyimps import pyghooks, pygments, winutils
 from xonsh.platform import HAS_PYGMENTS, ON_POSIX, ON_WINDOWS
 from xonsh.pygments_cache import get_all_styles
-from xonsh.shell import transform_command
+from xonsh.shell import deindent, transform_command
 from xonsh.shells.base_shell import BaseShell
 from xonsh.shells.ptk_shell.completer import PromptToolkitCompleter
 from xonsh.shells.ptk_shell.formatter import PTKPromptFormatter
@@ -451,7 +451,11 @@ class PromptToolkitShell(BaseShell):
         src = transform_command(src)
         try:
             code = self.execer.compile(
-                src, mode="single", glbs=self.ctx, locs=None, compile_empty_tree=False
+                deindent(src),
+                mode="single",
+                glbs=self.ctx,
+                locs=None,
+                compile_empty_tree=False,
             )
             self.reset_buffer()
         except Exception:  # pylint: disable=broad-except

--- a/xonsh/shells/ptk_shell/key_bindings.py
+++ b/xonsh/shells/ptk_shell/key_bindings.py
@@ -23,7 +23,7 @@ from prompt_toolkit.keys import Keys
 from xonsh.aliases import xonsh_exit
 from xonsh.built_ins import XSH
 from xonsh.platform import ON_WINDOWS
-from xonsh.shell import transform_command
+from xonsh.shell import deindent, transform_command
 from xonsh.tools import (
     check_for_partial_string,
     ends_with_colon_token,
@@ -95,7 +95,7 @@ def can_compile(src):
     """Returns whether the code can be compiled, i.e. it is valid xonsh."""
     src = src if src.endswith("\n") else src + "\n"
     src = transform_command(src, show_diff=False)
-    src = src.lstrip()
+    src = deindent(src)
     try:
         XSH.execer.compile(src, mode="single", glbs=None, locs=XSH.ctx)
         rtn = True

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -511,6 +511,48 @@ def get_line_continuation():
     return "\\"
 
 
+def _ends_with_line_continuation(line, linecont):
+    """True if ``line`` ends with ``linecont`` outside of a comment.
+
+    A ``#`` that is not inside a string literal starts a comment;
+    Python's tokenizer treats ``\\`` inside a comment as literal text,
+    not as a line continuation. ``xonsh``'s context-free subproc
+    fallback must agree, otherwise a comment ending in ``\\`` silently
+    swallows the next physical line (#6294 follow-up).
+    """
+    if not line.endswith(linecont):
+        return False
+    quote = None  # active string delimiter, or None
+    triple = False  # whether the active string is triple-quoted
+    escape = False  # previous char in a string opened an escape
+    i = 0
+    end = len(line) - len(linecont)
+    while i < end:
+        c = line[i]
+        if quote is None:
+            if c == "#":
+                return False
+            if c in ("'", '"'):
+                if line[i : i + 3] == c * 3:
+                    quote, triple = c, True
+                    i += 3
+                    continue
+                quote, triple = c, False
+        else:
+            if escape:
+                escape = False
+            elif c == "\\":
+                escape = True
+            elif triple and line[i : i + 3] == quote * 3:
+                quote, triple = None, False
+                i += 3
+                continue
+            elif not triple and c == quote:
+                quote, triple = None, False
+        i += 1
+    return True
+
+
 def get_logical_line(lines, idx):
     """Returns a single logical line (i.e. one without line continuations)
     from a list of lines.  This line should begin at index idx. This also
@@ -520,15 +562,17 @@ def get_logical_line(lines, idx):
     n = 1
     nlines = len(lines)
     linecont = get_line_continuation()
-    while idx > 0 and lines[idx - 1].endswith(linecont):
+    while idx > 0 and _ends_with_line_continuation(lines[idx - 1], linecont):
         idx -= 1
     start = idx
     line = lines[idx]
     open_triple = _have_open_triple_quotes(line)
-    while (line.endswith(linecont) or open_triple) and idx < nlines - 1:
+    while (
+        _ends_with_line_continuation(line, linecont) or open_triple
+    ) and idx < nlines - 1:
         n += 1
         idx += 1
-        if line.endswith(linecont):
+        if _ends_with_line_continuation(line, linecont):
             line = line[:-1] + lines[idx]
         else:
             line = line + "\n" + lines[idx]


### PR DESCRIPTION
We need to fix some cases described below.


### Before

```xsh
     echo 1 \
2
# SyntaxError: unexpected indent  - 🟡  This is expected after #6294

    if 1:  # \
       echo 1
# SyntaxError: None: no further code        # Bug 🔴 
```

### After 

```xsh
        echo 1 \
2
# 1 2 🟢 

    if 1:  # \
       echo 1
# 1 🟢 
```

### Implementation

1. Prompt: After #6294 we need to use smart dedent: dedent and lstrip in case of command with new line. It's more secure but still flexible.
2. [Fixed](https://github.com/xonsh/xonsh/pull/6321/commits/e817a4b92df84d7cab81bfb12549bb675f0c89b1) `# \` issue
3. Now on_postcommand has the text ot the command that was executed (after smart dedent)


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
