### PR TITLE
fix(parser): Fix SyntaxError in case `cmd && @() && cmd`

### DIFF
--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -1,4 +1,4 @@
-"""Tests the xonsh lexer. """
+"""Tests the xonsh lexer."""
 
 import os
 

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -1,4 +1,4 @@
-"""Tests the xonsh lexer."""
+"""Tests the xonsh lexer. """
 
 import os
 

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -301,6 +301,19 @@ def test_fstring_statement_stays_python(expr, xonsh_execer_parse):
     )
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        "git fetch && @(x) && git branch",
+        "git fetch || @(x) || git branch",
+        "ls && @(['a', 'b']) && echo done",
+    ],
+)
+def test_pyeval_in_andor_chain(line, xonsh_execer_parse):
+    """``cmd && @(...) && cmd`` must parse without a SyntaxError."""
+    assert xonsh_execer_parse(line + "\n")
+
+
 def pyast_unparse(tree):
     """Return ast.unparse on the tree (helper for the tests above)."""
     import ast as pyast

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -423,7 +423,6 @@ def subproc_toks(
                     pass
                 elif not greedy:
                     toks.clear()
-                    lparens.clear()
                     leading_paren_skipped = False
                 if tok.type in BEG_TOK_SKIPS:
                     if tok.type == "LPAREN":


### PR DESCRIPTION
Fixes https://github.com/xonsh/xonsh/issues/6379

cc #6191

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
