### PR TITLE
fix(parser): preserve "func()[subscript]" at statement level

### DIFF
--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -279,6 +279,28 @@ def test_forward_ref_call_subscript_in_function(xonsh_execer_parse):
     assert "pprint(" in stmts
 
 
+# The GH-6354 fix tightened subproc_toks on ``func()[subscript]``.  A
+# side-effect was that ``f"{q()[0]}"`` at statement level produced a
+# now-valid ``![f"{q()[0]}"]`` wrap and was mistakenly turned into a
+# subprocess (before the fix it produced a broken wrap that silently
+# fell back).  subproc_toks declines to wrap any statement whose first
+# collected token is FSTRING_START — those are always Python
+# expressions, never subprocess commands.
+@pytest.mark.parametrize(
+    "expr",
+    [
+        'f"{q()[0]}"',
+        'f"{q()}"',
+        'f"hi {x} {y}"',
+    ],
+)
+def test_fstring_statement_stays_python(expr, xonsh_execer_parse):
+    tree = xonsh_execer_parse(expr + "\n")
+    assert "subproc_captured_hiddenobject" not in pyast_unparse(tree), (
+        f"{expr!r} was turned into a subprocess"
+    )
+
+
 def pyast_unparse(tree):
     """Return ast.unparse on the tree (helper for the tests above)."""
     import ast as pyast

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -479,6 +479,17 @@ def subproc_toks(
             end_offset = len(el)
     if len(toks) == 0:
         return  # handle comment lines
+    # A statement that starts with an f-string token (``f"..."``) is a
+    # Python expression, not a subprocess command — e.g. ``f"{q()[0]}"``
+    # at statement level must stay Python.  Before the GH-6354 fix the
+    # same line produced a broken wrap that happened to re-parse as a
+    # SyntaxError and therefore round-tripped back to Python; now that
+    # the wrap is syntactically clean we have to decline it explicitly,
+    # otherwise ``try_subproc_toks`` would substitute the f-string as a
+    # subprocess command.  (``echo f"hi"`` still wraps: the f-string is
+    # not the first collected token there.)
+    if toks[0].type == "FSTRING_START":
+        return
     elif saw_macro or greedy:
         end_offset = len(toks[-1].value.rstrip()) + 1
     if toks[0].lineno != toks[-1].lineno:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -479,16 +479,22 @@ def subproc_toks(
             end_offset = len(el)
     if len(toks) == 0:
         return  # handle comment lines
-    # A statement that starts with an f-string token (``f"..."``) is a
-    # Python expression, not a subprocess command — e.g. ``f"{q()[0]}"``
-    # at statement level must stay Python.  Before the GH-6354 fix the
-    # same line produced a broken wrap that happened to re-parse as a
-    # SyntaxError and therefore round-tripped back to Python; now that
-    # the wrap is syntactically clean we have to decline it explicitly,
-    # otherwise ``try_subproc_toks`` would substitute the f-string as a
-    # subprocess command.  (``echo f"hi"`` still wraps: the f-string is
-    # not the first collected token there.)
-    if toks[0].type == "FSTRING_START":
+    # A statement that starts with a string literal — f-string or
+    # otherwise — is a Python expression, not a subprocess command.
+    # On Python 3.12+ with PEP 701 an f-string begins with FSTRING_START;
+    # on 3.11 the whole f-string collapses into a single STRING token
+    # with an ``f`` prefix.  Either way, ``f"{q()[0]}"`` at statement
+    # level must stay Python.  Before the GH-6354 fix the same line
+    # produced a broken wrap that round-tripped back to Python via a
+    # SyntaxError in re-parse; now that the wrap is syntactically clean
+    # we have to decline it explicitly, otherwise ``try_subproc_toks``
+    # would substitute the f-string as a subprocess command.  Plain
+    # string statements (``"hi"``) don't reach this path because
+    # ``CtxAwareTransformer.is_in_scope`` returns True when there are
+    # no Load names — but being defensive here costs nothing and keeps
+    # the intent explicit.  ``echo "x"`` / ``echo f"x"`` still wrap:
+    # the STRING token is not the first collected token in those lines.
+    if toks[0].type in ("FSTRING_START", "STRING"):
         return
     elif saw_macro or greedy:
         end_offset = len(toks[-1].value.rstrip()) + 1


### PR DESCRIPTION
### Motivation

* Fixes https://github.com/xonsh/xonsh/issues/6354

### Source

This is not a regress. The issue was in previous versions it was just highlighted in 0.23 because of more strict error handling.

### Implementation

First fix was in main (https://github.com/xonsh/xonsh/commit/6455edbc17f047db92a4e967c8cfa5d51c31953b) here is the second part.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
