### PR TITLE
fix: Xontrib load using entrypoint e.g. coconut

### DIFF
--- a/tests/built_ins/test_xontribs_llm.py
+++ b/tests/built_ins/test_xontribs_llm.py
@@ -1,0 +1,157 @@
+"""Tests for ``xonsh.xontribs.find_xontrib`` lookup pipeline.
+
+Regression coverage for the ``--no-rc`` / ``$XONTRIBS_AUTOLOAD_DISABLED``
+case: a xontrib whose only Python-visible mapping is a setuptools
+entry point in the ``xonsh.xontribs`` group (the wheel ships **no**
+``xontrib/<name>.py`` and no top-level ``<name>._load_xontrib_``) used
+to be unreachable from ``xontrib load <name>`` whenever autoload had
+not populated ``XSH.builtins.autoloaded_xontribs``.  The canonical
+example is the ``coconut`` xontrib whose loader lives in
+``coconut.integrations``.
+
+These tests pin the corrected lookup order without depending on
+coconut: a fake entry point is monkeypatched into
+``_get_xontrib_entrypoints`` and points at a temp module on
+``sys.path``.
+"""
+
+import sys
+
+import pytest
+
+from xonsh import xontribs
+from xonsh.xontribs import find_xontrib, xontribs_load
+
+
+@pytest.fixture
+def tmpmod(tmpdir):
+    """Fresh ``sys.path`` entry + module-cache cleanup, mirroring the
+    fixture in ``test_xontribs.py`` so tests don't leak modules."""
+    sys.path.insert(0, str(tmpdir))
+    loadedmods = set(sys.modules.keys())
+    try:
+        yield tmpdir
+    finally:
+        del sys.path[0]
+        newmods = set(sys.modules.keys()) - loadedmods
+        for m in newmods:
+            del sys.modules[m]
+
+
+class _FakeEntry:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``.  Only
+    the attributes ``find_xontrib``/``xontribs_load`` actually read
+    are populated.
+    """
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+        self.dist = None
+
+
+def _patch_entries(monkeypatch, entries):
+    """Replace the live entry-point iterator with ``entries``."""
+    monkeypatch.setattr(xontribs, "_get_xontrib_entrypoints", lambda: iter(entries))
+
+
+def test_find_xontrib_via_entry_point_without_autoload(tmpmod, monkeypatch):
+    """``find_xontrib`` must consult the entry-point registry, not just
+    the ``autoloaded_xontribs`` cache.  Mirrors the ``--no-rc`` /
+    ``$XONTRIBS_AUTOLOAD_DISABLED`` path where the cache is empty.
+    """
+    # Module the entry point points at — anywhere on sys.path is fine
+    # provided the dotted name resolves.
+    tmpmod.mkdir("ep_pkg").join("loader.py").write(
+        "def _load_xontrib_(xsh): return {'flag': 1}\n"
+    )
+    tmpmod.join("ep_pkg").join("__init__.py").write("")
+    _patch_entries(monkeypatch, [_FakeEntry("ep_pkg_xontrib", "ep_pkg.loader")])
+    spec = find_xontrib("ep_pkg_xontrib")
+    assert spec is not None, "entry-point lookup must succeed"
+    assert spec.name == "ep_pkg.loader"
+
+
+def test_find_xontrib_autoloaded_takes_priority(tmpmod, monkeypatch):
+    """When the same name is both in ``autoloaded_xontribs`` and the
+    entry-point list, the cached value wins (the cache is the primary
+    path during interactive sessions).
+    """
+    tmpmod.mkdir("auto_pkg").join("__init__.py").write("")
+    tmpmod.join("auto_pkg").join("real.py").write(
+        "def _load_xontrib_(xsh): return {}\n"
+    )
+    tmpmod.mkdir("ep_pkg").join("__init__.py").write("")
+    tmpmod.join("ep_pkg").join("other.py").write("def _load_xontrib_(xsh): return {}\n")
+    monkeypatch.setattr(
+        xontribs.XSH.builtins,
+        "autoloaded_xontribs",
+        {"shared_name": "auto_pkg.real"},
+        raising=False,
+    )
+    _patch_entries(monkeypatch, [_FakeEntry("shared_name", "ep_pkg.other")])
+    spec = find_xontrib("shared_name")
+    assert spec.name == "auto_pkg.real"
+
+
+def test_find_xontrib_falls_through_namespace_to_toplevel(tmpmod, monkeypatch):
+    """Pre-fix ``with contextlib.suppress(ValueError): return …`` returned
+    ``None`` from the namespace step and never reached the top-level
+    fallback.  Verify the corrected pass-through.
+    """
+    # No entry point and no ``xontrib.never_in_xontrib_ns`` submodule —
+    # but a top-level ``never_in_xontrib_ns`` module does exist.
+    tmpmod.join("never_in_xontrib_ns.py").write(
+        "def _load_xontrib_(xsh): return {'top_level': True}\n"
+    )
+    _patch_entries(monkeypatch, [])
+    monkeypatch.setattr(xontribs.XSH.builtins, "autoloaded_xontribs", {}, raising=False)
+    spec = find_xontrib("never_in_xontrib_ns")
+    assert spec is not None
+    assert spec.name == "never_in_xontrib_ns"
+
+
+def test_find_xontrib_namespace_package_still_wins(tmpmod, monkeypatch):
+    """A name available as ``xontrib.<name>`` (legacy layout) must still
+    resolve to that namespace submodule, taking priority over a
+    same-named top-level module.
+    """
+    tmpmod.mkdir("xontrib").join("ns_only.py").write(
+        "def _load_xontrib_(xsh): return {'ns': True}\n"
+    )
+    tmpmod.join("ns_only.py").write("def _load_xontrib_(xsh): return {'top': True}\n")
+    _patch_entries(monkeypatch, [])
+    monkeypatch.setattr(xontribs.XSH.builtins, "autoloaded_xontribs", {}, raising=False)
+    spec = find_xontrib("ns_only")
+    assert spec is not None
+    assert spec.name == "xontrib.ns_only"
+
+
+def test_find_xontrib_missing_returns_none(tmpmod, monkeypatch):
+    """A name that exists nowhere must still surface as ``None`` so the
+    ``XontribNotInstalled`` warning fires correctly.
+    """
+    _patch_entries(monkeypatch, [])
+    monkeypatch.setattr(xontribs.XSH.builtins, "autoloaded_xontribs", {}, raising=False)
+    assert find_xontrib("absolutely_no_such_xontrib_xyz") is None
+
+
+def test_xontribs_load_via_entry_point_without_autoload(tmpmod, monkeypatch):
+    """End-to-end: ``xontrib load <name>`` succeeds even when autoload
+    did not run, provided the name has an entry point.  This is the
+    exact symptom from the GH-6386 follow-up: ``xonsh --no-rc`` +
+    ``xontrib load coconut`` used to fail with «not installed» despite
+    coconut being correctly installed.
+    """
+    tmpmod.mkdir("ext_pkg").join("__init__.py").write("")
+    tmpmod.join("ext_pkg").join("xontrib_loader.py").write(
+        "def _load_xontrib_(xsh):\n"
+        "    xsh.ctx['ext_pkg_loaded'] = True\n"
+        "    return {'ext_pkg_loaded': True}\n"
+    )
+    _patch_entries(monkeypatch, [_FakeEntry("ext_xontrib", "ext_pkg.xontrib_loader")])
+    monkeypatch.setattr(xontribs.XSH.builtins, "autoloaded_xontribs", {}, raising=False)
+    stdout, stderr, rc = xontribs_load(["ext_xontrib"])
+    assert rc == xontribs.ExitCode.OK
+    assert stderr is None, f"unexpected stderr: {stderr!r}"
+    assert "ext_pkg.xontrib_loader" in sys.modules

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -125,12 +125,27 @@ def _get_installed_xontribs(pkg_name="xontrib"):
         yield entry.name, Xontrib(entry.value, distribution=entry.dist)
 
 
+def _find_xontrib_entrypoint(name):
+    """Return the ``xonsh.xontribs`` entry point for ``name`` or ``None``.
+
+    Reads the live setuptools entry-point registry rather than the
+    ``XSH.builtins.autoloaded_xontribs`` cache, so xontribs whose only
+    Python-visible name is an entry point (the wheel ships no
+    ``xontrib/<name>.py``) are discoverable even when autoload did not
+    run — e.g. ``xonsh --no-rc`` or ``$XONTRIBS_AUTOLOAD_DISABLED``.
+    """
+    for entry in _get_xontrib_entrypoints():
+        if entry.name == name:
+            return entry
+    return None
+
+
 def find_xontrib(name, full_module=False):
     """Finds a xontribution from its name."""
     _patch_in_userdir()
 
-    # here the order is important. We try to run the correct cases first and then later trial cases
-    # that will likely fail
+    # Order matters. Try the cheap, exact paths first; fall through to
+    # broader matches only when the previous lookup did not find anything.
 
     if name.startswith("."):
         return importlib.util.find_spec(name, package="xontrib")
@@ -138,13 +153,36 @@ def find_xontrib(name, full_module=False):
     if full_module:
         return importlib.util.find_spec(name)
 
+    # 1. Cache populated by ``auto_load_xontribs_from_entrypoints`` at
+    #    startup.  This is the common interactive-shell path.
     autoloaded = getattr(XSH.builtins, "autoloaded_xontribs", None) or {}
     if name in autoloaded:
         return importlib.util.find_spec(autoloaded[name])
 
-    with contextlib.suppress(ValueError):
-        return importlib.util.find_spec("." + name, package="xontrib")
+    # 2. Live entry-point lookup.  Required when autoload did not run
+    #    (``--no-rc``, ``$XONTRIBS_AUTOLOAD_DISABLED``, embedded use,
+    #    xontrib installed mid-session): without this step the only
+    #    Python-visible mapping for entry-point-only xontribs (the
+    #    ``coconut`` xontrib being the canonical example — its loader
+    #    lives in ``coconut.integrations`` and the wheel ships no
+    #    ``xontrib/coconut.py``) is unreachable from ``xontrib load``.
+    entry = _find_xontrib_entrypoint(name)
+    if entry is not None:
+        return importlib.util.find_spec(entry.value)
 
+    # 3. Legacy ``xontrib.<name>`` namespace-package layout.  ``find_spec``
+    #    only raises ``ValueError`` when ``xontrib`` is not a package at
+    #    all; otherwise it returns ``None`` for an absent submodule, in
+    #    which case we must continue to the top-level fallback rather
+    #    than returning that ``None``.  (The pre-fix code returned ``None``
+    #    here and never reached step 4.)
+    spec = None
+    with contextlib.suppress(ValueError):
+        spec = importlib.util.find_spec("." + name, package="xontrib")
+    if spec is not None:
+        return spec
+
+    # 4. Top-level module fallback (``import <name>``).
     return importlib.util.find_spec(name)
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
