### PR TITLE
fix(completer): Fix edge case with tilde/envvar file/dir completion

### DIFF
--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -73,6 +73,66 @@ def test_complete_path_substring(xession, completion_context_parse):
         assert "unrelated.txt" not in basenames
 
 
+@pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
+def test_complete_path_literal_tilde(is_dir, xession):
+    """A file/dir literally named ~ must appear as r'~' in completions."""
+    xession.env.update({
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    })
+    with tempfile.TemporaryDirectory() as td:
+        tilde_path = os.path.join(td, "~")
+        if is_dir:
+            os.mkdir(tilde_path)
+        else:
+            open(tilde_path, "w").close()
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            paths, _ = xcp._complete_path_raw("~", "ls ~", 3, 4, {})
+            raw_entries = {p for p in paths if p.startswith("r'")}
+            assert raw_entries, f"Expected r'~' entry, got: {paths}"
+            raw = raw_entries.pop()
+            if is_dir:
+                assert raw.rstrip("'").endswith("/"), f"Dir should have trailing slash: {raw}"
+            else:
+                assert not raw.rstrip("'").endswith("/"), f"File should not have trailing slash: {raw}"
+        finally:
+            os.chdir(old_cwd)
+
+
+@pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
+def test_complete_path_literal_dollar(is_dir, xession):
+    """A file/dir literally named $VAR must appear as r'$VAR' in completions."""
+    xession.env.update({
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    })
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "$VAR")
+        if is_dir:
+            os.mkdir(path)
+        else:
+            open(path, "w").close()
+        prefix = os.path.join(td, "$VA")
+        line = f"ls {prefix}"
+        paths, _ = xcp._complete_path_raw(prefix, line, 3, len(line), {})
+        raw_entries = {p for p in paths if p.startswith("r'")}
+        assert raw_entries, f"Expected r'$VAR' entry, got: {paths}"
+        raw = raw_entries.pop()
+        assert "$VAR" in raw, f"Expected $VAR in completion: {raw}"
+        if is_dir:
+            assert raw.rstrip("'").endswith("/"), f"Dir should have trailing slash: {raw}"
+        else:
+            assert not raw.rstrip("'").endswith("/"), f"File should not have trailing slash: {raw}"
+
+
 @pytest.mark.parametrize(
     "char, escape",
     [(chr(c), r) for c, r in xcp._CONTROL_CHAR_ESCAPE.items()],

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -96,10 +96,11 @@ def test_complete_path_literal_tilde(is_dir, xession):
             raw_entries = {p for p in paths if p.startswith("r'")}
             assert raw_entries, f"Expected r'~' entry, got: {paths}"
             raw = raw_entries.pop()
+            inner = raw[2:-1]  # strip r' and '
             if is_dir:
-                assert raw.rstrip("'").endswith("/"), f"Dir should have trailing slash: {raw}"
+                assert inner.endswith(os.sep), f"Dir should have trailing sep: {raw}"
             else:
-                assert not raw.rstrip("'").endswith("/"), f"File should not have trailing slash: {raw}"
+                assert not inner.endswith(os.sep), f"File should not have trailing sep: {raw}"
         finally:
             os.chdir(old_cwd)
 
@@ -127,10 +128,11 @@ def test_complete_path_literal_dollar(is_dir, xession):
         assert raw_entries, f"Expected r'$VAR' entry, got: {paths}"
         raw = raw_entries.pop()
         assert "$VAR" in raw, f"Expected $VAR in completion: {raw}"
+        inner = raw[2:-1]  # strip r' and '
         if is_dir:
-            assert raw.rstrip("'").endswith("/"), f"Dir should have trailing slash: {raw}"
+            assert inner.endswith(os.sep), f"Dir should have trailing sep: {raw}"
         else:
-            assert not raw.rstrip("'").endswith("/"), f"File should not have trailing slash: {raw}"
+            assert not inner.endswith(os.sep), f"File should not have trailing sep: {raw}"
 
 
 @pytest.mark.parametrize(

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -76,13 +76,15 @@ def test_complete_path_substring(xession, completion_context_parse):
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
 def test_complete_path_literal_tilde(is_dir, xession):
     """A file/dir literally named ~ must appear as r'~' in completions."""
-    xession.env.update({
-        "GLOB_SORTED": True,
-        "SUBSEQUENCE_PATH_COMPLETION": False,
-        "FUZZY_PATH_COMPLETION": False,
-        "SUGGEST_THRESHOLD": 3,
-        "CDPATH": set(),
-    })
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
     with tempfile.TemporaryDirectory() as td:
         tilde_path = os.path.join(td, "~")
         if is_dir:
@@ -100,7 +102,9 @@ def test_complete_path_literal_tilde(is_dir, xession):
             if is_dir:
                 assert inner.endswith(os.sep), f"Dir should have trailing sep: {raw}"
             else:
-                assert not inner.endswith(os.sep), f"File should not have trailing sep: {raw}"
+                assert not inner.endswith(os.sep), (
+                    f"File should not have trailing sep: {raw}"
+                )
         finally:
             os.chdir(old_cwd)
 
@@ -108,13 +112,15 @@ def test_complete_path_literal_tilde(is_dir, xession):
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
 def test_complete_path_literal_dollar(is_dir, xession):
     """A file/dir literally named $VAR must appear as r'$VAR' in completions."""
-    xession.env.update({
-        "GLOB_SORTED": True,
-        "SUBSEQUENCE_PATH_COMPLETION": False,
-        "FUZZY_PATH_COMPLETION": False,
-        "SUGGEST_THRESHOLD": 3,
-        "CDPATH": set(),
-    })
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "$VAR")
         if is_dir:
@@ -132,7 +138,9 @@ def test_complete_path_literal_dollar(is_dir, xession):
         if is_dir:
             assert inner.endswith(os.sep), f"Dir should have trailing sep: {raw}"
         else:
-            assert not inner.endswith(os.sep), f"File should not have trailing sep: {raw}"
+            assert not inner.endswith(os.sep), (
+                f"File should not have trailing sep: {raw}"
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -76,13 +76,15 @@ def test_complete_path_substring(xession, completion_context_parse):
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
 def test_complete_path_literal_tilde(is_dir, xession):
     """A file/dir literally named ~ must appear as r'~' in completions."""
-    xession.env.update({
-        "GLOB_SORTED": True,
-        "SUBSEQUENCE_PATH_COMPLETION": False,
-        "FUZZY_PATH_COMPLETION": False,
-        "SUGGEST_THRESHOLD": 3,
-        "CDPATH": set(),
-    })
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
     with tempfile.TemporaryDirectory() as td:
         tilde_path = os.path.join(td, "~")
         if is_dir:
@@ -97,9 +99,13 @@ def test_complete_path_literal_tilde(is_dir, xession):
             assert raw_entries, f"Expected r'~' entry, got: {paths}"
             raw = raw_entries.pop()
             if is_dir:
-                assert raw.rstrip("'").endswith("/"), f"Dir should have trailing slash: {raw}"
+                assert raw.rstrip("'").endswith("/"), (
+                    f"Dir should have trailing slash: {raw}"
+                )
             else:
-                assert not raw.rstrip("'").endswith("/"), f"File should not have trailing slash: {raw}"
+                assert not raw.rstrip("'").endswith("/"), (
+                    f"File should not have trailing slash: {raw}"
+                )
         finally:
             os.chdir(old_cwd)
 
@@ -107,13 +113,15 @@ def test_complete_path_literal_tilde(is_dir, xession):
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
 def test_complete_path_literal_dollar(is_dir, xession):
     """A file/dir literally named $VAR must appear as r'$VAR' in completions."""
-    xession.env.update({
-        "GLOB_SORTED": True,
-        "SUBSEQUENCE_PATH_COMPLETION": False,
-        "FUZZY_PATH_COMPLETION": False,
-        "SUGGEST_THRESHOLD": 3,
-        "CDPATH": set(),
-    })
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "$VAR")
         if is_dir:
@@ -128,9 +136,13 @@ def test_complete_path_literal_dollar(is_dir, xession):
         raw = raw_entries.pop()
         assert "$VAR" in raw, f"Expected $VAR in completion: {raw}"
         if is_dir:
-            assert raw.rstrip("'").endswith("/"), f"Dir should have trailing slash: {raw}"
+            assert raw.rstrip("'").endswith("/"), (
+                f"Dir should have trailing slash: {raw}"
+            )
         else:
-            assert not raw.rstrip("'").endswith("/"), f"File should not have trailing slash: {raw}"
+            assert not raw.rstrip("'").endswith("/"), (
+                f"File should not have trailing slash: {raw}"
+            )
 
 
 @pytest.mark.parametrize(

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -206,7 +206,9 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
         # isdir — expand_path("$HOME") and expand_path("~") resolve to
         # the home directory (always a dir), masking literal files.
         check_path = s if ("$" in s or s.startswith("~")) else expand_path(s)
-        if os.path.isdir(check_path) or (cdpath and _is_directory_in_cdpath(check_path)):
+        if os.path.isdir(check_path) or (
+            cdpath and _is_directory_in_cdpath(check_path)
+        ):
             _tail = slash
         elif end == "":
             _tail = space
@@ -340,7 +342,9 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     )
     if is_raw_string and prefix.startswith(tilde):
         # Use glob.glob directly to avoid iglobpath's expanduser
-        for s in sorted(glob.glob(prefix + "*")) if glob_sorted else glob.iglob(prefix + "*"):
+        for s in (
+            sorted(glob.glob(prefix + "*")) if glob_sorted else glob.iglob(prefix + "*")
+        ):
             paths.add(s)
     else:
         for s in xt.iglobpath(
@@ -478,9 +482,7 @@ def contextual_complete_path(command: CommandContext, cdpath=True, filtfunc=None
                 RichCompletion(comp, display=comp, append_closing_quote=False)
             )
         else:
-            rich_completions.add(
-                RichCompletion(comp, append_closing_quote=False)
-            )
+            rich_completions.add(RichCompletion(comp, append_closing_quote=False))
 
     return rich_completions, lprefix
 

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -202,8 +202,11 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
         end = orig_end
         if start == "" and need_quotes:
             start = end = _quote_to_use(s)
-        expanded = expand_path(s)
-        if os.path.isdir(expanded) or (cdpath and _is_directory_in_cdpath(expanded)):
+        # For paths with $ or starting with ~ use the literal path for
+        # isdir — expand_path("$HOME") and expand_path("~") resolve to
+        # the home directory (always a dir), masking literal files.
+        check_path = s if ("$" in s or s.startswith("~")) else expand_path(s)
+        if os.path.isdir(check_path) or (cdpath and _is_directory_in_cdpath(check_path)):
             _tail = slash
         elif end == "":
             _tail = space
@@ -212,7 +215,8 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
         # Filenames with control characters (newline, tab, etc.) must use
         # regular (non-raw) strings so the escape sequences are interpreted.
         has_ctrl = _has_control_chars(s)
-        if start != "" and "r" not in start.lower() and backslash in s and not has_ctrl:
+        needs_raw = (backslash in s or "$" in s) and not has_ctrl
+        if start != "" and "r" not in start.lower() and needs_raw:
             start = f"r{start}"
         s = s + _tail
         # Raw strings can't end with \ before closing quote (e.g. r"path\" is
@@ -324,6 +328,9 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
         if len(line) >= end + 1 and line[end] == path_str_end:
             append_end = False
     tilde = "~"
+    # Raw strings (r'...') treat ~ literally — skip tilde expansion
+    # so that r'~/' completes inside a directory named ~ in cwd.
+    is_raw_string = "r" in path_str_start.lower() if path_str_start else False
     paths = set()
     env = XSH.env
     glob_sorted = env.get("GLOB_SORTED")
@@ -331,10 +338,15 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     _prefix_is_dir_listing = prefix.endswith(os.sep) or (
         os.altsep and prefix.endswith(os.altsep)
     )
-    for s in xt.iglobpath(
-        prefix + "*", ignore_case=(not xp.ON_WINDOWS), sort_result=glob_sorted
-    ):
-        paths.add(s)
+    if is_raw_string and prefix.startswith(tilde):
+        # Use glob.glob directly to avoid iglobpath's expanduser
+        for s in sorted(glob.glob(prefix + "*")) if glob_sorted else glob.iglob(prefix + "*"):
+            paths.add(s)
+    else:
+        for s in xt.iglobpath(
+            prefix + "*", ignore_case=(not xp.ON_WINDOWS), sort_result=glob_sorted
+        ):
+            paths.add(s)
     # Substring matches: *prefix* catches files containing the prefix
     # anywhere in their name.  The pipeline's tier-based sort ensures
     # prefix matches rank above substring matches.
@@ -402,6 +414,19 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     paths, _ = _quote_paths(
         {_normpath(s) for s in paths}, path_str_start, path_str_end, append_end, cdpath
     )
+    # When a literal file/directory named ~ exists in cwd and the prefix
+    # starts with ~, add r'~...' completions so the user can select the
+    # local file instead of $HOME.  The bare ~/... entries are kept for
+    # home directory access.
+    if prefix.startswith(tilde) and not is_raw_string and os.path.exists(tilde):
+        tilde_local = set()
+        for p in list(paths):
+            raw = p.rstrip()
+            if raw.startswith(tilde) and not raw.startswith("r"):
+                quoted = "r'" + raw + "'"
+                tilde_local.add(quoted)
+        if tilde_local:
+            paths |= tilde_local
     paths.update(filter(filtfunc, _dots(prefix)))
     return paths, lprefix
 
@@ -443,10 +468,19 @@ def contextual_complete_path(command: CommandContext, cdpath=True, filtfunc=None
         filtfunc=filtfunc,
     )
 
-    # ``_complete_path_raw`` may have added closing quotes:
-    rich_completions = {
-        RichCompletion(comp, append_closing_quote=False) for comp in completions
-    }
+    # r'...' entries (for literal ~ or $VAR files) get an explicit
+    # display so the ptk menu shows them distinctly from their
+    # expanded counterparts.
+    rich_completions = set()
+    for comp in completions:
+        if comp.startswith("r'") or comp.startswith('r"'):
+            rich_completions.add(
+                RichCompletion(comp, display=comp, append_closing_quote=False)
+            )
+        else:
+            rich_completions.add(
+                RichCompletion(comp, append_closing_quote=False)
+            )
 
     return rich_completions, lprefix
 


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/4609

### Before

```xsh
cd /tmp
touch r'~'
showcmd ls ~<Tab>
# Completer has one option: 
# ~ (/home/snail)
```
The same case for `touch r'$HOME'`.

### After

```xsh
cd /tmp
touch r'~'
showcmd ls ~<Tab>
# Completer has two options: 
# ~ (/home/snail)
# r'~' (/tmp/~)
```
The same case for `touch r'$HOME'`.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
