### PR TITLE
feat: Added `@.debug` with `breakpoint` and `replace_builtin_breakpoint`

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -78,6 +78,7 @@ developer tools.
     completers
     xontrib
     embedding
+    debug
     api/index
     Create an extension <https://github.com/xonsh/xontrib-template>
 

--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -1,0 +1,152 @@
+.. _debug:
+
+***************
+Debug Utilities
+***************
+
+Xonsh ships a debugging helper attached to every session as ``@.debug``.
+Its main job is to drop into a debugger at the exact call site — like
+Python's builtin ``breakpoint()``, but with automatic engine selection,
+session-aware fallbacks, and a xonsh-syntax REPL when no external
+debugger is installed.
+
+Quick Start
+===========
+
+Drop into a debugger at any point in your xonsh code:
+
+.. code-block:: xonsh
+
+    @.debug.breakpoint()
+
+The engine is chosen automatically in priority order:
+``pdbp`` → ``ipdb`` → ``pdb`` → ``execer`` → ``eval``.
+The first one that is importable (or, for ``execer``, available on the
+session) wins.
+
+To force a specific engine for a single call:
+
+.. code-block:: xonsh
+
+    @.debug.breakpoint(engine='pdbp')
+    @.debug.breakpoint(engine='ipdb')
+    @.debug.breakpoint(engine='pdb')
+    @.debug.breakpoint(engine='execer')   # xonsh REPL at the call site
+    @.debug.breakpoint(engine='eval')     # plain-Python REPL
+
+Setting the Default Engine
+==========================
+
+Set ``$XONSH_DEBUG_BREAKPOINT_ENGINE`` in your ``.xonshrc`` to change the
+default used when ``engine`` is not passed (or is ``'auto'``):
+
+.. code-block:: xonsh
+
+    $XONSH_DEBUG_BREAKPOINT_ENGINE = 'pdbp'
+
+Allowed values: ``'auto'`` (default), ``'pdbp'``, ``'ipdb'``, ``'pdb'``,
+``'execer'``, ``'eval'``.
+
+An explicit argument to ``breakpoint()`` always beats the env var.
+
+Engines
+=======
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Engine
+     - Description
+   * - ``pdbp``
+     - `pdbp <https://pypi.org/project/pdbp/>`_ — enhanced pdb (sticky mode,
+       syntax highlighting, ``where``/``u``/``d`` frame hiding). Install with
+       ``xpip install pdbp``.
+   * - ``ipdb``
+     - IPython-flavored pdb. Install with ``xpip install ipdb``.
+   * - ``pdb``
+     - Stdlib ``pdb``. Always available.
+   * - ``execer``
+     - A REPL at the caller's frame backed by the session's
+       :class:`~xonsh.execer.Execer`. Full xonsh syntax is available —
+       subprocesses (``ls``, ``$(ls)``), env lookups (``@.env.HOME``),
+       aliases, and ``@.`` attribute access. Raises ``RuntimeError`` if no
+       execer is attached to the session.
+   * - ``eval``
+     - A minimal REPL using plain Python ``eval``/``exec``. Has no
+       dependency on a xonsh session — works in detached contexts (scripts,
+       tests) the same as inside an interactive shell.
+
+When ``engine='auto'`` resolves to an engine, ``@.debug`` prints a short
+banner identifying the choice and a one-line hint about how to continue or
+abort, then drops into that engine.
+
+REPL Commands (execer and eval engines)
+=======================================
+
+Both ``execer`` and ``eval`` engines start a small REPL at the caller's
+frame. The REPL accepts any Python/xonsh expression or statement, and
+recognizes the following control commands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - Effect
+   * - ``c`` / ``cont`` / ``continue``
+     - Resume execution after the breakpoint.
+   * - ``exit`` / ``quit`` / ``q``
+     - Abort execution — raises :class:`xonsh.debug.XonshDebugQuit`, which
+       propagates out of the ``breakpoint()`` call and unwinds the stack.
+   * - ``EOF`` / ``Ctrl-C``
+     - Same as ``continue`` (least destructive default).
+
+Expression results are printed automatically. Statements (assignments,
+loops, etc.) run in the caller's frame, so local variables are visible and
+modifiable:
+
+.. code-block:: xonsh
+
+    execer> @.env.HOME
+    '/Users/you'
+    execer> ls *.py | head -3
+    debug.py
+    environ.py
+    tools.py
+    execer> my_local_var = 42
+    execer> c
+
+Routing Python's builtin ``breakpoint()`` Through ``@.debug``
+============================================================
+
+PEP 553 makes Python's builtin ``breakpoint()`` go through
+``sys.breakpointhook``. ``@.debug`` can install a hook that routes every
+builtin ``breakpoint()`` call through the same engine as
+``@.debug.breakpoint()``:
+
+.. code-block:: xonsh
+
+    # In ~/.xonshrc
+    $XONSH_DEBUG_BREAKPOINT_ENGINE = 'pdbp'
+    @.debug.replace_builtin_breakpoint()
+
+After this, ``breakpoint()`` anywhere in xonsh code — or in any plain
+Python module loaded inside the session — drops into the configured engine
+at the call site. To restore Python's default behavior:
+
+.. code-block:: python
+
+    import sys
+    sys.breakpointhook = sys.__breakpointhook__
+
+
+Python API Reference
+====================
+
+.. currentmodule:: xonsh.debug
+
+.. autoclass:: XonshDebug
+   :members: breakpoint, replace_builtin_breakpoint
+
+.. autoexception:: XonshDebugQuit

--- a/tests/test_debug_llm.py
+++ b/tests/test_debug_llm.py
@@ -1,0 +1,548 @@
+"""Tests for xonsh.debug.XonshDebug and $XONSH_DEBUG_BREAKPOINT_ENGINE."""
+
+import builtins
+import importlib
+import sys
+import types
+
+import pytest
+
+from xonsh.debug import (
+    CANONIC_BREAKPOINT_ENGINES,
+    XonshDebug,
+    XonshDebugQuit,
+    is_breakpoint_engine,
+    to_breakpoint_engine,
+)
+
+# ---------------------------------------------------------------------------
+# validator helpers in tools.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", sorted(CANONIC_BREAKPOINT_ENGINES))
+def test_is_breakpoint_engine_accepts_canonical(value):
+    assert is_breakpoint_engine(value)
+
+
+@pytest.mark.parametrize("value", ["", "foo", 1, None, "PDB"])
+def test_is_breakpoint_engine_rejects_other(value):
+    assert not is_breakpoint_engine(value)
+
+
+def test_to_breakpoint_engine_passthrough():
+    for value in CANONIC_BREAKPOINT_ENGINES:
+        assert to_breakpoint_engine(value) == value
+
+
+def test_to_breakpoint_engine_lowercases():
+    assert to_breakpoint_engine("PDB") == "pdb"
+    assert to_breakpoint_engine("Auto") == "auto"
+
+
+def test_to_breakpoint_engine_unknown_falls_back():
+    with pytest.warns(RuntimeWarning):
+        assert to_breakpoint_engine("nonsense") == "auto"
+
+
+# ---------------------------------------------------------------------------
+# engine resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dbg():
+    return XonshDebug()
+
+
+@pytest.fixture
+def fake_specs(monkeypatch):
+    """Control the result of ``importlib.util.find_spec`` per engine."""
+
+    def make(available):
+        def find_spec(name):
+            return object() if name in available else None
+
+        monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+
+    return make
+
+
+@pytest.fixture
+def isolate_env(monkeypatch):
+    """Detach the real session so ``_env_default`` returns ``'auto'``."""
+    monkeypatch.setattr(
+        builtins, "__xonsh__", types.SimpleNamespace(env=None), raising=False
+    )
+
+
+def test_resolve_auto_prefers_pdbp(dbg, fake_specs, isolate_env):
+    fake_specs({"pdbp", "ipdb", "pdb"})
+    assert dbg._resolve_engine("auto") == "pdbp"
+
+
+def test_resolve_auto_falls_to_ipdb(dbg, fake_specs, isolate_env):
+    fake_specs({"ipdb", "pdb"})
+    assert dbg._resolve_engine("auto") == "ipdb"
+
+
+def test_resolve_auto_falls_to_pdb(dbg, fake_specs, isolate_env):
+    fake_specs({"pdb"})
+    assert dbg._resolve_engine("auto") == "pdb"
+
+
+def test_resolve_auto_falls_to_eval_when_none_found(dbg, fake_specs, isolate_env):
+    fake_specs(set())
+    assert dbg._resolve_engine("auto") == "eval"
+
+
+def test_resolve_explicit_engine_passes_through(dbg, fake_specs, isolate_env):
+    # Availability of the module is not consulted for an explicit choice.
+    fake_specs(set())
+    assert dbg._resolve_engine("pdb") == "pdb"
+    assert dbg._resolve_engine("eval") == "eval"
+
+
+def test_resolve_unknown_engine_raises(dbg):
+    with pytest.raises(ValueError, match="Unknown breakpoint engine"):
+        dbg._resolve_engine("gdb")
+
+
+# ---------------------------------------------------------------------------
+# env var interaction
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_overrides_auto(dbg, xession, fake_specs):
+    xession.env["XONSH_DEBUG_BREAKPOINT_ENGINE"] = "pdb"
+    # pdbp would win the priority walk, but env var forces pdb.
+    fake_specs({"pdbp", "ipdb", "pdb"})
+    assert dbg._resolve_engine("auto") == "pdb"
+
+
+def test_explicit_arg_beats_env_var(dbg, xession, fake_specs):
+    xession.env["XONSH_DEBUG_BREAKPOINT_ENGINE"] = "pdb"
+    fake_specs({"pdbp", "ipdb", "pdb"})
+    assert dbg._resolve_engine("ipdb") == "ipdb"
+
+
+def test_env_var_auto_walks_priority(dbg, xession, fake_specs):
+    xession.env["XONSH_DEBUG_BREAKPOINT_ENGINE"] = "auto"
+    fake_specs({"ipdb", "pdb"})
+    assert dbg._resolve_engine("auto") == "ipdb"
+
+
+# ---------------------------------------------------------------------------
+# breakpoint() dispatch — frame handling
+# ---------------------------------------------------------------------------
+
+
+def _stand_in_module(name, recorder):
+    """Build a stub debugger module that records the frame arg."""
+    mod = types.ModuleType(name)
+
+    if name == "pdb":
+        # pdb must be invoked via Pdb().set_trace(frame)
+        class Pdb:
+            def set_trace(self, frame):
+                recorder.append(("pdb", frame))
+
+        mod.Pdb = Pdb  # type: ignore[attr-defined]
+    else:
+        # ipdb / pdbp expose a module-level set_trace(frame=...)
+        def set_trace(frame=None):
+            recorder.append((name, frame))
+
+        mod.set_trace = set_trace  # type: ignore[attr-defined]
+
+    return mod
+
+
+@pytest.fixture
+def debugger_recorder(monkeypatch):
+    """Install stub pdb/ipdb/pdbp and record invocations."""
+    recorder: list = []
+    stubs = {name: _stand_in_module(name, recorder) for name in ("pdbp", "ipdb", "pdb")}
+    real_import = importlib.import_module
+
+    def fake_import(name, *a, **kw):
+        if name in stubs:
+            return stubs[name]
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    return recorder
+
+
+def test_breakpoint_dispatches_to_pdb_with_caller_frame(dbg, debugger_recorder):
+    expected_line = sys._getframe().f_lineno + 1
+    dbg.breakpoint(engine="pdb")
+    assert len(debugger_recorder) == 1
+    engine, frame = debugger_recorder[0]
+    assert engine == "pdb"
+    # The frame belongs to *this* function, not to dbg.breakpoint itself.
+    assert frame.f_code is sys._getframe().f_code
+    # Line just after entering the test's call site.
+    assert frame.f_lineno >= expected_line
+
+
+def test_breakpoint_dispatches_to_ipdb(dbg, debugger_recorder):
+    dbg.breakpoint(engine="ipdb")
+    assert debugger_recorder == [("ipdb", sys._getframe())] or (
+        debugger_recorder[0][0] == "ipdb"
+    )
+
+
+def test_breakpoint_dispatches_to_pdbp(dbg, debugger_recorder):
+    dbg.breakpoint(engine="pdbp")
+    assert debugger_recorder[0][0] == "pdbp"
+
+
+def test_breakpoint_auto_uses_first_available(
+    dbg, debugger_recorder, fake_specs, isolate_env
+):
+    fake_specs({"ipdb", "pdb"})  # pdbp missing
+    dbg.breakpoint(engine="auto")
+    assert debugger_recorder[0][0] == "ipdb"
+
+
+def test_breakpoint_unknown_engine_raises(dbg):
+    with pytest.raises(ValueError):
+        dbg.breakpoint(engine="gdb")
+
+
+# ---------------------------------------------------------------------------
+# eval REPL — plain Python
+# ---------------------------------------------------------------------------
+
+
+def _feed_lines(monkeypatch, lines):
+    """Replace builtins.input with an iterator over ``lines``."""
+    it = iter(lines)
+
+    def fake_input(prompt=""):
+        try:
+            return next(it)
+        except StopIteration as exc:
+            raise EOFError from exc
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+
+def test_eval_repl_python_continue_returns(dbg, monkeypatch, capsys, isolate_env):
+    _feed_lines(monkeypatch, ["c"])
+    dbg.breakpoint(engine="eval")  # returns without raising
+    out = capsys.readouterr().out
+    assert "python REPL" in out
+
+
+def test_eval_repl_python_prints_expression(dbg, monkeypatch, capsys, isolate_env):
+    _feed_lines(monkeypatch, ["1 + 2", "c"])
+    dbg.breakpoint(engine="eval")
+    out = capsys.readouterr().out
+    assert "3" in out
+
+
+def test_eval_repl_python_runs_statement(dbg, monkeypatch, capsys, isolate_env):
+    _feed_lines(monkeypatch, ["marker = 41 + 1", "marker", "c"])
+    dbg.breakpoint(engine="eval")
+    out = capsys.readouterr().out
+    assert "42" in out
+
+
+def test_eval_repl_python_recovers_from_error(dbg, monkeypatch, capsys, isolate_env):
+    _feed_lines(monkeypatch, ["1/0", "2 + 2", "c"])
+    dbg.breakpoint(engine="eval")
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "ZeroDivisionError" in combined
+    assert "4" in captured.out
+
+
+def test_eval_repl_python_eof_continues(dbg, monkeypatch, capsys, isolate_env):
+    # EOFError on first read should behave like 'continue', not abort.
+    _feed_lines(monkeypatch, [])
+    dbg.breakpoint(engine="eval")  # returns without raising
+
+
+@pytest.mark.parametrize("cmd", ["c", "cont", "continue"])
+def test_eval_repl_continue_aliases(dbg, monkeypatch, cmd, isolate_env):
+    _feed_lines(monkeypatch, [cmd])
+    dbg.breakpoint(engine="eval")  # returns
+
+
+@pytest.mark.parametrize("cmd", ["exit", "quit", "q"])
+def test_eval_repl_abort_aliases_raise(dbg, monkeypatch, cmd, isolate_env):
+    _feed_lines(monkeypatch, [cmd])
+    with pytest.raises(XonshDebugQuit):
+        dbg.breakpoint(engine="eval")
+
+
+def test_eval_repl_abort_runs_after_computation(dbg, monkeypatch, capsys, isolate_env):
+    # User evaluates an expression, then aborts.
+    _feed_lines(monkeypatch, ["1 + 2", "exit"])
+    with pytest.raises(XonshDebugQuit):
+        dbg.breakpoint(engine="eval")
+    out = capsys.readouterr().out
+    assert "3" in out
+
+
+# ---------------------------------------------------------------------------
+# execer REPL
+# ---------------------------------------------------------------------------
+
+
+class _ExecerStub:
+    def __init__(self):
+        self.calls: list = []
+
+    def exec(self, input, mode="exec", glbs=None, locs=None, **kw):
+        self.calls.append((input, mode))
+
+
+def _install_session_with_execer(monkeypatch, execer):
+    monkeypatch.setattr(
+        builtins,
+        "__xonsh__",
+        types.SimpleNamespace(env=None, execer=execer),
+        raising=False,
+    )
+
+
+def test_execer_repl_uses_execer(dbg, monkeypatch, capsys):
+    stub = _ExecerStub()
+    _install_session_with_execer(monkeypatch, stub)
+    _feed_lines(monkeypatch, ["echo hi", "c"])
+    dbg.breakpoint(engine="execer")
+    out = capsys.readouterr().out
+    assert "execer REPL" in out
+    assert stub.calls == [("echo hi", "single")]
+
+
+def test_execer_repl_shows_traceback_on_error(dbg, monkeypatch, capsys):
+    class Boom(_ExecerStub):
+        def exec(self, input, mode="exec", glbs=None, locs=None, **kw):
+            raise RuntimeError("bang")
+
+    _install_session_with_execer(monkeypatch, Boom())
+    _feed_lines(monkeypatch, ["anything", "c"])
+    dbg.breakpoint(engine="execer")
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RuntimeError" in combined
+    assert "bang" in combined
+
+
+def test_execer_repl_requires_execer(dbg, monkeypatch, isolate_env):
+    # isolate_env leaves __xonsh__ with env=None, no execer attribute.
+    with pytest.raises(RuntimeError, match="requires an active xonsh session"):
+        dbg.breakpoint(engine="execer")
+
+
+def test_eval_repl_ignores_execer(dbg, monkeypatch, capsys):
+    """engine='eval' must NOT route through execer even when present."""
+    stub = _ExecerStub()
+    _install_session_with_execer(monkeypatch, stub)
+    _feed_lines(monkeypatch, ["1 + 1", "c"])
+    dbg.breakpoint(engine="eval")
+    out = capsys.readouterr().out
+    assert "python REPL" in out
+    assert stub.calls == []  # execer was never called
+    assert "2" in out  # python eval produced the result
+
+
+# ---------------------------------------------------------------------------
+# execer/eval in the auto priority walk
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_auto_falls_to_execer_when_session_has_one(
+    dbg, fake_specs, monkeypatch
+):
+    fake_specs(set())  # no external debuggers installed
+    _install_session_with_execer(monkeypatch, _ExecerStub())
+    assert dbg._resolve_engine("auto") == "execer"
+
+
+def test_resolve_auto_final_fallback_is_eval(dbg, fake_specs, isolate_env):
+    # No debuggers, no execer attached.
+    fake_specs(set())
+    assert dbg._resolve_engine("auto") == "eval"
+
+
+# ---------------------------------------------------------------------------
+# per-engine hint line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("engine", ["pdb", "ipdb", "pdbp"])
+def test_external_debugger_prints_hint(dbg, debugger_recorder, capsys, engine):
+    dbg.breakpoint(engine=engine)
+    out = capsys.readouterr().out
+    assert f"BREAKPOINT WITH {engine!r}" in out
+    assert engine in out  # engine name appears in the hint line
+    assert "'c'" in out and "'q'" in out  # continue + quit
+
+
+def test_eval_engine_prints_hint(dbg, monkeypatch, capsys, isolate_env):
+    _feed_lines(monkeypatch, ["c"])
+    dbg.breakpoint(engine="eval")
+    out = capsys.readouterr().out
+    assert "eval REPL" in out
+    assert "'c'/'continue'" in out
+    assert "'q'/'quit'/'exit'" in out
+
+
+def test_execer_engine_prints_hint(dbg, monkeypatch, capsys):
+    _install_session_with_execer(monkeypatch, _ExecerStub())
+    _feed_lines(monkeypatch, ["c"])
+    dbg.breakpoint(engine="execer")
+    out = capsys.readouterr().out
+    assert "execer REPL" in out
+    assert "'c'/'continue'" in out
+    assert "'q'/'quit'/'exit'" in out
+
+
+# ---------------------------------------------------------------------------
+# __tracebackhide__ — parity with hand-rolled pdbp helpers
+# ---------------------------------------------------------------------------
+
+
+def test_intermediate_frames_are_tracebackhidden(dbg, monkeypatch):
+    """pdbp/pytest look at frame.f_locals['__tracebackhide__'] to hide a
+    frame from `where`/`u`/`d` listings. Our wrapper frames between the
+    user's code and the real debugger must set the flag so the frame
+    chain stays clean (matching the common pdbp pause() recipe).
+    """
+    captured: dict = {}
+
+    def fake_set_trace(frame=None):
+        # Walk up from the user's frame toward the root, collecting
+        # __tracebackhide__ from every frame in between. The 'frame'
+        # arg is the user's frame (the outermost caller), so we scan
+        # from the call site back up to include our wrapper frames.
+        seen = {}
+        f = sys._getframe()  # fake_set_trace itself
+        while f is not None:
+            name = f.f_code.co_name
+            seen[name] = f.f_locals.get("__tracebackhide__", False)
+            f = f.f_back
+        captured.update(seen)
+
+    fake_pdbp = types.ModuleType("pdbp")
+    fake_pdbp.set_trace = fake_set_trace  # type: ignore[attr-defined]
+    real_import = importlib.import_module
+
+    def fake_import(name, *a, **kw):
+        if name == "pdbp":
+            return fake_pdbp
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    dbg.breakpoint(engine="pdbp")
+
+    # Each of our wrapper methods must be tracebackhidden.
+    assert captured.get("breakpoint") is True
+    assert captured.get("_break_at") is True
+    assert captured.get("_start_debugger") is True
+
+
+def test_hook_frame_is_tracebackhidden(
+    dbg, restore_breakpointhook, monkeypatch
+):
+    """The sys.breakpointhook closure is also a wrapper frame — it must
+    be tracebackhidden so pdbp's `where` skips it too.
+    """
+    seen: dict = {}
+
+    def probing_set_trace(frame=None):
+        f = sys._getframe()
+        while f is not None:
+            seen[f.f_code.co_name] = f.f_locals.get("__tracebackhide__", False)
+            f = f.f_back
+
+    fake_pdbp = types.ModuleType("pdbp")
+    fake_pdbp.set_trace = probing_set_trace  # type: ignore[attr-defined]
+    real_import = importlib.import_module
+
+    def fake_import(name, *a, **kw):
+        if name == "pdbp":
+            return fake_pdbp
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    dbg.replace_builtin_breakpoint(engine="pdbp")
+    breakpoint()  # noqa: T100 - feature under test
+    assert seen.get("hook") is True
+
+
+# ---------------------------------------------------------------------------
+# replace_builtin_breakpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def restore_breakpointhook():
+    """Restore sys.breakpointhook after the test."""
+    original = sys.breakpointhook
+    yield
+    sys.breakpointhook = original
+
+
+def test_replace_builtin_breakpoint_installs_hook(
+    dbg, restore_breakpointhook, debugger_recorder
+):
+    dbg.replace_builtin_breakpoint(engine="pdb")
+    assert sys.breakpointhook is not sys.__breakpointhook__
+
+
+def test_builtin_breakpoint_routes_to_debugger(
+    dbg, restore_breakpointhook, debugger_recorder
+):
+    dbg.replace_builtin_breakpoint(engine="pdb")
+    # Call the builtin breakpoint, which should fire our hook.
+    breakpoint()  # noqa: T100 - this is the feature under test
+    assert len(debugger_recorder) == 1
+    engine, frame = debugger_recorder[0]
+    assert engine == "pdb"
+    # The hook must hand the *caller's* frame (this test function), not
+    # the hook's own frame, to the debugger.
+    assert frame.f_code is sys._getframe().f_code
+
+
+def test_builtin_breakpoint_passes_through_args(
+    dbg, restore_breakpointhook, debugger_recorder
+):
+    # PEP 553: breakpoint(*args, **kwargs) forwards to sys.breakpointhook.
+    # We accept and silently ignore them — should not raise.
+    dbg.replace_builtin_breakpoint(engine="pdb")
+    breakpoint(1, 2, key="value")  # noqa: T100
+    assert debugger_recorder[0][0] == "pdb"
+
+
+def test_replace_builtin_breakpoint_honours_engine_arg(
+    dbg, restore_breakpointhook, debugger_recorder
+):
+    dbg.replace_builtin_breakpoint(engine="ipdb")
+    breakpoint()  # noqa: T100
+    assert debugger_recorder[0][0] == "ipdb"
+
+
+# ---------------------------------------------------------------------------
+# session wiring
+# ---------------------------------------------------------------------------
+
+
+def test_xsh_has_debug(xession):
+    assert isinstance(xession.debug, XonshDebug)
+    assert xession.interface.debug is xession.debug
+
+
+def test_env_var_default_is_auto(xession):
+    assert xession.env.get("XONSH_DEBUG_BREAKPOINT_ENGINE") == "auto"
+
+
+def test_env_var_validator_rejects_invalid(xession):
+    with pytest.warns(RuntimeWarning):
+        xession.env["XONSH_DEBUG_BREAKPOINT_ENGINE"] = "nonsense"
+    assert xession.env["XONSH_DEBUG_BREAKPOINT_ENGINE"] == "auto"

--- a/tests/test_debug_llm.py
+++ b/tests/test_debug_llm.py
@@ -447,9 +447,7 @@ def test_intermediate_frames_are_tracebackhidden(dbg, monkeypatch):
     assert captured.get("_start_debugger") is True
 
 
-def test_hook_frame_is_tracebackhidden(
-    dbg, restore_breakpointhook, monkeypatch
-):
+def test_hook_frame_is_tracebackhidden(dbg, restore_breakpointhook, monkeypatch):
     """The sys.breakpointhook closure is also a wrapper frame — it must
     be tracebackhidden so pdbp's `where` skips it too.
     """

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -954,10 +954,6 @@ class XonshSessionInterface:
 
     Attributes
     ----------
-    debug : xonsh.debug.XonshDebug
-        Debug helpers for the running session e.g.
-        ``@.debug.breakpoint()`` to drop into a debugger.
-
     env : xonsh.environ.Env
         A xonsh environment e.g. `@.env.get('HOME', '/tmp')`.
 
@@ -973,6 +969,10 @@ class XonshSessionInterface:
     lastcmd : xonsh.procs.pipelines.CommandPipeline
         Last executed subprocess-mode command pipeline
         e.g. `@.lastcmd.rtn` returns exit code.
+
+    debug : xonsh.debug.XonshDebug
+        Debug helpers for the running session e.g.
+        ``@.debug.breakpoint()`` to drop into a debugger.
     """
 
     debug = None  # type: ignore

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -24,6 +24,7 @@ from ast import AST
 from collections.abc import Iterator
 from operator import attrgetter as _attrgetter
 
+from xonsh.debug import XonshDebug
 from xonsh.lib.inspectors import Inspector
 from xonsh.lib.lazyasd import lazyobject
 from xonsh.platform import ON_POSIX, ON_WINDOWS
@@ -953,6 +954,10 @@ class XonshSessionInterface:
 
     Attributes
     ----------
+    debug : xonsh.debug.XonshDebug
+        Debug helpers for the running session e.g.
+        ``@.debug.breakpoint()`` to drop into a debugger.
+
     env : xonsh.environ.Env
         A xonsh environment e.g. `@.env.get('HOME', '/tmp')`.
 
@@ -970,6 +975,7 @@ class XonshSessionInterface:
         e.g. `@.lastcmd.rtn` returns exit code.
     """
 
+    debug = None  # type: ignore
     env = None  # type: ignore
     history = None  # type: ignore
     imp: InlineImporter = InlineImporter()
@@ -1002,6 +1008,8 @@ class XonshSession:
         self.shell = None
         self.env = None
         self.imp = InlineImporter()
+        self.debug = XonshDebug()
+        self.interface.debug = self.debug
         self.rc_files = None
 
         # AST-invoked functions

--- a/xonsh/debug.py
+++ b/xonsh/debug.py
@@ -1,0 +1,277 @@
+"""Debug utilities for a running xonsh session.
+
+Provides :class:`XonshDebug`, which is attached to the session as
+``__xonsh__.debug`` and exposed to user code through the ``@.`` interface
+as ``@.debug``. The main entry point is :meth:`XonshDebug.breakpoint`.
+"""
+
+import builtins
+import importlib
+import importlib.util
+import sys
+import traceback
+import warnings
+
+CANONIC_BREAKPOINT_ENGINES = frozenset(
+    {"auto", "pdbp", "ipdb", "pdb", "execer", "eval"}
+)
+
+
+class XonshDebugQuit(Exception):
+    """Raised from the ``eval`` REPL when the user types ``exit``/``quit``/``q``.
+
+    Propagates out of :meth:`XonshDebug.breakpoint` so that execution at
+    the breakpoint site is aborted rather than resumed. Catch it
+    explicitly if you want to handle user-initiated aborts.
+    """
+
+
+def is_breakpoint_engine(x):
+    """Enumerated values of $XONSH_DEBUG_BREAKPOINT_ENGINE."""
+    return isinstance(x, str) and x in CANONIC_BREAKPOINT_ENGINES
+
+
+def to_breakpoint_engine(x):
+    """Convert user input to value of $XONSH_DEBUG_BREAKPOINT_ENGINE."""
+    y = str(x).casefold()
+    if y not in CANONIC_BREAKPOINT_ENGINES:
+        warnings.warn(
+            f"'{x}' is not valid for $XONSH_DEBUG_BREAKPOINT_ENGINE, "
+            f"must be one of {sorted(CANONIC_BREAKPOINT_ENGINES)}. Using 'auto'.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        y = "auto"
+    return y
+
+
+class XonshDebug:
+    """Debug helpers for a running xonsh session.
+
+    Accessible from xonsh code as ``@.debug``.
+
+    Examples
+    --------
+    Drop into the default debugger at the call site::
+
+        @.debug.breakpoint()
+
+    Force a specific engine::
+
+        @.debug.breakpoint(engine='ipdb')
+    """
+
+    AUTO_ENGINES = ("pdbp", "ipdb", "pdb")
+
+    def breakpoint(self, engine: str = "auto") -> None:
+        """Drop into a debugger at the caller's frame.
+
+        Parameters
+        ----------
+        engine : str, optional
+            Which debugger to use. One of ``"auto"``, ``"pdbp"``,
+            ``"ipdb"``, ``"pdb"``, ``"execer"``, or ``"eval"``. When
+            ``"auto"`` (the default), ``$XONSH_DEBUG_BREAKPOINT_ENGINE``
+            is consulted first; if it is also ``"auto"``, the first
+            available engine is chosen in priority order: ``pdbp`` ->
+            ``ipdb`` -> ``pdb`` -> ``execer`` (if a xonsh session is
+            loaded) -> ``eval`` (always).
+
+            The ``"execer"`` engine starts a REPL at the caller's
+            frame, backed by the session's :class:`~xonsh.execer.Execer`
+            (prompt ``"execer> "``) — xonsh syntax such as
+            subprocesses, env lookups, and aliases is available.
+            Raises :class:`RuntimeError` if no execer is attached.
+
+            The ``"eval"`` engine starts a REPL at the caller's frame
+            using plain Python ``eval``/``exec`` (prompt
+            ``"(xdebug) "``) — it has no dependency on a xonsh session.
+
+            In both REPLs, type ``c``/``cont``/``continue`` (or hit
+            EOF/Ctrl-C) to resume execution, or ``exit``/``quit``/``q``
+            to abort — the latter raises :class:`XonshDebugQuit`.
+        """
+        __tracebackhide__: bool = True  # hidden from pdbp/pytest frame walks
+        caller = sys._getframe(1)
+        try:
+            self._break_at(caller, engine)
+        finally:
+            # Break the reference to the caller frame so locals are
+            # not pinned any longer than necessary.
+            del caller
+
+    _HINTS = {
+        "pdb": "[xonsh-debug] pdb: 'c' continue | 'q' quit",
+        "ipdb": "[xonsh-debug] ipdb: 'c' continue | 'q' quit",
+        "pdbp": "[xonsh-debug] pdbp: 'c' continue | 'q' quit",
+        "execer": (
+            "[xonsh-debug] execer REPL: 'c'/'continue' resume | 'q'/'quit'/'exit' abort"
+        ),
+        "eval": (
+            "[xonsh-debug] eval REPL: 'c'/'continue' resume | 'q'/'quit'/'exit' abort"
+        ),
+    }
+
+    def _break_at(self, frame, engine: str) -> None:
+        __tracebackhide__: bool = True
+        resolved = self._resolve_engine(engine)
+        print(f"BREAKPOINT WITH {resolved!r}")
+        print(self._HINTS[resolved])
+        if resolved == "execer":
+            self._execer_repl(frame)
+        elif resolved == "eval":
+            self._eval_repl(frame)
+        else:
+            self._start_debugger(resolved, frame)
+
+    def replace_builtin_breakpoint(self, engine: str = "auto") -> None:
+        """Route Python's builtin ``breakpoint()`` through this debugger.
+
+        After this call, any ``breakpoint()`` or PEP 553 breakpoint
+        statement — whether in xonsh code or in plain Python modules
+        loaded from xonsh — drops into the engine chosen by this
+        object. Call it from ``~/.xonshrc`` to make the integration
+        persistent.
+
+        Parameters
+        ----------
+        engine : str, optional
+            Engine to use when the builtin ``breakpoint()`` fires.
+            Accepts the same values as :meth:`breakpoint`. Captured by
+            the installed hook; call again with a different value to
+            change it, or assign ``sys.breakpointhook =
+            sys.__breakpointhook__`` to restore the default.
+        """
+
+        def hook(*_args, **_kwargs):
+            __tracebackhide__: bool = True
+            # Python's breakpoint() builtin is a C function, so
+            # sys._getframe(1) from inside this hook is the user's
+            # Python frame that invoked breakpoint().
+            caller = sys._getframe(1)
+            try:
+                self._break_at(caller, engine)
+            finally:
+                del caller
+
+        sys.breakpointhook = hook
+
+    def _resolve_engine(self, engine: str) -> str:
+        if engine not in CANONIC_BREAKPOINT_ENGINES:
+            raise ValueError(
+                f"Unknown breakpoint engine {engine!r}. "
+                f"Must be one of {sorted(CANONIC_BREAKPOINT_ENGINES)}."
+            )
+        if engine == "auto":
+            env_engine = self._env_default()
+            if env_engine != "auto":
+                engine = env_engine
+        if engine != "auto":
+            return engine
+        for name in self.AUTO_ENGINES:
+            if importlib.util.find_spec(name) is not None:
+                return name
+        # No external debugger available — prefer execer if we have a
+        # session, else fall through to the plain-Python eval REPL.
+        if self._has_execer():
+            return "execer"
+        return "eval"
+
+    @staticmethod
+    def _has_execer() -> bool:
+        xsh = getattr(builtins, "__xonsh__", None)
+        return getattr(xsh, "execer", None) is not None
+
+    @staticmethod
+    def _env_default() -> str:
+        xsh = getattr(builtins, "__xonsh__", None)
+        env = getattr(xsh, "env", None) if xsh is not None else None
+        if env is None:
+            return "auto"
+        value = env.get("XONSH_DEBUG_BREAKPOINT_ENGINE", "auto")
+        if value not in CANONIC_BREAKPOINT_ENGINES:
+            return "auto"
+        return value
+
+    @staticmethod
+    def _start_debugger(name: str, frame) -> None:
+        __tracebackhide__: bool = True
+        module = importlib.import_module(name)
+        if name == "pdb":
+            module.Pdb().set_trace(frame)
+        elif name == "ipdb":
+            module.set_trace(frame=frame)
+        elif name == "pdbp":
+            module.set_trace(frame=frame)
+        else:
+            raise ValueError(f"Unsupported debugger engine: {name!r}")
+
+    _CONTINUE_COMMANDS = ("c", "cont", "continue")
+    _ABORT_COMMANDS = ("exit", "quit", "q")
+
+    def _execer_repl(self, frame) -> None:
+        """REPL that dispatches each line through the session's Execer."""
+        xsh = getattr(builtins, "__xonsh__", None)
+        execer = getattr(xsh, "execer", None) if xsh is not None else None
+        if execer is None:
+            raise RuntimeError(
+                "The 'execer' breakpoint engine requires an active xonsh "
+                "session with an Execer attached. Use engine='eval' for a "
+                "plain-Python REPL, or run inside a xonsh session."
+            )
+        self._interactive_repl(
+            frame,
+            banner_backend="execer",
+            prompt="execer> ",
+            runner=lambda line, g, loc: execer.exec(
+                line, mode="single", glbs=g, locs=loc
+            ),
+        )
+
+    def _eval_repl(self, frame) -> None:
+        """REPL that evaluates each line with plain Python eval/exec."""
+        self._interactive_repl(
+            frame,
+            banner_backend="python",
+            prompt="(xdebug) ",
+            runner=self._python_eval,
+        )
+
+    def _interactive_repl(
+        self, frame, *, banner_backend: str, prompt: str, runner
+    ) -> None:
+        location = f"{frame.f_code.co_filename}:{frame.f_lineno}"
+        print(f"[xonsh-debug] {banner_backend} REPL at {location}")
+        globs, locs = frame.f_globals, frame.f_locals
+        while True:
+            try:
+                line = input(prompt)
+            except (EOFError, KeyboardInterrupt):
+                # EOF / Ctrl-C behave like 'continue' — least destructive.
+                print()
+                return
+            stripped = line.strip()
+            if stripped in self._CONTINUE_COMMANDS:
+                return
+            if stripped in self._ABORT_COMMANDS:
+                raise XonshDebugQuit(
+                    f"aborted from {banner_backend} REPL at {location}"
+                )
+            if not stripped:
+                continue
+            try:
+                runner(line, globs, locs)
+            except (SystemExit, XonshDebugQuit):
+                raise
+            except BaseException:
+                traceback.print_exc()
+
+    @staticmethod
+    def _python_eval(line: str, globs, locs) -> None:
+        try:
+            result = eval(line, globs, locs)
+        except SyntaxError:
+            exec(line, globs, locs)
+            return
+        if result is not None:
+            print(repr(result))

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -28,6 +28,7 @@ from xonsh.ansi_colors import (
 )
 from xonsh.built_ins import XSH
 from xonsh.codecache import run_script_with_cache
+from xonsh.debug import is_breakpoint_engine, to_breakpoint_engine
 from xonsh.dirstack import _get_cwd
 from xonsh.events import events
 from xonsh.lib.lazyasd import LazyBool, lazyobject
@@ -1195,6 +1196,18 @@ class GeneralSetting(Xettings):
         "With ``2`` or a higher number will make more debugging information "
         "presented, like PLY parsing messages.",
         is_configurable=False,
+    )
+    XONSH_DEBUG_BREAKPOINT_ENGINE = Var(
+        is_breakpoint_engine,
+        to_breakpoint_engine,
+        str,
+        "auto",
+        "Default engine used by ``@.debug.breakpoint()`` when called "
+        "without an explicit ``engine=`` argument. One of ``'auto'``, "
+        "``'pdbp'``, ``'ipdb'``, ``'pdb'``, ``'eval'``. When set to "
+        "``'auto'``, the first importable debugger is used, in priority "
+        "order ``pdbp`` -> ``ipdb`` -> ``pdb``, falling back to the "
+        "``'eval'`` REPL if none are available.",
     )
     XONSH_DATA_DIR = Var.with_default(
         xonsh_data_dir,


### PR DESCRIPTION
### Breakpoint

Drop into a debugger at any point in your xonsh code:

```xsh
@.debug.breakpoint()  # enging='auto' by default
@.debug.breakpoint('execer')   # xonsh REPL at the call site
```

The engine is chosen automatically in priority order: ``pdbp`` → ``ipdb`` → ``pdb`` → ``execer`` → ``eval``.

### Set debugger explicitly

```xsh
$XONSH_DEBUG_BREAKPOINT_ENGINE = 'pdbp'
```

### Replace builtin `breakpoint()`

```xsh
@.debug.replace_builtin_breakpoint()  # auto by default
@.debug.replace_builtin_breakpoint('pdbp')  # set debugger

breakpoint()  # will be replaced by @.debug.replace_builtin_breakpoint
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
