### PR TITLE
fix(parser): Fix lost LHS in `cmd && ![…]` chain wrap

### DIFF
--- a/tests/test_execer_llm.py
+++ b/tests/test_execer_llm.py
@@ -1,0 +1,78 @@
+"""End-to-end tests for ``CtxAwareTransformer.try_subproc_toks`` in eval mode.
+
+Regression coverage for GH-6386: with the ``coconut`` xontrib loaded,
+``CtxAwareTransformer.mode`` is forced to ``"eval"`` so the whole
+stripped logical line is fed to ``subproc_toks``.  When phase 1 has
+already wrapped part of the line as ``![…]`` (e.g. for
+``echo && echo hi`` → ``echo && ![echo hi]``), the eval-mode wrap of
+the remaining bare ``Name`` used to produce ``![![echo hi]]`` (invalid
+xonsh), the parser raised ``SyntaxError``, ``try_subproc_toks``
+swallowed it, and the bare ``Name('echo')`` survived to runtime as a
+``NameError``.  A second variant silently miscompiled
+``cmd1 && cmd2`` (both bare, both single-token) into ``cmd2 && cmd2``.
+
+The tests reproduce both classes without depending on coconut by
+driving ``CtxAwareTransformer`` in eval mode directly via the same
+``mode = "eval"`` flip the coconut xontrib performs (see
+``coconut.integrations.CoconutXontribLoader.new_try_subproc_toks``).
+"""
+
+import ast as pyast
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "echo && echo hi",
+        "echo hi && echo",
+        "echo a && echo b",
+        "ls && pwd",
+        "pwd && ls",
+        "ls && pwd /",
+        "echo a && pwd b",
+        "true && false || echo hi",
+        "false || echo hi",
+        "(echo) && (echo hi)",
+        "echo && echo",
+    ],
+)
+def test_andor_chain_eval_mode(line, xession):
+    """Phase-2 eval-mode wrap must produce the same AST as exec-mode for
+    plain xonsh subproc chains.  Coconut forces eval-mode for every
+    call to ``try_subproc_toks``; without the GH-6386 fix the bare
+    ``Name`` on the left of ``&&``/``||`` is left untransformed (loud
+    ``NameError``) or silently replaced with the wrong subproc wrap
+    (silent miscompile).
+    """
+    execer = xession.execer
+    ctx = {"__xonsh__": object()}
+    src = line + "\n"
+    exec_tree = execer.parse(src, ctx=ctx, mode="single")
+    exec_unparsed = pyast.unparse(exec_tree)
+    # Drive eval-mode the way the coconut xontrib does: temporarily flip
+    # ``ctxtransformer.mode`` to ``"eval"`` for every ``try_subproc_toks``
+    # call.  This mirrors ``CoconutXontribLoader.new_try_subproc_toks``.
+    ctxt = execer.ctxtransformer
+    orig_try_subproc_toks = ctxt.try_subproc_toks
+
+    def eval_mode_try_subproc_toks(node, strip_expr=False):
+        prev = ctxt.mode
+        ctxt.mode = "eval"
+        try:
+            return orig_try_subproc_toks(node, strip_expr=strip_expr)
+        finally:
+            ctxt.mode = prev
+
+    ctxt.try_subproc_toks = eval_mode_try_subproc_toks
+    try:
+        eval_tree = execer.parse(src, ctx=ctx, mode="single")
+    finally:
+        ctxt.try_subproc_toks = orig_try_subproc_toks
+    eval_unparsed = pyast.unparse(eval_tree)
+    assert eval_unparsed == exec_unparsed, (
+        f"eval-mode wrap diverged from exec-mode wrap for {line!r}\n"
+        f"  exec: {exec_unparsed}\n"
+        f"  eval: {eval_unparsed}"
+    )

--- a/tests/test_tools_llm.py
+++ b/tests/test_tools_llm.py
@@ -1,0 +1,76 @@
+"""Tests for ``xonsh.tools.subproc_toks`` against already-wrapped lines.
+
+Regression coverage for GH-6386: ``subproc_toks`` called on a line that
+has already been partially wrapped by an earlier parse pass (e.g. xonsh
+phase 1 turning ``echo && echo hi`` into ``echo && ![echo hi]``) used
+to re-wrap the existing ``![…]`` block, producing ``![![…]]`` — which
+is not valid xonsh, since neither ``![…]`` nor ``&&``/``||`` may appear
+inside ``![…]``.  The bug surfaced in xontribs that force
+``CtxAwareTransformer.mode = "eval"`` to compensate for shifted column
+numbers in their compiled output (the ``coconut`` xontrib being the
+canonical example), making the whole-line wrap reach phase-1 output.
+
+These tests pin the corrected behaviour at the ``subproc_toks`` layer
+without depending on coconut: skip already-wrapped ``![…]``/``$[…]``
+blocks, fall back to the bare region preceding the skip when the
+trailing region is fully wrapped, and decline (return ``None``) when
+every region in the chain is already wrapped.
+"""
+
+import pytest
+
+from xonsh.parsers.lexer import Lexer
+from xonsh.tools import subproc_toks
+
+LEXER = Lexer()
+LEXER.build()
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "echo && ![echo hi]",
+        "echo && $[echo hi]",
+        "![echo a] && ![echo b]",
+        "$[echo a] && $[echo b]",
+        "![echo a] || ![echo b]",
+        "true && ![echo hi]",
+        "false || ![echo hi]",
+    ],
+)
+def test_subproc_toks_skips_already_wrapped(line):
+    """Whole-line wrap must not produce ``![![…]]`` when the line has
+    already-wrapped subproc blocks.  Either the bare side gets a
+    correct fresh wrap, or the function declines to wrap entirely.
+    """
+    for greedy in (False, True):
+        obs = subproc_toks(
+            line, mincol=0, maxcol=None, lexer=LEXER, returnline=False, greedy=greedy
+        )
+        if obs is None:
+            continue
+        assert "![![" not in obs, f"double wrap in {obs!r}"
+        assert "![$[" not in obs, f"double wrap in {obs!r}"
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        # Bare LEFT, already-wrapped RIGHT: wrap only the bare LEFT.
+        ("echo && ![echo hi]", "![echo]"),
+        ("echo && $[echo hi]", "![echo]"),
+        # Bare LEFT, already-wrapped RIGHT, with ||.
+        ("echo || ![echo hi]", "![echo]"),
+        # Both sides already-wrapped: nothing left to wrap, return None.
+        ("![echo a] && ![echo b]", None),
+        ("$[echo a] && $[echo b]", None),
+        ("![echo a] || $[echo b]", None),
+    ],
+)
+def test_subproc_toks_already_wrapped_chain(line, expected):
+    """Whole-line wrap on a chain that includes ``![…]``/``$[…]`` must
+    only produce a wrap for the still-bare side (or ``None`` when every
+    side is already wrapped).
+    """
+    obs = subproc_toks(line, mincol=0, maxcol=None, lexer=LEXER, returnline=False)
+    assert obs == expected

--- a/xonsh/parsers/ast.py
+++ b/xonsh/parsers/ast.py
@@ -439,62 +439,90 @@ class CtxAwareTransformer(NodeTransformer):
                 ctx.remove(value)
                 break
 
+    def _column_window(self, node, line, nlogical):
+        """Compute the (mincol, maxcol) window that brackets ``node`` in ``line``.
+
+        Mirrors the column-based branch of ``try_subproc_toks`` and is used
+        both as the primary window in ``exec``-mode and as the fallback for
+        ``eval``-mode when the whole-line wrap can't produce valid xonsh
+        (e.g. the line was already partially wrapped by phase 1).
+        """
+        mincol = max(min_col(node) - 1, 0)
+        maxcol = max_col(node)
+        if mincol == maxcol:
+            maxcol = find_next_break(line, mincol=mincol, lexer=self.parser.lexer)
+        elif nlogical > 1:
+            maxcol = None
+        elif maxcol < len(line) and line[maxcol] == ";":
+            pass
+        else:
+            maxcol += 1
+        return mincol, maxcol
+
     def try_subproc_toks(self, node, strip_expr=False):
         """Tries to parse the line of the node as a subprocess."""
         line, nlogical, idx = get_logical_line(self.lines, node.lineno - 1)
+        # Build the list of (mincol, maxcol) windows to try, most precise
+        # first.  In ``exec`` mode we use the column window of the node
+        # itself.  In ``eval`` mode we historically used the whole stripped
+        # line — but that produces ``![![…]]`` whenever the line has been
+        # partially wrapped by an earlier phase (the case xontribs that
+        # force ``mode = "eval"`` to compensate for shifted column numbers
+        # in their compiled output, such as the ``coconut`` xontrib, hit
+        # for plain ``cmd && cmd`` — see GH-6386).  Try the column window
+        # first there too, falling back to the whole stripped line only if
+        # the precise window can't yield a parsable wrap.  When the node's
+        # column metadata happens to be wrong (the original eval-mode use
+        # case) the column attempt fails parse and the fallback runs.
+        col_window = self._column_window(node, line, nlogical)
         if self.mode == "eval":
-            mincol = len(line) - len(line.lstrip())
-            maxcol = None
+            eval_window = (len(line) - len(line.lstrip()), None)
+            windows = [col_window, eval_window]
         else:
-            mincol = max(min_col(node) - 1, 0)
-            maxcol = max_col(node)
-            if mincol == maxcol:
-                maxcol = find_next_break(line, mincol=mincol, lexer=self.parser.lexer)
-            elif nlogical > 1:
-                maxcol = None
-            elif maxcol < len(line) and line[maxcol] == ";":
-                pass
-            else:
-                maxcol += 1
-        spline = subproc_toks(
-            line,
-            mincol=mincol,
-            maxcol=maxcol,
-            returnline=False,
-            lexer=self.parser.lexer,
-        )
-        if spline is None:
-            # non-greedy produced nothing, try greedy
+            windows = [col_window]
+        newnode = node
+        for mincol, maxcol in windows:
             spline = subproc_toks(
                 line,
                 mincol=mincol,
                 maxcol=maxcol,
                 returnline=False,
                 lexer=self.parser.lexer,
-                greedy=True,
             )
-        if spline is None:
-            return node
-        try:
-            newnode = self.parser.parse(
-                spline,
-                mode=self.mode,
-                filename=self.filename,
-                debug_level=(self.debug_level >= 2),
-            )
-            newnode = newnode.body
-            if not isinstance(newnode, AST):
+            if spline is None:
+                # non-greedy produced nothing, try greedy
+                spline = subproc_toks(
+                    line,
+                    mincol=mincol,
+                    maxcol=maxcol,
+                    returnline=False,
+                    lexer=self.parser.lexer,
+                    greedy=True,
+                )
+            if spline is None:
+                continue
+            try:
+                parsed = self.parser.parse(
+                    spline,
+                    mode=self.mode,
+                    filename=self.filename,
+                    debug_level=(self.debug_level >= 2),
+                )
+            except SyntaxError:
+                continue
+            parsed = parsed.body
+            if not isinstance(parsed, AST):
                 # take the first (and only) Expr
-                newnode = newnode[0]
-            increment_lineno(newnode, n=node.lineno - 1)
-            newnode.col_offset = node.col_offset
+                parsed = parsed[0]
+            increment_lineno(parsed, n=node.lineno - 1)
+            parsed.col_offset = node.col_offset
             if self.debug_level >= 1:
                 msg = "{0}:{1}:{2}{3} - {4}\n{0}:{1}:{2}{3} + {5}"
                 mstr = "" if maxcol is None else ":" + str(maxcol)
                 msg = msg.format(self.filename, node.lineno, mincol, mstr, line, spline)
                 print(msg, file=sys.stderr)
-        except SyntaxError:
-            newnode = node
+            newnode = parsed
+            break
         if strip_expr and isinstance(newnode, Expr):
             newnode = newnode.value
         return newnode

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -383,8 +383,34 @@ def subproc_toks(
     # call or sub-expression) and must stay in the wrap.
     leading_paren_skipped = False
     end_offset = 0
+    # Depth of an already-wrapped uncaptured-subproc block (``![…]`` or
+    # ``$[…]``) we are skipping.  A line passed to subproc_toks may have
+    # been partially wrapped by an earlier parse pass (e.g. xonsh phase 1
+    # turning ``echo && echo hi`` into ``echo && ![echo hi]`` before
+    # phase 2 needs to wrap the remaining bare ``echo`` on the left).
+    # Re-wrapping such a block would produce ``![![…]]``, which is not
+    # valid xonsh syntax — neither ``![…]`` nor ``&&``/``||`` may appear
+    # inside ``![…]``.  Treat the whole already-wrapped block as a single
+    # opaque token so we never include it in a fresh wrap window.
+    skip_depth = 0
+    # Snapshot of the most-recent collectable region (the tokens just
+    # before an ``&&``/``||`` cleared ``toks``).  If the *next* region
+    # turns out to be entirely an already-wrapped ``![…]``/``$[…]`` and
+    # gets skipped, we restore this snapshot so the bare side preceding
+    # the skip still gets wrapped.  Without it ``subproc_toks`` would
+    # return ``None`` for ``echo && ![echo hi]`` and the caller's bare
+    # ``Name('echo')`` would survive untransformed (GH-6386).
+    saved_toks = None
+    saved_lparens = None
+    saved_leading_paren_skipped = False
     for tok in lexer:
         pos = tok.lexpos
+        if skip_depth > 0:
+            if tok.type in ("BANG_LBRACKET", "DOLLAR_LBRACKET", "LBRACKET"):
+                skip_depth += 1
+            elif tok.type == "RBRACKET":
+                skip_depth -= 1
+            continue
         if tok.type not in END_TOK_TYPES and pos >= maxcol:
             break
         if tok.type == "BANG":
@@ -422,6 +448,14 @@ def subproc_toks(
                 ):
                     pass
                 elif not greedy:
+                    # Save the tokens we are about to drop (everything up
+                    # to but not including the END_TOK) as a fallback in
+                    # case the next region is an already-wrapped block we
+                    # end up skipping.  See GH-6386.
+                    if len(toks) > 1:
+                        saved_toks = toks[:-1]
+                        saved_lparens = list(lparens)
+                        saved_leading_paren_skipped = leading_paren_skipped
                     toks.clear()
                     leading_paren_skipped = False
                 if tok.type in BEG_TOK_SKIPS:
@@ -430,6 +464,15 @@ def subproc_toks(
                     continue
             else:
                 break
+        # An ``![…]`` / ``$[…]`` opens an uncaptured subproc block that
+        # is already complete.  Skip it without wrapping (and without
+        # including its tokens in any other wrap).  Only honour this at
+        # window start — a bracket appearing after collected tokens is
+        # part of an expression (e.g. ``foo[0]``) and falls through to
+        # the normal token append below.
+        if len(toks) == 0 and tok.type in ("BANG_LBRACKET", "DOLLAR_LBRACKET"):
+            skip_depth = 1
+            continue
         if pos < mincol:
             continue
         toks.append(tok)
@@ -467,8 +510,29 @@ def subproc_toks(
                 pass
             else:
                 toks.pop()
+        # If everything from the last END_TOK onwards was an already-wrapped
+        # ``![…]``/``$[…]`` block we skipped, ``toks`` is now empty even
+        # though the bare side preceding the skip is wrappable.  Restore
+        # the snapshot we took before the END_TOK clear so that side
+        # gets the wrap (GH-6386).
+        if len(toks) == 0 and saved_toks is not None:
+            toks = saved_toks
+            lparens = saved_lparens
+            leading_paren_skipped = saved_leading_paren_skipped
         if len(toks) == 0:
             return  # handle comment lines
+        tok = toks[-1]
+        pos = tok.lexpos
+        if isinstance(tok.value, str):
+            end_offset = len(tok.value.rstrip())
+        else:
+            el = line[pos:].split("#")[0].rstrip()
+            end_offset = len(el)
+    if len(toks) == 0 and saved_toks is not None:
+        # Same recovery for the ``break``-out-of-loop path.
+        toks = saved_toks
+        lparens = saved_lparens
+        leading_paren_skipped = saved_leading_paren_skipped
         tok = toks[-1]
         pos = tok.lexpos
         if isinstance(tok.value, str):


### PR DESCRIPTION
Fixes https://github.com/xonsh/xonsh/issues/6386

Fixes #6386: with the coconut xontrib loaded, `echo && echo hi` raised `NameError: name 'echo' is not defined`, and the closely related shape `cmd1 && cmd2` (both bare, both single-token) silently miscompiled to `cmd2 && cmd2` — losing the LHS without any error.

The same silent miscompile was reachable from plain xonsh through `Execer.eval()` (used by f-string field evaluation, macro arg evaluation, and the Python completer), so this is not coconut-specific.

Root cause was twofold: `xonsh.tools.subproc_toks` did not recognise already-wrapped `![…]` / `$[…]` blocks (they are absent from `LPARENS` and `BEG_TOK_SKIPS`), so when a line had been partially wrapped by phase 1 (e.g. `echo && ![echo hi]`) the eval-mode whole-line wrap re-wrapped the inner block as `![![…]]`, which is not valid xonsh; and `CtxAwareTransformer.try_subproc_toks` then silently swallowed the resulting `SyntaxError` and left the bare `Name` in the AST.

The fix teaches `subproc_toks` to skip already-wrapped uncaptured-subproc blocks (with a snapshot/restore so the bare side preceding a skipped trailing block still gets a fresh wrap, returning `None` only when every region in the chain is already wrapped), and rewrites `try_subproc_toks` to try the precise column-aware window first in eval mode and fall back to whole-line wrap only when the precise attempt can't produce parsable xonsh — preserving coconut's column-shift workaround while making bare xonsh chains transform correctly.

Also fixes

```xsh
from xonsh.built_ins import XSH
XSH.execer.eval("ls && pwd")
# Before
# <pwd> result 🔴 
# <pwd> result 🟢 

# After
# <ls> result 🟢 
# <pwd> result 🟢 
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
