### PR TITLE
feat(completer): Use quotation only if needed + some fixes

### DIFF
--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -460,6 +460,37 @@ def test_complete_path_no_double_closing_quote(xession, completion_context_parse
             assert not c.endswith("''"), f"Double closing quote: {c!r}"
 
 
+def test_complete_path_per_path_quoting(xession, completion_context_parse):
+    """Only quote paths that actually need it. A plain ``file`` should
+    appear unquoted even when a sibling ``fi$le`` requires ``r'…'``.
+    """
+    xession.env = {
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    }
+    with tempfile.TemporaryDirectory() as td:
+        open(os.path.join(td, "file"), "w").close()
+        open(os.path.join(td, "fi$le"), "w").close()
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            line = "ls fi"
+            ctx = completion_context_parse(line, len(line))
+            comps, _ = xcp.contextual_complete_path(ctx.command)
+            completions = {str(c) for c in comps}
+            assert "file " in completions, (
+                f"Plain 'file' should be unquoted, got: {completions}"
+            )
+            assert "r'fi$le' " in completions, (
+                f"'fi$le' should be raw-quoted, got: {completions}"
+            )
+        finally:
+            os.chdir(old_cwd)
+
+
 @pytest.mark.parametrize("quote", ("'", '"'))
 @pytest.mark.parametrize(
     "closed",

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -104,6 +104,36 @@ def test_complete_path_tilde_expanded_on_windows(prefix_fmt, xession):
         assert paths, "Expected non-empty completions"
 
 
+@pytest.mark.skipif(xcp.xp.ON_WINDOWS, reason="POSIX tilde expansion")
+def test_complete_path_tilde_subdir_trailing_sep(xession):
+    """``~/<subdir>`` completion must end with the path separator so that
+    a second Tab keeps drilling into the directory. Regression from
+    PR #6339 which made ``_quote_paths`` use the literal path for any
+    ``~``-prefixed string, breaking ``isdir("~/git")``.
+    """
+    xession.env.update(
+        {
+            "GLOB_SORTED": True,
+            "SUBSEQUENCE_PATH_COMPLETION": False,
+            "FUZZY_PATH_COMPLETION": False,
+            "SUGGEST_THRESHOLD": 3,
+            "CDPATH": set(),
+        }
+    )
+    home = os.path.expanduser("~")
+    with tempfile.TemporaryDirectory(dir=home) as td:
+        name = os.path.basename(td)
+        prefix = f"~/{name[:3]}"
+        line = f"ls {prefix}"
+        paths, _ = xcp._complete_path_raw(prefix, line, 3, len(line), {})
+        match = {p for p in paths if name in p}
+        assert match, f"Expected completion for ~/{name[:3]}, got: {paths}"
+        for p in match:
+            assert p.rstrip().endswith(os.sep), (
+                f"Expected trailing sep for ~/<dir>, got: {p!r}"
+            )
+
+
 @pytest.mark.parametrize(
     "prefix, line, start, end, filtfunc, extra_files",
     [

--- a/tests/completers/test_path_completers.py
+++ b/tests/completers/test_path_completers.py
@@ -331,7 +331,8 @@ def test_complete_path_when_prefix_is_raw_path_string(
         prefix = f"pr{quote}{prefix_file_name}"
         line = f"ls {prefix}"
         out = xcp.complete_path(completion_context_parse(line, len(line)))
-        expected = f"pr{quote}{tmp.name}{quote}"
+        # File completion gets a trailing space AFTER the closing quote.
+        expected = f"pr{quote}{tmp.name}{quote} "
         assert expected == out[0].pop()
 
 
@@ -457,6 +458,100 @@ def test_complete_path_no_double_closing_quote(xession, completion_context_parse
         completions = {str(c) for c in comps}
         for c in completions:
             assert not c.endswith("''"), f"Double closing quote: {c!r}"
+
+
+@pytest.mark.parametrize("quote", ("'", '"'))
+@pytest.mark.parametrize(
+    "closed",
+    [False, True],
+    ids=["unclosed", "closed-cursor-at-end"],
+)
+def test_complete_path_quoted_file_appends_trailing_space(
+    quote, closed, xession, completion_context_parse
+):
+    """File completion inside quotes must add a trailing space AFTER the
+    closing quote, so `ls 'f<Tab>` advances to the next arg just like
+    `ls f<Tab>` does (issue #6362)."""
+    xession.env = {
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    }
+    with tempfile.TemporaryDirectory() as td:
+        open(os.path.join(td, "file"), "w").close()
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            arg = f"{quote}f{quote}" if closed else f"{quote}f"
+            line = f"ls {arg}"
+            ctx = completion_context_parse(line, len(line))
+            comps, _ = xcp.contextual_complete_path(ctx.command)
+            completions = {str(c) for c in comps}
+            expected = f"{quote}file{quote} "
+            assert expected in completions, (
+                f"Expected {expected!r} in completions, got: {completions}"
+            )
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_complete_path_quoted_dir_no_trailing_space(xession, completion_context_parse):
+    """Directory completion inside quotes keeps the trailing sep, no space —
+    so a second Tab can drill deeper."""
+    xession.env = {
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    }
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "sub"))
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            line = "ls 's"
+            ctx = completion_context_parse(line, len(line))
+            comps, _ = xcp.contextual_complete_path(ctx.command)
+            completions = {str(c) for c in comps}
+            for c in completions:
+                assert not c.endswith("' "), (
+                    f"Dir completion should not have trailing space: {c!r}"
+                )
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_complete_path_cursor_before_closing_quote_no_inside_space(
+    xession, completion_context_parse
+):
+    """When the cursor sits before an existing closing quote, the trailing
+    space must NOT be added — it would fall inside the quotes."""
+    xession.env = {
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    }
+    with tempfile.TemporaryDirectory() as td:
+        open(os.path.join(td, "file"), "w").close()
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            line = "ls 'f'"
+            cursor = len(line) - 1  # before closing quote
+            ctx = completion_context_parse(line, cursor)
+            comps, _ = xcp.contextual_complete_path(ctx.command)
+            completions = {str(c) for c in comps}
+            for c in completions:
+                assert not c.endswith(" "), (
+                    f"No space when cursor is before closing quote: {c!r}"
+                )
+        finally:
+            os.chdir(old_cwd)
 
 
 @pytest.mark.skipif(os.sep != "\\", reason="Backslash separator is Windows-only")

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -203,16 +203,22 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
     slash = xt.get_sep()
     orig_start = start
     orig_end = end
-    # quote on all or none, to make readline completes to max prefix
-    need_quotes = any(
-        re.search(PATTERN_NEED_QUOTES, x) or (backslash in x and slash != backslash)
-        for x in paths
-    )
+    # Decide per-path whether quoting is needed: a plain ``file`` should
+    # appear unquoted even when a sibling ``fi$le`` requires ``r'…'``.
+    # Prompt-toolkit's completion menu shows both forms side by side, so
+    # the historical "quote all or none" rule (needed for readline's
+    # longest-common-prefix) is no longer warranted.
+    need_quotes = False
 
     for s in paths:
         start = orig_start
         end = orig_end
-        if start == "" and need_quotes:
+        path_needs_quotes = bool(re.search(PATTERN_NEED_QUOTES, s)) or (
+            backslash in s and slash != backslash
+        )
+        if path_needs_quotes:
+            need_quotes = True
+        if start == "" and path_needs_quotes:
             start = end = _quote_to_use(s)
         # For a bare ``~`` or ``$VAR`` use the literal path for isdir —
         # expand_path("$HOME") and expand_path("~") resolve to the home

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -225,9 +225,10 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
         has_sep = os.sep in s or (bool(os.altsep) and os.altsep in s)
         ambiguous_literal = not has_sep and ("$" in s or s.startswith("~"))
         check_path = s if ambiguous_literal else expand_path(s)
-        if os.path.isdir(check_path) or (
+        is_dir = os.path.isdir(check_path) or (
             cdpath and _is_directory_in_cdpath(check_path)
-        ):
+        )
+        if is_dir:
             _tail = slash
         elif end == "":
             _tail = space
@@ -254,6 +255,13 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
         if has_ctrl:
             s = s.translate(_CONTROL_CHAR_ESCAPE)
         s = start + s + end if append_end else start + s
+        # For a non-directory completion inside quotes, append the trailing
+        # separator space AFTER the closing quote so `ls 'f<Tab>` advances
+        # to the next arg just like `ls f<Tab>` does. Skip when
+        # ``append_end=False``: the closing quote is already in the line
+        # after the cursor, and a space here would fall inside it.
+        if not is_dir and end != "" and append_end:
+            s = s + space
         out.add(s)
     return out, need_quotes
 

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -214,10 +214,17 @@ def _quote_paths(paths, start, end, append_end=True, cdpath=False):
         end = orig_end
         if start == "" and need_quotes:
             start = end = _quote_to_use(s)
-        # For paths with $ or starting with ~ use the literal path for
-        # isdir — expand_path("$HOME") and expand_path("~") resolve to
-        # the home directory (always a dir), masking literal files.
-        check_path = s if ("$" in s or s.startswith("~")) else expand_path(s)
+        # For a bare ``~`` or ``$VAR`` use the literal path for isdir —
+        # expand_path("$HOME") and expand_path("~") resolve to the home
+        # directory (always a dir), masking a local file with that exact
+        # name. Compound paths like ``~/git`` or ``$HOME/bin`` are
+        # unambiguous (a separator means it's a subpath, not a literal
+        # filename), so fall through to ``expand_path`` — otherwise
+        # ``os.path.isdir("~/git")`` is False and the trailing-sep
+        # detection for directories breaks.
+        has_sep = os.sep in s or (bool(os.altsep) and os.altsep in s)
+        ambiguous_literal = not has_sep and ("$" in s or s.startswith("~"))
+        check_path = s if ambiguous_literal else expand_path(s)
         if os.path.isdir(check_path) or (
             cdpath and _is_directory_in_cdpath(check_path)
         ):


### PR DESCRIPTION
### 1. Use quotation only if needed (part 5 from https://github.com/xonsh/xonsh/issues/3914)

Before
```xsh
cd /tmp
touch file 'fi$le'
ls fi<tab>  # 'file', 'fi$le'
```
After
```
ls fi<tab>  # file, 'fi$le'
```

### 2. Fixes https://github.com/xonsh/xonsh/issues/6362

```xsh
lf 'fi<Tab>
lf 'file'<cur>  # before
lf 'file' <cur>  # after
```

### 3. Additional fix to https://github.com/xonsh/xonsh/pull/6339

```xsh
mkdir ~/dir
cd ~/di<Tab>
cd ~/dir <cur>  # before
cd ~/dir/<cur>  # after
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
