### PR TITLE
fix: Python 3.15: Fix ResourceWarning in procs and specs

### DIFF
--- a/tests/procs/test_proxies_llm.py
+++ b/tests/procs/test_proxies_llm.py
@@ -4,6 +4,7 @@ import sys
 from unittest.mock import patch
 
 from xonsh.procs.proxies import ProcProxy, ProcProxyThread, still_writable
+from xonsh.procs.readers import safe_fdclose
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -121,7 +122,9 @@ class TestProcProxyWaitFdCleanup:
             stdin.read()
 
         p = _make_proc_proxy(alias, xession, stdin=r)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             # At least one call should be a TextIOWrapper wrapping our fd
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
@@ -137,7 +140,9 @@ class TestProcProxyWaitFdCleanup:
             stdout.write("hi")
 
         p = _make_proc_proxy(alias, xession, stdout=w)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
             assert any(isinstance(h, io.TextIOWrapper) for h in closed_handles), (
@@ -153,7 +158,9 @@ class TestProcProxyWaitFdCleanup:
             stderr.write("err")
 
         p = _make_proc_proxy(alias, xession, stderr=w)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
             assert any(isinstance(h, io.TextIOWrapper) for h in closed_handles), (
@@ -168,7 +175,9 @@ class TestProcProxyWaitFdCleanup:
             pass
 
         p = _make_proc_proxy(alias, xession)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
             assert sys.stdout not in closed_handles
@@ -182,7 +191,9 @@ class TestProcProxyWaitFdCleanup:
             stdout.write("hi")
 
         p = _make_proc_proxy(alias, xession, stdout=buf)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
             assert buf not in closed_handles
@@ -195,7 +206,9 @@ class TestProcProxyWaitFdCleanup:
             raise RuntimeError("boom")
 
         p = _make_proc_proxy(alias, xession, stdout=w)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             assert p.returncode == 1
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
@@ -216,7 +229,9 @@ class TestProcProxyWaitFdCleanup:
             stdout.write(stdin.read())
 
         p = _make_proc_proxy(alias, xession, stdin=in_r, stdout=out_w, stderr=err_w)
-        with patch("xonsh.procs.proxies.safe_fdclose") as mock_close:
+        with patch(
+            "xonsh.procs.proxies.safe_fdclose", wraps=safe_fdclose
+        ) as mock_close:
             p.wait()
             closed_handles = [c.args[0] for c in mock_close.call_args_list]
             wrappers = [h for h in closed_handles if isinstance(h, io.TextIOWrapper)]

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -1,9 +1,11 @@
 """Tests the xonsh.procs.specs"""
 
+import gc
 import itertools
 import os
 import signal
 import sys
+import warnings
 from subprocess import CalledProcessError, Popen
 
 import pytest
@@ -46,34 +48,40 @@ def test_cmds_to_specs_thread_subproc(xession):
     env = xession.env
     cmds = [["pwd"]]
 
+    def _check_cls(cmds, expected_cls):
+        # `cmds_to_specs` opens pipe wrappers for captured specs that this
+        # test never executes; close them so they don't leak as
+        # `ResourceWarning: unclosed file`.
+        specs = cmds_to_specs(cmds, captured="hiddenobject")
+        try:
+            assert specs[0].cls is expected_cls
+        finally:
+            for s in specs:
+                s.close()
+
     # XONSH_CAPTURE_ALWAYS=False should disable interactive threaded subprocs
     env["XONSH_CAPTURE_ALWAYS"] = False
     env["THREAD_SUBPROCS"] = True
-    specs = cmds_to_specs(cmds, captured="hiddenobject")
-    assert specs[0].cls is Popen
+    _check_cls(cmds, Popen)
 
     # Now for the other situations
     env["XONSH_CAPTURE_ALWAYS"] = True
 
     # First check that threadable subprocs become threadable
     env["THREAD_SUBPROCS"] = True
-    specs = cmds_to_specs(cmds, captured="hiddenobject")
-    assert specs[0].cls is PopenThread
+    _check_cls(cmds, PopenThread)
     # turn off threading and check we use Popen
     env["THREAD_SUBPROCS"] = False
-    specs = cmds_to_specs(cmds, captured="hiddenobject")
-    assert specs[0].cls is Popen
+    _check_cls(cmds, Popen)
 
     # now check the threadbility of callable aliases
     cmds = [[lambda: "Keras Selyrian"]]
     # check that threadable alias become threadable
     env["THREAD_SUBPROCS"] = True
-    specs = cmds_to_specs(cmds, captured="hiddenobject")
-    assert specs[0].cls is ProcProxyThread
+    _check_cls(cmds, ProcProxyThread)
     # turn off threading and check we use ProcProxy
     env["THREAD_SUBPROCS"] = False
-    specs = cmds_to_specs(cmds, captured="hiddenobject")
-    assert specs[0].cls is ProcProxy
+    _check_cls(cmds, ProcProxy)
 
 
 @pytest.mark.parametrize("thread_subprocs", [True, False])
@@ -84,8 +92,59 @@ def test_cmds_to_specs_capture_stdout_not_stderr(thread_subprocs, xonsh_session)
     env["THREAD_SUBPROCS"] = thread_subprocs
 
     specs = cmds_to_specs(cmds, captured="stdout")
-    assert specs[0].stdout is not None
-    assert specs[0].stderr is None
+    try:
+        assert specs[0].stdout is not None
+        assert specs[0].stderr is None
+    finally:
+        # The spec is never executed here; release its pipe wrappers so they
+        # don't surface as `ResourceWarning: unclosed file` at GC time.
+        for s in specs:
+            s.close()
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize("captured", ["stdout", "object", "hiddenobject"])
+def test_subproc_spec_close_releases_pipe_wrappers(captured, xession):
+    """Regression: SubprocSpec.close() must release every pipe wrapper.
+
+    `cmds_to_specs` opens pipe wrappers via `PipeChannel.open_writer/
+    open_reader` (with `closefd=False`) for any captured spec. When the
+    spec is never executed, GC reaping the wrappers triggers
+    `ResourceWarning: unclosed file` (delivered via sys.unraisablehook,
+    invisible to ordinary warning filters). `SubprocSpec.close()` must
+    drop them deterministically.
+    """
+    xession.env["THREAD_SUBPROCS"] = True
+    if captured == "hiddenobject":
+        xession.env["XONSH_CAPTURE_ALWAYS"] = True
+
+    # Reap any garbage left over from earlier tests so its ResourceWarnings
+    # don't leak into our tracking window.
+    gc.collect()
+
+    unraisable = []
+    orig_hook = sys.unraisablehook
+    sys.unraisablehook = lambda args: unraisable.append(args)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ResourceWarning)
+
+            specs = cmds_to_specs([["pwd"]], captured=captured)
+            assert specs[0].pipe_channels, "test premise: spec must own pipes"
+            for s in specs:
+                s.close()
+            del specs
+            gc.collect()
+    finally:
+        sys.unraisablehook = orig_hook
+
+    leaks = [
+        u
+        for u in unraisable
+        if isinstance(u.exc_value, ResourceWarning)
+        and "unclosed file" in str(u.exc_value)
+    ]
+    assert not leaks, f"pipe wrappers leaked: {[str(u.exc_value) for u in leaks]}"
 
 
 @skip_if_on_windows

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -200,6 +200,11 @@ class CommandPipeline:
             except Exception:
                 xt.print_exception()
                 self._return_terminal()
+                # Release any pipe wrappers held by specs that won't be
+                # routed through _close_proc(): the failing spec, plus any
+                # later specs that never got to run().
+                for s in specs[i:]:
+                    s.close()
                 self.proc = None
                 return
             if proc.pid and pipeline_group is None and not spec.is_proxy:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -582,6 +582,24 @@ class SubprocSpec:
     def get_command_str(self):
         return " ".join(arg for arg in self.args)
 
+    def close(self):
+        """Release any pipe wrappers and channels held by this spec.
+
+        Required when a spec is created via ``cmds_to_specs`` but never
+        executed (no ``CommandPipeline._close_proc`` is invoked). The
+        wrappers from ``PipeChannel.open_writer/open_reader`` use
+        ``closefd=False``, so leaving them for GC produces a
+        ``ResourceWarning: unclosed file`` on Python 3.12+. Idempotent.
+        """
+        safe_close(self._stdin)
+        safe_close(self._stdout)
+        safe_close(self._stderr)
+        safe_close(self.captured_stdout)
+        safe_close(self.captured_stderr)
+        for ch in self.pipe_channels:
+            ch.close()
+        self.pipe_channels.clear()
+
     #
     # Execution methods
     #
@@ -1211,76 +1229,83 @@ def cmds_to_specs(cmds, captured=False, envs=None, in_boolop=False):
     # first build the subprocs independently and separate from the redirects
     specs = []
     redirects = []
-    for i, cmd in enumerate(cmds):
-        if isinstance(cmd, str):
-            redirects.append(cmd)
-        else:
-            env = envs[i] if envs is not None else None
-            spec = SubprocSpec.build(cmd, captured=captured, env=env)
-            spec.pipeline_index = len(specs)
-            spec.in_boolop = in_boolop
-            specs.append(spec)
-    # now modify the subprocs based on the redirects.
-    for i, redirect in enumerate(redirects):
-        if redirect == "|":
-            # these should remain integer file descriptors, and not Python
-            # file objects since they connect processes.
-            pipe = PipeChannel.from_pipe()
-            upstream = specs[i]
-            # `e>p` adds stderr to the pipe; stdout still goes through the
-            # pipe by default, unless the user diverted it with `o>`/`>`.
-            if upstream._stderr is _PIPE_ERR:
-                upstream._stderr = None
-                upstream.stderr = pipe.write_fd
-                # Skip wiring stdout if it is already redirected elsewhere
-                # (e.g. `cmd o> file e>p | grep` — stdout to file, pipe gets
-                # only stderr).
-                skip_stdout = upstream._stdout is not None
+    try:
+        for i, cmd in enumerate(cmds):
+            if isinstance(cmd, str):
+                redirects.append(cmd)
             else:
-                skip_stdout = False
-            # `a>p`: stdout goes to the pipe and stderr is merged into it
-            # (stderr was already set to subprocess.STDOUT by _redirect_streams).
-            if upstream._stdout is _PIPE_ALL:
-                upstream._stdout = None
-            if not skip_stdout:
-                upstream.stdout = pipe.write_fd
-            specs[i + 1].stdin = pipe.read_fd
-            upstream.pipe_channels.append(pipe)
-        elif redirect == "&" and i == len(redirects) - 1:
-            specs[i].background = True
-        else:
-            raise xt.XonshError(f"unrecognized redirect {redirect!r}")
-    # Any pipe-redirect sentinel still present means `a>p`/`e>p` was used
-    # without a following `|` pipe.
-    for spec in specs:
-        if spec._stdout is _PIPE_ALL or spec._stderr is _PIPE_ERR:
-            raise xt.XonshError(
-                "xonsh: redirect 'a>p'/'e>p' requires a following pipe '|'"
-            )
-
-    # Apply boundary conditions
-    if not XSH.env.get("XONSH_CAPTURE_ALWAYS"):
-        # Make sure sub-specs are always captured in case:
-        # `![some_alias | grep x]`, `$(some_alias)`, `some_alias > file`.
-        last = spec
-        is_redirected_stdout = bool(last.stdout)
-        specs_to_capture = (
-            specs
-            if captured in STDOUT_CAPTURE_KINDS or is_redirected_stdout
-            else specs[:-1]
-        )
-        _set_specs_capture_always(specs_to_capture)
-
-    # Validate: unthreadable callable aliases cannot be used in pipelines
-    if len(specs) > 1:
+                env = envs[i] if envs is not None else None
+                spec = SubprocSpec.build(cmd, captured=captured, env=env)
+                spec.pipeline_index = len(specs)
+                spec.in_boolop = in_boolop
+                specs.append(spec)
+        # now modify the subprocs based on the redirects.
+        for i, redirect in enumerate(redirects):
+            if redirect == "|":
+                # these should remain integer file descriptors, and not Python
+                # file objects since they connect processes.
+                pipe = PipeChannel.from_pipe()
+                upstream = specs[i]
+                # `e>p` adds stderr to the pipe; stdout still goes through the
+                # pipe by default, unless the user diverted it with `o>`/`>`.
+                if upstream._stderr is _PIPE_ERR:
+                    upstream._stderr = None
+                    upstream.stderr = pipe.write_fd
+                    # Skip wiring stdout if it is already redirected elsewhere
+                    # (e.g. `cmd o> file e>p | grep` — stdout to file, pipe gets
+                    # only stderr).
+                    skip_stdout = upstream._stdout is not None
+                else:
+                    skip_stdout = False
+                # `a>p`: stdout goes to the pipe and stderr is merged into it
+                # (stderr was already set to subprocess.STDOUT by _redirect_streams).
+                if upstream._stdout is _PIPE_ALL:
+                    upstream._stdout = None
+                if not skip_stdout:
+                    upstream.stdout = pipe.write_fd
+                specs[i + 1].stdin = pipe.read_fd
+                upstream.pipe_channels.append(pipe)
+            elif redirect == "&" and i == len(redirects) - 1:
+                specs[i].background = True
+            else:
+                raise xt.XonshError(f"unrecognized redirect {redirect!r}")
+        # Any pipe-redirect sentinel still present means `a>p`/`e>p` was used
+        # without a following `|` pipe.
         for spec in specs:
-            if callable(spec.alias) and not spec.threadable:
+            if spec._stdout is _PIPE_ALL or spec._stderr is _PIPE_ERR:
                 raise xt.XonshError(
-                    f"Callable alias {spec.alias_name!r} is explicitly marked as unthreadable and is not supported in pipelines.\n"
-                    f"If it's really threadable try to add command decorator `@thread {spec.alias_name}`."
+                    "xonsh: redirect 'a>p'/'e>p' requires a following pipe '|'"
                 )
 
-    _update_last_spec(specs[-1])
+        # Apply boundary conditions
+        if not XSH.env.get("XONSH_CAPTURE_ALWAYS"):
+            # Make sure sub-specs are always captured in case:
+            # `![some_alias | grep x]`, `$(some_alias)`, `some_alias > file`.
+            last = spec
+            is_redirected_stdout = bool(last.stdout)
+            specs_to_capture = (
+                specs
+                if captured in STDOUT_CAPTURE_KINDS or is_redirected_stdout
+                else specs[:-1]
+            )
+            _set_specs_capture_always(specs_to_capture)
+
+        # Validate: unthreadable callable aliases cannot be used in pipelines
+        if len(specs) > 1:
+            for spec in specs:
+                if callable(spec.alias) and not spec.threadable:
+                    raise xt.XonshError(
+                        f"Callable alias {spec.alias_name!r} is explicitly marked as unthreadable and is not supported in pipelines.\n"
+                        f"If it's really threadable try to add command decorator `@thread {spec.alias_name}`."
+                    )
+
+        _update_last_spec(specs[-1])
+    except BaseException:
+        # Any pipes/files opened during spec construction would otherwise
+        # leak as `ResourceWarning: unclosed file` once GC reaps them.
+        for s in specs:
+            s.close()
+        raise
     return specs
 
 


### PR DESCRIPTION
To support future Python 3.15 we need to fix ResourceWarning in procs and specs. This is additive changes: we had no closing for specs in some places and in case of exceptions but now we have.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
