### PR TITLE
feat: Add full featured git completer

### DIFF
--- a/docs/completers.rst
+++ b/docs/completers.rst
@@ -107,8 +107,9 @@ appropriate completions, and ``prefixlength`` is the number of characters in
 The docstring of a completer should contain a brief description of its
 functionality, which will be displayed by ``completer list``.
 
-Some simple examples follow.  For more examples, see the source code of the completers
-xonsh actually uses, in the ``xonsh.completers`` module.
+Some simple examples follow.  For real-world examples, see
+``xonsh.completers.git`` (subprocess-based, uses ``--git-completion-helper``)
+and ``xonsh.completers.man`` (man page parsing with disk cache).
 
 .. code-block:: xonshcon
 

--- a/docs/completers.rst
+++ b/docs/completers.rst
@@ -553,6 +553,51 @@ This is only one of many knobs; see
 for the full list (display style, menu rows, threading, trace output, and more).
 
 
+Man Page Completer
+==================
+
+When no dedicated completer exists for a command, xonsh falls back to
+parsing the command's **man page** to extract option names (``-v``,
+``--verbose``, etc.). This works automatically for most CLI tools.
+
+For commands that use per-subcommand man pages (``docker-run``,
+``cargo-build``, ``systemctl-start``, etc.), xonsh tries the hyphenated
+form ``man <cmd>-<subcmd>`` first and falls back to ``man <cmd>``.
+
+Parsed options are cached on disk under
+``$XONSH_DATA_DIR/generated_completions/man/``. The cache is invalidated
+automatically when the man page file is updated (e.g. after a package
+upgrade). To force a refresh — for example, after upgrading xonsh
+itself with an improved parser — clear the cache:
+
+.. code-block:: xonshcon
+
+   @ rm $XONSH_DATA_DIR/generated_completions/man/*
+
+Installing man pages for tools
+------------------------------
+
+Some tools (Docker, Podman, etc.) ship man pages in a separate package.
+If ``docker run -<TAB>`` returns no completions, the man page may not be
+installed. On macOS with Homebrew:
+
+.. code-block:: console
+
+   $ brew install docker
+
+On Linux, man pages are usually part of the main package, but some
+distributions split them out (e.g. ``docker-doc`` on Debian/Ubuntu).
+
+You can verify whether a man page is available:
+
+.. code-block:: console
+
+   $ man -w docker-run
+
+If this prints a path, completions will work. If it prints an error,
+install the corresponding package.
+
+
 Legacy Completers Support
 =========================
 

--- a/xonsh/completers/git.py
+++ b/xonsh/completers/git.py
@@ -1,0 +1,71 @@
+"""Git completer: subcommands, options, and refs."""
+
+import subprocess
+
+from xonsh.completers.tools import (
+    RichCompletion,
+    contextual_command_completer_for,
+)
+from xonsh.parsers.completion_context import CommandContext
+
+_REF_SUBCMDS = frozenset({
+    "checkout", "switch", "merge", "rebase", "branch",
+    "cherry-pick", "log", "diff", "show", "reset",
+    "push", "pull", "fetch", "stash",
+    "bisect", "blame", "revert", "tag",
+})
+
+
+def _run_git(*args) -> "str | None":
+    try:
+        return subprocess.check_output(
+            ["git", *args],
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.CalledProcessError as e:
+        err = (e.stderr or "").strip()
+        if err:
+            from xonsh.tools import print_above_prompt
+
+            print_above_prompt(f"completer git: {err}")
+        return None
+    except (OSError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+@contextual_command_completer_for("git")
+def complete_git(context: CommandContext):
+    """Complete git subcommands, options, and branch/tag refs."""
+    if context.arg_index == 0:
+        return
+
+    # git <subcmd><Tab>
+    if context.arg_index == 1:
+        out = _run_git("--list-cmds=main,others")
+        if out is None:
+            return
+        comps = {RichCompletion(s, append_space=True) for s in out.split()}
+        return comps, False
+
+    subcmd = context.args[1].value
+
+    # git <subcmd> -<Tab>
+    if context.prefix.startswith("-"):
+        out = _run_git(subcmd, "--git-completion-helper")
+        if out is None:
+            return
+        comps = {RichCompletion(o) for o in out.split() if o.startswith("-")}
+        return comps, False
+
+    # git <subcmd> <ref><Tab>
+    if subcmd in _REF_SUBCMDS:
+        out = _run_git(
+            "for-each-ref", "--format=%(refname:short)",
+            "refs/heads/", "refs/tags/", "refs/remotes/",
+        )
+        if out is None:
+            return
+        comps = {RichCompletion(r, append_space=True) for r in out.split()}
+        return comps, False

--- a/xonsh/completers/git.py
+++ b/xonsh/completers/git.py
@@ -8,12 +8,28 @@ from xonsh.completers.tools import (
 )
 from xonsh.parsers.completion_context import CommandContext
 
-_REF_SUBCMDS = frozenset({
-    "checkout", "switch", "merge", "rebase", "branch",
-    "cherry-pick", "log", "diff", "show", "reset",
-    "push", "pull", "fetch", "stash",
-    "bisect", "blame", "revert", "tag",
-})
+_REF_SUBCMDS = frozenset(
+    {
+        "checkout",
+        "switch",
+        "merge",
+        "rebase",
+        "branch",
+        "cherry-pick",
+        "log",
+        "diff",
+        "show",
+        "reset",
+        "push",
+        "pull",
+        "fetch",
+        "stash",
+        "bisect",
+        "blame",
+        "revert",
+        "tag",
+    }
+)
 
 
 def _run_git(*args) -> "str | None":
@@ -62,8 +78,11 @@ def complete_git(context: CommandContext):
     # git <subcmd> <ref><Tab>
     if subcmd in _REF_SUBCMDS:
         out = _run_git(
-            "for-each-ref", "--format=%(refname:short)",
-            "refs/heads/", "refs/tags/", "refs/remotes/",
+            "for-each-ref",
+            "--format=%(refname:short)",
+            "refs/heads/",
+            "refs/tags/",
+            "refs/remotes/",
         )
         if out is None:
             return

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -13,6 +13,7 @@ from xonsh.completers.commands import (
     complete_xompletions,
 )
 from xonsh.completers.emoji import complete_emoji
+from xonsh.completers.git import complete_git
 from xonsh.completers.environment import complete_environment_vars
 from xonsh.completers.imports import complete_import
 from xonsh.completers.man import complete_from_man
@@ -32,6 +33,7 @@ def default_completers(cmd_cache):
         ("skip", complete_skipper),
         ("alias", complete_aliases),
         ("xompleter", complete_xompletions),
+        ("git", complete_git),
         ("import", complete_import),
     ]
 

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -13,8 +13,8 @@ from xonsh.completers.commands import (
     complete_xompletions,
 )
 from xonsh.completers.emoji import complete_emoji
-from xonsh.completers.git import complete_git
 from xonsh.completers.environment import complete_environment_vars
+from xonsh.completers.git import complete_git
 from xonsh.completers.imports import complete_import
 from xonsh.completers.man import complete_from_man
 from xonsh.completers.path import complete_path

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -164,7 +164,9 @@ def complete_from_man(context: CommandContext):
     def completions():
         for desc, opts in _parse_man_page_options(cmd).items():
             yield RichCompletion(
-                value=opts[-1], display=", ".join(opts), description=desc,
+                value=opts[-1],
+                display=", ".join(opts),
+                description=desc,
                 provider=f"man:{cmd}",
             )
 

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -90,6 +90,7 @@ def generate_options_of(cmd: str):
         for head in (
             "options",
             "command options",
+            "command line options",
             "description",
         ):  # prefer sections in this order
             if head in small_names:

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -42,7 +42,7 @@ def _get_man_page(cmd: str):
 @functools.cache
 def _man_option_string_regex():
     return re.compile(
-        r"(?:(,\s?)|^|(\sor\s))(?P<option>-[\w]|--[\w-]+)(?=\[?(\s|,|=\w+|$))"
+        r"(?:(,\s?)|^|(\sor\s))(?P<option>-[\w]|--[\w-]+)(?=\[?(\s|,|=|$))"
     )
 
 
@@ -57,7 +57,7 @@ def generate_options_of(cmd: str):
             return
         header = ""
         body = []
-        for line in textwrap.dedent(text.replace("\n\t", "\n    ")).splitlines():
+        for line in textwrap.dedent(text.expandtabs(8)).splitlines():
             if not line.strip():
                 continue
             if line.startswith((" ", "\t")):
@@ -154,10 +154,18 @@ def complete_from_man(context: CommandContext):
         return
     cmd = context.args[0].value
 
+    # Tools like cargo, docker use per-subcommand man pages
+    # (e.g. cargo-build). Try the hyphenated form first.
+    if context.arg_index >= 2:
+        subcmd_man = f"{cmd}-{context.args[1].value}"
+        if _man_page_path(subcmd_man) is not None:
+            cmd = subcmd_man
+
     def completions():
         for desc, opts in _parse_man_page_options(cmd).items():
             yield RichCompletion(
-                value=opts[-1], display=", ".join(opts), description=desc
+                value=opts[-1], display=", ".join(opts), description=desc,
+                provider=f"man:{cmd}",
             )
 
     return completions(), False


### PR DESCRIPTION
### Changes

* Added git completer
* Added provider to man completer to see it in `$XONSH_COMPLETER_TRACE=1`
* Added checking `cmd-subcmd` to man completer e.g. `docker run -<Tab>` will use `man docker-run`.
* Fixed issue in man completer - wrong parsing.
* Added docs

### Before

```xsh
git checkout <Tab>
# nothing

docker run -<Tab>
# wrong completer
```

### After

```xsh
git checkout <Tab>
# branches

docker run -<Tab>
# options from `man docker-run`
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
