### PR TITLE
fix(nix): fix nix build

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -16,6 +16,7 @@
   pytest-mock,
   pytest-rerunfailures,
   pytest-subprocess,
+  pytest-timeout,
   pytestCheckHook,
   requests,
   virtualenv,
@@ -55,6 +56,7 @@ buildPythonPackage {
     pytest-mock
     pytest-rerunfailures
     pytest-subprocess
+    pytest-timeout
     pytestCheckHook
     requests
 
@@ -70,9 +72,7 @@ buildPythonPackage {
   disabledTests = [
     # fails on sandbox
     "test_colorize_file"
-    "test_repath_HOME_PATH_itself"
-    "test_repath_HOME_PATH_var"
-    "test_repath_HOME_PATH_var_brace"
+    "test_complete_path_tilde_subdir_trailing_sep"
 
     # flaky tests in test_integrations.py
     "test_script"
@@ -122,7 +122,7 @@ buildPythonPackage {
     sed -i -e 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
     sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/xintegration/test_integrations.py
 
-    for script in tests/xintegration/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
+    for script in conftest.py tests/xintegration/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
       sed -i -e 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
     done
     patchShebangs .

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -889,12 +889,12 @@ def test_printfile():
 
 @_bad_case
 def test_printname():
-    check_run_xonsh("printfile.xsh", None, "printfile.xsh\n")
+    check_run_xonsh("printname.xsh", None, "__main__\n")
 
 
 @_bad_case
 def test_sourcefile():
-    check_run_xonsh("printfile.xsh", None, "printfile.xsh\n")
+    check_run_xonsh("sourcefile.xsh", None, "printfile.xsh\n")
 
 
 @_bad_case


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

Currently `nix build 'github:xonsh/xonsh' -L'` fails with the following test failures:

```
python3.13-xonsh-main> =================================== FAILURES ===================================
python3.13-xonsh-main> _________________ test_complete_path_tilde_subdir_trailing_sep _________________
python3.13-xonsh-main> xession = <xonsh.built_ins.XonshSession object at 0x7ffff5676900>
python3.13-xonsh-main>     @pytest.mark.skipif(xcp.xp.ON_WINDOWS, reason="POSIX tilde expansion")
python3.13-xonsh-main>     def test_complete_path_tilde_subdir_trailing_sep(xession):
python3.13-xonsh-main>         """``~/<subdir>`` completion must end with the path separator so that
python3.13-xonsh-main>         a second Tab keeps drilling into the directory. Regression from
python3.13-xonsh-main>         PR #6339 which made ``_quote_paths`` use the literal path for any
python3.13-xonsh-main>         ``~``-prefixed string, breaking ``isdir("~/git")``.
python3.13-xonsh-main>         """
python3.13-xonsh-main>         xession.env.update(
python3.13-xonsh-main>             {
python3.13-xonsh-main>                 "GLOB_SORTED": True,
python3.13-xonsh-main>                 "SUBSEQUENCE_PATH_COMPLETION": False,
python3.13-xonsh-main>                 "FUZZY_PATH_COMPLETION": False,
python3.13-xonsh-main>                 "SUGGEST_THRESHOLD": 3,
python3.13-xonsh-main>                 "CDPATH": set(),
python3.13-xonsh-main>             }
python3.13-xonsh-main>         )
python3.13-xonsh-main>         home = os.path.expanduser("~")
python3.13-xonsh-main>         with tempfile.TemporaryDirectory(dir=home) as td:
python3.13-xonsh-main>             name = os.path.basename(td)
python3.13-xonsh-main>             prefix = f"~/{name[:3]}"
python3.13-xonsh-main>             line = f"ls {prefix}"
python3.13-xonsh-main>             paths, _ = xcp._complete_path_raw(prefix, line, 3, len(line), {})
python3.13-xonsh-main>             match = {p for p in paths if name in p}
python3.13-xonsh-main> >           assert match, f"Expected completion for ~/{name[:3]}, got: {paths}"
python3.13-xonsh-main> E           AssertionError: Expected completion for ~/tmp, got: set()
python3.13-xonsh-main> E           assert set()
python3.13-xonsh-main> tests/completers/test_path_completers.py:133: AssertionError
python3.13-xonsh-main> ________________________________ test_printfile ________________________________
python3.13-xonsh-main>     @_bad_case
python3.13-xonsh-main>     def test_printfile():
python3.13-xonsh-main> >       check_run_xonsh("printfile.xsh", None, "printfile.xsh\n")
python3.13-xonsh-main> tests/xintegration/test_integrations.py:887:
python3.13-xonsh-main> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.13-xonsh-main> cmd = 'printfile.xsh', fmt = None, exp = 'printfile.xsh\n', exp_rtn = 0
python3.13-xonsh-main>     def check_run_xonsh(cmd, fmt, exp, exp_rtn=0):
python3.13-xonsh-main>         """The ``fmt`` parameter is a function
python3.13-xonsh-main>         that formats the output of cmd, can be None.
python3.13-xonsh-main>         """
python3.13-xonsh-main>         out, err, rtn = run_xonsh(cmd, stderr=sp.PIPE)
python3.13-xonsh-main>         if callable(fmt):
python3.13-xonsh-main>             out = fmt(out)
python3.13-xonsh-main>         if callable(exp):
python3.13-xonsh-main>             exp = exp()
python3.13-xonsh-main> >       assert out == exp, err
python3.13-xonsh-main> E       AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = 'error.log'
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 647, in _run_binary
python3.13-xonsh-main> E             p = self.cls(cmd, bufsize=bufsize, **kwargs)
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1039, in __init__
python3.13-xonsh-main> E             self._execute_child(args, executable, preexec_fn, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 pass_fds, cwd, env,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E             ...<5 lines>...
python3.13-xonsh-main> E                                 gid, gids, uid, umask,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 start_new_session, process_group)
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1876, in _execute_child
python3.13-xonsh-main> E             self._posix_spawn(args, executable, env, restore_signals, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               p2cread, p2cwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               c2pread, c2pwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               errread, errwrite)
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1820, in _posix_spawn
python3.13-xonsh-main> E             self.pid = os.posix_spawn(executable, args, env, **kwargs)
python3.13-xonsh-main> E                        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E         FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         The above exception was the direct cause of the following exception:
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/pipelines.py", line 199, in __init__
python3.13-xonsh-main> E             proc = spec.run(pipeline_group=pipeline_group)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 620, in run
python3.13-xonsh-main> E             p = self._run_binary(kwargs)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 704, in _run_binary
python3.13-xonsh-main> E             raise xt.XonshError(e) from ex
python3.13-xonsh-main> E         xonsh.tools.XonshError: xonsh: subprocess mode: command not found: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E       assert '' == 'printfile.xsh\n'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         - printfile.xsh
python3.13-xonsh-main> tests/xintegration/conftest.py:129: AssertionError
python3.13-xonsh-main> ________________________________ test_printname ________________________________
python3.13-xonsh-main>     @_bad_case
python3.13-xonsh-main>     def test_printname():
python3.13-xonsh-main> >       check_run_xonsh("printfile.xsh", None, "printfile.xsh\n")
python3.13-xonsh-main> tests/xintegration/test_integrations.py:892:
python3.13-xonsh-main> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.13-xonsh-main> cmd = 'printfile.xsh', fmt = None, exp = 'printfile.xsh\n', exp_rtn = 0
python3.13-xonsh-main>     def check_run_xonsh(cmd, fmt, exp, exp_rtn=0):
python3.13-xonsh-main>         """The ``fmt`` parameter is a function
python3.13-xonsh-main>         that formats the output of cmd, can be None.
python3.13-xonsh-main>         """
python3.13-xonsh-main>         out, err, rtn = run_xonsh(cmd, stderr=sp.PIPE)
python3.13-xonsh-main>         if callable(fmt):
python3.13-xonsh-main>             out = fmt(out)
python3.13-xonsh-main>         if callable(exp):
python3.13-xonsh-main>             exp = exp()
python3.13-xonsh-main> >       assert out == exp, err
python3.13-xonsh-main> E       AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = 'error.log'
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 647, in _run_binary
python3.13-xonsh-main> E             p = self.cls(cmd, bufsize=bufsize, **kwargs)
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1039, in __init__
python3.13-xonsh-main> E             self._execute_child(args, executable, preexec_fn, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 pass_fds, cwd, env,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E             ...<5 lines>...
python3.13-xonsh-main> E                                 gid, gids, uid, umask,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 start_new_session, process_group)
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1876, in _execute_child
python3.13-xonsh-main> E             self._posix_spawn(args, executable, env, restore_signals, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               p2cread, p2cwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               c2pread, c2pwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               errread, errwrite)
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1820, in _posix_spawn
python3.13-xonsh-main> E             self.pid = os.posix_spawn(executable, args, env, **kwargs)
python3.13-xonsh-main> E                        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E         FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         The above exception was the direct cause of the following exception:
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/pipelines.py", line 199, in __init__
python3.13-xonsh-main> E             proc = spec.run(pipeline_group=pipeline_group)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 620, in run
python3.13-xonsh-main> E             p = self._run_binary(kwargs)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 704, in _run_binary
python3.13-xonsh-main> E             raise xt.XonshError(e) from ex
python3.13-xonsh-main> E         xonsh.tools.XonshError: xonsh: subprocess mode: command not found: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E       assert '' == 'printfile.xsh\n'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         - printfile.xsh
python3.13-xonsh-main> tests/xintegration/conftest.py:129: AssertionError
python3.13-xonsh-main> _______________________________ test_sourcefile ________________________________
python3.13-xonsh-main>     @_bad_case
python3.13-xonsh-main>     def test_sourcefile():
python3.13-xonsh-main> >       check_run_xonsh("printfile.xsh", None, "printfile.xsh\n")
python3.13-xonsh-main> tests/xintegration/test_integrations.py:897:
python3.13-xonsh-main> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.13-xonsh-main> cmd = 'printfile.xsh', fmt = None, exp = 'printfile.xsh\n', exp_rtn = 0
python3.13-xonsh-main>     def check_run_xonsh(cmd, fmt, exp, exp_rtn=0):
python3.13-xonsh-main>         """The ``fmt`` parameter is a function
python3.13-xonsh-main>         that formats the output of cmd, can be None.
python3.13-xonsh-main>         """
python3.13-xonsh-main>         out, err, rtn = run_xonsh(cmd, stderr=sp.PIPE)
python3.13-xonsh-main>         if callable(fmt):
python3.13-xonsh-main>             out = fmt(out)
python3.13-xonsh-main>         if callable(exp):
python3.13-xonsh-main>             exp = exp()
python3.13-xonsh-main> >       assert out == exp, err
python3.13-xonsh-main> E       AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = 'error.log'
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 647, in _run_binary
python3.13-xonsh-main> E             p = self.cls(cmd, bufsize=bufsize, **kwargs)
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1039, in __init__
python3.13-xonsh-main> E             self._execute_child(args, executable, preexec_fn, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 pass_fds, cwd, env,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E             ...<5 lines>...
python3.13-xonsh-main> E                                 gid, gids, uid, umask,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 start_new_session, process_group)
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1876, in _execute_child
python3.13-xonsh-main> E             self._posix_spawn(args, executable, env, restore_signals, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               p2cread, p2cwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               c2pread, c2pwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               errread, errwrite)
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1820, in _posix_spawn
python3.13-xonsh-main> E             self.pid = os.posix_spawn(executable, args, env, **kwargs)
python3.13-xonsh-main> E                        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E         FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         The above exception was the direct cause of the following exception:
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/pipelines.py", line 199, in __init__
python3.13-xonsh-main> E             proc = spec.run(pipeline_group=pipeline_group)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 620, in run
python3.13-xonsh-main> E             p = self._run_binary(kwargs)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 704, in _run_binary
python3.13-xonsh-main> E             raise xt.XonshError(e) from ex
python3.13-xonsh-main> E         xonsh.tools.XonshError: xonsh: subprocess mode: command not found: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E       assert '' == 'printfile.xsh\n'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         - printfile.xsh
python3.13-xonsh-main> tests/xintegration/conftest.py:129: AssertionError
python3.13-xonsh-main> __________________________________ test_argv0 __________________________________
python3.13-xonsh-main>     @skip_if_on_msys
python3.13-xonsh-main>     @skip_if_on_windows
python3.13-xonsh-main>     @skip_if_on_darwin
python3.13-xonsh-main>     @skip_if_on_bsd
python3.13-xonsh-main>     def test_argv0():
python3.13-xonsh-main>         # The check script uses /proc/<pid>/cmdline, which is only available on
python3.13-xonsh-main>         # Linux's procfs. macOS and the BSDs have no /proc by default (and
python3.13-xonsh-main>         # FreeBSD's optional linprocfs is rarely mounted), so the helper has no
python3.13-xonsh-main>         # portable way to read argv[0] there.
python3.13-xonsh-main> >       check_run_xonsh("checkargv0.xsh", None, "OK\n")
python3.13-xonsh-main> tests/xintegration/test_integrations.py:1068:
python3.13-xonsh-main> _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
python3.13-xonsh-main> cmd = 'checkargv0.xsh', fmt = None, exp = 'OK\n', exp_rtn = 0
python3.13-xonsh-main>     def check_run_xonsh(cmd, fmt, exp, exp_rtn=0):
python3.13-xonsh-main>         """The ``fmt`` parameter is a function
python3.13-xonsh-main>         that formats the output of cmd, can be None.
python3.13-xonsh-main>         """
python3.13-xonsh-main>         out, err, rtn = run_xonsh(cmd, stderr=sp.PIPE)
python3.13-xonsh-main>         if callable(fmt):
python3.13-xonsh-main>             out = fmt(out)
python3.13-xonsh-main>         if callable(exp):
python3.13-xonsh-main>             exp = exp()
python3.13-xonsh-main> >       assert out == exp, err
python3.13-xonsh-main> E       AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBACK_LOGFILE = 'error.log'
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 647, in _run_binary
python3.13-xonsh-main> E             p = self.cls(cmd, bufsize=bufsize, **kwargs)
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1039, in __init__
python3.13-xonsh-main> E             self._execute_child(args, executable, preexec_fn, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 pass_fds, cwd, env,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E             ...<5 lines>...
python3.13-xonsh-main> E                                 gid, gids, uid, umask,
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                                 start_new_session, process_group)
python3.13-xonsh-main> E                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1876, in _execute_child
python3.13-xonsh-main> E             self._posix_spawn(args, executable, env, restore_signals, close_fds,
python3.13-xonsh-main> E             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               p2cread, p2cwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               c2pread, c2pwrite,
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E                               errread, errwrite)
python3.13-xonsh-main> E                               ^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E           File "/nix/store/0r6k8xa2kgqyp3r4v2w7yrb80ma2iawm-python3-3.13.12/lib/python3.13/subprocess.py", line 1820, in _posix_spawn
python3.13-xonsh-main> E             self.pid = os.posix_spawn(executable, args, env, **kwargs)
python3.13-xonsh-main> E                        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.13-xonsh-main> E         FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         The above exception was the direct cause of the following exception:
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         Traceback (most recent call last):
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/pipelines.py", line 199, in __init__
python3.13-xonsh-main> E             proc = spec.run(pipeline_group=pipeline_group)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 620, in run
python3.13-xonsh-main> E             p = self._run_binary(kwargs)
python3.13-xonsh-main> E           File "/build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/xonsh/procs/specs.py", line 704, in _run_binary
python3.13-xonsh-main> E             raise xt.XonshError(e) from ex
python3.13-xonsh-main> E         xonsh.tools.XonshError: xonsh: subprocess mode: command not found: '/usr/bin/env'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E       assert '' == 'OK\n'
python3.13-xonsh-main> E         
python3.13-xonsh-main> E         - OK
python3.13-xonsh-main> tests/xintegration/conftest.py:129: AssertionError
python3.13-xonsh-main> =============================== warnings summary ===============================
python3.13-xonsh-main> tests/procs/test_pipelines.py:173
python3.13-xonsh-main>   /build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/tests/procs/test_pipelines.py:173: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
python3.13-xonsh-main>     @pytest.mark.timeout(30, method="thread")
python3.13-xonsh-main> tests/procs/test_pipelines.py:203
python3.13-xonsh-main>   /build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/tests/procs/test_pipelines.py:203: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
python3.13-xonsh-main>     @pytest.mark.timeout(30, method="thread")
python3.13-xonsh-main> tests/procs/test_specs.py:415
python3.13-xonsh-main>   /build/4wmm7c1nx6vq98d1lr19kmrk3059vpdr-source/tests/procs/test_specs.py:415: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
python3.13-xonsh-main>     @pytest.mark.timeout(15)
python3.13-xonsh-main> -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
python3.13-xonsh-main> =========================== short test summary info ============================
python3.13-xonsh-main> FAILED tests/completers/test_path_completers.py::test_complete_path_tilde_subdir_trailing_sep - AssertionError: Expected completion for ~/tmp, got: set()
python3.13-xonsh-main> FAILED tests/xintegration/test_integrations.py::test_printfile - AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBAC...
python3.13-xonsh-main> FAILED tests/xintegration/test_integrations.py::test_printname - AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBAC...
python3.13-xonsh-main> FAILED tests/xintegration/test_integrations.py::test_sourcefile - AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBAC...
python3.13-xonsh-main> FAILED tests/xintegration/test_integrations.py::test_argv0 - AssertionError: xonsh: To log full traceback to a file set: $XONSH_TRACEBAC...
python3.13-xonsh-main> = 5 failed, 6208 passed, 52 skipped, 188 deselected, 3 xfailed, 3 warnings in 104.24s (0:01:44) =
```

The reason of the failing integration tests is the non-existence of  `/usr/bin/env` in the build sandbox. It is resolved by replacing the hard-coded `/usr/bin/env` in `conftest.py` with the real path in `/nix/store` at build time.

`test_complete_path_tilde_subdir_trailing_sep` passes when I manually run it on NixOS, and I'm not sure how to fix it in sandbox. Disabling it for now.

`test_repath_HOME_PATH_*` passed in sandbox when I tested. Removing them from disabled tests.

The warnings are due to the missing test dependency `pytest-timeout`.

Also, I found possible typos in `test_printname` and `test_sourcefile`, because they look the same as `test_printfile`, and I fixed them in a way that I think they should be :)

### To test

```
nix build 'github:SamLukeYes/xonsh/fix_nix_build_0.23.3' -L
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
