### PR TITLE
fix: avoid error when output dir is not `_build`

### DIFF
--- a/docs/extensions/jinja_rst_ext.py
+++ b/docs/extensions/jinja_rst_ext.py
@@ -43,7 +43,9 @@ def rstjinja(app, docname, source):
         source[0] = rendered
 
         # for debugging purpose write output
-        Path(utils.docs_dir / "_build" / f"{docname}.rst.out").write_text(rendered)
+        out_path = Path(utils.docs_dir / "_build" / f"{docname}.rst.out")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(rendered)
 
 
 class FixEnvVarSectionIds(SphinxTransform):


### PR DESCRIPTION
When Sphinx is configured to output HTML into a directory other than `_build`, rstjinja attempted to write a debug file at `docs/_build/<docname>.rst.out` even if the `_build` subdirectory did not exist, causing a failure.

This fix ensures the output file's parent directory is created before writing the file to avoid this error.

Close: #6356 

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.

🤖 If your code was generated by AI/LLM tell about this directly.
🤖 Ask AI/LLM about putting functions/modules to `<module>_llm.py` files instead of using directly into the code.

-->

cc https://github.com/xonsh/xonsh/issues/5083

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
