### PR TITLE
fix: Nix: Now flake uses the package built from source

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  pythonEnv = python3.withPackages (ps: [ ps.xonsh ] ++ extraPackages ps);
+  pythonEnv = python3.withPackages (ps: [ xonsh ] ++ extraPackages ps);
   xonsh = python3.pkgs.callPackage ./unwrapped.nix { };
 in
 runCommand "xonsh-${xonsh.version}"


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/6360

In `nix/package.nix` the `runCommand` wrapper was juggling two different xonsh packages at once: the local `xonsh = python3.pkgs.callPackage ./unwrapped.nix { }` (built from `src = ../.;`, version `main`/`0.23.1`) was only used to name the derivation and to enumerate binary names via `lib.getBin xonsh`, while the actual symlinks placed into `$out/bin` pointed at `${pythonEnv}/bin/...`, where `pythonEnv = python3.withPackages (ps: [ ps.xonsh ] ++ extraPackages ps)` pulled in `ps.xonsh` — the xonsh shipped by the flake's pinned `nixpkgs-unstable` (0.22.8 at the time of the report), not the one built from source. As a result `nix run 'github:xonsh/xonsh'` honestly built a wheel from the repository but executed the nixpkgs binary, so `xonfig` kept printing the stale version. The fix is to replace `ps.xonsh` with the local `xonsh` binding (Nix `let` bindings are mutually recursive, so the declaration order does not matter): `withPackages` accepts any package compatible with the given interpreter, and the local `xonsh` was built with the same `python3.pkgs.callPackage`, so it qualifies. After the change both the derivation name/version and the symlink targets come from the same source-built package; verified via `nix build` in a `nixos/nix` container — the test suite is green and `result/bin/xonsh` reports `0.23.1`.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
