### PR TITLE
feat: Add `xcontext --json` and XContext class

### DIFF
--- a/tests/xoreutils/test_xcontext_llm.py
+++ b/tests/xoreutils/test_xcontext_llm.py
@@ -1,6 +1,7 @@
 """Tests for ``xonsh.xoreutils.xcontext``."""
 
 import io
+import json
 import os
 import subprocess
 from unittest import mock
@@ -269,3 +270,139 @@ def test_resolve_path_list_head_uses_pathext_probe(tmp_path, xession):
     assert os.path.samefile(resolved[0], str(real))
     assert resolved[1:] == ["-m", "pip"]
     assert bad is False
+
+
+# ---------------------------------------------------------------------------
+# xcontext_main — --json output mode
+# ---------------------------------------------------------------------------
+
+
+def _run_xcontext_json(xession, locate=None):
+    """Run ``xcontext_main(as_json=True)`` and return the parsed JSON.
+
+    ``locate`` overrides the per-name return value of ``locate_executable``;
+    pass a dict like ``{"xonsh": "/x", "uv": None}`` to simulate names
+    that are missing from ``$PATH``. Unspecified names default to
+    ``"/fake/" + name``.
+    """
+    buf = io.StringIO()
+    locate_map = {
+        cmd: f"/fake/{cmd}" for cmd in ("xonsh", "python", "pip", "pytest", "uv")
+    }
+    if locate:
+        locate_map.update(locate)
+    xession.aliases["xpip"] = ["/fake/python", "-m", "pip"]
+    with (
+        mock.patch.object(
+            xcontext, "locate_executable", side_effect=lambda c: locate_map.get(c)
+        ),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+    ):
+        rc = xcontext.xcontext_main(as_json=True, _stdout=buf)
+    assert rc == 0
+    return json.loads(buf.getvalue()), buf.getvalue()
+
+
+def test_json_output_has_expected_top_level_keys(xession):
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    report, _ = _run_xcontext_json(xession)
+    assert set(report) == {"session", "commands", "env"}
+
+
+def test_json_session_carries_xpython_xxonsh_xpip(xession):
+    """``session`` joins list-valued ``xpip`` with spaces — same flat
+    string the colored output shows for the ``xpip:`` row.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    report, _ = _run_xcontext_json(xession)
+    assert report["session"] == {
+        "xxonsh": "/fake/xonsh",
+        "xpython": mock.ANY,  # sys.executable, untouched by stubbed _resolve_path
+        "xpip": "/fake/python -m pip",
+    }
+    assert isinstance(report["session"]["xpython"], str)
+
+
+def test_json_commands_includes_all_probed_names(xession):
+    """``commands`` always lists every probed name (xonsh/python/pip/
+    pytest/uv) so consumers don't have to special-case missing keys.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    report, _ = _run_xcontext_json(xession)
+    assert set(report["commands"]) == {"xonsh", "python", "pip", "pytest", "uv"}
+    for cmd, path in report["commands"].items():
+        assert path == f"/fake/{cmd}"
+
+
+def test_json_commands_null_when_not_on_path(xession):
+    """A name absent from ``$PATH`` shows up as JSON ``null``, not as a
+    missing key — the schema is stable.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    report, _ = _run_xcontext_json(xession, locate={"pytest": None, "uv": None})
+    assert report["commands"]["pytest"] is None
+    assert report["commands"]["uv"] is None
+    assert report["commands"]["xonsh"] == "/fake/xonsh"
+
+
+def test_json_env_empty_when_no_vars_set(xession):
+    """``env`` mirrors the text section: only set variables appear, and
+    the section is an empty object when none are."""
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    report, _ = _run_xcontext_json(xession)
+    assert report["env"] == {}
+
+
+def test_json_env_includes_virtualenv_when_set(xession):
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env["VIRTUAL_ENV"] = "/tmp/my-venv"
+    report, _ = _run_xcontext_json(xession)
+    assert report["env"] == {"VIRTUAL_ENV": "/tmp/my-venv"}
+
+
+def test_json_env_includes_conda_when_set(xession):
+    xession.env["CONDA_DEFAULT_ENV"] = "myenv"
+    xession.env.pop("VIRTUAL_ENV", None)
+    report, _ = _run_xcontext_json(xession)
+    assert report["env"] == {"CONDA_DEFAULT_ENV": "myenv"}
+
+
+def test_json_env_includes_both_when_set(xession):
+    xession.env["CONDA_DEFAULT_ENV"] = "myenv"
+    xession.env["VIRTUAL_ENV"] = "/tmp/my-venv"
+    report, _ = _run_xcontext_json(xession)
+    assert report["env"] == {
+        "CONDA_DEFAULT_ENV": "myenv",
+        "VIRTUAL_ENV": "/tmp/my-venv",
+    }
+
+
+def test_json_output_is_pretty_printed(xession):
+    """Output is indented (indent=2) so it's human-readable in a
+    terminal pipe and round-trips through ``json.loads``."""
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    _, raw = _run_xcontext_json(xession)
+    assert "\n  " in raw  # indented at least once
+    assert raw.rstrip().endswith("}")
+
+
+def test_json_skips_print_color_calls(xession):
+    """JSON mode must not emit any ANSI escape sequences — the colored
+    ``print_color`` path must be bypassed entirely so the output is safe
+    to pipe to ``jq``.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    with mock.patch.object(xcontext, "print_color") as pc:
+        _, raw = _run_xcontext_json(xession)
+    assert pc.call_count == 0
+    assert "\x1b[" not in raw  # no ANSI escape sequences

--- a/tests/xoreutils/test_xcontext_llm.py
+++ b/tests/xoreutils/test_xcontext_llm.py
@@ -406,3 +406,395 @@ def test_json_skips_print_color_calls(xession):
         _, raw = _run_xcontext_json(xession)
     assert pc.call_count == 0
     assert "\x1b[" not in raw  # no ANSI escape sequences
+
+
+# ---------------------------------------------------------------------------
+# Resolved dataclass — display rendering
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_display_string_path():
+    """A plain string path is returned as-is."""
+    r = xcontext.Resolved(path="/usr/bin/xonsh")
+    assert r.display == "/usr/bin/xonsh"
+
+
+def test_resolved_display_list_path_joined_with_spaces():
+    """A list path (xpip alias) is space-joined for the colored row and
+    the JSON ``session.xpip`` field — same shape both consumers expect.
+    """
+    r = xcontext.Resolved(path=["/usr/bin/python", "-m", "pip"])
+    assert r.display == "/usr/bin/python -m pip"
+
+
+def test_resolved_display_none_path():
+    """``path=None`` (not found / no such alias) renders as ``None`` so
+    callers can distinguish "missing" from "empty string"."""
+    assert xcontext.Resolved(path=None).display is None
+    assert xcontext.Resolved().display is None
+
+
+def test_resolved_display_empty_string():
+    """Falsy ``path`` (empty string) also renders as ``None`` — same
+    "missing" signal as ``path=None``."""
+    assert xcontext.Resolved(path="").display is None
+
+
+def test_resolved_display_list_with_non_string_passthrough():
+    """A list whose elements aren't all strings can't be space-joined —
+    fall back to ``str(path)`` rather than raising."""
+    value = [object(), "-m", "pip"]
+    assert xcontext.Resolved(path=value).display == str(value)
+
+
+def test_resolved_defaults_are_safe():
+    """Default ``Resolved()`` is a "nothing found" placeholder — bad is
+    False, version is empty, path is None. Lets callers construct from
+    optional fields without juggling sentinels.
+    """
+    r = xcontext.Resolved()
+    assert r.path is None
+    assert r.bad is False
+    assert r.version == ""
+
+
+# ---------------------------------------------------------------------------
+# XContext — session getters
+# ---------------------------------------------------------------------------
+
+
+def test_xcontext_get_session_xxonsh_returns_resolved(xession):
+    """``get_session_xxonsh`` returns the resolved running interpreter
+    wrapped in a :class:`Resolved`. Stub ``_resolve_path`` so the test
+    is independent of what's actually on disk.
+    """
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+    ):
+        r = xcontext.XContext().get_session_xxonsh()
+    assert isinstance(r, xcontext.Resolved)
+    assert r.path == "/fake/xonsh"
+    assert r.bad is False
+
+
+def test_xcontext_get_session_xxonsh_passes_resolve_flag(xession):
+    """``XContext(resolve=False)`` must propagate that to ``_resolve_path``
+    so ``--no-resolve`` actually skips symlink chasing.
+    """
+    seen = []
+
+    def fake(value, resolve):
+        seen.append(resolve)
+        return value, False
+
+    with (
+        mock.patch.object(xcontext, "_resolve_path", side_effect=fake),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+    ):
+        xcontext.XContext(resolve=False).get_session_xxonsh()
+    assert seen == [False]
+
+
+def test_xcontext_get_session_xxonsh_caches_when_enabled(xession):
+    """With ``cache=True`` two calls to ``get_session_xxonsh`` must hit
+    the per-instance cache and only resolve once. Without the cache,
+    every property read in ``xcontext_main`` would re-import
+    ``xonsh.main`` (heavy) and re-resolve the path.
+    """
+    calls = mock.MagicMock(return_value="/fake/xonsh")
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch("xonsh.main.get_current_xonsh", side_effect=calls),
+    ):
+        xc = xcontext.XContext(cache=True)
+        first = xc.get_session_xxonsh()
+        second = xc.get_session_xxonsh()
+    assert first is second  # same Resolved instance, not a fresh one
+    assert calls.call_count == 1
+
+
+def test_xcontext_default_does_not_cache(xession):
+    """Default ``XContext()`` has ``cache=False`` so a long-lived holder
+    (e.g. an xontrib that stashes the instance) sees fresh ``$PATH`` /
+    alias state on every read instead of a stale snapshot.
+    """
+    calls = mock.MagicMock(return_value="/fake/xonsh")
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch("xonsh.main.get_current_xonsh", side_effect=calls),
+    ):
+        xc = xcontext.XContext()
+        first = xc.get_session_xxonsh()
+        second = xc.get_session_xxonsh()
+    # Each call re-runs the underlying probe → distinct Resolved
+    # objects (equal-valued, but freshly built).
+    assert first is not second
+    assert calls.call_count == 2
+
+
+def test_xcontext_get_session_xpython_records_version(xession):
+    """``get_session_xpython`` runs ``--version`` once and stores the
+    trimmed string on the returned :class:`Resolved`.
+    """
+    completed = subprocess.CompletedProcess(
+        args=["python", "--version"],
+        returncode=0,
+        stdout="Python 3.13.3\n",
+        stderr="",
+    )
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(xcontext.subprocess, "run", return_value=completed) as run,
+    ):
+        r = xcontext.XContext().get_session_xpython()
+    assert r.version == "Python 3.13.3"
+    assert r.bad is False
+    assert run.call_count == 1
+
+
+def test_xcontext_get_session_xpython_marks_bad_on_spawn_error(xession):
+    """A spawn error (Windows Store ``python.exe`` alias case) must
+    propagate to ``Resolved.bad`` even when path resolution itself
+    succeeded.
+    """
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(
+            xcontext.subprocess,
+            "run",
+            side_effect=OSError(1920, "The file cannot be accessed by the system"),
+        ),
+    ):
+        r = xcontext.XContext().get_session_xpython()
+    assert r.bad is True
+    assert r.version == ""
+
+
+def test_xcontext_get_session_xpython_caches_subprocess_when_enabled(xession):
+    """With ``cache=True`` the version probe is only allowed to run once
+    per instance — every extra spawn would slow down ``xcontext`` and
+    (worse) could produce inconsistent output between rows of the same
+    report.
+    """
+    completed = subprocess.CompletedProcess(
+        args=["python", "--version"], returncode=0, stdout="Python 3.13.3\n", stderr=""
+    )
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(xcontext.subprocess, "run", return_value=completed) as run,
+    ):
+        xc = xcontext.XContext(cache=True)
+        xc.get_session_xpython()
+        xc.get_session_xpython()
+    assert run.call_count == 1
+
+
+def test_xcontext_default_reruns_subprocess(xession):
+    """With cache off (the default), each call re-spawns the probe.
+    Documents the contract: long-lived holders pay the spawn cost on
+    every read but always see current state.
+    """
+    completed = subprocess.CompletedProcess(
+        args=["python", "--version"], returncode=0, stdout="Python 3.13.3\n", stderr=""
+    )
+    with (
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(xcontext.subprocess, "run", return_value=completed) as run,
+    ):
+        xc = xcontext.XContext()
+        xc.get_session_xpython()
+        xc.get_session_xpython()
+    assert run.call_count == 2
+
+
+def test_xcontext_get_session_xpip_returns_alias(xession):
+    """``get_session_xpip`` reads ``XSH.aliases['xpip']`` (typically a
+    ``[python, -m, pip]`` list) and the :attr:`Resolved.display` joins
+    it with spaces — the same shape the JSON ``session.xpip`` field
+    serializes.
+    """
+    xession.aliases["xpip"] = ["/fake/python", "-m", "pip"]
+    with mock.patch.object(
+        xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+    ):
+        r = xcontext.XContext().get_session_xpip()
+    assert r.path == ["/fake/python", "-m", "pip"]
+    assert r.display == "/fake/python -m pip"
+    assert r.bad is False
+
+
+def test_xcontext_get_session_xpip_missing_alias(xession):
+    """If ``xpip`` isn't aliased, the getter returns a "not found"
+    Resolved (path is None, display is None) — the colored renderer
+    falls back to the literal string ``not found``.
+    """
+    xession.aliases.pop("xpip", None)
+    with mock.patch.object(
+        xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+    ):
+        r = xcontext.XContext().get_session_xpip()
+    assert r.path is None
+    assert r.display is None
+
+
+# ---------------------------------------------------------------------------
+# XContext — commands getters
+# ---------------------------------------------------------------------------
+
+
+def test_xcontext_get_commands_xonsh_uses_locate_executable(xession):
+    """The ``xonsh`` row in the commands section is whatever
+    :func:`locate_executable` returns for ``xonsh``."""
+    with (
+        mock.patch.object(xcontext, "locate_executable", return_value="/path/xonsh"),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+    ):
+        r = xcontext.XContext().get_commands_xonsh()
+    assert r.path == "/path/xonsh"
+    assert r.bad is False
+
+
+def test_xcontext_get_commands_python_records_version(xession):
+    """The ``python`` commands row runs the same ``--version`` probe so
+    the row can show ``# Python X.Y.Z`` and flag the spawn-broken case.
+    """
+    completed = subprocess.CompletedProcess(
+        args=["python", "--version"],
+        returncode=0,
+        stdout="Python 3.13.3\n",
+        stderr="",
+    )
+    with (
+        mock.patch.object(xcontext, "locate_executable", return_value="/path/python"),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(xcontext.subprocess, "run", return_value=completed),
+    ):
+        r = xcontext.XContext().get_commands_python()
+    assert r.path == "/path/python"
+    assert r.version == "Python 3.13.3"
+    assert r.bad is False
+
+
+def test_xcontext_get_commands_python_skips_probe_when_missing(xession):
+    """If python isn't on ``$PATH``, no version probe is attempted —
+    spawning ``None --version`` would raise."""
+    with (
+        mock.patch.object(xcontext, "locate_executable", return_value=None),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(xcontext.subprocess, "run") as run,
+    ):
+        r = xcontext.XContext().get_commands_python()
+    assert r.path is None
+    assert r.version == ""
+    assert run.call_count == 0
+
+
+def test_xcontext_get_commands_python_marks_bad_on_spawn_error(xession):
+    """Same Windows Store alias case as the session row, but for the
+    PATH-resolved python."""
+    with (
+        mock.patch.object(xcontext, "locate_executable", return_value="/store/python"),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+        mock.patch.object(
+            xcontext.subprocess, "run", side_effect=OSError(1920, "WinError 1920")
+        ),
+    ):
+        r = xcontext.XContext().get_commands_python()
+    assert r.bad is True
+
+
+def test_xcontext_get_commands_pip_pytest_uv(xession):
+    """The remaining commands rows are plain PATH lookups — no version
+    probe, just a Resolved wrapping whatever ``locate_executable`` finds.
+    Parameterized via dict to keep the assertions tight.
+    """
+    locate_map = {"pip": "/path/pip", "pytest": "/path/pytest", "uv": "/path/uv"}
+    with (
+        mock.patch.object(
+            xcontext, "locate_executable", side_effect=lambda c: locate_map.get(c)
+        ),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+    ):
+        xc = xcontext.XContext()
+        assert xc.get_commands_pip().path == "/path/pip"
+        assert xc.get_commands_pytest().path == "/path/pytest"
+        assert xc.get_commands_uv().path == "/path/uv"
+
+
+def test_xcontext_get_commands_missing_returns_none(xession):
+    """A name not on ``$PATH`` produces ``Resolved(path=None)`` — the
+    JSON output relies on this to emit ``null`` for missing entries.
+    """
+    with (
+        mock.patch.object(xcontext, "locate_executable", return_value=None),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+    ):
+        r = xcontext.XContext().get_commands_pytest()
+    assert r.path is None
+
+
+def test_xcontext_get_commands_caches_when_enabled(xession):
+    """With ``cache=True`` each commands getter is cached — repeated
+    reads in ``xcontext_main`` (color check + row print) only hit
+    ``locate_executable`` once.
+    """
+    locate = mock.MagicMock(return_value="/path/xonsh")
+    with (
+        mock.patch.object(xcontext, "locate_executable", side_effect=locate),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        ),
+    ):
+        xc = xcontext.XContext(cache=True)
+        first = xc.get_commands_xonsh()
+        second = xc.get_commands_xonsh()
+    assert first is second
+    assert locate.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# XContext — env getters
+# ---------------------------------------------------------------------------
+
+
+def test_xcontext_env_getters_return_set_values(xession):
+    xession.env["CONDA_DEFAULT_ENV"] = "myenv"
+    xession.env["VIRTUAL_ENV"] = "/tmp/venv"
+    xc = xcontext.XContext()
+    assert xc.get_env_conda_default_env() == "myenv"
+    assert xc.get_env_virtual_env() == "/tmp/venv"
+
+
+def test_xcontext_env_getters_return_none_when_unset(xession):
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    xc = xcontext.XContext()
+    assert xc.get_env_conda_default_env() is None
+    assert xc.get_env_virtual_env() is None

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -1,10 +1,12 @@
 """The xontext command."""
 
 import errno
+import functools
 import json
 import os
 import subprocess
 import sys
+from dataclasses import dataclass
 
 from xonsh.built_ins import XSH
 from xonsh.cli_utils import ArgParserAlias
@@ -186,6 +188,165 @@ def _resolve_path(value, resolve):
     return value, False
 
 
+@dataclass(frozen=True)
+class Resolved:
+    """A resolved binary path probed by :class:`XContext`.
+
+    ``path`` may be a string (resolved file path), a list (alias args
+    where ``path[0]`` is the executable), or ``None`` (not found / no
+    such alias). ``bad`` is True when the entry is unusable: symlink
+    loop, missing file, not a regular file, lacks ``+x``, or its
+    ``--version`` probe failed (Windows Store ``python.exe`` alias).
+    ``version`` is the trimmed ``--version`` output, populated only
+    for python-family entries.
+
+    The :attr:`display` property renders the entry as a single string —
+    list paths are space-joined the way the CLI shows them, plain
+    strings pass through, and ``None`` becomes ``None`` so callers can
+    detect "not found" without re-checking ``path``.
+    """
+
+    path: object = None
+    bad: bool = False
+    version: str = ""
+
+    @property
+    def display(self):
+        if isinstance(self.path, list) and all(isinstance(x, str) for x in self.path):
+            return " ".join(self.path)
+        return str(self.path) if self.path else None
+
+
+def _cached_method(method):
+    """Per-instance, opt-in memoization for no-arg instance methods.
+
+    Stores the result in ``self._cache`` keyed by the method name when
+    caching is enabled, so the cache is bounded to the lifetime of the
+    instance — a plain :func:`functools.cache` on bound methods would
+    leak ``self`` references at the class level. When the holder
+    instance has ``self._cache is None`` (the default constructor mode),
+    every call re-runs the underlying probe so callers that hold onto an
+    :class:`XContext` see fresh ``$PATH`` / alias state on each read.
+    """
+    name = method.__name__
+
+    @functools.wraps(method)
+    def wrapper(self):
+        if self._cache is None:
+            return method(self)
+        if name not in self._cache:
+            self._cache[name] = method(self)
+        return self._cache[name]
+
+    return wrapper
+
+
+class XContext:
+    """Lazy collector of every value displayed by ``xcontext``.
+
+    Each ``get_*`` method computes its value and returns a
+    :class:`Resolved` (or, for env getters, a plain string / ``None``).
+    Construct with ``resolve=False`` to skip symlink resolution — the
+    accessibility / ``+x`` check still runs, matching the
+    ``--no-resolve`` CLI flag.
+
+    Caching is **off by default** so a long-lived instance always
+    reflects the current ``$PATH`` and alias state — callers that read a
+    getter twice after mutating the environment get the new value, not a
+    stale snapshot. Pass ``cache=True`` to enable per-instance memoization
+    for the lifetime of the report; ``xcontext_main`` does this so each
+    ``--version`` subprocess runs at most once per invocation.
+    """
+
+    def __init__(self, resolve=True, cache=False):
+        self._resolve = resolve
+        self._cache: dict | None = {} if cache else None
+
+    # ---- session: what the running xonsh process actually uses --------
+
+    @_cached_method
+    def get_session_xxonsh(self) -> Resolved:
+        """Return the path to the currently running xonsh interpreter."""
+        # Local import: ``xonsh.main`` pulls in heavy modules.
+        from xonsh.main import get_current_xonsh
+
+        path, bad = _resolve_path(get_current_xonsh(), self._resolve)
+        return Resolved(path=path, bad=bad)
+
+    @_cached_method
+    def get_session_xpython(self) -> Resolved:
+        """Return the python interpreter that's running this xonsh.
+
+        Inside an AppImage, ``sys.executable`` points at the AppImage
+        bootstrap rather than the bundled python — fall back to ``$_``
+        so the displayed binary is something the user can actually
+        invoke.
+        """
+        appimage_python = XSH.env.get("_") if IN_APPIMAGE else None
+        path, bad = _resolve_path(
+            appimage_python if appimage_python else sys.executable, self._resolve
+        )
+        ver, ver_ok = _get_version(path)
+        return Resolved(path=path, bad=bad or not ver_ok, version=ver)
+
+    @_cached_method
+    def get_session_xpip(self) -> Resolved:
+        """Return the ``xpip`` alias value (typically ``[python, -m, pip]``)."""
+        path, bad = _resolve_path(XSH.aliases.get("xpip"), self._resolve)
+        return Resolved(path=path, bad=bad)
+
+    # ---- commands: what ``$PATH`` lookup currently resolves to --------
+
+    def _get_command(self, name: str) -> Resolved:
+        path, bad = _resolve_path(locate_executable(name), self._resolve)
+        return Resolved(path=path, bad=bad)
+
+    @_cached_method
+    def get_commands_xonsh(self) -> Resolved:
+        """Return the ``xonsh`` binary that ``$PATH`` resolves to."""
+        return self._get_command("xonsh")
+
+    @_cached_method
+    def get_commands_python(self) -> Resolved:
+        """Return the ``python`` binary on ``$PATH``, with version probed.
+
+        The version probe doubles as a spawn check — a Windows Store
+        ``python.exe`` App Execution Alias can be located on ``$PATH``
+        but raises WinError 1920 on execution. Such entries get
+        ``bad=True`` so the row renders red.
+        """
+        base = self._get_command("python")
+        if not base.path:
+            return base
+        ver, ver_ok = _get_version(base.path)
+        return Resolved(path=base.path, bad=base.bad or not ver_ok, version=ver)
+
+    @_cached_method
+    def get_commands_pip(self) -> Resolved:
+        """Return the ``pip`` binary that ``$PATH`` resolves to."""
+        return self._get_command("pip")
+
+    @_cached_method
+    def get_commands_pytest(self) -> Resolved:
+        """Return the ``pytest`` binary that ``$PATH`` resolves to."""
+        return self._get_command("pytest")
+
+    @_cached_method
+    def get_commands_uv(self) -> Resolved:
+        """Return the ``uv`` binary that ``$PATH`` resolves to."""
+        return self._get_command("uv")
+
+    # ---- env: virtualenv / conda flags --------------------------------
+
+    def get_env_conda_default_env(self):
+        """Return ``$CONDA_DEFAULT_ENV`` or ``None`` if unset."""
+        return XSH.env.get("CONDA_DEFAULT_ENV")
+
+    def get_env_virtual_env(self):
+        """Return ``$VIRTUAL_ENV`` or ``None`` if unset."""
+        return XSH.env.get("VIRTUAL_ENV")
+
+
 def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None):
     """Report information about the current xonsh environment.
 
@@ -208,62 +369,54 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
         includes every probed name with ``null`` for entries not on
         ``$PATH``; ``env`` only contains variables that are set.
     """
-    # Local import: xonsh.main pulls in heavy modules, keep the dependency lazy.
-    from xonsh.main import get_current_xonsh
-
     stdout = _stdout or sys.stdout
-    resolve = not no_resolve
+    # cache=True so each ``--version`` subprocess runs at most once
+    # across the color-check + row-print + match comparisons.
+    xc = XContext(resolve=not no_resolve, cache=True)
 
-    current_xonsh, xxonsh_bad = _resolve_path(get_current_xonsh(), resolve)
-    appimage_python = XSH.env.get("_") if IN_APPIMAGE else None
-    xpy, xpython_bad = _resolve_path(
-        appimage_python if appimage_python else sys.executable, resolve
-    )
-    xpy_ver, xpy_ver_ok = _get_version(xpy)
-    xpython_bad = xpython_bad or not xpy_ver_ok
-
-    # Pre-resolve the PATH-visible binaries once so we can both display them
-    # in the "commands environment" section and compare them against the
-    # session-specific values (xxonsh/xpython/xpip) to decide coloring.
-    # Uses xonsh's own ``locate_executable`` rather than ``shutil.which``
-    # because the stdlib one is flagged (deprecated for ``PathLike`` args on
-    # Windows < 3.12), and xonsh's version is the recommended replacement.
-    path_resolved = {}
-    path_bad: dict[str, bool] = {}
-    for cmd in ("xonsh", "python", "pip", "pytest", "uv"):
-        path, bad = _resolve_path(locate_executable(cmd), resolve)
-        path_resolved[cmd] = path
-        path_bad[cmd] = bad
-
-    # xpip alias value as a single string (for display AND for match check).
-    xpip, xpip_bad = _resolve_path(XSH.aliases.get("xpip"), resolve)
-    if isinstance(xpip, list) and all(isinstance(x, str) for x in xpip):
-        xpip_display = " ".join(xpip)
-    elif xpip:
-        xpip_display = str(xpip)
-    else:
-        xpip_display = None
+    session_xxonsh = xc.get_session_xxonsh()
+    session_xpython = xc.get_session_xpython()
+    session_xpip = xc.get_session_xpip()
+    cmd_xonsh = xc.get_commands_xonsh()
+    cmd_pip = xc.get_commands_pip()
+    cmd_pytest = xc.get_commands_pytest()
+    cmd_uv = xc.get_commands_uv()
 
     if as_json:
         # Skip color/version probes — JSON consumers want raw paths only.
         # ``commands`` keeps every probed key (None for not-on-PATH) so the
         # shape is predictable; ``env`` mirrors the text section and omits
-        # unset variables.
+        # unset variables. Use ``_get_command`` for python here so we don't
+        # spawn a subprocess just to throw the version away.
+        cmd_python_raw = xc._get_command("python")
         report = {
             "session": {
-                "xxonsh": current_xonsh,
-                "xpython": xpy,
-                "xpip": xpip_display,
+                "xxonsh": session_xxonsh.path,
+                "xpython": session_xpython.path,
+                "xpip": session_xpip.display,
             },
-            "commands": {cmd: path_resolved[cmd] for cmd in path_resolved},
+            "commands": {
+                "xonsh": cmd_xonsh.path,
+                "python": cmd_python_raw.path,
+                "pip": cmd_pip.path,
+                "pytest": cmd_pytest.path,
+                "uv": cmd_uv.path,
+            },
             "env": {
-                ev: XSH.env.get(ev)
-                for ev in ("CONDA_DEFAULT_ENV", "VIRTUAL_ENV")
-                if XSH.env.get(ev)
+                ev: val
+                for ev, val in (
+                    ("CONDA_DEFAULT_ENV", xc.get_env_conda_default_env()),
+                    ("VIRTUAL_ENV", xc.get_env_virtual_env()),
+                )
+                if val
             },
         }
         print(json.dumps(report, indent=2), file=stdout)
         return 0
+
+    # The version-probing variant only runs in the colored path, where
+    # the version string is actually displayed.
+    cmd_python = xc.get_commands_python()
 
     # Color tokens: section headers are purple; within a family (xonsh/xxonsh,
     # python/xpython, pip/xpip) both labels go GREEN when the session binary
@@ -280,9 +433,9 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
     RED = "{RED}"
     RESET = "{RESET}"
 
-    xonsh_color = GREEN if current_xonsh == path_resolved["xonsh"] else BLUE
-    python_color = GREEN if xpy == path_resolved["python"] else BLUE
-    pip_color = GREEN if xpip_display == path_resolved["pip"] else BLUE
+    xonsh_color = GREEN if session_xxonsh.path == cmd_xonsh.path else BLUE
+    python_color = GREEN if session_xpython.path == cmd_python.path else BLUE
+    pip_color = GREEN if session_xpip.display == cmd_pip.path else BLUE
 
     label_color = {
         "xonsh": xonsh_color,
@@ -311,16 +464,21 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
 
     print_color(f"{PURPLE}[Current xonsh session]{RESET}", file=stdout)
     print_color(
-        _format_row("xxonsh", current_xonsh, bad=xxonsh_bad),
+        _format_row("xxonsh", session_xxonsh.path, bad=session_xxonsh.bad),
         file=stdout,
     )
     print_color(
-        _format_row("xpython", xpy, ver=f"  # {xpy_ver}", bad=xpython_bad),
+        _format_row(
+            "xpython",
+            session_xpython.path,
+            ver=f"  # {session_xpython.version}",
+            bad=session_xpython.bad,
+        ),
         file=stdout,
     )
-    if xpip_display is not None:
+    if session_xpip.display is not None:
         print_color(
-            _format_row("xpip", xpip_display, bad=xpip_bad),
+            _format_row("xpip", session_xpip.display, bad=session_xpip.bad),
             file=stdout,
         )
     else:
@@ -328,29 +486,30 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
 
     print("", file=stdout)
     print_color(f"{PURPLE}[Current commands environment]{RESET}", file=stdout)
-    cmds = ["xonsh", "python", "pip"]
-    if path_resolved["pytest"]:
-        cmds.append("pytest")
-    if path_resolved["uv"]:
-        cmds.append("uv")
-    for cmd in cmds:
-        path = path_resolved[cmd]
-        bad = path_bad[cmd]
-        if path:
-            ver = ""
-            if cmd == "python":
-                ver_str, ver_ok = _get_version(path)
-                ver = f"  # {ver_str}"
-                # Spawn failure (e.g. Windows Store ``python.exe``
-                # alias) → flag the whole row as bad even though the
-                # file technically "exists".
-                bad = bad or not ver_ok
-            print_color(_format_row(cmd, path, ver=ver, bad=bad), file=stdout)
+    cmd_rows: list[tuple[str, Resolved]] = [
+        ("xonsh", cmd_xonsh),
+        ("python", cmd_python),
+        ("pip", cmd_pip),
+    ]
+    if cmd_pytest.path:
+        cmd_rows.append(("pytest", cmd_pytest))
+    if cmd_uv.path:
+        cmd_rows.append(("uv", cmd_uv))
+    for name, r in cmd_rows:
+        if r.path:
+            ver = f"  # {r.version}" if r.version else ""
+            print_color(_format_row(name, r.path, ver=ver, bad=r.bad), file=stdout)
         else:
-            print_color(_format_row(cmd, "not found"), file=stdout)
-    envs = ["CONDA_DEFAULT_ENV", "VIRTUAL_ENV"]
-    env_rows = [(ev, XSH.env.get(ev)) for ev in envs]
-    env_rows = [(ev, val) for ev, val in env_rows if val]
+            print_color(_format_row(name, "not found"), file=stdout)
+
+    env_rows = [
+        (ev, val)
+        for ev, val in (
+            ("CONDA_DEFAULT_ENV", xc.get_env_conda_default_env()),
+            ("VIRTUAL_ENV", xc.get_env_virtual_env()),
+        )
+        if val
+    ]
     if env_rows:
         print("", file=stdout)
         print_color(f"{PURPLE}[Current environment]{RESET}", file=stdout)

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -1,6 +1,7 @@
 """The xontext command."""
 
 import errno
+import json
 import os
 import subprocess
 import sys
@@ -185,7 +186,7 @@ def _resolve_path(value, resolve):
     return value, False
 
 
-def xcontext_main(no_resolve: bool = False, _stdout=None):
+def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None):
     """Report information about the current xonsh environment.
 
     By default, all displayed binary paths (xxonsh, xpython, xpip and the
@@ -200,6 +201,12 @@ def xcontext_main(no_resolve: bool = False, _stdout=None):
     no_resolve : -n, --no-resolve
         Show raw paths as-is without following symlinks (turns off the
         default resolution).
+    as_json : -j, --json
+        Emit the resolved paths as a JSON object on stdout instead of the
+        colored text report. Top-level keys mirror the text sections
+        (``session``, ``commands``, ``env``); ``commands`` always
+        includes every probed name with ``null`` for entries not on
+        ``$PATH``; ``env`` only contains variables that are set.
     """
     # Local import: xonsh.main pulls in heavy modules, keep the dependency lazy.
     from xonsh.main import get_current_xonsh
@@ -236,6 +243,27 @@ def xcontext_main(no_resolve: bool = False, _stdout=None):
         xpip_display = str(xpip)
     else:
         xpip_display = None
+
+    if as_json:
+        # Skip color/version probes — JSON consumers want raw paths only.
+        # ``commands`` keeps every probed key (None for not-on-PATH) so the
+        # shape is predictable; ``env`` mirrors the text section and omits
+        # unset variables.
+        report = {
+            "session": {
+                "xxonsh": current_xonsh,
+                "xpython": xpy,
+                "xpip": xpip_display,
+            },
+            "commands": {cmd: path_resolved[cmd] for cmd in path_resolved},
+            "env": {
+                ev: XSH.env.get(ev)
+                for ev in ("CONDA_DEFAULT_ENV", "VIRTUAL_ENV")
+                if XSH.env.get(ev)
+            },
+        }
+        print(json.dumps(report, indent=2), file=stdout)
+        return 0
 
     # Color tokens: section headers are purple; within a family (xonsh/xxonsh,
     # python/xpython, pip/xpip) both labels go GREEN when the session binary


### PR DESCRIPTION
```xsh
xcontext --json
```
```xsh
{
  "session": {
    "xxonsh": "/Users/pc/Documents/git/xonsh/xonsh/__main__.py",
    "xpython": "/Users/pc/micromamba/envs/xonsh-dev/bin/python",
    "xpip": "/Users/pc/micromamba/envs/xonsh-dev/bin/python -m pip"
  },
  "commands": {
    "xonsh": "/Users/pc/micromamba/envs/xonsh-dev/bin/xonsh",
    "python": "/Users/pc/micromamba/envs/xonsh-dev/bin/python",
    "pip": "/Users/pc/micromamba/envs/xonsh-dev/bin/pip",
    "pytest": "/Users/pc/micromamba/envs/xonsh-dev/bin/pytest",
    "uv": "/opt/homebrew/bin/uv"
  },
  "env": {
    "CONDA_DEFAULT_ENV": "xonsh-dev"
  }
}
```
So now it's easy to get:
```xsh
$(@json xcontext --json -n)['session']['xxonsh']
# /Users/pc/Documents/git/xonsh/xonsh/__main__.py
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
