### PR TITLE
fix(parser): Fix Syntax Error: `foo('spam'='eggs')`

### DIFF
--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -85,6 +85,18 @@ def test_bad_indent(xonsh_execer_parse):
         xonsh_execer_parse(code)
 
 
+def test_keyword_arg_with_non_name_lhs_raises_syntax_error(xonsh_execer_parse):
+    # Regression for #2574: `foo('spam'='eggs')` used to raise an opaque
+    # AttributeError ('Constant' object has no attribute 'id') from inside
+    # the parser action.  Match CPython's diagnostic message instead.
+    code = "foo('spam'='eggs')\n"
+    with pytest.raises(SyntaxError) as exc_info:
+        xonsh_execer_parse(code)
+    err = exc_info.value
+    assert "expression cannot contain assignment" in err.msg
+    assert err.lineno == 1
+
+
 def test_non_default_after_default_arg_raises_syntax_error(xonsh_execer_parse):
     # Regression for #4915. Two layers of bug here:
     #   1. The parser's argument-list rule already detected the problem

--- a/xonsh/parsers/v36.py
+++ b/xonsh/parsers/v36.py
@@ -142,6 +142,16 @@ class Parser(BaseParser):
     def p_argument_eq(self, p):
         """argument : test EQUALS test"""
         p1 = p[1]
+        if not isinstance(p1, ast.Name):
+            # Anything other than a bare identifier on the LHS of `=` in a
+            # call argument is a syntax error: `foo('spam'='eggs')`,
+            # `foo(a+b='eggs')`, etc.  Without this guard the action would
+            # do `p1.id` on e.g. an ast.Constant and raise an opaque
+            # AttributeError instead of a proper SyntaxError (issue #2574).
+            self._set_error(
+                'expression cannot contain assignment, perhaps you meant "=="?',
+                self.currloc(lineno=p1.lineno, column=p1.col_offset),
+            )
         p[0] = ast.keyword(
             arg=p1.id, value=p[3], lineno=p1.lineno, col_offset=p1.col_offset
         )


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/2574

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
