### PR TITLE
fix(completer): Hide syntax and private methods if line is empty

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Please do this:
 2. Add the documentation to `/docs/`.
 3. Add the example of usage or before-after behavior.
 4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
-5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`. 
+5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.
 
 -->
 

--- a/tests/completers/test_python.py
+++ b/tests/completers/test_python.py
@@ -301,3 +301,58 @@ class TestAtSignCompletion:
         comps, _ = res
         assert "@.lastcmd.rtn" in comps
         assert "@.lastcmd.out[" in comps
+
+
+def test_complete_python_empty_prefix_hides_noise():
+    """Bare Tab on a completely empty prefix must not surface
+    xonsh-syntax tokens (``!(``, ``@(``, ``$(``, …), Python operators
+    and keywords from ``XONSH_TOKENS``, or underscore-prefixed builtins
+    (dunders, private names). Without filtering every entry would match
+    and bury actually useful completions.
+    """
+    res = complete_python(CompletionContext(python=PythonContext("", 0, ctx={})))
+    assert res is not None
+    comps, _ = res
+    comps_str = {str(c) for c in comps}
+
+    # xonsh-specific syntax — explicitly named in the user request.
+    for tok in ("!(", "@(", "$(", "${", "$[", "![", "@$(", "@", "?", "??"):
+        assert tok not in comps_str, f"{tok!r} leaked into bare-Tab menu"
+    # Operators / keywords from XONSH_TOKENS — also noise on bare Tab.
+    for tok in ("+", "==", "if", "for", "lambda"):
+        assert tok not in comps_str, f"{tok!r} leaked into bare-Tab menu"
+    # No underscore-prefixed names (dunders or private).
+    leaked_underscore = sorted(s for s in comps_str if s.startswith("_"))
+    assert not leaked_underscore, (
+        f"underscore-prefixed names leaked into bare-Tab menu: {leaked_underscore}"
+    )
+    # Sanity: the menu is not empty — common builtins still come through.
+    assert "print" in comps_str
+    assert "len" in comps_str
+
+
+def test_complete_python_dunder_prefix_still_shows_dunders():
+    """The bare-Tab filter must only kick in for an empty prefix —
+    if the user actually typed ``__``, dunder builtins must appear.
+    """
+    res = complete_python(CompletionContext(python=PythonContext("__", 2, ctx={})))
+    assert res is not None
+    comps, _ = res
+    comps_str = {str(c) for c in comps}
+    assert any(s.startswith("__") for s in comps_str), (
+        "expected dunder builtins to be offered for prefix '__'"
+    )
+
+
+def test_complete_python_empty_prefix_hides_underscore_ctx():
+    """Underscore-prefixed names from the local context must also be
+    hidden on bare Tab (same noise rule as for builtins).
+    """
+    ctx = {"_hidden": 1, "visible": 2, "__dunder__": 3}
+    res = complete_python(CompletionContext(python=PythonContext("", 0, ctx=ctx)))
+    assert res is not None
+    comps, _ = res
+    comps_str = {str(c) for c in comps}
+    assert "visible" in comps_str
+    assert "_hidden" not in comps_str
+    assert "__dunder__" not in comps_str

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -586,3 +586,38 @@ def test_trace_completions_reports_zero_results(
     assert "TRACE COMPLETIONS: Got 1 from exclusive 'third' for 'pre':" in captured
     # 0-result header ends with "." and has no body lines.
     assert "from non-exclusive 'first' for 'pre'.\n" in captured
+
+
+def test_trace_completions_when_query_limit_hit_midstream(
+    completer, completers_mock, xession, monkeypatch, capsys
+):
+    """When ``$COMPLETION_QUERY_LIMIT`` cuts the consumer mid-completer,
+    the trace must still show the items that were yielded — and the
+    ``"Stopped..."`` line must come *after* them, not before. Previously
+    a ``break`` on the consumer side raised ``GeneratorExit`` at the
+    suspended ``yield`` and the per-completer trace block was skipped,
+    so users saw only the names of completers that had already finished.
+    """
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+    monkeypatch.setitem(xession.env, "COMPLETION_QUERY_LIMIT", 3)
+
+    completers_mock["env"] = non_exclusive_completer(lambda *a: set())
+    completers_mock["big"] = lambda *a: {f"c{i}" for i in range(10)}
+
+    completer.complete("", "ls ", 3, 3, {}, multiline_text="ls ", cursor_index=3)
+    captured = capsys.readouterr().out
+
+    # The non-exclusive completer that produced nothing is still reported.
+    assert "TRACE COMPLETIONS: Got 0 from non-exclusive 'env' for ''." in captured
+    # The interrupted completer is reported with the items that were
+    # actually yielded before the break (i.e. the limit count).
+    assert "TRACE COMPLETIONS: Got 3 from exclusive 'big' for '':" in captured
+    # Three per-line entries for the three yielded items (set order isn't
+    # stable so we don't pin specific names — only the count and tag).
+    assert captured.count("src=big, type=exclusive") == 3
+    # The "Stopped" line follows the items, not precedes them.
+    big_idx = captured.index("Got 3 from exclusive 'big'")
+    stopped_idx = captured.index(
+        "TRACE COMPLETIONS: Stopped after $COMPLETION_QUERY_LIMIT reached."
+    )
+    assert big_idx < stopped_idx

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -277,53 +277,57 @@ class Completer:
             # that ``res is None`` is valid — it just yields an empty
             # ``items``, and trace will report ``Got 0 results``.
             items: list = []
-            if res is not None:
-                for comp in res:
-                    if (not is_filtered) and (not filter_func(comp, prefix)):
-                        continue
-                    # Skip empty or whitespace-only completions as if the
-                    # completer had not returned them. Without this an
-                    # exclusive completer that yields only blanks (e.g. a
-                    # subprocess-based completer returning spurious empty
-                    # lines) would short-circuit the pipeline and hide
-                    # the fallback ``python``/``path`` completers. See #5810.
-                    if not str(comp).strip():
-                        continue
-                    comp = Completer._format_completion(
-                        comp,
-                        completion_context,
-                        completing_contextual_command,
-                        lprefix or 0,
-                        custom_lprefix,
-                    )
-                    items.append(comp)
-                    yield comp
-
             exclusive = is_exclusive_completer(func)
-
-            if trace:
-                exclusivity = "exclusive" if exclusive else "non-exclusive"
-                if not items:
-                    # Completer was invoked but produced nothing usable —
-                    # still report it so the user can see which completers
-                    # ran. Trailing ``.`` since no list follows.
-                    print(
-                        f"TRACE COMPLETIONS: Got 0"
-                        f" from {exclusivity} '{name}'"
-                        f" for {prefix!r}."
-                    )
-                else:
-                    print(
-                        f"TRACE COMPLETIONS: Got {len(items)}"
-                        f" from {exclusivity} '{name}'"
-                        f" for {prefix!r}:"
-                    )
-                    for item_comp, item_lprefix in items:
-                        print(
-                            Completer._format_trace_item(
-                                item_comp, item_lprefix, name, exclusive
-                            )
+            try:
+                if res is not None:
+                    for comp in res:
+                        if (not is_filtered) and (not filter_func(comp, prefix)):
+                            continue
+                        # Skip empty or whitespace-only completions as if the
+                        # completer had not returned them. Without this an
+                        # exclusive completer that yields only blanks (e.g. a
+                        # subprocess-based completer returning spurious empty
+                        # lines) would short-circuit the pipeline and hide
+                        # the fallback ``python``/``path`` completers. See #5810.
+                        if not str(comp).strip():
+                            continue
+                        comp = Completer._format_completion(
+                            comp,
+                            completion_context,
+                            completing_contextual_command,
+                            lprefix or 0,
+                            custom_lprefix,
                         )
+                        items.append(comp)
+                        yield comp
+            finally:
+                # Trace lives in ``finally`` so it still runs when the
+                # consumer breaks mid-completer (``GeneratorExit`` at the
+                # ``yield``) — otherwise the items that triggered
+                # ``$COMPLETION_QUERY_LIMIT`` would never be printed.
+                if trace:
+                    exclusivity = "exclusive" if exclusive else "non-exclusive"
+                    if not items:
+                        # Completer was invoked but produced nothing usable —
+                        # still report it so the user can see which completers
+                        # ran. Trailing ``.`` since no list follows.
+                        print(
+                            f"TRACE COMPLETIONS: Got 0"
+                            f" from {exclusivity} '{name}'"
+                            f" for {prefix!r}."
+                        )
+                    else:
+                        print(
+                            f"TRACE COMPLETIONS: Got {len(items)}"
+                            f" from {exclusivity} '{name}'"
+                            f" for {prefix!r}:"
+                        )
+                        for item_comp, item_lprefix in items:
+                            print(
+                                Completer._format_trace_item(
+                                    item_comp, item_lprefix, name, exclusive
+                                )
+                            )
 
             if not items:  # empty completion
                 continue
@@ -359,23 +363,32 @@ class Completer:
             elif completion_context.python is not None:
                 has_line_content = bool(completion_context.python.prefix)
 
-        for comp in self.generate_completions(
+        gen = self.generate_completions(
             completion_context,
             old_completer_args,
             trace,
-        ):
-            completion, lprefix = comp
-            completions[completion] = None
-            if query_limit and len(completions) >= query_limit:
-                if trace:
-                    print(
-                        "TRACE COMPLETIONS: Stopped after $COMPLETION_QUERY_LIMIT reached."
-                    )
-                if has_line_content:
-                    print_above_prompt(
-                        f"List truncated by $COMPLETION_QUERY_LIMIT = {query_limit}"
-                    )
-                break
+        )
+        limit_reached = False
+        try:
+            for comp in gen:
+                completion, lprefix = comp
+                completions[completion] = None
+                if query_limit and len(completions) >= query_limit:
+                    limit_reached = True
+                    if has_line_content:
+                        print_above_prompt(
+                            f"List truncated by $COMPLETION_QUERY_LIMIT = {query_limit}"
+                        )
+                    break
+        finally:
+            # Force the generator's ``finally`` (the per-completer trace
+            # block) to run before any post-loop output, so the items of
+            # the completer that was interrupted by the query-limit
+            # ``break`` actually get printed.
+            gen.close()
+
+        if trace and limit_reached:
+            print("TRACE COMPLETIONS: Stopped after $COMPLETION_QUERY_LIMIT reached.")
 
         # Deduplicate completions that differ only by a trailing space.
         # For example, ``_cd`` (from Python name completions) and ``_cd ``

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -250,6 +250,15 @@ def _complete_python(prefix, context: PythonContext):
         if ctx is not None:
             rtn |= {"@" + s for s in ctx if filt(s, dp)}
         rtn |= {"@" + s for s in dir(builtins) if filt(s, dp)}
+    if not prefix:
+        # Bare Tab on an empty prefix is the noisiest case: every
+        # builtin (dunders included) and every ``XONSH_TOKENS`` entry
+        # (shell syntax like ``!(``/``@(``/``$(``, plus operators and
+        # keywords) match. Drop them so the menu shows only useful
+        # candidates. Anything the user has actually typed bypasses
+        # this branch — ``filt`` already restricts to that prefix.
+        tokens = set(XONSH_TOKENS)
+        rtn = {s for s in rtn if not str(s).startswith("_") and s not in tokens}
     return rtn
 
 


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/6155
* Fix tracing in case of reach the limit

### Before

```xsh
<Tab>
# $( !( @( _func __func ... 🔴 
```

### After 

```xsh
<Tab>
# 7z abs adig aliases ... 🟢 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
