### PR TITLE
fix: CI/Embedding guard around sending signals from main thread

### DIFF
--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -22,6 +22,28 @@ own code. The public entry point for this is :func:`xonsh.main.setup`,
 documented in :mod:`xonsh.main`.
 
 
+Calling ``setup()`` Off the Main Thread
+=======================================
+
+:func:`xonsh.main.setup` is safe to call from a non-main thread. Python
+disallows installing signal handlers from worker threads, so xonsh skips
+that step when it detects it is not on the main thread. Historically this
+path raised ``ValueError: signal only works in main thread`` during load
+(see `xonsh#3689 <https://github.com/xonsh/xonsh/issues/3689>`_).
+
+Consequences for embedders:
+
+* ``setup()`` completes normally from any thread; the execer, session,
+  environment and aliases work as expected.
+* The :func:`atexit` history-flush registration still runs, so history is
+  flushed on normal interpreter shutdown.
+* Termination-signal handlers that would flush history on ``SIGTERM``,
+  ``SIGHUP``, ``SIGQUIT``, ``SIGTSTP`` etc. are **not** installed in this
+  case — the host process owns signals in embedded scenarios. If you need
+  signal-driven flushes, call ``setup()`` once on the main thread at
+  startup or install your own handlers there.
+
+
 Controlling Terminal Handshake for Embedded Interactive Shells
 ==============================================================
 

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -26,6 +26,7 @@ from xonsh.built_ins import (
     regexmatchsearch,
     regexsearch,
     reglob,
+    resetting_signal_handle,
     superhelper,
 )
 from xonsh.environ import Env
@@ -547,3 +548,23 @@ def test_xonshpathliteral_contextmanager(tmp_path):
             os.chdir(start_cwd)
         except Exception:
             pass
+
+
+def test_resetting_signal_handle_off_main_thread_is_noop():
+    """Regression for xonsh#3689: setup() called from a non-main thread must
+    not crash with ValueError('signal only works in main thread')."""
+    import signal
+    import threading
+
+    errors: list[BaseException] = []
+
+    def worker():
+        try:
+            resetting_signal_handle(signal.SIGTERM, lambda s, f: None)
+        except BaseException as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert errors == []

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -31,6 +31,7 @@ from xonsh.tools import (
     XonshError,
     expand_path,
     globpath,
+    on_main_thread,
     print_color,
 )
 
@@ -57,6 +58,13 @@ def resetting_signal_handle(sig, f):
     """Sets a new signal handle that will automatically restore the old value
     once the new handle is finished.
     """
+    # signal.signal() only works on the main thread; from a worker it raises
+    # ValueError. When xonsh is set up from a non-main thread (e.g. an embedded
+    # host calling xonsh.main.setup() off-main, like the 2020 virtualenv CI
+    # case in xonsh/xonsh#3689), skip registration rather than crash — the host
+    # owns process signals in that scenario. Same guard is used in procs/posix.py.
+    if not on_main_thread():
+        return
     prev_signal_handler = signal.getsignal(sig)
 
     def new_signal_handler(s=None, frame=None):


### PR DESCRIPTION
### Motivation

We had a case in https://github.com/xonsh/xonsh/issues/3689#issuecomment-748621587  that also can appear in xonsh embedding cases:

```xsh
INTERNALERROR>   File "D:\a\virtualenv\virtualenv\.tox\py38\lib\site-packages\xonsh\main.py", line 548, in setup
INTERNALERROR>     execer = Execer(xonsh_ctx=ctx)
INTERNALERROR>   File "D:\a\virtualenv\virtualenv\.tox\py38\lib\site-packages\xonsh\execer.py", line 63, in __init__
INTERNALERROR>     load_builtins(execer=self, ctx=xonsh_ctx)
INTERNALERROR>   File "D:\a\virtualenv\virtualenv\.tox\py38\lib\site-packages\xonsh\built_ins.py", line 1346, in load_builtins
INTERNALERROR>     builtins.__xonsh__.link_builtins(execer=execer)
INTERNALERROR>   File "D:\a\virtualenv\virtualenv\.tox\py38\lib\site-packages\xonsh\built_ins.py", line 1480, in link_builtins
INTERNALERROR>     resetting_signal_handle(sig, _lastflush)
INTERNALERROR>   File "D:\a\virtualenv\virtualenv\.tox\py38\lib\site-packages\xonsh\built_ins.py", line 87, in resetting_signal_handle
INTERNALERROR>     signal.signal(sig, newh)
INTERNALERROR>   File "C:\hostedtoolcache\windows\Python\3.8.6\x64\lib\signal.py", line 47, in signal
INTERNALERROR>     handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
INTERNALERROR> ValueError: signal only works in main thread
```

To prevent this in the future we need a guard in main thread.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
