### PR TITLE
fix: Switch path to substring and move git to xompleters

### DIFF
--- a/docs/completers.rst
+++ b/docs/completers.rst
@@ -108,7 +108,7 @@ The docstring of a completer should contain a brief description of its
 functionality, which will be displayed by ``completer list``.
 
 Some simple examples follow.  For real-world examples, see
-``xonsh.completers.git`` (subprocess-based, uses ``--git-completion-helper``)
+``xompletions.git`` (subprocess-based, uses ``--git-completion-helper``)
 and ``xonsh.completers.man`` (man page parsing with disk cache).
 
 .. code-block:: xonshcon

--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -114,7 +114,5 @@ def test_filter_function_substring(xession):
     assert not _filter_substring("ls", "longprefix")
 
     # RichCompletion with display text
-    assert _filter_substring(
-        RichCompletion("val", display="Foo, Bar-Deploy"), "deploy"
-    )
+    assert _filter_substring(RichCompletion("val", display="Foo, Bar-Deploy"), "deploy")
     assert not _filter_substring(RichCompletion("val", display="foo, bar"), "xyz")

--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -97,24 +97,24 @@ def test_filter_function_substring(xession):
     """Filter functions should use case-insensitive substring matching."""
     from xonsh.completers.tools import (
         RichCompletion,
-        _filter_ignorecase,
+        _filter_substring,
     )
 
     # case-insensitive substring match (middle of string)
-    assert _filter_ignorecase("Dev-Xonsh-Deploy", "deploy")
-    assert _filter_ignorecase("ASDFGH", "asd")
-    assert not _filter_ignorecase("asdfgh", "xyz")
+    assert _filter_substring("Dev-Xonsh-Deploy", "deploy")
+    assert _filter_substring("ASDFGH", "asd")
+    assert not _filter_substring("asdfgh", "xyz")
 
     # prefix match should still work
-    assert _filter_ignorecase("asdfgh", "asdf")
+    assert _filter_substring("asdfgh", "asdf")
 
     # empty prefix matches everything
-    assert _filter_ignorecase("anything", "")
+    assert _filter_substring("anything", "")
     # prefix longer than text
-    assert not _filter_ignorecase("ls", "longprefix")
+    assert not _filter_substring("ls", "longprefix")
 
     # RichCompletion with display text
-    assert _filter_ignorecase(
+    assert _filter_substring(
         RichCompletion("val", display="Foo, Bar-Deploy"), "deploy"
     )
-    assert not _filter_ignorecase(RichCompletion("val", display="foo, bar"), "xyz")
+    assert not _filter_substring(RichCompletion("val", display="foo, bar"), "xyz")

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -46,12 +46,12 @@ def test_complete_path_substring(xession, completion_context_parse):
         # tier 2: case-sensitive substring — various positions
         # no match
         for name in (
-            "test1",          # tier 0, pos 0
-            "test2",          # tier 0, pos 0
-            "test3",          # tier 0, pos 0
-            "a_test4",        # tier 2, pos 2
-            "bb_test5",       # tier 2, pos 3
-            "ccc_test6",      # tier 2, pos 4
+            "test1",  # tier 0, pos 0
+            "test2",  # tier 0, pos 0
+            "test3",  # tier 0, pos 0
+            "a_test4",  # tier 2, pos 2
+            "bb_test5",  # tier 2, pos 3
+            "ccc_test6",  # tier 2, pos 4
             "unrelated.txt",  # no match
         ):
             open(os.path.join(td, name), "w").close()

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -28,6 +28,51 @@ def test_complete_path(xession, completion_context_parse):
     xcp.complete_path(completion_context_parse("[1-0.1]", 7))
 
 
+def test_complete_path_substring(xession, completion_context_parse):
+    """Path completer should return both prefix and substring matches.
+
+    Verifies that all tiers are present and sorted by substring position
+    within each tier.
+    """
+    xession.env = {
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    }
+    with tempfile.TemporaryDirectory() as td:
+        # tier 0: case-sensitive prefix — pos 0
+        # tier 2: case-sensitive substring — various positions
+        # no match
+        for name in (
+            "test1",          # tier 0, pos 0
+            "test2",          # tier 0, pos 0
+            "test3",          # tier 0, pos 0
+            "a_test4",        # tier 2, pos 2
+            "bb_test5",       # tier 2, pos 3
+            "ccc_test6",      # tier 2, pos 4
+            "unrelated.txt",  # no match
+        ):
+            open(os.path.join(td, name), "w").close()
+
+        prefix = os.path.join(td, "test")
+        line = f"ls {prefix}"
+        out = xcp.complete_path(completion_context_parse(line, len(line)))
+        basenames = {os.path.basename(str(c).rstrip()) for c in out[0]}
+
+        # Prefix matches included
+        assert "test1" in basenames
+        assert "test2" in basenames
+        assert "test3" in basenames
+        # Substring matches included, sorted by position
+        assert "a_test4" in basenames
+        assert "bb_test5" in basenames
+        assert "ccc_test6" in basenames
+        # Non-match excluded
+        assert "unrelated.txt" not in basenames
+
+
 @patch("xonsh.completers.path._add_cdpaths")
 def test_cd_path_no_cd(mock_add_cdpaths, xession, completion_context_parse):
     xession.env = {

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -84,9 +84,9 @@ def test_cursor_after_closing_quote_override(completer, completers_mock):
         "", "", 0, 0, {}, multiline_text="'test'", cursor_index=6
     ) == (
         (
-            "a",
             "test1'",
             "test_no_quote",
+            "a",
         ),
         5,
     )
@@ -95,9 +95,9 @@ def test_cursor_after_closing_quote_override(completer, completers_mock):
         "", "", 0, 0, {}, multiline_text="'''test'''", cursor_index=10
     ) == (
         (
-            "a",
             "test1'''",
             "test_no_quote",
+            "a",
         ),
         7,
     )
@@ -171,7 +171,16 @@ def test_env_completer_sort(completer, completers_mock):
 
 
 def test_sortkey_tiers(completer, completers_mock):
-    """Completions should be ranked by match quality tier."""
+    """Completions should be ranked by match quality tier.
+
+    Sort order:
+      tier 0 — case-sensitive prefix match
+      tier 1 — case-insensitive prefix match
+      tier 2 — case-sensitive substring match
+      tier 3 — case-insensitive substring match
+      tier 4 — no match
+    Within a tier: _-prefixed last, then by match position, then alphabetically.
+    """
 
     @contextual_command_completer
     def comp(context: CommandContext):
@@ -183,14 +192,37 @@ def test_sortkey_tiers(completer, completers_mock):
         "dec", "dec", 0, 3, {}, multiline_text="dec", cursor_index=3
     )
     result = comps[0]
-    # Tier 0 (case-sensitive prefix) before tier 1 (case-insensitive prefix)
-    assert result.index("decoder") < result.index("Decoder")
-    # Tier 1 (case-insensitive prefix) before tier 2 (case-sensitive substring)
-    assert result.index("Decoder") < result.index("jsondecoder")
-    # Tier 2 (case-sensitive substring) before tier 3 (case-insensitive substring)
-    assert result.index("jsondecoder") < result.index("JSONDecoder")
-    # All matches before non-matches
-    assert result.index("JSONDecoder") < result.index("foobar")
+    assert result == ("decoder", "Decoder", "jsondecoder", "JSONDecoder", "foobar")
+
+
+def test_sortkey_substring_position(completer, completers_mock):
+    """Within the same tier, earlier substring position sorts first."""
+
+    @contextual_command_completer
+    def comp(context: CommandContext):
+        return {
+            "patch-1",           # tier 0: prefix match, pos 0
+            "origin/patch-1",    # tier 2: substring, pos 7
+            "anki-code-patch",   # tier 2: substring, pos 10
+            "x-patch-2",         # tier 2: substring, pos 2
+            "PATCH-3",           # tier 1: case-insensitive prefix, pos 0
+            "unrelated",         # tier 4: no match
+        }
+
+    completers_mock["a"] = comp
+
+    comps = completer.complete(
+        "patch", "patch", 0, 5, {}, multiline_text="patch", cursor_index=5
+    )
+    result = comps[0]
+    assert result == (
+        "patch-1",           # tier 0
+        "PATCH-3",           # tier 1
+        "x-patch-2",         # tier 2, pos 2
+        "origin/patch-1",    # tier 2, pos 7
+        "anki-code-patch",   # tier 2, pos 10
+        "unrelated",         # tier 4
+    )
 
 
 def test_deduplicate_trailing_space(completer, completers_mock):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -196,32 +196,60 @@ def test_sortkey_tiers(completer, completers_mock):
 
 
 def test_sortkey_substring_position(completer, completers_mock):
-    """Within the same tier, earlier substring position sorts first."""
+    """Each tier has 3 entries sorted by substring position, then alphabetically."""
 
     @contextual_command_completer
     def comp(context: CommandContext):
         return {
-            "patch-1",           # tier 0: prefix match, pos 0
-            "origin/patch-1",    # tier 2: substring, pos 7
-            "anki-code-patch",   # tier 2: substring, pos 10
-            "x-patch-2",         # tier 2: substring, pos 2
-            "PATCH-3",           # tier 1: case-insensitive prefix, pos 0
-            "unrelated",         # tier 4: no match
+            # tier 0: case-sensitive prefix (pos 0)
+            "test1",
+            "test2",
+            "test3",
+            # tier 1: case-insensitive prefix (pos 0)
+            "TEST4",
+            "TEST5",
+            "TEST6",
+            # tier 2: case-sensitive substring (various pos)
+            "a_test7",       # pos 2
+            "bb_test8",      # pos 3
+            "ccc_test9",     # pos 4
+            # tier 3: case-insensitive substring (various pos)
+            "a_TEST10",      # pos 2
+            "bb_TEST11",     # pos 3
+            "ccc_TEST12",    # pos 4
+            # tier 4: no match
+            "zzz_no_match",
+            "aaa_no_match",
+            "mmm_no_match",
         }
 
     completers_mock["a"] = comp
 
     comps = completer.complete(
-        "patch", "patch", 0, 5, {}, multiline_text="patch", cursor_index=5
+        "test", "test", 0, 4, {}, multiline_text="test", cursor_index=4
     )
     result = comps[0]
     assert result == (
-        "patch-1",           # tier 0
-        "PATCH-3",           # tier 1
-        "x-patch-2",         # tier 2, pos 2
-        "origin/patch-1",    # tier 2, pos 7
-        "anki-code-patch",   # tier 2, pos 10
-        "unrelated",         # tier 4
+        # tier 0: case-sensitive prefix, alphabetical
+        "test1",
+        "test2",
+        "test3",
+        # tier 1: case-insensitive prefix, alphabetical
+        "TEST4",
+        "TEST5",
+        "TEST6",
+        # tier 2: case-sensitive substring, by position then alphabetical
+        "a_test7",       # pos 2
+        "bb_test8",      # pos 3
+        "ccc_test9",     # pos 4
+        # tier 3: case-insensitive substring, by position then alphabetical
+        "a_TEST10",      # pos 2
+        "bb_TEST11",     # pos 3
+        "ccc_TEST12",    # pos 4
+        # tier 4: no match, alphabetical
+        "aaa_no_match",
+        "mmm_no_match",
+        "zzz_no_match",
     )
 
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -210,13 +210,13 @@ def test_sortkey_substring_position(completer, completers_mock):
             "TEST5",
             "TEST6",
             # tier 2: case-sensitive substring (various pos)
-            "a_test7",       # pos 2
-            "bb_test8",      # pos 3
-            "ccc_test9",     # pos 4
+            "a_test7",  # pos 2
+            "bb_test8",  # pos 3
+            "ccc_test9",  # pos 4
             # tier 3: case-insensitive substring (various pos)
-            "a_TEST10",      # pos 2
-            "bb_TEST11",     # pos 3
-            "ccc_TEST12",    # pos 4
+            "a_TEST10",  # pos 2
+            "bb_TEST11",  # pos 3
+            "ccc_TEST12",  # pos 4
             # tier 4: no match
             "zzz_no_match",
             "aaa_no_match",
@@ -239,13 +239,13 @@ def test_sortkey_substring_position(completer, completers_mock):
         "TEST5",
         "TEST6",
         # tier 2: case-sensitive substring, by position then alphabetical
-        "a_test7",       # pos 2
-        "bb_test8",      # pos 3
-        "ccc_test9",     # pos 4
+        "a_test7",  # pos 2
+        "bb_test8",  # pos 3
+        "ccc_test9",  # pos 4
         # tier 3: case-insensitive substring, by position then alphabetical
-        "a_TEST10",      # pos 2
-        "bb_TEST11",     # pos 3
-        "ccc_TEST12",    # pos 4
+        "a_TEST10",  # pos 2
+        "bb_TEST11",  # pos 3
+        "ccc_TEST12",  # pos 4
         # tier 4: no match, alphabetical
         "aaa_no_match",
         "mmm_no_match",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -201,12 +201,12 @@ def test_sortkey_substring_position(completer, completers_mock):
     @contextual_command_completer
     def comp(context: CommandContext):
         return {
-            "patch-1",           # tier 0: prefix match, pos 0
-            "origin/patch-1",    # tier 2: substring, pos 7
-            "anki-code-patch",   # tier 2: substring, pos 10
-            "x-patch-2",         # tier 2: substring, pos 2
-            "PATCH-3",           # tier 1: case-insensitive prefix, pos 0
-            "unrelated",         # tier 4: no match
+            "patch-1",  # tier 0: prefix match, pos 0
+            "origin/patch-1",  # tier 2: substring, pos 7
+            "anki-code-patch",  # tier 2: substring, pos 10
+            "x-patch-2",  # tier 2: substring, pos 2
+            "PATCH-3",  # tier 1: case-insensitive prefix, pos 0
+            "unrelated",  # tier 4: no match
         }
 
     completers_mock["a"] = comp
@@ -216,12 +216,12 @@ def test_sortkey_substring_position(completer, completers_mock):
     )
     result = comps[0]
     assert result == (
-        "patch-1",           # tier 0
-        "PATCH-3",           # tier 1
-        "x-patch-2",         # tier 2, pos 2
-        "origin/patch-1",    # tier 2, pos 7
-        "anki-code-patch",   # tier 2, pos 10
-        "unrelated",         # tier 4
+        "patch-1",  # tier 0
+        "PATCH-3",  # tier 1
+        "x-patch-2",  # tier 2, pos 2
+        "origin/patch-1",  # tier 2, pos 7
+        "anki-code-patch",  # tier 2, pos 10
+        "unrelated",  # tier 4
     )
 
 

--- a/xompletions/git.py
+++ b/xompletions/git.py
@@ -2,10 +2,7 @@
 
 import subprocess
 
-from xonsh.completers.tools import (
-    RichCompletion,
-    contextual_command_completer_for,
-)
+from xonsh.completers.tools import RichCompletion
 from xonsh.parsers.completion_context import CommandContext
 
 _REF_SUBCMDS = frozenset(
@@ -51,8 +48,7 @@ def _run_git(*args) -> "str | None":
         return None
 
 
-@contextual_command_completer_for("git")
-def complete_git(context: CommandContext):
+def xonsh_complete(context: CommandContext):
     """Complete git subcommands, options, and branch/tag refs."""
     if context.arg_index == 0:
         return
@@ -62,8 +58,7 @@ def complete_git(context: CommandContext):
         out = _run_git("--list-cmds=main,others")
         if out is None:
             return
-        comps = {RichCompletion(s, append_space=True) for s in out.split()}
-        return comps, False
+        return {RichCompletion(s, append_space=True) for s in out.split()}, False
 
     subcmd = context.args[1].value
 
@@ -72,8 +67,7 @@ def complete_git(context: CommandContext):
         out = _run_git(subcmd, "--git-completion-helper")
         if out is None:
             return
-        comps = {RichCompletion(o) for o in out.split() if o.startswith("-")}
-        return comps, False
+        return {RichCompletion(o) for o in out.split() if o.startswith("-")}, False
 
     # git <subcmd> <ref><Tab>
     if subcmd in _REF_SUBCMDS:
@@ -86,5 +80,4 @@ def complete_git(context: CommandContext):
         )
         if out is None:
             return
-        comps = {RichCompletion(r, append_space=True) for r in out.split()}
-        return comps, False
+        return {RichCompletion(r, append_space=True) for r in out.split()}, False

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -372,10 +372,10 @@ class Completer:
             }
 
         if completion_context:
-            if completion_context.python is not None:
-                prefix = completion_context.python.prefix
-            elif completion_context.command is not None:
+            if completion_context.command is not None:
                 prefix = completion_context.command.prefix
+            elif completion_context.python is not None:
+                prefix = completion_context.python.prefix
             else:
                 raise RuntimeError("Completion context is empty")
 

--- a/xonsh/completers/init.py
+++ b/xonsh/completers/init.py
@@ -14,7 +14,6 @@ from xonsh.completers.commands import (
 )
 from xonsh.completers.emoji import complete_emoji
 from xonsh.completers.environment import complete_environment_vars
-from xonsh.completers.git import complete_git
 from xonsh.completers.imports import complete_import
 from xonsh.completers.man import complete_from_man
 from xonsh.completers.path import complete_path
@@ -33,7 +32,6 @@ def default_completers(cmd_cache):
         ("skip", complete_skipper),
         ("alias", complete_aliases),
         ("xompleter", complete_xompletions),
-        ("git", complete_git),
         ("import", complete_import),
     ]
 

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -316,7 +316,11 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     # Substring matches: *prefix* catches files containing the prefix
     # anywhere in their name.  The pipeline's tier-based sort ensures
     # prefix matches rank above substring matches.
-    if prefix and not _prefix_is_dir_listing:
+    if (
+        prefix
+        and not _prefix_is_dir_listing
+        and env.get("XONSH_COMPLETER_MODE", "substring_tier") == "substring_tier"
+    ):
         dirpart = os.path.dirname(prefix)
         namepart = os.path.basename(prefix)
         if namepart:

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -306,17 +306,25 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     env = XSH.env
     glob_sorted = env.get("GLOB_SORTED")
     prefix = glob.escape(prefix)
+    _prefix_is_dir_listing = prefix.endswith(os.sep) or (
+        os.altsep and prefix.endswith(os.altsep)
+    )
     for s in xt.iglobpath(
         prefix + "*", ignore_case=(not xp.ON_WINDOWS), sort_result=glob_sorted
     ):
         paths.add(s)
-    # When the prefix ends with a path separator we are listing directory
-    # contents, not matching a partial name.  If the glob above found nothing
-    # the directory is simply empty — skip subsequence and fuzzy matching
-    # which would incorrectly match unrelated paths.
-    _prefix_is_dir_listing = prefix.endswith(os.sep) or (
-        os.altsep and prefix.endswith(os.altsep)
-    )
+    # Substring matches: *prefix* catches files containing the prefix
+    # anywhere in their name.  The pipeline's tier-based sort ensures
+    # prefix matches rank above substring matches.
+    if prefix and not _prefix_is_dir_listing:
+        dirpart = os.path.dirname(prefix)
+        namepart = os.path.basename(prefix)
+        if namepart:
+            pattern = os.path.join(dirpart, "*" + namepart + "*") if dirpart else "*" + namepart + "*"
+            for s in xt.iglobpath(
+                pattern, ignore_case=(not xp.ON_WINDOWS), sort_result=glob_sorted
+            ):
+                paths.add(s)
     if (
         len(paths) == 0
         and env.get("SUBSEQUENCE_PATH_COMPLETION")

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -320,7 +320,11 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
         dirpart = os.path.dirname(prefix)
         namepart = os.path.basename(prefix)
         if namepart:
-            pattern = os.path.join(dirpart, "*" + namepart + "*") if dirpart else "*" + namepart + "*"
+            pattern = (
+                os.path.join(dirpart, "*" + namepart + "*")
+                if dirpart
+                else "*" + namepart + "*"
+            )
             for s in xt.iglobpath(
                 pattern, ignore_case=(not xp.ON_WINDOWS), sort_result=glob_sorted
             ):

--- a/xonsh/completers/tools.py
+++ b/xonsh/completers/tools.py
@@ -21,19 +21,33 @@ def _filter_with_func(text, prefix, func):
     return func(text, prefix)
 
 
-def _filter_ignorecase(text, prefix):
+def _filter_substring(text, prefix):
     func = lambda txt, pre: pre.lower() in txt.lower()
     return _filter_with_func(text, prefix, func)
 
 
-def get_filter_function():
-    """Return a case-insensitive filtering function for completions.
+def _filter_prefix(text, prefix):
+    func = lambda txt, pre: txt.lower().startswith(pre.lower())
+    return _filter_with_func(text, prefix, func)
 
-    Completions are always filtered case-insensitively; the sort order
-    (see ``Completer.complete_from_context``) already ranks exact-case
-    matches above case-insensitive ones.
+
+def get_filter_function():
+    """Return the completion filter function based on ``$XONSH_COMPLETER_MODE``.
+
+    Modes:
+
+    * ``"substring_tier"`` (default) — completions are filtered by
+      case-insensitive substring match.  The pipeline's tier-based sort
+      ranks prefix matches above substring matches.
+    * ``"prefix"`` — only completions that start with the prefix are
+      shown (case-insensitive).
     """
-    return _filter_ignorecase
+    from xonsh.built_ins import XSH
+
+    mode = (XSH.env or {}).get("XONSH_COMPLETER_MODE", "substring_tier")
+    if mode == "prefix":
+        return _filter_prefix
+    return _filter_substring
 
 
 def justify(s, max_length, left_pad=0):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2122,12 +2122,18 @@ class AutoCompletionSetting(Xettings):
         "substring_tier",
         "Controls how completions are filtered.\n\n"
         "``'substring_tier'`` (default) — shows all completions that "
-        "contain the typed text as a substring.  Results are sorted by "
-        "match quality: case-sensitive prefix > case-insensitive prefix "
-        "> case-sensitive substring > case-insensitive substring, then "
-        "by substring position.\n"
+        "contain the typed text as a substring, ranked in tiers "
+        "from best to worst match:\n\n"
+        "  1. Exact prefix (``test`` matches ``test_foo``)\n"
+        "  2. Case-insensitive prefix (``test`` matches ``TEST_FOO``)\n"
+        "  3. Substring (``test`` matches ``my_test_bar``)\n"
+        "  4. Case-insensitive substring (``test`` matches ``MY_TEST_BAR``)\n\n"
+        "Within each tier, results are sorted by the position of the "
+        "match, then alphabetically.  This gives a natural ranking where "
+        "the best matches appear first while still showing all "
+        "possibilities.\n\n"
         "``'prefix'`` — shows only completions that start with the "
-        "typed text (case-insensitive).",
+        "typed text (case-insensitive).  Substring matches are hidden.",
     )
     CMD_COMPLETIONS_SHOW_DESC = Var.with_default(
         doc="If True, command completions will show description part with path to the binary and alias in case of "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2118,6 +2118,17 @@ class AutoCompletionSetting(Xettings):
         "This is to reduce the noise in generated completions.",
         default=False,
     )
+    XONSH_COMPLETER_MODE = Var.with_default(
+        "substring_tier",
+        "Controls how completions are filtered.\n\n"
+        "``'substring_tier'`` (default) — shows all completions that "
+        "contain the typed text as a substring.  Results are sorted by "
+        "match quality: case-sensitive prefix > case-insensitive prefix "
+        "> case-sensitive substring > case-insensitive substring, then "
+        "by substring position.\n"
+        "``'prefix'`` — shows only completions that start with the "
+        "typed text (case-insensitive).",
+    )
     CMD_COMPLETIONS_SHOW_DESC = Var.with_default(
         doc="If True, command completions will show description part with path to the binary and alias in case of "
         "xonsh functions.",

--- a/xonsh/shells/ptk_shell/completer.py
+++ b/xonsh/shells/ptk_shell/completer.py
@@ -180,9 +180,12 @@ class PromptToolkitCompleter(Completer):
                 plen = len(prefix)
                 completions = (sug_comp,)
             else:
-                completions = set(completions)
-                completions.discard(sug_comp)
-                completions = (sug_comp,) + tuple(sorted(completions))
+                # Preserve the sort order from complete_from_context
+                # (tier-based: prefix > substring > no match) while
+                # moving the auto-suggest entry to the front.
+                completions = (sug_comp,) + tuple(
+                    c for c in completions if c != sug_comp
+                )
         # reserve space, if needed.
         if len(completions) <= 1:
             pass


### PR DESCRIPTION
1. After testing https://github.com/xonsh/xonsh/pull/6333 we need to move git to xompleters

2. During testing I noticed that xonsh.compleer.path is working with old logic: matching by prefix and if no results matching by substring. Now I understood why many many many many many times I saw weird behavior when `ls` shows file but I can't choose it in completer - it was case when I had `qwe_asd` and `asd_qwe` and `asd<Tab>` will show just one file. Now path switched to matching by substring by default. It's much more sane and consistent behavior after we did [#6125](https://github.com/xonsh/xonsh/pull/6125).

3. Add `$XONSH_COMPLETER_MODE` to have an ability to switch mode to prefix.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
