### PR TITLE
fix: virtualenv name now has smarter formatting

### DIFF
--- a/docs/_static/robots.txt
+++ b/docs/_static/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Disallow: /dev/
 Disallow: /docs-ahundt-sphinx
-Disallow: /linux.html
+Disallow: /_sources/
 
 Sitemap: https://xon.sh/sitemap.xml

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -74,6 +74,8 @@ Manages xonsh configuration information.
 Manages xonsh extensions. More information is available at :doc:`xontrib`
 
 
+.. _aliases-xcontext:
+
 ``xcontext``
 --------------------
 

--- a/docs/prompt.rst
+++ b/docs/prompt.rst
@@ -512,7 +512,12 @@ xonsh also allows for an explicit override of the rendering of ``{env_name}``,
 via the ``$VIRTUAL_ENV_PROMPT`` environment variable. If this variable is
 set to a non-empty value, ``{env_name}`` will *always* render as its value,
 regardless of whether a virtual environment is active. The value is used
-as-is, without the usual ``{env_prefix}`` / ``{env_postfix}`` wrapping.
+as-is, without the usual ``{env_prefix}`` / ``{env_postfix}`` wrapping ---
+*except* when it matches the name derived from ``$VIRTUAL_ENV`` (the
+``prompt = ...`` field in ``<venv>/pyvenv.cfg`` or the venv directory
+basename). In that case it is treated as an auto-populated value from
+``activate.xsh`` and wrapped like the other sources, so the prompt reads
+``(venv) user@host`` instead of ``venvuser@host``.
 ``$VIRTUAL_ENV_PROMPT`` is overridden by ``$VIRTUAL_ENV_DISABLE_PROMPT``.
 
 When neither variable is set, ``{env_name}`` falls back to the active

--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -2,9 +2,9 @@
 
 .. _python_virtual_environments:
 
-===========================
-Python Virtual Environments
-===========================
+====================
+Virtual Environments
+====================
 
 Python virtual environments let you isolate a project's dependencies from
 the system Python, and xonsh works with the usual tools for creating them.

--- a/docs/python_virtual_environments.rst
+++ b/docs/python_virtual_environments.rst
@@ -6,20 +6,49 @@
 Python Virtual Environments
 ===========================
 
-The usual tools for creating Python virtual environments—``venv``, ``virtualenv``, ``pew``—don't play well with xonsh. We won't dig deeper into why it is so, but the general gist is that these tools are hacky and hard-coded for traditional shells.
+Python virtual environments let you isolate a project's dependencies from
+the system Python, and xonsh works with the usual tools for creating them.
+Whichever tool you pick, the :ref:`xcontext <aliases-xcontext>` command
+will always tell you which interpreter, ``pip``, and environment variables
+are in effect right now — handy when something isn't resolving where you
+expected.
 
-Luckily, xonsh has its own virtual environments manager called **Vox**. Run to install Vox::
+``virtualenv``
+==============
 
-    $ xpip install xontrib-vox
+`virtualenv <https://virtualenv.pypa.io/>`_ ships with a native xonsh
+activator, so creating and entering an environment takes just two steps:
 
-Vox
-===
+.. code-block:: xonshcon
 
-First, load the vox xontrib::
+    @ virtualenv myenv
+    @ source myenv/bin/activate.xsh
+    (myenv) @
 
+To leave the environment, run ``deactivate``.
+
+
+``vox``
+=======
+
+xonsh works with the usual Python virtual environment tools — ``venv``,
+``virtualenv``, ``pew`` — and on top of that ships its own environments
+manager called **Vox**. Vox is an xontrib that makes creating, listing,
+activating, and removing virtualenvs feel natural right inside the shell,
+so you don't have to leave the REPL or remember a separate activation
+script per project.
+
+Install and load Vox:
+
+.. code-block:: xonshcon
+
+    @ xpip install xontrib-vox
     @ xontrib load vox
 
-To create a new environment with vox, run ``vox new <envname>``::
+To create a new environment with vox, run ``vox new <envname>``:
+
+
+.. code-block:: xonshcon
 
     @ vox new myenv
     Creating environment...
@@ -27,7 +56,9 @@ To create a new environment with vox, run ``vox new <envname>``::
 
 The interpreter ``vox`` uses to create a virtualenv is configured via the ``$VOX_DEFAULT_INTERPRETER`` environment variable.
 
-You may also set the interpreter used to create the virtual environment by passing it explicitly to ``vox new`` i.e.::
+You may also set the interpreter used to create the virtual environment by passing it explicitly to ``vox new`` i.e.:
+
+.. code-block:: xonshcon
 
     @ vox new python2-env -p /usr/local/bin/python2
 
@@ -37,7 +68,9 @@ If a Python 2 interpreter is chosen, it will use the Python 2 interpreter's ``vi
 
 By default, environments are stored in ``~/.virtualenvs``, but you can override it by setting the ``$VIRTUALENV_HOME`` environment variable.
 
-To see all existing environments, run ``vox list``::
+To see all existing environments, run ``vox list``:
+
+.. code-block:: xonshcon
 
     @ vox list
     Available environments:
@@ -45,62 +78,51 @@ To see all existing environments, run ``vox list``::
         myenv
         spam
 
-To activate an environment, run ``vox activate <envname>``::
+To activate an environment, run ``vox activate <envname>``:
+
+.. code-block:: xonshcon
 
     @ vox activate myenv
     Activated "myenv".
 
 Instead of ``activate``, you can call ``workon`` or ``enter``.
 
-If you want to activate an environment which is stored somewhere else (maybe because it was created by another tool) you can pass to ``vox activate`` a path to a virtual environment::
+If you want to activate an environment which is stored somewhere else (maybe because it was created by another tool) you can pass to ``vox activate`` a path to a virtual environment:
+
+
+.. code-block:: xonshcon
 
     @ vox activate /home/user/myenv
     Activated "/home/user/myenv".
 
-To exit the currently active environment, run ``vox deactivate`` or ``vox exit``::
+To exit the currently active environment, run ``vox deactivate`` or ``vox exit``:
+
+.. code-block:: xonshcon
 
     @ vox deactivate
     Deactivated "myenv".
 
-To remove an environment, run ``vox remove <envname>``::
+To remove an environment, run ``vox remove <envname>``:
+
+.. code-block:: xonshcon
 
     @ vox remove myenv
     Environment "myenv" removed.
 
 Instead of ``remove``, you can call ``rm``, ``delete``, or ``del``.
 
-To see all available commands, run ``vox help``, ``vox --help``, or ``vox -h``::
-
-    Vox is a virtual environment manager for xonsh.
-
-    Available commands:
-        vox new <env>
-            Create new virtual environment in $VIRTUALENV_HOME
-
-        vox activate (workon, enter) <env>
-            Activate virtual environment
-
-        vox deactivate (exit)
-            Deactivate current virtual environment
-
-        vox list (ls)
-            List environments available in $VIRTUALENV_HOME
-
-        vox remove (rm, delete, del) <env> <env2> ...
-            Remove virtual environments
-
-        vox help (-h, --help)
-            Show help
-
+To see all available commands, run ``vox help``, ``vox --help``, or ``vox -h``.
 
 ``virtualenv`` like prompt
 --------------------------
 Although it's included in the default prompt, you can customize your prompt
 to automatically update in the same way as ``virtualenv``.
 
-Simply add the ``'{env_name}'`` variable to your ``$PROMPT``::
+Simply add the ``'{env_name}'`` variable to your ``$PROMPT``:
 
-    $PROMPT = '{env_name: {}}' + restofmyprompt
+.. code-block:: xonshcon
+
+    @ $PROMPT = '{env_name: {}}' + restofmyprompt
 
 Note that you do **not** need to load the ``vox`` xontrib for this to work.
 For more details see :ref:`customprompt`.
@@ -111,7 +133,9 @@ Automatically Switching Environments
 
 Automatic environment switching based on the current directory is managed with the ``autovox`` xontrib (``xontrib load autovox``). Third-party xontribs may register various policies for use with autovox. Pick and choose xontribs that implement policies that match your work style.
 
-Implementing policies is easy! Just register with the ``autovox_policy`` event and return a ``Path`` if there is a matching venv. For example, this policy implements handling if there is a ``.venv`` directory in the project::
+Implementing policies is easy! Just register with the ``autovox_policy`` event and return a ``Path`` if there is a matching venv. For example, this policy implements handling if there is a ``.venv`` directory in the project:
+
+.. code-block:: xonsh
 
     @events.autovox_policy
     def dotvenv_policy(path, **_):
@@ -120,3 +144,13 @@ Implementing policies is easy! Just register with the ``autovox_policy`` event a
             return venv
 
 Note that you should only return if there is an environment for this directory exactly. Scanning parent directories is managed by autovox. You should also make the policy check relatively cheap. (Local IO is ok, but probably shouldn't call out to network services.)
+
+
+See also
+========
+
+* :ref:`aliases-xcontext` — inspect the interpreter, ``pip``, and active
+  environment variables of the current session.
+* :ref:`customprompt_ref` — customize ``{env_name}``, ``{env_prefix}``,
+  and ``{env_postfix}`` to control how the active environment appears in
+  the prompt.

--- a/tests/prompt/test_base.py
+++ b/tests/prompt/test_base.py
@@ -256,6 +256,30 @@ def test_custom_env_overrides_default(formatter, xession, live_fields, disable):
     assert formatter("{env_name}", fields=live_fields) == exp
 
 
+def test_virtual_env_prompt_matching_basename_is_wrapped(
+    formatter, xession, live_fields, tmp_path
+):
+    """Regression: activate.xsh sets VIRTUAL_ENV_PROMPT to the bare venv name.
+
+    When the value of $VIRTUAL_ENV_PROMPT matches the name derived from
+    $VIRTUAL_ENV (directory basename or pyvenv.cfg ``prompt=``), it is
+    auto-populated by activate.xsh and must be wrapped with
+    env_prefix/env_postfix. Otherwise the prompt collapses into e.g.
+    ``vvv1pc@pc`` instead of ``(vvv1) pc@pc``.
+    """
+    venv = tmp_path / "vvv1"
+    venv.mkdir()
+    prompt_env._determine_env_name.cache_clear()
+    xession.shell.prompt_formatter = formatter
+    xession.env.update(
+        dict(
+            VIRTUAL_ENV=str(venv),
+            VIRTUAL_ENV_PROMPT="vvv1",
+        )
+    )
+    assert formatter("{env_name}", fields=live_fields) == "(vvv1) "
+
+
 def test_promptformatter_cache(formatter):
     spam = Mock()
     template = "{spam} and {spam}"

--- a/xonsh/prompt/env.py
+++ b/xonsh/prompt/env.py
@@ -29,14 +29,21 @@ def find_env_name() -> str | None:
 def env_name() -> str:
     """Build env_name based on different sources. Respect order of precedence.
 
-    Name from VIRTUAL_ENV_PROMPT will be used as-is.
-    Names from other sources are surrounded with ``{env_prefix}`` and
-    ``{env_postfix}`` fields.
+    Name from ``$VIRTUAL_ENV_PROMPT`` is used as-is — so users can override
+    the prompt verbatim. As an exception, if the value matches the name
+    derived from ``$VIRTUAL_ENV`` (via the ``prompt=`` field in
+    ``pyvenv.cfg`` or the directory basename), it is treated as a value
+    auto-populated by ``activate.xsh`` and wrapped with ``{env_prefix}`` /
+    ``{env_postfix}`` like the other sources. Names from other sources are
+    always surrounded with ``{env_prefix}`` and ``{env_postfix}``.
     """
     if XSH.env.get("VIRTUAL_ENV_DISABLE_PROMPT"):
         return ""
     virtual_env_prompt = XSH.env.get("VIRTUAL_ENV_PROMPT")
     if virtual_env_prompt:
+        virtual_env = XSH.env.get("VIRTUAL_ENV")
+        if virtual_env and virtual_env_prompt == _determine_env_name(virtual_env):
+            return _surround_env_name(virtual_env_prompt)
         return virtual_env_prompt
     found_envname = find_env_name()
     return _surround_env_name(found_envname) if found_envname else ""

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -405,8 +405,8 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
             "env": {
                 ev: val
                 for ev, val in (
-                    ("CONDA_DEFAULT_ENV", xc.get_env_conda_default_env()),
                     ("VIRTUAL_ENV", xc.get_env_virtual_env()),
+                    ("CONDA_DEFAULT_ENV", xc.get_env_conda_default_env()),
                 )
                 if val
             },
@@ -505,8 +505,8 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
     env_rows = [
         (ev, val)
         for ev, val in (
-            ("CONDA_DEFAULT_ENV", xc.get_env_conda_default_env()),
             ("VIRTUAL_ENV", xc.get_env_virtual_env()),
+            ("CONDA_DEFAULT_ENV", xc.get_env_conda_default_env()),
         )
         if val
     ]


### PR DESCRIPTION
During testing `virtualenv` I've noticed the lack of formatting logic.

### Before

```xsh
snail@host /tmp @  source myvenv/bin/activate
myvenvsnail@host /tmp @  source myvenv/bin/activate
```

### After

If `$VIRTUAL_ENV` and `$VIRTUAL_ENV_PROMPT` are the same we're using our own formatting.

```xsh
snail@host /tmp @  source myvenv/bin/activate
(myvenv) snail@host /tmp @  source myvenv/bin/activate
(myvenv) snail@host /tmp @  $VIRTUAL_ENV_PROMPT = '~myvenv~ '
~myvenv~ snail@host /tmp @ 
```



## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
