### PR TITLE
fix: The `cd` command should not perform expanduser

### DIFF
--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -136,3 +136,19 @@ def test_cd_home(xession, tmpdir):
     dirstack.popd([])
 
     xession.env.update(dict(HOME=old_home))
+
+
+def test_cd_literal_tilde_dir(xession, tmpdir):
+    """cd should not expand ~ when the argument is a literal string.
+
+    A directory literally named ``~`` in cwd should be reachable via
+    ``cd r'~'`` (raw string prevents tilde expansion at the parser level).
+    ``dirstack.cd`` must not call ``expanduser`` on the argument.
+    """
+    tilde_dir = os.path.join(str(tmpdir), "~")
+    os.mkdir(tilde_dir)
+    xession.env.update(dict(PWD=str(tmpdir)))
+    os.chdir(str(tmpdir))
+
+    dirstack.cd(["~"])
+    assert os.getcwd() == os.path.realpath(tilde_dir)

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -226,7 +226,7 @@ def cd(args, stdin=None):
     if len(args) == 0:
         d = env.get("HOME", os.path.expanduser("~"))
     elif len(args) == 1:
-        d = os.path.expanduser(args[0])
+        d = args[0]
         if not os.path.isdir(d):
             if d == "-":
                 if oldpwd is not None:


### PR DESCRIPTION
During work on https://github.com/xonsh/xonsh/issues/4609 I found a bug that `cd` command has expanduser code. This behavior was introduced from the beginning of the xonsh project because at start there was no way to expand user. But user expanding and substitutions is a parser/completer/shell responsibility (not `cd` command) and we have it all now. This PR fixes this behavior.

### Before

```xsh
cd /tmp
mkdir r'~'
showcmd cd r'~'
# ['cd', '~']
cd r'~' # User expectation: I'm using raw-string so r'~' points to the created directory.
pwd
# /home/snail 🔴 
```
```xsh
showcmd cd ~
# ['cd', '/home/snail'] 🟢 
```

### After

```xsh
cd /tmp
mkdir r'~'
showcmd cd r'~'
# ['cd', '~']
cd r'~' # User expectation: I'm using raw-string so r'~' points to the created directory.
pwd
# /tmp/~/ 🟢 
```

```xsh
showcmd cd ~
# ['cd', '/home/snail'] 🟢 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
