### PR TITLE
feat: Show alias description in completion menu

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -390,6 +390,61 @@ that poly fills the "run as Admin" behavior with the help of ``ShellExecuteEx`` 
 command to run.
 
 
+User Aliases with Descriptions
+==============================
+
+Every alias can carry a one-line description. It surfaces in the tab-completion
+dropdown next to the alias name, and in the ``cmd?`` / ``cmd??`` help output.
+
+For callable aliases, the function's docstring is used automatically:
+
+.. code-block:: xonshcon
+
+    @ @aliases.register('qwe')
+      def _qwe():
+          """List files in long format."""
+          ls -la
+
+    @ qw<TAB>
+    qwe  List files in long format.
+
+For string and list aliases — which have nowhere to attach a docstring —
+use the dict form:
+
+.. code-block:: xonshcon
+
+    @ aliases['qwe'] = {'alias': 'ls -la', 'doc': 'List files'}
+    @ aliases |= {
+          'psg':  {'alias': ['ps', 'aux'], 'doc': 'Process list'},
+          'g':    {'alias': 'git',         'doc': 'Git wrapper'},
+      }
+
+The dict form recognises two keys: ``'alias'`` (required, the alias value
+itself — string, list, or callable) and ``'doc'`` (optional, the one-line
+description). Other keys are reserved for future use and currently ignored.
+
+When ``'doc'`` is set on a callable alias, it overrides the function's own
+``__doc__`` — handy for showing a shorter summary in completions while
+keeping a longer docstring in the source:
+
+.. code-block:: xonshcon
+
+    @ def _bar():
+          """Long, detailed description of bar..."""
+          echo bar
+    @ aliases['bar'] = {'alias': _bar, 'doc': 'Short summary'}
+    @ ba<TAB>
+    bar  Short summary
+
+Reassigning an alias without a ``'doc'`` clears the previous description, so
+descriptions never accidentally stick to a different value bound under the
+same name.
+
+By default, the description shows in the dropdown only when the alias has a
+docstring (or an explicit ``'doc'``). To also show the binary path for
+non-alias commands, set ``$CMD_COMPLETIONS_SHOW_DESC = True``.
+
+
 See also
 ========
 

--- a/tests/completers/test_alias_doc_llm.py
+++ b/tests/completers/test_alias_doc_llm.py
@@ -1,0 +1,527 @@
+"""Alias docstring shows up as the completion-dropdown description.
+
+Both ``@aliases.register`` and ``@aliases.return_command`` produce
+``FuncAlias`` instances; the wrapped function's docstring is preserved on
+the alias object, and ``complete_command`` surfaces it as the
+``RichCompletion.description``.
+"""
+
+import pytest
+
+from xonsh.aliases import Aliases
+from xonsh.completers.commands import (
+    _alias_completion_description,
+    complete_command,
+)
+
+
+def _completion(comps, value):
+    """Return the single RichCompletion for ``value`` (assert it's there)."""
+    matches = [c for c in comps if str(c) == value]
+    assert len(matches) == 1, (
+        f"expected exactly one completion for {value!r}, got {matches!r}"
+    )
+    return matches[0]
+
+
+def test_register_with_docstring_shows_description(xession, completion_context_parse):
+    """``@aliases.register("qwe")`` with a docstring → description is the doc."""
+
+    @xession.aliases.register("qwe")
+    def _qwe():
+        """qwe asd ad"""
+        pass
+
+    comps = list(complete_command(completion_context_parse("qw", 2).command))
+    completion = _completion(comps, "qwe")
+    assert completion.description == "qwe asd ad"
+    assert completion.provider == "alias"
+
+
+def test_register_with_trailing_whitespace_in_docstring(
+    xession, completion_context_parse
+):
+    """Trailing whitespace from a single-line docstring is stripped."""
+
+    @xession.aliases.register("foo")
+    def _foo():
+        """foo description here"""
+        pass
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("fo", 2).command)), "foo"
+    )
+    assert completion.description == "foo description here"
+
+
+def test_return_command_alias_with_docstring(xession, completion_context_parse):
+    """``@aliases.return_command`` is a thin marker — the docstring still flows
+    through ``FuncAlias`` to the completion description."""
+
+    @Aliases.return_command
+    def _bar(args):
+        """bar redirects somewhere"""
+        return ["echo", "redirected"] + list(args)
+
+    xession.aliases["bar"] = _bar
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("ba", 2).command)), "bar"
+    )
+    assert completion.description == "bar redirects somewhere"
+    assert completion.provider == "alias"
+
+
+def test_register_then_return_command_combined(xession, completion_context_parse):
+    """Stacking ``@aliases.register`` on top of ``@aliases.return_command``
+    is the canonical way to register a return-command alias — the
+    docstring still surfaces."""
+
+    @xession.aliases.register("baz")
+    @Aliases.return_command
+    def _baz(args):
+        """baz hands off the command"""
+        return ["echo", "hi"]
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("ba", 2).command)), "baz"
+    )
+    assert completion.description == "baz hands off the command"
+
+
+def test_multiline_docstring_uses_first_nonempty_line(
+    xession, completion_context_parse
+):
+    """A PEP 257-style multi-line docstring contributes only the summary
+    line to the dropdown description (which is single-line)."""
+
+    @xession.aliases.register("multi")
+    def _multi():
+        """Summary line.
+
+        Body paragraph that should not appear in the dropdown.
+        """
+        pass
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("mu", 2).command)), "multi"
+    )
+    assert completion.description == "Summary line."
+
+
+def test_indented_first_line_is_dedented(xession, completion_context_parse):
+    """First non-empty line of an indented docstring still produces a
+    clean, unindented summary."""
+
+    @xession.aliases.register("dent")
+    def _dent():
+        """
+        First real line, indented in source.
+        """
+        pass
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("de", 2).command)), "dent"
+    )
+    assert completion.description == "First real line, indented in source."
+
+
+def test_no_docstring_falls_back_to_alias_label_only_when_show_desc(
+    xession, completion_context_parse
+):
+    """Without a docstring: empty description by default; ``"Alias"`` only
+    when ``$CMD_COMPLETIONS_SHOW_DESC`` is on."""
+
+    @xession.aliases.register("nodoc")
+    def _nodoc():
+        pass
+
+    # Default: no docstring, no description.
+    xession.env["CMD_COMPLETIONS_SHOW_DESC"] = False
+    completion = _completion(
+        list(complete_command(completion_context_parse("no", 2).command)), "nodoc"
+    )
+    assert completion.description == ""
+
+    # Opted in: legacy "Alias" placeholder.
+    xession.env["CMD_COMPLETIONS_SHOW_DESC"] = True
+    completion = _completion(
+        list(complete_command(completion_context_parse("no", 2).command)), "nodoc"
+    )
+    assert completion.description == "Alias"
+
+
+def test_docstring_shows_regardless_of_show_desc(xession, completion_context_parse):
+    """Writing a docstring is an explicit opt-in; surface it whether or not
+    ``$CMD_COMPLETIONS_SHOW_DESC`` is enabled."""
+
+    @xession.aliases.register("docalways")
+    def _docalways():
+        """always shown"""
+        pass
+
+    for show_desc in (False, True):
+        xession.env["CMD_COMPLETIONS_SHOW_DESC"] = show_desc
+        completion = _completion(
+            list(complete_command(completion_context_parse("doc", 3).command)),
+            "docalways",
+        )
+        assert completion.description == "always shown"
+
+
+def test_string_and_list_aliases_have_no_description(xession, completion_context_parse):
+    """Plain string and list aliases carry no docstring; description falls
+    back to the legacy behaviour."""
+
+    xession.aliases["lsx"] = ["ls", "-G"]
+    xession.aliases["greppy"] = "echo hi"
+
+    xession.env["CMD_COMPLETIONS_SHOW_DESC"] = True
+    comps = list(complete_command(completion_context_parse("ls", 2).command))
+    assert _completion(comps, "lsx").description == "Alias"
+    comps = list(complete_command(completion_context_parse("gre", 3).command))
+    assert _completion(comps, "greppy").description == "Alias"
+
+
+def test_alias_completion_description_helper_handles_missing_aliases():
+    """The helper tolerates ``aliases=None`` and unknown names."""
+    assert _alias_completion_description(None, "anything") == ""
+
+    aliases = Aliases()
+    assert _alias_completion_description(aliases, "absent") == ""
+
+
+# ---------------------------------------------------------------------------
+# Aliases.get_doc — the underlying API the completer (and ``cmd?``) consume.
+# ---------------------------------------------------------------------------
+
+
+def test_get_doc_funcalias_with_docstring():
+    aliases = Aliases()
+
+    @aliases.register("hello")
+    def _hello():
+        """Greet the world."""
+        pass
+
+    assert aliases.get_doc("hello") == "Greet the world."
+
+
+def test_get_doc_funcalias_without_docstring_returns_empty():
+    """Critical: must NOT leak ``FuncAlias.__doc__`` (the class docstring)."""
+    aliases = Aliases()
+
+    @aliases.register("plain")
+    def _plain():
+        pass
+
+    assert aliases.get_doc("plain") == ""
+
+
+def test_get_doc_string_alias_returns_empty():
+    aliases = Aliases()
+    aliases["echohi"] = "echo hi"
+    assert aliases.get_doc("echohi") == ""
+
+
+def test_get_doc_list_alias_returns_empty():
+    aliases = Aliases()
+    aliases["lsg"] = ["ls", "-G"]
+    assert aliases.get_doc("lsg") == ""
+
+
+def test_get_doc_missing_alias_returns_empty():
+    aliases = Aliases()
+    assert aliases.get_doc("does-not-exist") == ""
+
+
+def test_get_doc_multiline_is_dedented():
+    aliases = Aliases()
+
+    @aliases.register("ml")
+    def _ml():
+        """First line.
+
+        Second paragraph that
+        spans multiple lines.
+        """
+        pass
+
+    expected = "First line.\n\nSecond paragraph that\nspans multiple lines."
+    assert aliases.get_doc("ml") == expected
+
+
+@pytest.mark.parametrize(
+    "decorator_factory",
+    [
+        # @aliases.register("name")
+        lambda aliases: aliases.register("decorated"),
+        # @Aliases.return_command followed by aliases.register
+        lambda aliases: (
+            lambda f: aliases.register("decorated")(Aliases.return_command(f))
+        ),
+    ],
+    ids=["register", "register+return_command"],
+)
+def test_get_doc_works_for_register_and_return_command(decorator_factory):
+    """Single source of truth for both decorator forms — the docstring
+    is preserved through ``FuncAlias`` regardless of ``return_what``."""
+    aliases = Aliases()
+
+    @decorator_factory(aliases)
+    def _decorated(args=None):
+        """decorated alias docstring"""
+        return ["true"]
+
+    assert aliases.get_doc("decorated") == "decorated alias docstring"
+
+
+# ---------------------------------------------------------------------------
+# Click integration — ``@aliases.register_click_command`` flows the user's
+# docstring through ``functools.update_wrapper`` to the wrapper that
+# ``register()`` ultimately wraps in ``FuncAlias``.
+# ---------------------------------------------------------------------------
+
+
+def test_register_click_command_surfaces_docstring(xession, completion_context_parse):
+    """Bare ``@aliases.register_click_command`` (no parens, plain function)."""
+    pytest.importorskip("click")
+
+    @xession.aliases.register_click_command
+    def my_click(ctx):
+        """My click command summary"""
+        pass
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("my", 2).command)), "my-click"
+    )
+    assert completion.description == "My click command summary"
+    assert completion.provider == "alias"
+
+
+def test_register_click_command_with_explicit_name(xession, completion_context_parse):
+    """``@aliases.register_click_command("custom-name")``."""
+    pytest.importorskip("click")
+
+    @xession.aliases.register_click_command("renamed-cmd")
+    def _renamed(ctx):
+        """Renamed click cmd"""
+        pass
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("ren", 3).command)),
+        "renamed-cmd",
+    )
+    assert completion.description == "Renamed click cmd"
+
+
+def test_register_click_command_on_predecorated_click_command(
+    xession, completion_context_parse
+):
+    """Stacking ``@aliases.register_click_command`` on top of an existing
+    ``@click.command()`` chain — the docstring still travels via
+    ``functools.update_wrapper`` and surfaces in the dropdown."""
+    click = pytest.importorskip("click")
+
+    @xession.aliases.register_click_command
+    @click.command()
+    @click.argument("name")
+    def predecorated(ctx, name):
+        """Pre-decorated click command"""
+        pass
+
+    completion = _completion(
+        list(complete_command(completion_context_parse("pre", 3).command)),
+        "predecorated",
+    )
+    assert completion.description == "Pre-decorated click command"
+
+
+def test_register_click_command_get_doc_directly():
+    """Same flow at the ``Aliases.get_doc`` level — independent of the
+    completer pipeline."""
+    pytest.importorskip("click")
+    aliases = Aliases()
+
+    @aliases.register_click_command
+    def hello(ctx):
+        """Hello click cmd"""
+        pass
+
+    assert aliases.get_doc("hello") == "Hello click cmd"
+
+
+# ---------------------------------------------------------------------------
+# Dict-form setter — ``aliases[k] = {"alias": ..., "doc": "..."}``.
+#
+# Lets list/string aliases (which have no ``__doc__`` slot) carry a
+# description, and lets callable aliases override their function's docstring
+# with a different one-line summary. ``__ior__`` / ``|=`` flow through
+# ``__setitem__`` so the same form works for bulk merging.
+# ---------------------------------------------------------------------------
+
+
+def test_dict_form_string_alias_carries_doc():
+    aliases = Aliases()
+    aliases["qwe"] = {"alias": "ls -la", "doc": "All files"}
+    assert aliases.get_doc("qwe") == "All files"
+
+
+def test_dict_form_list_alias_carries_doc():
+    aliases = Aliases()
+    aliases["lsg"] = {"alias": ["ls", "-G"], "doc": "Coloured ls"}
+    assert aliases.get_doc("lsg") == "Coloured ls"
+    assert aliases["lsg"] == ["ls", "-G"]
+
+
+def test_dict_form_overrides_funcalias_docstring():
+    """Explicit ``doc`` wins over the wrapped function's ``__doc__`` —
+    it's the user's one-line summary, takes priority."""
+    aliases = Aliases()
+
+    def _bar():
+        """from docstring"""
+        pass
+
+    aliases["bar"] = {"alias": _bar, "doc": "OVERRIDE"}
+    assert aliases.get_doc("bar") == "OVERRIDE"
+
+
+def test_dict_form_without_doc_falls_back_to_funcalias_docstring():
+    """If ``doc`` is omitted, the alias's own ``__doc__`` is still used —
+    dict-form is purely additive."""
+    aliases = Aliases()
+
+    def _bar():
+        """from docstring"""
+        pass
+
+    aliases["bar"] = {"alias": _bar}
+    assert aliases.get_doc("bar") == "from docstring"
+
+
+def test_dict_form_empty_doc_string_is_treated_as_no_doc():
+    """``"doc": ""`` does not register a description (so a later non-empty
+    function docstring still wins)."""
+    aliases = Aliases()
+
+    def _bar():
+        """from docstring"""
+        pass
+
+    aliases["bar"] = {"alias": _bar, "doc": ""}
+    assert aliases.get_doc("bar") == "from docstring"
+
+
+def test_rewrite_without_doc_clears_stale_doc():
+    """Reassigning a key without an explicit doc must drop the previous
+    dict-form description so it doesn't stick to a different value."""
+    aliases = Aliases()
+    aliases["qwe"] = {"alias": "ls -la", "doc": "All files"}
+    assert aliases.get_doc("qwe") == "All files"
+
+    aliases["qwe"] = "ls"
+    assert aliases.get_doc("qwe") == ""
+
+
+def test_delete_clears_doc():
+    aliases = Aliases()
+    aliases["baz"] = {"alias": "echo hi", "doc": "Greet"}
+    assert aliases.get_doc("baz") == "Greet"
+
+    del aliases["baz"]
+    assert aliases.get_doc("baz") == ""
+    assert "baz" not in aliases._docs
+
+
+def test_ior_propagates_dict_form_doc():
+    """``aliases |= {"k": {"alias": ..., "doc": ...}}`` flows through
+    ``__setitem__`` and ends up in the doc registry."""
+    aliases = Aliases()
+    aliases |= {"foo": {"alias": "ps aux", "doc": "Process list"}}
+    assert aliases.get_doc("foo") == "Process list"
+
+
+def test_or_with_plain_dict_preserves_self_docs_and_applies_other_docs():
+    """``a | {"k": dict-form}`` — produces a new Aliases with self's
+    docs preserved (for non-overridden keys) and other's docs applied."""
+    a = Aliases()
+    a["a"] = {"alias": "ls", "doc": "self-A"}
+    a["b"] = {"alias": "ps", "doc": "self-B"}
+
+    merged = a | {"b": {"alias": "ps -ef", "doc": "other-B"}, "c": "echo"}
+
+    assert merged.get_doc("a") == "self-A"
+    assert merged.get_doc("b") == "other-B"
+    assert merged.get_doc("c") == ""
+
+
+def test_or_with_other_aliases_propagates_other_docs():
+    """When the right operand is itself an ``Aliases`` instance, its docs
+    travel through too — even though ``Aliases.__getitem__`` returns raw
+    values without dict-form wrapping."""
+    a = Aliases()
+    a["a"] = {"alias": "ls", "doc": "self-A"}
+
+    b = Aliases()
+    b["b"] = {"alias": "ps", "doc": "other-B"}
+
+    merged = a | b
+    assert merged.get_doc("a") == "self-A"
+    assert merged.get_doc("b") == "other-B"
+
+
+def test_or_other_overrides_without_doc_drops_self_doc():
+    """If ``other`` overrides a key without supplying a doc, ``self``'s old
+    doc is dropped — it described the previous value, not the name."""
+    a = Aliases()
+    a["k"] = {"alias": "ls", "doc": "self-K"}
+
+    merged = a | {"k": "echo"}
+    assert merged.get_doc("k") == ""
+
+
+def test_ior_with_other_aliases_propagates_docs():
+    a = Aliases()
+    a["a"] = {"alias": "ls", "doc": "self-A"}
+
+    b = Aliases()
+    b["b"] = {"alias": "ps", "doc": "other-B"}
+
+    a |= b
+    assert a.get_doc("a") == "self-A"
+    assert a.get_doc("b") == "other-B"
+
+
+def test_dict_form_completion_description():
+    """End-to-end through the completer: dict-form doc shows up as the
+    ``RichCompletion.description``."""
+    # Use a fresh Aliases instance via xession monkeypatch indirectly —
+    # this test goes straight through ``Aliases.get_doc``, which the
+    # completer helper also calls.
+    aliases = Aliases()
+    aliases["foo"] = {"alias": "ps aux", "doc": "Process list"}
+    assert _alias_completion_description(aliases, "foo") == "Process list"
+
+
+def test_dict_form_extra_keys_ignored():
+    """Unknown keys in the dict-form value are silently ignored — this
+    leaves room for future extensions (e.g. ``"category"``) without
+    breaking existing rc files."""
+    aliases = Aliases()
+    aliases["k"] = {
+        "alias": "ls",
+        "doc": "Listing",
+        "category": "fs",  # not yet meaningful, must not raise
+    }
+    assert aliases.get_doc("k") == "Listing"
+
+
+def test_dict_form_multiline_doc_is_dedented():
+    aliases = Aliases()
+    aliases["k"] = {
+        "alias": "ls",
+        "doc": "Summary line.\n\n    Body paragraph indented in source.",
+    }
+    expected = "Summary line.\n\nBody paragraph indented in source."
+    assert aliases.get_doc("k") == expected

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -237,14 +237,7 @@ def print_alias_help(name: str, superhelp: bool = False) -> None:
     func = getattr(alias, "func", None)
 
     # Docstring is shown for both ``?`` and ``??``.
-    # Read from the underlying function — FuncAlias instance falls through
-    # to the class docstring when the function has no doc.
-    if func is not None:
-        doc = getattr(func, "__doc__", "") or ""
-    elif isinstance(alias, (list, str)):
-        doc = ""
-    else:
-        doc = getattr(alias, "__doc__", "") or ""
+    doc = XSH.aliases.get_doc(name)
     if doc:
         from xonsh.environ import _rst_inline_to_color
 
@@ -541,6 +534,36 @@ class Aliases(cabc.MutableMapping):
         else:
             msg = "alias of {!r} has an inappropriate type: {!r}"
             raise TypeError(msg.format(key, val))
+
+    def get_doc(self, name: str) -> str:
+        """Return the cleaned docstring of an alias.
+
+        For ``FuncAlias`` instances the docstring is read from the wrapped
+        function (``alias.func.__doc__``) — never from the ``FuncAlias``
+        instance, which inherits ``FuncAlias.__doc__`` from the class when
+        the wrapped function has no docstring of its own and would otherwise
+        leak the placeholder ``"Provides a callable alias for xonsh
+        commands."`` into UIs that surface this text.
+
+        List- and string-aliases carry no docstring and yield ``""``. For
+        any other alias object (e.g. ``ArgParserAlias``, ``ExecAlias``)
+        the object's own ``__doc__`` is used.
+
+        The returned string is run through :func:`inspect.cleandoc` so
+        multi-line docstrings have shared indentation removed.
+        """
+        try:
+            alias = self._raw[name]
+        except KeyError:
+            return ""
+        func = getattr(alias, "func", None)
+        if func is not None:
+            doc = getattr(func, "__doc__", None)
+        elif isinstance(alias, (list, str)):
+            return ""
+        else:
+            doc = getattr(alias, "__doc__", None)
+        return inspect.cleandoc(doc) if doc else ""
 
     def expand_alias(self, line: str, cursor_index: int) -> str:
         """Expands any aliases present in line if alias does not point to a

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -282,6 +282,13 @@ class Aliases(cabc.MutableMapping):
 
     def __init__(self, *args, **kwargs):
         self._raw = {}
+        # Per-alias docstring registry. Populated when an alias is assigned
+        # via the dict-form ``aliases[k] = {"alias": ..., "doc": "..."}``
+        # (which lets list/string aliases carry a description), and consumed
+        # by :meth:`get_doc` with priority over the alias object's own
+        # ``__doc__``. Cleared on overwrite/delete so a stale doc never
+        # sticks to a different value bound under the same name.
+        self._docs: dict[str, str] = {}
         self.update(*args, **kwargs)
 
     def __dir__(self):
@@ -538,20 +545,27 @@ class Aliases(cabc.MutableMapping):
     def get_doc(self, name: str) -> str:
         """Return the cleaned docstring of an alias.
 
-        For ``FuncAlias`` instances the docstring is read from the wrapped
-        function (``alias.func.__doc__``) — never from the ``FuncAlias``
-        instance, which inherits ``FuncAlias.__doc__`` from the class when
-        the wrapped function has no docstring of its own and would otherwise
-        leak the placeholder ``"Provides a callable alias for xonsh
-        commands."`` into UIs that surface this text.
+        Resolution order:
 
-        List- and string-aliases carry no docstring and yield ``""``. For
-        any other alias object (e.g. ``ArgParserAlias``, ``ExecAlias``)
-        the object's own ``__doc__`` is used.
+        1. An explicit doc set via the dict-form
+           ``aliases[k] = {"alias": ..., "doc": "..."}`` takes priority
+           over everything else — it's the only way to attach a description
+           to a list/string alias and an intentional override for callable
+           aliases.
+        2. For ``FuncAlias`` instances, the wrapped function's
+           ``__doc__`` (read from ``alias.func`` directly to avoid falling
+           back to ``FuncAlias.__doc__``, which would otherwise leak the
+           class placeholder ``"Provides a callable alias for xonsh
+           commands."``).
+        3. For any other alias object (e.g. ``ArgParserAlias``,
+           ``ExecAlias``), the object's own ``__doc__``.
+        4. List- and string-aliases without an explicit doc yield ``""``.
 
         The returned string is run through :func:`inspect.cleandoc` so
         multi-line docstrings have shared indentation removed.
         """
+        if name in self._docs:
+            return inspect.cleandoc(self._docs[name])
         try:
             alias = self._raw[name]
         except KeyError:
@@ -588,6 +602,18 @@ class Aliases(cabc.MutableMapping):
         return self._raw[key]
 
     def __setitem__(self, key, val):
+        # Dict-form: ``aliases[k] = {"alias": <value>, "doc": "..."}``.
+        # Lets list/string aliases (which carry no ``__doc__``) advertise a
+        # description for tab-completion and ``cmd?``. Also overrides the
+        # ``__doc__`` of a function/FuncAlias when the user wants a
+        # different one-line summary than the function's docstring.
+        # Recognised keys: "alias" (required), "doc" (optional). Any other
+        # keys are reserved for future use and currently ignored.
+        explicit_doc: str | None = None
+        if isinstance(val, dict) and "alias" in val:
+            explicit_doc = val.get("doc") or None
+            val = val["alias"]
+
         if isinstance(val, str):
             f = "<exec-alias:" + key + ">"
             if EXEC_ALIAS_RE.search(val) is not None:
@@ -605,11 +631,32 @@ class Aliases(cabc.MutableMapping):
         else:
             self._raw[key] = val
 
+        # Update the per-alias doc registry. Always clear first so a
+        # rewrite without ``"doc"`` doesn't leave a stale description from
+        # a prior dict-form assignment.
+        self._docs.pop(key, None)
+        if explicit_doc:
+            self._docs[key] = explicit_doc
+
     def _common_or(self, other):
         new_dict = self._raw.copy()
         for key in dict(other):
             new_dict[key] = other[key]
-        return Aliases(new_dict)
+        result = Aliases(new_dict)
+        # ``Aliases(new_dict)`` re-feeds every entry through ``__setitem__``,
+        # which clears any per-key doc — so docs that came from ``self._docs``
+        # or from ``other._docs`` (when ``other`` is itself an ``Aliases``)
+        # need to be re-applied here. Keys whose values came from ``other``
+        # surrender their old doc unless ``other`` supplies a new one,
+        # mirroring ``__ior__`` semantics.
+        other_keys = set(dict(other))
+        for key, doc in self._docs.items():
+            if key not in other_keys:
+                result._docs.setdefault(key, doc)
+        if isinstance(other, Aliases):
+            for key, doc in other._docs.items():
+                result._docs[key] = doc
+        return result
 
     def __or__(self, other):
         return self._common_or(other)
@@ -620,10 +667,18 @@ class Aliases(cabc.MutableMapping):
     def __ior__(self, other):
         for key in dict(other):
             self[key] = other[key]
+        # When ``other`` is an ``Aliases``, ``other[key]`` returns the raw
+        # alias (FuncAlias / list / string) — its dict-form is gone, so any
+        # docs in ``other._docs`` were not propagated through __setitem__.
+        # Apply them now so an Aliases-to-Aliases merge keeps descriptions.
+        if isinstance(other, Aliases):
+            for key, doc in other._docs.items():
+                self._docs[key] = doc
         return self
 
     def __delitem__(self, key):
         del self._raw[key]
+        self._docs.pop(key, None)
 
     def update(self, *args, **kwargs):
         for key, val in dict(*args, **kwargs).items():

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -22,6 +22,27 @@ END_PROC_TOKENS = ("|", ";", "&&")  # includes ||
 END_PROC_KEYWORDS = {"and", "or"}
 
 
+def _alias_completion_description(aliases, name: str) -> str:
+    """Return the first non-empty line of the alias docstring, or ``""``.
+
+    The completion dropdown's ``display_meta`` is rendered as a single line
+    (prompt-toolkit replaces newlines with spaces in
+    ``PromptToolkitCompleter.get_completions``), so a multi-line docstring is
+    summarised down to its first non-empty line — typically the docstring's
+    one-line summary in PEP 257 style.
+    """
+    if aliases is None:
+        return ""
+    doc = aliases.get_doc(name)
+    if not doc:
+        return ""
+    for line in doc.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
 def complete_command(command: CommandContext):
     """
     Returns a list of valid commands starting with the first argument
@@ -29,9 +50,22 @@ def complete_command(command: CommandContext):
 
     cmd = command.prefix
     show_desc = (XSH.env or {}).get("CMD_COMPLETIONS_SHOW_DESC", False)
+    aliases = XSH.aliases
     for s, (path, is_alias) in XSH.commands_cache.iter_commands():
         if get_filter_function()(s, cmd):
-            description = ("Alias" if is_alias else path) if show_desc else ""
+            description = ""
+            if is_alias:
+                # Surface the alias docstring as the dropdown description
+                # whenever the user wrote one — the docstring is an explicit
+                # opt-in, so showing it doesn't depend on
+                # ``$CMD_COMPLETIONS_SHOW_DESC``. Fall back to the static
+                # ``"Alias"`` label only when descriptions are explicitly
+                # enabled and there is no docstring to show.
+                description = _alias_completion_description(aliases, s)
+                if not description and show_desc:
+                    description = "Alias"
+            elif show_desc:
+                description = path
             yield RichCompletion(
                 s,
                 append_space=True,


### PR DESCRIPTION
### Before

```xsh
@aliases.register("qwe")
# or @aliases.return_command
# or @aliases.register_click_command
def _qwe():
    """This is qwe."""
    pass

qw<Tab>
# qwe
```
```xsh
aliases['asd'] = 'ls -la'
as<Tab>
# asd
```

### After

```xsh
qw<Tab>
# qwe - This is qwe.
```

```xsh
aliases['asd'] = {"alias": "ls -la", "doc":"All files."}
as<Tab>
# asd - All files.
```

* Closes https://github.com/xonsh/xonsh/issues/6083
* cc https://github.com/xonsh/xonsh/issues/5998

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
