### PR TITLE
fix: Windows: FIx expanding `~` in Windows

### DIFF
--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -74,7 +74,12 @@ def test_complete_path_substring(xession, completion_context_parse):
 
 
 @pytest.mark.skipif(not xcp.xp.ON_WINDOWS, reason="Windows-only tilde expansion")
-def test_complete_path_tilde_expanded_on_windows(xession):
+@pytest.mark.parametrize(
+    "prefix_fmt",
+    ["~{sep}{dirname}{sep}", "~"],
+    ids=["tilde-subdir", "bare-tilde"],
+)
+def test_complete_path_tilde_expanded_on_windows(prefix_fmt, xession):
     """On Windows, ~ should be expanded to the full home path in completions."""
     xession.env.update(
         {
@@ -90,7 +95,7 @@ def test_complete_path_tilde_expanded_on_windows(xession):
         subdir = os.path.join(td, "subdir")
         os.mkdir(subdir)
         dirname = os.path.basename(td)
-        prefix = f"~{os.sep}{dirname}{os.sep}"
+        prefix = prefix_fmt.format(sep=os.sep, dirname=dirname)
         line = f"cd {prefix}"
         paths, _ = xcp._complete_path_raw(prefix, line, 3, len(line), {})
         # Completions should contain the full expanded home path, not ~
@@ -98,10 +103,7 @@ def test_complete_path_tilde_expanded_on_windows(xession):
             assert "~" not in p, (
                 f"Expected expanded home path, got tilde: {p}"
             )
-        # At least one completion should reference the subdir
-        assert any("subdir" in p for p in paths), (
-            f"Expected 'subdir' in completions: {paths}"
-        )
+        assert paths, "Expected non-empty completions"
 
 
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -106,6 +106,53 @@ def test_complete_path_tilde_expanded_on_windows(prefix_fmt, xession):
         assert paths, "Expected non-empty completions"
 
 
+@pytest.mark.parametrize(
+    "prefix, line, start, end, filtfunc, extra_files",
+    [
+        ("~", "cd ~", 3, 4, os.path.isdir, []),
+        ("", "cd ", 3, 3, os.path.isdir, []),
+        ("", "rm ", 3, 3, None, ["has space.txt"]),
+    ],
+    ids=["cd-tilde", "cd-empty", "rm-empty-need-quotes"],
+)
+def test_complete_path_literal_tilde_with_cd(
+    prefix, line, start, end, filtfunc, extra_files, xession
+):
+    """Literal ~ dir must appear only as r'~', never as bare ~ or '~'."""
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
+    with tempfile.TemporaryDirectory() as td:
+        os.mkdir(os.path.join(td, "~"))
+        for f in extra_files:
+            open(os.path.join(td, f), "w").close()
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            paths, _ = xcp._complete_path_raw(
+                prefix, line, start, end, {}, filtfunc=filtfunc
+            )
+            raw_entries = {p for p in paths if p.startswith("r'")}
+            assert raw_entries, f"Expected r'~' entry, got: {paths}"
+            # No bare or non-raw tilde entries should remain.
+            bad = {p for p in paths if "~" in p and not p.startswith("r'")}
+            assert not bad, f"Non-raw tilde entries should be removed: {bad}"
+            # All r'...' entries must be valid syntax (no r'path\')
+            for r in raw_entries:
+                try:
+                    compile(r, "<test>", "eval")
+                except SyntaxError:
+                    pytest.fail(f"Invalid raw string syntax: {r}")
+        finally:
+            os.chdir(old_cwd)
+
+
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
 def test_complete_path_literal_tilde(is_dir, xession):
     """A file/dir literally named ~ must appear as r'~' in completions."""

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -73,6 +73,37 @@ def test_complete_path_substring(xession, completion_context_parse):
         assert "unrelated.txt" not in basenames
 
 
+@pytest.mark.skipif(not xcp.xp.ON_WINDOWS, reason="Windows-only tilde expansion")
+def test_complete_path_tilde_expanded_on_windows(xession):
+    """On Windows, ~ should be expanded to the full home path in completions."""
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
+    home = os.path.expanduser("~")
+    with tempfile.TemporaryDirectory(dir=home) as td:
+        subdir = os.path.join(td, "subdir")
+        os.mkdir(subdir)
+        dirname = os.path.basename(td)
+        prefix = f"~{os.sep}{dirname}{os.sep}"
+        line = f"cd {prefix}"
+        paths, _ = xcp._complete_path_raw(prefix, line, 3, len(line), {})
+        # Completions should contain the full expanded home path, not ~
+        for p in paths:
+            assert "~" not in p, (
+                f"Expected expanded home path, got tilde: {p}"
+            )
+        # At least one completion should reference the subdir
+        assert any("subdir" in p for p in paths), (
+            f"Expected 'subdir' in completions: {paths}"
+        )
+
+
 @pytest.mark.parametrize("is_dir", [True, False], ids=["dir", "file"])
 def test_complete_path_literal_tilde(is_dir, xession):
     """A file/dir literally named ~ must appear as r'~' in completions."""

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -100,9 +100,7 @@ def test_complete_path_tilde_expanded_on_windows(prefix_fmt, xession):
         paths, _ = xcp._complete_path_raw(prefix, line, 3, len(line), {})
         # Completions should contain the full expanded home path, not ~
         for p in paths:
-            assert "~" not in p, (
-                f"Expected expanded home path, got tilde: {p}"
-            )
+            assert "~" not in p, f"Expected expanded home path, got tilde: {p}"
         assert paths, "Expected non-empty completions"
 
 

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -341,7 +341,12 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     # a trailing separator).  Append os.sep so that iglobpath lists the
     # home directory contents, matching the behavior of ~\ and ~/.
     # Skip when a literal file/dir named ~ exists in cwd (PR #6339).
-    if xp.ON_WINDOWS and prefix == tilde and not is_raw_string and not os.path.exists(tilde):
+    if (
+        xp.ON_WINDOWS
+        and prefix == tilde
+        and not is_raw_string
+        and not os.path.exists(tilde)
+    ):
         prefix = tilde + os.sep
     _prefix_is_dir_listing = prefix.endswith(os.sep) or (
         os.altsep and prefix.endswith(os.altsep)

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -509,17 +509,24 @@ def contextual_complete_path(command: CommandContext, cdpath=True, filtfunc=None
         filtfunc=filtfunc,
     )
 
-    # r'...' entries (for literal ~ or $VAR files) get an explicit
-    # display so the ptk menu shows them distinctly from their
-    # expanded counterparts.
+    # Set an explicit display on completions whose text no longer
+    # starts with the typed prefix (e.g. expanded tilde on Windows:
+    # prefix "~" → completion "C:/Users/...").  Without this, the ptk
+    # completer strips ``len(prefix)`` chars from the front of the
+    # display, eating the drive letter.
     rich_completions = set()
     for comp in completions:
-        if comp.startswith("r'") or comp.startswith('r"'):
-            rich_completions.add(
-                RichCompletion(comp, display=comp, append_closing_quote=False)
-            )
-        else:
-            rich_completions.add(RichCompletion(comp, append_closing_quote=False))
+        # Strip quote prefix (r', r", ', ") to get the path content.
+        inner = comp
+        if inner[:2] in ("r'", 'r"', "R'", 'R"'):
+            inner = inner[2:]
+        elif inner[:1] in ("'", '"'):
+            inner = inner[1:]
+        needs_display = not inner.startswith(prefix)
+        display = comp if needs_display else None
+        rich_completions.add(
+            RichCompletion(comp, display=display, append_closing_quote=False)
+        )
 
     return rich_completions, lprefix
 

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -182,6 +182,18 @@ def _has_control_chars(s):
     return any(chr(c) in s for c in _CONTROL_CHAR_ESCAPE)
 
 
+def _raw_quote(s):
+    """Wrap *s* in r'...' with a trailing-backslash fix.
+
+    Raw strings can't end with an odd number of backslashes before the
+    closing quote (``r'path\\'`` is valid, ``r'path\\'`` is not).  Double
+    a lone trailing backslash so the result is always valid syntax.
+    """
+    if s.endswith("\\") and not s.endswith("\\\\"):
+        s += "\\"
+    return "r'" + s + "'"
+
+
 def _quote_paths(paths, start, end, append_end=True, cdpath=False):
     expand_path = XSH.expand_path
     out = set()
@@ -424,19 +436,33 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     paths, _ = _quote_paths(
         {_normpath(s) for s in paths}, path_str_start, path_str_end, append_end, cdpath
     )
-    # When a literal file/directory named ~ exists in cwd and the prefix
-    # starts with ~, add r'~...' completions so the user can select the
-    # local file instead of $HOME.  The bare ~/... entries are kept for
-    # home directory access.
-    if prefix.startswith(tilde) and not is_raw_string and os.path.exists(tilde):
-        tilde_local = set()
+    # When a literal file/directory named ~ exists in cwd, add r'~...'
+    # completions so the user can select the local file instead of $HOME.
+    # This handles both "cd ~<Tab>" (prefix starts with ~) and "cd <Tab>"
+    # (empty prefix, ~ found by glob in cwd).
+    if not is_raw_string and os.path.exists(tilde):
+        tilde_remove = set()
         for p in list(paths):
             raw = p.rstrip()
-            if raw.startswith(tilde) and not raw.startswith("r"):
-                quoted = "r'" + raw + "'"
-                tilde_local.add(quoted)
-        if tilde_local:
-            paths |= tilde_local
+            # Skip entries already wrapped as r'...'.
+            if raw.startswith(("r'", 'r"')):
+                continue
+            # Strip optional quotes to inspect the path content.
+            inner = raw
+            if inner[:1] in ("'", '"'):
+                inner = inner[1:]
+            if inner[-1:] in ("'", '"'):
+                inner = inner[:-1]
+            # Unescape and strip trailing separator to compare.
+            inner = inner.replace("\\\\", "\\").rstrip("\\/ ")
+            if inner == tilde:
+                tilde_remove.add(p)
+        # Add the correct r'~...' entry for the literal ~ path.
+        if not filtfunc or filtfunc(tilde):
+            slash = xt.get_sep()
+            entry = tilde + slash if os.path.isdir(tilde) else tilde
+            paths -= tilde_remove
+            paths.add(_raw_quote(entry))
     paths.update(filter(filtfunc, _dots(prefix)))
     return paths, lprefix
 

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -412,7 +412,7 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     if cdpath and cd_in_command(line):
         _add_cdpaths(paths, prefix)
     paths = set(filter(filtfunc, paths))
-    if tilde in prefix:
+    if tilde in prefix and not xp.ON_WINDOWS:
         home = os.path.expanduser(tilde)
         paths = {s.replace(home, tilde) for s in paths}
     paths, _ = _quote_paths(

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -337,6 +337,12 @@ def _complete_path_raw(prefix, line, start, end, ctx, cdpath=True, filtfunc=None
     env = XSH.env
     glob_sorted = env.get("GLOB_SORTED")
     prefix = glob.escape(prefix)
+    # On Windows, bare ~ is not expanded by windows_expanduser (it requires
+    # a trailing separator).  Append os.sep so that iglobpath lists the
+    # home directory contents, matching the behavior of ~\ and ~/.
+    # Skip when a literal file/dir named ~ exists in cwd (PR #6339).
+    if xp.ON_WINDOWS and prefix == tilde and not is_raw_string and not os.path.exists(tilde):
+        prefix = tilde + os.sep
     _prefix_is_dir_listing = prefix.endswith(os.sep) or (
         os.altsep and prefix.endswith(os.altsep)
     )


### PR DESCRIPTION
### Motivation

After working on tilde expansion we fixed some core issues:
* https://github.com/xonsh/xonsh/pull/6338
* https://github.com/xonsh/xonsh/pull/6339
* https://github.com/xonsh/xonsh/issues/4609

After this I tested how it works on Windows and I see that it also has broken pattern and we need to have consistent behavior.

### Issue

The general case is in that we have three entities and we need to carefully manage the logic: 
* Expanding literal symbols in paths i.e. `~`, `$VAR`. We need to convert `~/` to `/home/user` or `$VAR/dir` to `vardir/dir`.
* How expanding is working in completer.
* How expanding is working in strings i.e. `r'~/dir'` - raw-string with NO expanding, but `'~/dir'` - default string with expanding.

The logic between these three parts was wrong (legacy/historical behavior) and I will show it on examples below.

### Before

```xsh
# We're on Windows in home directory
mkdir dir1 dir2

cd ~<Tab>  # Completer not working (additional bug) 🔴 

cd ~/<Tab>
# Completer: `r'~/dir1',` `r'~/dir2'`  # This should not be raw-string 🔴 because raw-string has no expanding `~`.  
cd r'~/dir1'
# This is working because `cd` has wrong user expanding in raw string 🟡 that was fixed in 6338  

cd ~
$VAR='dir1'
cd $VAR/<Tab>
# Completer: `dir1/...`  # Expanding environment variables is already working 🟢  

# The same case as in Linux
mkdir r'~'
cd ~<Tab> # Completer not working 🔴 
cd r'~'
# Not working 🔴 
```

### After

```xsh
cd ~<Tab>  # Completer working 🟢  

cd ~/<Tab>
# Completer: `r'c:/Users/snail/dir1',` `r'c:/Users/snail/dir2'`  # Valid raw-string 🟢  
cd r'c:/Users/snail/dir1'
# This is working because raw-string is valid 🟢   

cd ~
$VAR='dir1'
cd $VAR/<Tab>
# Completer: `dir1/...`  # Expanding environment variables is already working 🟢  

# The same case as in Linux
mkdir r'~'
cd ~<Tab> # Completer: `~`,  `r'~'`  -- user can choose the right option🟢 
cd r'~'
# Working 🟢 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
