### PR TITLE
fix(parser): Fixed exception processing in parser

### DIFF
--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -85,6 +85,26 @@ def test_bad_indent(xonsh_execer_parse):
         xonsh_execer_parse(code)
 
 
+def test_non_default_after_default_arg_raises_syntax_error(xonsh_execer_parse):
+    # Regression for #4915. Two layers of bug here:
+    #   1. The parser's argument-list rule already detected the problem
+    #      and stashed the message via `_set_error`, but PLY caught the
+    #      bare SyntaxError as a parse-error signal, ran error recovery,
+    #      and ultimately raised `unexpected dedent` on a later line —
+    #      hiding the real error.
+    #   2. The execer's recovery loop in `_try_parse` then dereferenced
+    #      `lines[idx]` past EOF, surfacing a raw IndexError to the user.
+    # After the fix the parser surfaces CPython-shaped diagnostics:
+    #   `non-default argument follows default argument` on the offending
+    #   line, with column pointing at the parameter.
+    code = "def f(x=0,y):\n    print()\n"
+    with pytest.raises(SyntaxError) as exc_info:
+        xonsh_execer_parse(code)
+    err = exc_info.value
+    assert "non-default argument follows default argument" in err.msg
+    assert err.lineno == 1
+
+
 def test_comment_colon_ending(xonsh_execer_parse):
     code = "# this is a comment:\necho hello"
     assert xonsh_execer_parse(code)

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -290,6 +290,13 @@ class Execer:
                     lines = input.splitlines()
                     if input.endswith("\n"):
                         lines.append("")
+                    if idx >= len(lines):
+                        # Parser reports an error past EOF (e.g. "unexpected
+                        # dedent" right after the last statement). There is
+                        # no source there to wrap as a subprocess command,
+                        # so recovery cannot help — surface the original
+                        # SyntaxError instead of crashing in get_logical_line.
+                        raise original_error from None
                     line, nlogical, idx = get_logical_line(lines, idx)
                     if nlogical > 1 and not logical_input:
                         _, sbpline = self._parse_ctx_free(

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -724,7 +724,18 @@ class BaseParser:
             self._yacc_loader.ready.wait()
             if self._yacc_loader.error is not None:
                 raise self._yacc_loader.error
-        tree = self.parser.parse(input=s, lexer=self.lexer, debug=debug_level)
+        try:
+            tree = self.parser.parse(input=s, lexer=self.lexer, debug=debug_level)
+        except SyntaxError:
+            # PLY catches SyntaxError raised by action handlers as a
+            # parse-error signal, then enters error recovery and may
+            # die later on a structurally-related token (e.g. dedent
+            # after the malformed argument list).  When we set a
+            # specific user-friendly message via `_set_error`, surface
+            # it instead of whatever recovery eventually choked on.
+            if self._error is not None:
+                self._parse_error(self._error[0], self._error[1])
+            raise
         if self._error is not None:
             self._parse_error(self._error[0], self._error[1])
         if tree is not None:


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/4915

### Before

```xsh
def f(x=0,y):
    print()

# IndexError: list index out of range 🔴 
```

### After
```xsh
def f(x=0,y):
    print()

#   File "<python-input-0>", line 1
#    def f(x=0,y):
#              ^
# SyntaxError: non-default argument follows default argument 🟢 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
