### PR TITLE
fix: Show notification about list truncated by $COMPLETION_QUERY_LIMIT

### DIFF
--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -477,6 +477,93 @@ def test_trace_completions_uses_close_quote_alias(
     assert "append_closing_quote" not in captured
 
 
+def test_query_limit_warns_above_prompt(
+    completer, completers_mock, xession, monkeypatch
+):
+    """Hitting ``$COMPLETION_QUERY_LIMIT`` must surface a notice via
+    ``print_above_prompt`` so the user sees that the list was truncated.
+    """
+    monkeypatch.setitem(xession.env, "COMPLETION_QUERY_LIMIT", 3)
+
+    completers_mock["a"] = lambda *a: {f"c{i}" for i in range(10)}
+
+    messages = []
+    monkeypatch.setattr(
+        "xonsh.completer.print_above_prompt", lambda msg: messages.append(msg)
+    )
+
+    result, _ = completer.complete(
+        "c", "c", 0, 1, {}, multiline_text="c", cursor_index=1
+    )
+
+    assert len(result) == 3
+    assert messages == ["List truncated by $COMPLETION_QUERY_LIMIT = 3"]
+
+
+def test_query_limit_silent_when_not_hit(
+    completer, completers_mock, xession, monkeypatch
+):
+    """No warning when the number of completions stays under the limit."""
+    monkeypatch.setitem(xession.env, "COMPLETION_QUERY_LIMIT", 10)
+
+    completers_mock["a"] = lambda *a: {"x", "y", "z"}
+
+    messages = []
+    monkeypatch.setattr(
+        "xonsh.completer.print_above_prompt", lambda msg: messages.append(msg)
+    )
+
+    completer.complete("", "", 0, 0)
+
+    assert messages == []
+
+
+def test_query_limit_silent_for_empty_line(
+    completer, completers_mock, xession, monkeypatch
+):
+    """Bare Tab on a completely empty line always yields a large list;
+    the truncation notice would be noise, so it must be suppressed even
+    when the limit is hit.
+    """
+    monkeypatch.setitem(xession.env, "COMPLETION_QUERY_LIMIT", 3)
+
+    completers_mock["a"] = lambda *a: {f"c{i}" for i in range(10)}
+
+    messages = []
+    monkeypatch.setattr(
+        "xonsh.completer.print_above_prompt", lambda msg: messages.append(msg)
+    )
+
+    result, _ = completer.complete("", "", 0, 0, {}, multiline_text="", cursor_index=0)
+
+    assert len(result) == 3
+    assert messages == []
+
+
+def test_query_limit_warns_for_empty_prefix_with_command(
+    completer, completers_mock, xession, monkeypatch
+):
+    """Typing ``ls <Tab>`` — empty arg prefix but a real command line —
+    must still surface the truncation notice. Suppression is only for a
+    fully empty line.
+    """
+    monkeypatch.setitem(xession.env, "COMPLETION_QUERY_LIMIT", 3)
+
+    completers_mock["a"] = lambda *a: {f"c{i}" for i in range(10)}
+
+    messages = []
+    monkeypatch.setattr(
+        "xonsh.completer.print_above_prompt", lambda msg: messages.append(msg)
+    )
+
+    result, _ = completer.complete(
+        "", "ls ", 3, 3, {}, multiline_text="ls ", cursor_index=3
+    )
+
+    assert len(result) == 3
+    assert messages == ["List truncated by $COMPLETION_QUERY_LIMIT = 3"]
+
+
 def test_trace_completions_reports_zero_results(
     completer, completers_mock, xession, monkeypatch, capsys
 ):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -15,7 +15,7 @@ from xonsh.completers.tools import (
     is_exclusive_completer,
 )
 from xonsh.parsers.completion_context import CompletionContext, CompletionContextParser
-from xonsh.tools import print_exception
+from xonsh.tools import print_above_prompt, print_exception
 
 
 class Completer:
@@ -344,6 +344,21 @@ class Completer:
 
         query_limit = XSH.env.get("COMPLETION_QUERY_LIMIT")
 
+        # Whether there is any typed content at all. Bare Tab on a
+        # completely empty line always yields a huge candidate list, so
+        # the truncation notice would be pure noise there. For anything
+        # else (including ``ls <Tab>`` — empty arg prefix but a real
+        # command line) we want the notice to surface.
+        has_line_content = False
+        if old_completer_args and len(old_completer_args) >= 2:
+            has_line_content = bool(old_completer_args[1])
+        elif completion_context is not None:
+            if completion_context.command is not None:
+                cmd = completion_context.command
+                has_line_content = bool(cmd.args or cmd.prefix)
+            elif completion_context.python is not None:
+                has_line_content = bool(completion_context.python.prefix)
+
         for comp in self.generate_completions(
             completion_context,
             old_completer_args,
@@ -355,6 +370,10 @@ class Completer:
                 if trace:
                     print(
                         "TRACE COMPLETIONS: Stopped after $COMPLETION_QUERY_LIMIT reached."
+                    )
+                if has_line_content:
+                    print_above_prompt(
+                        f"List truncated by $COMPLETION_QUERY_LIMIT = {query_limit}"
                     )
                 break
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2171,9 +2171,11 @@ class AutoCompletionSetting(Xettings):
         doc_default="True",
     )
     COMPLETION_QUERY_LIMIT = Var.with_default(
-        100,
-        "The number of completions to display before the user is asked "
-        "for confirmation.",
+        1000,
+        "Maximum number of completions to collect. In prompt_toolkit the "
+        "list is truncated at this value and a notice is shown above the "
+        "prompt; in readline the user is asked 'Display all N "
+        "possibilities?'.",
     )
     FUZZY_PATH_COMPLETION = Var.with_default(
         True,


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/4516

### Implementation

* Increase limit from 100 to 1000
* Show "List truncated by $COMPLETION_QUERY_LIMIT = 1000" notiification above terminal

```xsh
mkdir tmp
cd tmp
for i in range($COMPLETION_QUERY_LIMIT+1):
    touch test_@(i).txt

ls <Tab>
# List truncated by $COMPLETION_QUERY_LIMIT = 1000
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
