### PR TITLE
feat: Xonsh code formatter alpha version. Run `xonsh format file.xsh`

### DIFF
--- a/docs/editors.rst
+++ b/docs/editors.rst
@@ -96,3 +96,16 @@ There is `xonsh syntax file for vim`_. To install run:
     git clone --depth 1 https://github.com/linkinpark342/xonsh-vim ~/.vim
 
 .. _xonsh syntax file for vim: https://github.com/linkinpark342/xonsh-vim
+
+
+Formatting xonsh code
+=====================
+
+Xonsh ships a built-in code formatter accessible as the ``xonsh format``
+subcommand. It can be wired into any editor that lets you pipe the
+current buffer through an external command — point the editor at
+``xonsh format -`` to read the buffer from stdin and replace it with
+the formatted output.
+
+See :ref:`formatting_xonsh_code` for the full set of invocations and
+flags.

--- a/docs/xonsh_projects.rst
+++ b/docs/xonsh_projects.rst
@@ -65,3 +65,47 @@ above, the session setup is as follows:
     del setup
 
 Enjoy!
+
+.. _formatting_xonsh_code:
+
+Formatting xonsh code
+=====================
+Xonsh ships a built-in formatter, available as the ``xonsh format``
+subcommand. It re-emits the source with normalized indentation,
+spacing and blank-line rules while preserving every xonsh-specific
+construct.
+
+Format a single file in place:
+
+.. code-block:: console
+
+    @ xonsh format mypkg/tell.xsh
+
+Format several files at once — every path that needs reformatting is
+rewritten on disk, and a status line is printed for each:
+
+.. code-block:: console
+
+    @ xonsh format mypkg/tell.xsh mypkg/subpkg/b.xsh
+
+Read from standard input and write the result to standard output —
+the canonical way to produce a separate output file or to plug the
+formatter into an editor / pipeline:
+
+.. code-block:: console
+
+    @ xonsh format - < 1.xsh > 2.xsh
+
+Useful flags:
+
+* ``--check`` — don't touch any files. Exits with code ``1`` if at
+  least one file would be reformatted, ``0`` otherwise. Handy for CI.
+* ``--diff`` — print a unified diff for each file that would change,
+  again without touching disk.
+* ``-q`` / ``--quiet`` — suppress per-file status messages on stderr.
+
+For example, to fail a CI job when any file needs reformatting:
+
+.. code-block:: console
+
+    @ xonsh format --check mypkg

--- a/tests/format/test_formatter_cli_llm.py
+++ b/tests/format/test_formatter_cli_llm.py
@@ -1,0 +1,173 @@
+"""Tests for ``xonsh format`` CLI behaviour.
+
+Mirrors Black's CLI conventions: in-place by default, ``--check`` for
+non-zero exit on would-be reformat, ``--diff`` for unified-diff output,
+``-`` for stdin/stdout streaming.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from xonsh.formatter import cli as fcli
+
+
+def _run(argv, capsys, monkeypatch, stdin_text=None):
+    """Invoke the formatter CLI and capture stdout/stderr/exit."""
+    if stdin_text is not None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
+    rc = fcli.main(argv)
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+# ---------------------------------------------------------------------
+# In-place writes
+# ---------------------------------------------------------------------
+
+
+def test_in_place_rewrites_file(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x=1\n")
+    rc, out, err = _run([str(f)], capsys, monkeypatch)
+    assert rc == fcli.EXIT_OK
+    assert f.read_text() == "x = 1\n"
+    assert "reformatted" in err
+
+
+def test_in_place_unchanged_file(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x = 1\n")
+    rc, out, err = _run([str(f)], capsys, monkeypatch)
+    assert rc == fcli.EXIT_OK
+    assert "unchanged" in err
+
+
+def test_quiet_suppresses_status(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x=1\n")
+    rc, out, err = _run([str(f), "-q"], capsys, monkeypatch)
+    assert rc == fcli.EXIT_OK
+    assert err == ""
+
+
+# ---------------------------------------------------------------------
+# --check
+# ---------------------------------------------------------------------
+
+
+def test_check_flags_changes_with_exit_one(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x=1\n")
+    rc, out, err = _run([str(f), "--check"], capsys, monkeypatch)
+    assert rc == fcli.EXIT_CHANGED
+    # File must NOT be modified by --check.
+    assert f.read_text() == "x=1\n"
+    assert "would reformat" in err
+
+
+def test_check_clean_file_exits_zero(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x = 1\n")
+    rc, out, err = _run([str(f), "--check"], capsys, monkeypatch)
+    assert rc == fcli.EXIT_OK
+
+
+# ---------------------------------------------------------------------
+# --diff
+# ---------------------------------------------------------------------
+
+
+def test_diff_emits_unified_diff(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x=1\n")
+    rc, out, err = _run([str(f), "--diff"], capsys, monkeypatch)
+    assert rc == fcli.EXIT_CHANGED
+    # File must NOT be modified by --diff.
+    assert f.read_text() == "x=1\n"
+    assert "-x=1" in out
+    assert "+x = 1" in out
+
+
+# ---------------------------------------------------------------------
+# Stdin via "-"
+# ---------------------------------------------------------------------
+
+
+def test_stdin_dash_writes_to_stdout(capsys, monkeypatch):
+    rc, out, err = _run(["-"], capsys, monkeypatch, stdin_text="x=1\n")
+    assert rc == fcli.EXIT_OK
+    assert out == "x = 1\n"
+
+
+def test_stdin_dash_check_mode(capsys, monkeypatch):
+    rc, out, err = _run(["-", "--check"], capsys, monkeypatch, stdin_text="x=1\n")
+    assert rc == fcli.EXIT_CHANGED
+
+
+def test_stdin_dash_check_clean(capsys, monkeypatch):
+    rc, out, err = _run(["-", "--check"], capsys, monkeypatch, stdin_text="x = 1\n")
+    assert rc == fcli.EXIT_OK
+
+
+# ---------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------
+
+
+def test_missing_file_exits_with_error_code(tmp_path, capsys, monkeypatch):
+    rc, out, err = _run([str(tmp_path / "does_not_exist.xsh")], capsys, monkeypatch)
+    assert rc == fcli.EXIT_ERROR
+    assert "error" in err
+
+
+def test_unparseable_file_exits_with_error_code(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "bad.xsh"
+    # EOF inside an open paren — the tokenizer raises TokenError,
+    # which the formatter wraps as FormatError.
+    f.write_text("x = (1 + \n")
+    rc, out, err = _run([str(f)], capsys, monkeypatch)
+    assert rc == fcli.EXIT_ERROR
+    # File must NOT be modified when tokenization fails.
+    assert f.read_text() == "x = (1 + \n"
+
+
+# ---------------------------------------------------------------------
+# Multi-file handling
+# ---------------------------------------------------------------------
+
+
+def test_multiple_files_one_dirty(tmp_path, capsys, monkeypatch):
+    a = tmp_path / "a.xsh"
+    b = tmp_path / "b.xsh"
+    a.write_text("x = 1\n")  # clean
+    b.write_text("y=2\n")  # dirty
+    rc, out, err = _run([str(a), str(b), "--check"], capsys, monkeypatch)
+    assert rc == fcli.EXIT_CHANGED
+    assert a.read_text() == "x = 1\n"
+    assert b.read_text() == "y=2\n"
+
+
+def test_multiple_files_in_place_writes_dirty(tmp_path, capsys, monkeypatch):
+    a = tmp_path / "a.xsh"
+    b = tmp_path / "b.xsh"
+    a.write_text("x = 1\n")
+    b.write_text("y=2\n")
+    rc, out, err = _run([str(a), str(b)], capsys, monkeypatch)
+    assert rc == fcli.EXIT_OK
+    assert a.read_text() == "x = 1\n"
+    assert b.read_text() == "y = 2\n"
+
+
+# ---------------------------------------------------------------------
+# argparse help / no-files behaviour
+# ---------------------------------------------------------------------
+
+
+def test_no_files_errors():
+    """argparse must reject an empty argument list."""
+    with pytest.raises(SystemExit):
+        fcli.main([])

--- a/tests/format/test_formatter_llm.py
+++ b/tests/format/test_formatter_llm.py
@@ -1,0 +1,721 @@
+"""Tests for the xonsh formatter engine (``xonsh.formatter.core``)."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from xonsh.formatter import format_source
+from xonsh.formatter.core import FormatError
+from xonsh.parsers.tokenize import (
+    DEDENT,
+    ENCODING,
+    ENDMARKER,
+    INDENT,
+    NEWLINE,
+    NL,
+    tokenize,
+)
+
+
+def _token_skeleton(src: str) -> list[tuple[int, str]]:
+    """Return ``[(token_type, token_string)]`` for ``src``, dropping
+    whitespace-bearing tokens whose value the formatter is allowed to
+    rewrite (INDENT spelling, NL placement, ENCODING). The remaining
+    sequence must be invariant under formatting if the formatter is
+    behaving correctly."""
+    skip = {ENCODING, INDENT, DEDENT, NEWLINE, NL, ENDMARKER}
+    out = []
+    if not src.endswith("\n"):
+        src = src + "\n"
+    rl = io.BytesIO(src.encode("utf-8")).readline
+    for tok in tokenize(rl, tolerant=True):
+        if tok.type in skip:
+            continue
+        out.append((tok.type, tok.string))
+    return out
+
+
+# ---------------------------------------------------------------------
+# Basic spacing / operators
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        ("x=1\n", "x = 1\n"),
+        ("x  =   1\n", "x = 1\n"),
+        ("x = 1\n", "x = 1\n"),
+        ("a==b\n", "a == b\n"),
+        ("a!=b\n", "a != b\n"),
+        ("a+=1\n", "a += 1\n"),
+        ("a*=2\n", "a *= 2\n"),
+        ("a:=1\n", "a := 1\n"),
+        ("def f()->None: pass\n", "def f() -> None: pass\n"),
+    ],
+)
+def test_assignment_and_comparison_get_spaces(src, expected):
+    # ``a>=b`` / ``a<=b`` without surrounding whitespace are *not*
+    # in this list: the xonsh tokenizer treats ``name>`` as an
+    # IO-redirect token (think ``2>err``), so a bare ``a>=b`` cannot
+    # be losslessly distinguished from a redirect at the token level.
+    # When the user writes proper xonsh comparisons (with at least one
+    # space — ``a >= b``) the operator arrives as a single OP token
+    # and the formatter handles it; that case is exercised by
+    # :func:`test_comparison_with_whitespace_kept` below.
+    assert format_source(src) == expected
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "a >= b\n",
+        "a <= b\n",
+        "a > b\n",
+        "a < b\n",
+    ],
+)
+def test_comparison_with_whitespace_kept(src):
+    assert format_source(src) == src
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "f(x=1)\n",
+        "def f(x=1): pass\n",
+        "def f(a, b=2, c=3): pass\n",
+        "lambda x=1: x\n",
+        "lambda: 1\n",
+        "lambda x, y=2: x + y\n",
+    ],
+)
+def test_kwargs_and_defaults_keep_glued_equals(src):
+    """``=`` inside parens or in ``lambda`` params must stay glued."""
+    assert format_source(src) == src
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        ("a,b,c\n", "a, b, c\n"),
+        ("a , b , c\n", "a, b, c\n"),
+        ("a;b;c\n", "a; b; c\n"),
+        ("(a,)\n", "(a,)\n"),  # trailing comma before closer
+        ("[1,2,3]\n", "[1, 2, 3]\n"),
+        ("f( x , y )\n", "f(x, y)\n"),
+        ("{ 'a' : 1 , 'b' : 2 }\n", "{'a': 1, 'b': 2}\n"),
+    ],
+)
+def test_comma_semicolon_spacing(src, expected):
+    assert format_source(src) == expected
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "a[1:2]\n",
+        "a[1:2:3]\n",
+        "a[:5]\n",
+        "a[::-1]\n",
+        "a[i:j, k:l]\n",
+    ],
+)
+def test_slice_colons_stay_glued(src):
+    assert format_source(src) == src
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        ("{a:1}\n", "{a: 1}\n"),
+        ("{a:1, b:2}\n", "{a: 1, b: 2}\n"),
+        ("def f(x:int, y:str): pass\n", "def f(x: int, y: str): pass\n"),
+    ],
+)
+def test_colon_in_dict_or_annotation_gets_space_after(src, expected):
+    assert format_source(src) == expected
+
+
+# ---------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # Comment bodies are preserved byte-for-byte. Users routinely
+        # keep commented-out code as ``#def foo():`` and the formatter
+        # must not insert a space after ``#``.
+        "#hello\n",
+        "# hello\n",
+        "#  hello\n",
+        "#\n",
+        "#def _foo(args):\n",
+        "#class Bar:\n",
+        "#noqa\n",
+        "#:\n",
+        "# -*- coding: utf-8 -*-\n",
+    ],
+)
+def test_comment_body_preserved_verbatim(src):
+    assert format_source(src) == src
+
+
+def test_shebang_preserved():
+    src = "#!/usr/bin/env xonsh\nx = 1\n"
+    assert format_source(src) == src
+
+
+def test_inline_comment_gets_two_spaces_padding_only():
+    """The *padding* before an inline comment is normalized to two
+    spaces (PEP 8), but the comment body itself is left untouched."""
+    src = "x = 1 # ok\n"
+    assert format_source(src) == "x = 1  # ok\n"
+
+    src2 = "x = 1  #ok\n"
+    # Body kept as-is — including the missing space after ``#``.
+    assert format_source(src2) == "x = 1  #ok\n"
+
+
+def test_trailing_comment_outside_block_indented_at_outer_level():
+    src = "def f():\n    pass\n# trailing\n"
+    expected = "def f():\n    pass\n# trailing\n"
+    assert format_source(src) == expected
+
+
+def test_comment_between_methods_at_class_level():
+    src = (
+        "class C:\n"
+        "    def a(self):\n"
+        "        pass\n"
+        "    # between\n"
+        "    def b(self):\n"
+        "        pass\n"
+    )
+    out = format_source(src)
+    # The "# between" line must be at 1-level indent (4 spaces),
+    # not 2-level.
+    assert "    # between\n" in out
+    assert "        # between\n" not in out
+
+
+def test_tab_indented_comment_in_space_indented_file():
+    """Mixed tab/space indentation: a comment indented with a single
+    TAB in a file whose code uses four-space indentation must resolve
+    to indent level 1 (one tab = one level), not get stranded at
+    column 0 because a single tab character is shorter than the
+    detected source-indent width."""
+    src = (
+        "def install_mac():\n"
+        "    if cond:\n"
+        "        printx('hello')\n"
+        "\t# comment indented with a tab\n"
+        "        body()\n"
+    )
+    expected = (
+        "def install_mac():\n"
+        "    if cond:\n"
+        "        printx('hello')\n"
+        "    # comment indented with a tab\n"
+        "        body()\n"
+    )
+    assert format_source(src) == expected
+
+
+def test_leading_comment_in_function_body():
+    src = "def f():\n    # leading\n    pass\n"
+    out = format_source(src)
+    assert "    # leading\n" in out
+
+
+# ---------------------------------------------------------------------
+# Indentation
+# ---------------------------------------------------------------------
+
+
+def test_tabs_normalized_to_four_spaces():
+    src = "def f():\n\tif x:\n\t\treturn 1\n"
+    out = format_source(src)
+    assert "\t" not in out
+    assert "    if x:\n" in out
+    assert "        return 1\n" in out
+
+
+def test_two_space_indent_renormalized_to_four():
+    src = "def f():\n  if x:\n    return 1\n"
+    out = format_source(src)
+    assert "    if x:\n" in out
+    assert "        return 1\n" in out
+
+
+def test_custom_indent():
+    src = "def f():\n    pass\n"
+    out = format_source(src, indent="  ")
+    assert "  pass\n" in out
+
+
+# ---------------------------------------------------------------------
+# Blank lines
+# ---------------------------------------------------------------------
+
+
+def test_excess_top_level_blank_lines_collapsed_to_two():
+    src = "x = 1\n\n\n\n\ny = 2\n"
+    assert format_source(src) == "x = 1\n\n\ny = 2\n"
+
+
+def test_excess_nested_blank_lines_collapsed_to_one():
+    src = "def f():\n    a = 1\n\n\n\n    b = 2\n"
+    assert format_source(src) == "def f():\n    a = 1\n\n    b = 2\n"
+
+
+def test_trailing_newlines_collapsed_to_single():
+    src = "x = 1\n\n\n\n"
+    assert format_source(src) == "x = 1\n"
+
+
+def test_missing_trailing_newline_added():
+    src = "x = 1"
+    assert format_source(src) == "x = 1\n"
+
+
+def test_empty_source():
+    assert format_source("") == ""
+
+
+# ---------------------------------------------------------------------
+# Trailing whitespace
+# ---------------------------------------------------------------------
+
+
+def test_trailing_whitespace_stripped():
+    src = "x = 1   \ny = 2\t\n"
+    assert format_source(src) == "x = 1\ny = 2\n"
+
+
+# ---------------------------------------------------------------------
+# xonsh-specific syntax preservation
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "x = $(ls -la)\n",
+        "x = $[ls -la]\n",
+        "x = !(grep py)\n",
+        "x = ![grep py]\n",
+        "echo ${HOME}\n",
+        "x = @(some_var)\n",
+        "x = @$(echo a)\n",
+        "echo a && echo b\n",
+        "echo a || echo b\n",
+        "cat file.txt | grep py\n",
+        "cmd > out.txt\n",
+        "cmd 2> err.txt\n",
+        "cmd >> out.txt\n",
+        "cmd 2>&1\n",
+    ],
+)
+def test_xonsh_subprocess_syntax_preserved(src):
+    """xonsh-specific tokens must round-trip unchanged."""
+    assert format_source(src) == src
+
+
+def test_glob_path_preserved():
+    # Search-path glob token (g`...`, p`...`, r`...`)
+    src = "for f in g`*.py`:\n    print(f)\n"
+    assert format_source(src) == src
+
+
+def test_nested_subprocess_preserved():
+    src = "x = $(echo $(date))\n"
+    assert format_source(src) == src
+
+
+def test_subprocess_inside_python_expr():
+    src = "x = [f for f in $(ls).split()]\n"
+    assert format_source(src) == src
+
+
+# ---------------------------------------------------------------------
+# Subprocess statements & macros (https://xon.sh/macros.html)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # ``--flag=value`` arguments stay glued — no ``=`` spacing.
+        "echo 1 2 --qwe=123\n",
+        "cmd --flag=value other\n",
+        "cmd -a -b -c\n",
+        "cmd -aBC --long-flag\n",
+    ],
+)
+def test_subprocess_keeps_kwarg_flags_glued(src):
+    assert format_source(src) == src
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        # Multiple spaces between subprocess args collapse to one,
+        # mirroring the behaviour of ``$(...)`` captures and matching
+        # the shell's own treatment of inter-arg whitespace.
+        (
+            'echo 123          @("""hello {x}""")\n',
+            'echo 123 @("""hello {x}""")\n',
+        ),
+        ("echo a   b --flag=v\n", "echo a b --flag=v\n"),
+        ("cmd  arg1   arg2\n", "cmd arg1 arg2\n"),
+        # Inside an ``if`` body — heuristic still fires.
+        (
+            "if x:\n    echo a   b --flag=v\n",
+            "if x:\n    echo a b --flag=v\n",
+        ),
+    ],
+)
+def test_subprocess_collapses_inter_arg_whitespace(src, expected):
+    assert format_source(src) == expected
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # Alias macro (``name!``): the args after the bang are raw text
+        # — runs of whitespace between them must be preserved.
+        "echo! 1   2\n",
+        "echo!  hello   world\n",
+        # Function macro ``name!(args)`` — body is raw text.
+        "f!(any  raw  text)\n",
+        "f!(no   change   here)\n",
+    ],
+)
+def test_macros_keep_args_verbatim(src):
+    assert format_source(src) == src
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # Block macro: ``with! ctx:`` — the bang is glued to ``with``,
+        # the keyword-force-space rule must not pry them apart.
+        "with! qwe:\n    pass\n",
+        # Bang glued to NAME (alias macro) — already handled by
+        # alias-macro detection, included here for completeness.
+        "echo!stuff\n",
+    ],
+)
+def test_glued_bang_macro_marker_keeps_no_space(src):
+    assert format_source(src) == src
+
+
+def test_user_written_spaces_around_subproc_equals_preserved():
+    """``--flag = value`` (with user-typed spaces around ``=``) keeps
+    its shape — neither added nor removed by the formatter."""
+    src = "echo 1 2 --qwe = 123\n"
+    assert format_source(src) == src
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        # Single ``\``-continuation: replace whatever leading
+        # whitespace the user typed on the continuation line with the
+        # standard indent (one level past the statement's base).
+        (
+            "echo 1 2 \\\n --qwe=123\n",
+            "echo 1 2 \\\n    --qwe=123\n",
+        ),
+        (
+            "cmd 1 2 \\\n          --qwe=123\n",
+            "cmd 1 2 \\\n    --qwe=123\n",
+        ),
+        # Multiple chained continuations.
+        (
+            "echo 1 2 \\\n --qwe --qwe \\\n          --asd=123\n",
+            "echo 1 2 \\\n    --qwe --qwe \\\n    --asd=123\n",
+        ),
+        # Continuation inside a nested block — indent goes one level
+        # deeper than the surrounding ``def``/``if`` body.
+        (
+            "if x:\n    echo 1 \\\n        --flag=v\n",
+            "if x:\n    echo 1 \\\n        --flag=v\n",
+        ),
+    ],
+)
+def test_subprocess_continuation_uses_standard_indent(src, expected):
+    assert format_source(src) == expected
+
+
+def test_subprocess_capture_collapses_inner_whitespace():
+    """``$(...)`` and ``!(...)`` capture *expressions* (Python value =
+    captured pipeline) get the regular paren-aware Python rules — runs
+    of whitespace between args collapse to a single space, while string
+    contents and ``--flag=value`` syntax are preserved by the existing
+    rules. ``@(...)`` switches back to a fully Python eval, so its
+    leading whitespace also collapses."""
+    src = '$(echo 1 2 --qwe="        123"        --asd=@(      f"{$HOME}"))\n'
+    expected = '$(echo 1 2 --qwe="        123" --asd=@(f"{$HOME}"))\n'
+    assert format_source(src) == expected
+
+
+def test_subprocess_capture_preserves_strings_and_kwargs():
+    src = '$(cmd --flag="a   b" other)\n'
+    assert format_source(src) == src
+
+
+def test_bang_capture_collapses_inner_whitespace():
+    src = "!(echo a    b)\n"
+    assert format_source(src) == "!(echo a b)\n"
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        # ``or`` aligned with ``if``: same column under both.
+        (
+            "    if (a) \\\n    or (b):\n        pass\n",
+            "    if (a) \\\n    or (b):\n        pass\n",
+        ),
+        # Continuation 4 spaces deeper than the statement's indent.
+        (
+            "    if (a) \\\n        or (b):\n        pass\n",
+            "    if (a) \\\n        or (b):\n        pass\n",
+        ),
+        # Top level, continuation indented one level.
+        (
+            "if (a) \\\n    or (b):\n    pass\n",
+            "if (a) \\\n    or (b):\n    pass\n",
+        ),
+        # 12-space source indent (3 indent units of 4 chars each in the
+        # source's own scheme): formatter normalizes to 4-space indent,
+        # the continuation must stay aligned with the normalized
+        # statement indent, not stranded at the original source column.
+        (
+            "            if (a) \\\n            or (b):\n                pass\n",
+            "    if (a) \\\n    or (b):\n        pass\n",
+        ),
+    ],
+)
+def test_python_backslash_continuation_alignment_preserved(src, expected):
+    assert format_source(src) == expected
+
+
+def test_subproc_line_with_triple_quoted_fstring_arg_preserved():
+    """A subprocess line that takes a multi-line triple-quoted f-string
+    as one of its arguments must round-trip: the xonsh tokenizer
+    reports inverted positions for multi-line ``FSTRING_MIDDLE`` tokens
+    (start col > end col), and previously the verbatim ``_raw_between``
+    mode in subprocess context would synthesize a fake "gap" out of
+    those positions and end up duplicating the entire f-string body.
+    Now the f-string-segment glue rule wins over any verbatim mode."""
+    src = (
+        'docker run --rm -it -h @(host) xonsh/xonsh bash -lc @(f"""\n'
+        "    set -e\n"
+        "    git clone --depth 1 --branch {branch} {url} /tmp/xonsh\n"
+        "    exec bash\n"
+        '    """)\n'
+    )
+    assert format_source(src) == src
+
+
+def test_dollar_subscript_at_top_level_assignment():
+    """``$VAR = 'value'`` is a Python-level env assignment — gets the
+    usual ``=`` spacing, not subprocess treatment."""
+    src = "$PATH='/usr/bin'\n"
+    assert format_source(src) == "$PATH = '/usr/bin'\n"
+
+
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        # Plain Python lines must NOT be misclassified as subprocess
+        # — the ``=`` rule and the indent / comma normalisation should
+        # apply as usual.
+        ("x=1\n", "x = 1\n"),
+        ("x = 1\n", "x = 1\n"),
+        ("f(x=1)\n", "f(x=1)\n"),
+        ("a.b.c\n", "a.b.c\n"),
+        ("x and y\n", "x and y\n"),
+        ("x or y\n", "x or y\n"),
+        ("x is None\n", "x is None\n"),
+        ("x in s\n", "x in s\n"),
+        ("x not in s\n", "x not in s\n"),
+        ("x - 1\n", "x - 1\n"),
+        ("x + y\n", "x + y\n"),
+        ("True == False\n", "True == False\n"),
+        ("if x:\n    pass\n", "if x:\n    pass\n"),
+        ("lambda x=1: x\n", "lambda x=1: x\n"),
+        (
+            "match foo:\n    case _:\n        pass\n",
+            "match foo:\n    case _:\n        pass\n",
+        ),
+        ("type X = int\n", "type X = int\n"),
+    ],
+)
+def test_python_lines_not_misclassified_as_subprocess(src, expected):
+    assert format_source(src) == expected
+
+
+def test_env_var_assignment():
+    src = "$PATH = '/usr/bin'\n"
+    assert format_source(src) == src
+
+
+# ---------------------------------------------------------------------
+# F-strings
+# ---------------------------------------------------------------------
+
+
+def test_fstring_preserved():
+    src = 'x = f"hello {name}"\n'
+    assert format_source(src) == src
+
+
+def test_fstring_with_format_spec():
+    src = 'x = f"{value:>10.2f}"\n'
+    assert format_source(src) == src
+
+
+def test_fstring_double_brace_escape_preserved():
+    """``{{`` and ``}}`` are the f-string escapes for literal braces.
+
+    The tokenizer emits ``FSTRING_MIDDLE`` with the *decoded* value
+    (one brace, not two), so a naive emitter would silently change
+    the format string. The formatter must extract the original source
+    bytes for ``FSTRING_MIDDLE`` to keep the escapes intact.
+    """
+    src = 'x = f"{{{name}}}{value}{{LITERAL}}"\n'
+    assert format_source(src) == src
+
+
+def test_fstring_format_spec_with_braces_preserved():
+    src = 'x = f"|{{:<{width}}}|"\n'
+    assert format_source(src) == src
+
+
+def test_fstring_colon_between_expressions_preserved():
+    """``f"{a}:{b}"`` has a literal ``:`` between two interpolations.
+
+    That ``:`` arrives as a 1-character ``FSTRING_MIDDLE`` token and
+    must not trigger the dict-colon spacing rule.
+    """
+    src = 'x = f"{a}:{b}"\n'
+    assert format_source(src) == src
+
+
+def test_inline_comment_after_opener_keeps_padding():
+    """Inline trailing comment after ``(`` must keep its 2-space gap,
+    not get glued by the no-space-after-opener rule."""
+    src = "f(  # opener comment\n    x,\n)\n"
+    out = format_source(src)
+    assert "(  # opener comment" in out
+
+
+def test_inline_comment_after_dollar_capture_in_string():
+    """Regression: xonsh's tokenizer can emit a ``COMMENT`` token whose
+    value carries a stray leading space when a ``$(...)`` capture
+    appeared earlier inside a string literal. The formatter must not
+    double-count that into the inter-token padding."""
+    src = '''script = """
+$(echo)
+"""
+@deco(x=1)  # comment
+def f():
+    pass
+'''
+    out = format_source(src)
+    # Exactly two spaces (PEP 8 inline-comment padding), not three.
+    assert "@deco(x=1)  # comment" in out
+    assert "@deco(x=1)   # comment" not in out
+
+
+def test_triple_quoted_fstring_with_brace_escapes_preserved():
+    # Multi-line triple-quoted f-strings with literal-brace escapes
+    # must not lose content. The xonsh tokenizer reports bogus end
+    # positions for these tokens, so the formatter relies on a
+    # fallback that re-escapes braces on the decoded value.
+    src = 'WIZARD = f"""\n  {{TITLE}} hi {name}\n  {{END}}\n"""\n'
+    out = format_source(src)
+    # Content (including {{TITLE}} and {{END}}) must survive round-trip.
+    assert "{{TITLE}}" in out
+    assert "{{END}}" in out
+    assert "hi {name}" in out
+    # And the result must remain a valid f-string (re-tokenize cleanly).
+    from xonsh.formatter.core import _Formatter
+
+    _Formatter(out).run()  # raises FormatError if it became unparseable
+
+
+# ---------------------------------------------------------------------
+# Idempotence — `format(format(x)) == format(x)`
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "x = 1\n",
+        "x=1\n",
+        "def f(a,b=1):\n    return a+b\n",
+        "class Foo:\n    def m(self):\n        pass\n# tail\n",
+        "echo ${HOME} && !(grep py)\n",
+        "for f in g`*.py`:\n    print(f)\n",
+        "x = $(ls)\n",
+        "#hello\nx = 1\n",
+        "if x:\n    if y:\n        z = 1\n",
+        "lambda x=1: x + 1\n",
+    ],
+)
+def test_idempotent(src):
+    once = format_source(src)
+    twice = format_source(once)
+    assert once == twice
+
+
+# ---------------------------------------------------------------------
+# Token-stream invariance — the structural token sequence must be
+# preserved across formatting (the only changes happen in whitespace
+# tokens). This is the closest equivalent of "AST round-trip" for a
+# token-based formatter.
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "x = 1\n",
+        "x=1\n",
+        "def f(a, b=1):\n    return a + b\n",
+        "x = $(ls -la)\n",
+        "echo ${HOME} && !(grep py)\n",
+        "for f in g`*.py`:\n    print(f)\n",
+        "class C:\n    def m(self):\n        pass\n# tail\n",
+        "if x: y = 1\n",
+        "lambda x=1: x\n",
+    ],
+)
+def test_token_stream_invariant(src):
+    """Formatting must not alter the meaningful token sequence."""
+    assert _token_skeleton(src) == _token_skeleton(format_source(src))
+
+
+# ---------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------
+
+
+def test_format_error_on_eof_in_paren():
+    with pytest.raises(FormatError):
+        format_source("x = (1 + \n")
+
+
+def test_format_error_on_eof_in_triple_quoted_string():
+    with pytest.raises(FormatError):
+        format_source('x = """unterminated\n')

--- a/xonsh/formatter/__init__.py
+++ b/xonsh/formatter/__init__.py
@@ -1,0 +1,20 @@
+"""Token-stream based formatter for xonsh source code.
+
+The formatter walks the raw token stream produced by
+:mod:`xonsh.parsers.tokenize` (which preserves comments, blank lines and
+all xonsh-specific tokens such as ``$(``, ``!(``, ``${``, ``@$``, IO
+redirects and globs) and re-emits the source with normalized whitespace
+and indentation.
+
+The public API is intentionally small:
+
+- :func:`format_source` — format a string of xonsh source.
+- :class:`FormatError` — raised on unrecoverable tokenizer errors.
+
+The CLI entry point used by ``xonsh format ...`` lives in
+:mod:`xonsh.formatter.cli`.
+"""
+
+from xonsh.formatter.core import DEFAULT_INDENT, FormatError, format_source
+
+__all__ = ["DEFAULT_INDENT", "FormatError", "format_source"]

--- a/xonsh/formatter/cli.py
+++ b/xonsh/formatter/cli.py
@@ -1,0 +1,146 @@
+"""Command-line interface for ``xonsh format``.
+
+The dispatcher in :mod:`xonsh.main` peeks at ``sys.argv`` and, if the
+first non-option argument is ``format``, hands the rest off to
+:func:`main` here. We deliberately do *not* go through xonsh's own
+argparse — the format subcommand has no need for a shell session,
+xontribs, or rc files, and avoiding that machinery makes ``xonsh
+format`` startup fast and side-effect free.
+
+Behaviour mirrors common formatters (e.g. Black):
+
+* by default each path is rewritten in place;
+* ``--check`` reports which files would change and exits non-zero;
+* ``--diff`` writes a unified diff to stdout instead of touching files;
+* ``-`` reads from stdin and writes to stdout.
+
+Exit codes
+----------
+* ``0`` — nothing needed reformatting (or every file was rewritten
+  successfully when not in ``--check`` / ``--diff`` mode);
+* ``1`` — at least one file would be (or was) changed in
+  ``--check`` / ``--diff`` mode;
+* ``123`` — at least one file failed to tokenize or could not be read /
+  written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+
+from xonsh.formatter.core import FormatError, format_source
+
+_PROG = "xonsh format"
+EXIT_OK = 0
+EXIT_CHANGED = 1
+EXIT_ERROR = 123
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog=_PROG,
+        description="Format xonsh source files in place.",
+    )
+    p.add_argument(
+        "files",
+        nargs="+",
+        metavar="FILE",
+        help="One or more files to format. Use '-' to read from stdin "
+        "and write to stdout.",
+    )
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="Don't write the files back. Exit with code 1 if any file "
+        "would be changed.",
+    )
+    p.add_argument(
+        "--diff",
+        action="store_true",
+        help="Don't write the files back. Print a unified diff for "
+        "each file that would change. Exit code matches --check.",
+    )
+    p.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file status messages on stderr.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    changed = 0
+    errors = 0
+    for path in args.files:
+        try:
+            rc = _process_one(path, args)
+        except FormatError as exc:
+            print(f"{path}: error: {exc}", file=sys.stderr)
+            errors += 1
+            continue
+        except OSError as exc:
+            print(f"{path}: error: {exc}", file=sys.stderr)
+            errors += 1
+            continue
+        if rc:
+            changed += 1
+
+    if errors:
+        return EXIT_ERROR
+    if (args.check or args.diff) and changed:
+        return EXIT_CHANGED
+    return EXIT_OK
+
+
+def _process_one(path: str, args: argparse.Namespace) -> bool:
+    """Format one file; return True if it changed (or would have)."""
+    if path == "-":
+        original = sys.stdin.read()
+        formatted = format_source(original)
+        if args.check:
+            if original != formatted and not args.quiet:
+                print("stdin: would reformat", file=sys.stderr)
+            return original != formatted
+        if args.diff:
+            _write_diff("stdin", original, formatted)
+            return original != formatted
+        sys.stdout.write(formatted)
+        return original != formatted
+
+    with open(path, encoding="utf-8") as fh:
+        original = fh.read()
+    formatted = format_source(original)
+    if original == formatted:
+        if not args.quiet and not (args.check or args.diff):
+            print(f"{path}: unchanged", file=sys.stderr)
+        return False
+
+    if args.check:
+        if not args.quiet:
+            print(f"{path}: would reformat", file=sys.stderr)
+        return True
+    if args.diff:
+        _write_diff(path, original, formatted)
+        return True
+
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(formatted)
+    if not args.quiet:
+        print(f"{path}: reformatted", file=sys.stderr)
+    return True
+
+
+def _write_diff(name: str, original: str, formatted: str) -> None:
+    sys.stdout.writelines(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            formatted.splitlines(keepends=True),
+            fromfile=name,
+            tofile=f"{name} (formatted)",
+        )
+    )

--- a/xonsh/formatter/core.py
+++ b/xonsh/formatter/core.py
@@ -1,0 +1,848 @@
+"""Token-stream based formatting engine for xonsh source.
+
+Why tokens, not AST
+-------------------
+xonsh has no xonsh-specific AST nodes — ``$(ls)`` parses to a regular
+``Call(__xonsh__.subproc_capture_stdout, ...)``, ``${VAR}`` to a
+``Subscript`` of ``__xonsh__.env``, and so on. Round-tripping through the
+AST would lose the original syntactic form (was it ``$(...)`` or
+``$[...]``?), drop comments, and erase the user's line breaks. Working
+on the raw token stream from :mod:`xonsh.parsers.tokenize` keeps every
+character of the source available — including ``COMMENT`` and ``NL``
+tokens that the parser-facing lexer normally filters out.
+
+What the formatter changes
+--------------------------
+* normalizes indentation to a configurable indent string (4 spaces);
+* strips trailing whitespace from each line;
+* ensures the file ends with exactly one ``\\n``;
+* collapses runs of blank lines (max 2 at module top level, max 1
+  nested);
+* leaves ``#``-comment bodies untouched — commented-out code stays
+  byte-for-byte (``#def foo():`` is *not* rewritten to ``# def …``);
+* normalizes the *padding* before an inline comment to two spaces;
+* forces a single space around top-level ``=`` (assignment) but leaves
+  ``f(x=1)`` / ``def f(x=1)`` / ``lambda x=1:`` untouched, and is
+  suppressed in subprocess statements (``--flag=value`` stays glued);
+* forces single spaces around augmented assignments, ``==``, ``!=``,
+  ``<=``, ``>=``, ``->``, and ``:=``;
+* normalizes ``,`` and ``;`` to be followed by exactly one space (or a
+  newline / closer);
+* collapses runs of inter-arg whitespace inside subprocess statements
+  (``echo a   b`` → ``echo a b``); macros (``name!`` and
+  ``name!(...)``) are exempt and keep their bodies verbatim;
+* normalizes ``\\``-newline continuation indentation to one indent
+  unit past the statement's base (subprocess) or preserves the user's
+  intentional alignment (Python — ``or`` lined up under ``if``, etc.);
+* preserves all xonsh-specific syntax verbatim — ``$()``, ``!()``,
+  ``${...}``, ``$[]``, ``![]``, ``@()``, ``@$()``, IO redirects,
+  ``&&`` / ``||``, search-path globs, f-strings.
+
+What it deliberately leaves alone
+---------------------------------
+Long-line splitting, magic trailing comma, quote normalization, and
+import sorting are out of scope for this MVP — those are stylistic
+rewrites that need richer context than a single token-stream pass.
+"""
+
+from __future__ import annotations
+
+import io
+
+from xonsh.parsers.tokenize import (
+    COMMENT,
+    DEDENT,
+    DOLLARNAME,
+    ENCODING,
+    ENDMARKER,
+    ERRORTOKEN,
+    FSTRING_END,
+    FSTRING_MIDDLE,
+    FSTRING_START,
+    INDENT,
+    NAME,
+    NEWLINE,
+    NL,
+    NUMBER,
+    OP,
+    SEARCHPATH,
+    STRING,
+    TokenError,
+    tokenize,
+)
+
+DEFAULT_INDENT = "    "
+
+# Bracket-like openers (Python + xonsh subprocess).
+_OPENERS = frozenset(("(", "[", "{", "$(", "$[", "${", "!(", "![", "@(", "@!(", "@$("))
+_CLOSERS = frozenset((")", "]", "}"))
+
+# Operators that always take a space on each side in Python mode.
+_ALWAYS_SPACED = frozenset(
+    (
+        "==",
+        "!=",
+        "<=",
+        ">=",
+        "->",
+        ":=",
+        "+=",
+        "-=",
+        "*=",
+        "/=",
+        "//=",
+        "%=",
+        "**=",
+        "@=",
+        "|=",
+        "&=",
+        "^=",
+        "<<=",
+        ">>=",
+    )
+)
+
+# Python keywords that must be followed by whitespace before the next
+# meaningful token (excludes ``:`` / closers, which are handled by
+# their own rules so that e.g. ``else:`` stays glued). Soft keywords
+# (``match``, ``case``, ``type``) are deliberately omitted: they only
+# act like keywords in specific syntactic positions, and forcing a
+# space after them would mangle uses like ``add_argument(type=int)``.
+_PY_KEYWORDS = frozenset(
+    (
+        "and",
+        "as",
+        "assert",
+        "async",
+        "await",
+        "class",
+        "def",
+        "del",
+        "elif",
+        "else",
+        "except",
+        "finally",
+        "for",
+        "from",
+        "global",
+        "if",
+        "import",
+        "in",
+        "is",
+        "lambda",
+        "nonlocal",
+        "not",
+        "or",
+        "raise",
+        "return",
+        "try",
+        "while",
+        "with",
+        "yield",
+    )
+)
+
+# Names that, when they lead a logical line, mark it as a Python
+# statement rather than a subprocess command. Includes hard keywords
+# above plus the Python literal names (``True``/``False``/``None``)
+# and the soft keywords used for ``match`` / ``type`` statements.
+# A bare name followed by ``=`` etc. is independently caught by the
+# operator-after-name check, so this set only needs the names that
+# would otherwise appear before another NAME and get misclassified.
+_LINE_START_PYTHON_NAMES = _PY_KEYWORDS | frozenset(
+    {"True", "False", "None", "match", "case", "type"}
+)
+
+# Operators that, when they follow the leading NAME of a line,
+# definitively mark the line as Python (assignment / call / member
+# access / arithmetic / comparison / etc.). Anything not in this set
+# (NAME, NUMBER, STRING, ``-``, ``!``, …) suggests a subprocess
+# command.
+_PY_AFTER_LEADING_NAME = frozenset(
+    {
+        "(",
+        "[",
+        ".",
+        "=",
+        ",",
+        ":",
+        ";",
+        "+=",
+        "-=",
+        "*=",
+        "/=",
+        "//=",
+        "%=",
+        "**=",
+        "@=",
+        "|=",
+        "&=",
+        "^=",
+        "<<=",
+        ">>=",
+        "==",
+        "!=",
+        "<",
+        "<=",
+        ">",
+        ">=",
+        ":=",
+        "+",
+        "*",
+        "/",
+        "//",
+        "%",
+        "**",
+        "<<",
+        ">>",
+        "&",
+        "|",
+        "^",
+        "->",
+    }
+)
+
+# Word-like operators that, when they appear as the SECOND token after
+# a leading NAME, mean the line is a Python expression (``x and y``,
+# ``x or y``, ``x is None``, ``x in s``, ``x not in s``).
+_PY_INFIX_KEYWORDS = frozenset({"and", "or", "is", "in", "not"})
+
+
+class FormatError(Exception):
+    """Raised when the source cannot be tokenized."""
+
+
+def format_source(src: str, *, indent: str = DEFAULT_INDENT) -> str:
+    """Return ``src`` reformatted as xonsh source code.
+
+    Parameters
+    ----------
+    src
+        The xonsh source code to format.
+    indent
+        The string used per indent level. Defaults to four spaces.
+    """
+    return _Formatter(src, indent=indent).run()
+
+
+class _Formatter:
+    """One-shot formatter; instantiate per-source-string."""
+
+    def __init__(self, src: str, *, indent: str = DEFAULT_INDENT) -> None:
+        # The tokenizer expects a trailing newline to produce a clean
+        # final NEWLINE/ENDMARKER. Empty input is handled by the
+        # short-circuit in :meth:`run`.
+        if src and not src.endswith("\n"):
+            src = src + "\n"
+        self._src = src
+        # Cached split of source by line, used by the continuation-line
+        # branch in :meth:`run` to recover the original hanging indent
+        # of an expression broken across lines inside brackets.
+        self._src_lines = src.split("\n")
+        self._indent_str = indent
+        # Width (in source characters) of one indent level in the input.
+        # Resolved lazily from the first indented line we see so that
+        # comment-column → indent-level conversion is accurate for
+        # tab-indented or 2-space sources, not just 4-space ones.
+        self._src_indent_width: int | None = None
+
+        # State for the emit pass.
+        self._out: list[str] = []
+        self._indent_level = 0
+        # Stack of opener strings — top tells us which kind of bracket
+        # we're currently inside ("[" means slice context for ``:``).
+        self._brackets: list[str] = []
+        # Number of unfinished ``lambda`` parameter lists. Bumped when
+        # the keyword is emitted, decremented on the matching ``:``.
+        # Used to keep ``lambda x=1: x`` and ``lambda: x`` unmodified.
+        self._lambda_depth = 0
+        # True at the start of every physical line (before indent has
+        # been emitted). Becomes False after the first token on a line.
+        self._line_start = True
+        # Pending blank lines accumulated from NL tokens — applied
+        # (capped) when the next real token arrives.
+        self._pending_blanks = 0
+        # When the current logical statement looks like a subprocess
+        # command (``echo 1 2 --flag=value`` and friends), the
+        # Python-mode ``=`` rule is suppressed (``--flag=value`` is
+        # one argument, not an assignment) and ``\``-newline
+        # continuations get a normalized indent. Detected via
+        # lookahead at line-start; reset on ``NEWLINE``.
+        self._subproc_line = False
+        # Alias-macro statement (``name! raw text``) — the args after
+        # the bang are raw text whose whitespace must be preserved
+        # exactly. Separate from ``_subproc_line`` because regular
+        # subprocess commands collapse runs of inter-arg whitespace
+        # while macros must not.
+        self._macro_alias_line = False
+        # Paren depth at which we entered an active function-macro
+        # call (``name!(args)``). Inside a macro the args are raw
+        # strings — preserve their whitespace exactly. ``0`` means
+        # "not in a macro".
+        self._macro_until_depth = 0
+
+    @property
+    def _paren_depth(self) -> int:
+        return len(self._brackets)
+
+    def run(self) -> str:
+        if not self._src:
+            return ""
+
+        tokens = list(self._iter_tokens())
+        prev = None  # last emitted real (non-structural) token
+
+        for i, tok in enumerate(tokens):
+            ttype = tok.type
+
+            if ttype == ENCODING:
+                continue
+            if ttype == ENDMARKER:
+                break
+
+            if ttype == INDENT:
+                # The first INDENT we see authoritatively defines the
+                # source's indent step (one tab, four spaces, two
+                # spaces, …). This is more reliable than scanning
+                # ``self._src_lines`` for indented prose, which would
+                # be fooled by docstring wrap-continuations.
+                if self._src_indent_width is None:
+                    self._src_indent_width = len(tok.string) or len(self._indent_str)
+                self._indent_level += 1
+                continue
+            if ttype == DEDENT:
+                self._indent_level -= 1
+                continue
+
+            if ttype == NEWLINE:
+                # End of a logical statement.
+                self._out.append("\n")
+                self._line_start = True
+                self._pending_blanks = 0
+                self._subproc_line = False
+                self._macro_alias_line = False
+                continue
+
+            if ttype == NL:
+                if self._line_start:
+                    # Blank line between statements — defer until we
+                    # know whether the next token is at top level or
+                    # nested, so the cap can be applied correctly.
+                    self._pending_blanks += 1
+                else:
+                    # Implicit line continuation inside brackets.
+                    self._out.append("\n")
+                    self._line_start = True
+                continue
+
+            # A real token (or a leading comment). Flush blank lines,
+            # emit indent if at line start, then the inter-token gap.
+            if self._line_start:
+                if self._paren_depth > 0:
+                    # Continuation line inside brackets — preserve the
+                    # source's leading whitespace verbatim so hanging
+                    # indents and visual alignment of multi-line
+                    # imports / calls / collections survive untouched.
+                    self._flush_blank_lines(self._indent_level)
+                    line = self._src_lines[tok.start[0] - 1]
+                    self._out.append(line[: tok.start[1]])
+                else:
+                    level = (
+                        self._comment_indent(tok)
+                        if ttype == COMMENT
+                        else self._indent_level
+                    )
+                    self._flush_blank_lines(level)
+                    self._out.append(self._indent_str * max(level, 0))
+                    # Decide whether this statement is a subprocess
+                    # command and/or an alias-macro line — comments
+                    # don't change either decision.
+                    if ttype != COMMENT:
+                        self._subproc_line = self._is_subproc_statement(tokens, i)
+                        self._macro_alias_line = self._is_alias_macro_line(tokens, i)
+                self._line_start = False
+            else:
+                self._out.append(self._space_between(prev, tok))
+
+            self._out.append(self._render_token(tok))
+            self._update_state(tok)
+            # Function-macro entry: ``name!(`` with no gap turns the
+            # body into raw arguments. Recognised once we've seen the
+            # ``!(`` opener (so paren depth has just been pushed).
+            if (
+                tok.type == OP
+                and tok.string == "!("
+                and prev is not None
+                and prev.type == NAME
+                and prev.end == tok.start
+            ):
+                self._macro_until_depth = self._paren_depth
+            # Macro exit: dropped below the depth we entered at.
+            if self._macro_until_depth and self._paren_depth < self._macro_until_depth:
+                self._macro_until_depth = 0
+            prev = tok
+
+        return self._finalize("".join(self._out))
+
+    def _comment_indent(self, tok) -> int:
+        """Indent level for a leading-line comment, derived from its
+        source column.
+
+        The tokenizer associates comments with whatever block was open
+        when they were lexed — a trailing comment whose source column
+        sits at the *outer* level still arrives *before* the matching
+        DEDENTs, and a comment that opens a new body arrives *before*
+        the matching INDENT. Both cases mean ``self._indent_level`` is
+        a poor signal for where to render the comment.
+
+        The most reliable signal is the comment's own source column.
+        We translate that column into an indent level by walking the
+        line's leading whitespace character-by-character: each ``\\t``
+        counts as one level (regardless of the spaces-based source
+        indent width), each space counts as ``1 / source_width`` of a
+        level. This is what makes mixed tab/space sources Just Work —
+        a comment indented with a single tab in a file whose other
+        lines use four-space indents still resolves to level 1, which
+        matches the user's clear visual intent.
+        """
+        col = tok.start[1]
+        if col == 0:
+            return 0
+        width = self._source_indent_width()
+        if width <= 0:
+            return 0
+        line = self._src_lines[tok.start[0] - 1]
+        leading = line[:col]
+        levels = 0.0
+        for ch in leading:
+            if ch == "\t":
+                levels += 1
+            elif ch == " ":
+                levels += 1.0 / width
+            else:
+                # Non-whitespace before ``col`` shouldn't happen for a
+                # leading-line comment, but guard against weird inputs.
+                break
+        return max(round(levels), 0)
+
+    def _source_indent_width(self) -> int:
+        """Return the source's indent step in characters (4, 2, 1=tab,
+        …). Set by the run loop on the first ``INDENT`` token; falls
+        back to ``len(self._indent_str)`` for files with no indented
+        blocks (e.g. a single-line module).
+        """
+        if self._src_indent_width is None:
+            self._src_indent_width = len(self._indent_str) or 4
+        return self._src_indent_width
+
+    # ---------------------------------------------------------------
+    # Token iteration
+    # ---------------------------------------------------------------
+    def _iter_tokens(self):
+        readline = io.BytesIO(self._src.encode("utf-8")).readline
+        try:
+            yield from tokenize(readline, tolerant=False)
+        except (TokenError, IndentationError) as exc:
+            raise FormatError(str(exc)) from exc
+
+    # ---------------------------------------------------------------
+    # Per-token state updates (paren / lambda tracking)
+    # ---------------------------------------------------------------
+    def _update_state(self, tok) -> None:
+        ttype, tstr = tok.type, tok.string
+        if ttype == OP:
+            if tstr in _OPENERS:
+                self._brackets.append(tstr)
+            elif tstr in _CLOSERS and self._brackets:
+                self._brackets.pop()
+            elif tstr == ":" and self._lambda_depth > 0:
+                # Close the most recent lambda parameter scope. The
+                # ``:`` belongs to the lambda regardless of any
+                # enclosing parens, so we always decrement on the
+                # first ``:`` after a ``lambda``.
+                self._lambda_depth -= 1
+        elif ttype == NAME and tstr == "lambda":
+            self._lambda_depth += 1
+
+    # ---------------------------------------------------------------
+    # Blank-line handling
+    # ---------------------------------------------------------------
+    def _flush_blank_lines(self, target_level: int) -> None:
+        if self._pending_blanks <= 0:
+            return
+        # Cap depends on the destination level, not on the current
+        # ``_indent_level``: a top-level comment that arrives before
+        # the matching DEDENTs should still get up to two blank lines
+        # of separation, even though ``_indent_level`` is still > 0
+        # while we process it.
+        cap = 2 if target_level == 0 else 1
+        for _ in range(min(self._pending_blanks, cap)):
+            self._out.append("\n")
+        self._pending_blanks = 0
+
+    # ---------------------------------------------------------------
+    # Inter-token spacing
+    # ---------------------------------------------------------------
+    def _space_between(self, prev, cur) -> str:
+        pt, ps = prev.type, prev.string
+        ct, cs = cur.type, cur.string
+
+        # f-string segments are always glued — *before* any other
+        # rule, including the subproc/macro verbatim modes below. The
+        # xonsh tokenizer reports unreliable (often inverted) source
+        # positions for multi-line ``FSTRING_MIDDLE`` tokens; if a
+        # verbatim-mode ``_raw_between`` were allowed to consult those
+        # positions it would synthesize a "gap" that re-emits the
+        # f-string body, duplicating its content. Always glue.
+        if ct in (FSTRING_MIDDLE, FSTRING_END):
+            return ""
+        if pt in (FSTRING_START, FSTRING_MIDDLE):
+            return ""
+
+        # Bang macro marker glued to its lead token — alias macros
+        # (``name!``), block macros (``with! ctx:``), and friends. The
+        # ``!`` is an ``ERRORTOKEN`` from the tokenizer's perspective,
+        # so without this rule the keyword-force-space below would
+        # turn ``with! qwe:`` into ``with ! qwe:``.
+        if ct == ERRORTOKEN and cs == "!" and prev.end == cur.start:
+            return ""
+
+        # Macro bodies — both alias macros (``name! raw text`` until
+        # NEWLINE) and function macros (``name!(args)`` until the
+        # matching paren) — are full source-verbatim: their arguments
+        # are raw text and any whitespace the user typed is part of
+        # the call. Regular top-level subprocess statements
+        # (``echo 1 2 --flag=value``) do *not* go through this path —
+        # users expect runs of whitespace between args collapsed, the
+        # same way ``$(...)`` captures normalize their content.
+        # Subproc-specific quirks (``=`` flag values, ``\\\n``
+        # continuations) are handled below by targeted rules.
+        if self._macro_until_depth > 0 or self._macro_alias_line:
+            return self._raw_between(prev, cur)
+
+        # ``\\\n`` line continuation. Subprocess commands always use
+        # one indent unit past the statement's base — the original
+        # column carries no meaning to the shell. Python statements
+        # preserve the user's intentional vertical alignment (an
+        # ``or`` lined up under its ``if``, etc.), rescaled to the
+        # formatter's indent width so that alignment survives indent
+        # normalization (12-space, tabs, 2-space → 4-space).
+        if pt == ERRORTOKEN and ps in ("\\\n", "\\\r\n"):
+            if self._subproc_line:
+                return self._indent_str * (self._indent_level + 1)
+            src_w = self._source_indent_width()
+            src_base = self._indent_level * src_w
+            visual_chars = max(cur.start[1] - src_base, 0)
+            levels = visual_chars / src_w if src_w else 0
+            new_base = self._indent_level * len(self._indent_str)
+            out_offset = round(levels * len(self._indent_str))
+            return " " * (new_base + out_offset)
+
+        # Inline comments get two spaces of leading padding (PEP 8) —
+        # checked before the bracket-glue rules so that a trailing
+        # comment immediately after ``(`` (line-continuation comment)
+        # keeps its visual offset from the opener.
+        if ct == COMMENT:
+            return "  "
+
+        # Bracket adjacency: glue.
+        if ps in _OPENERS:
+            return ""
+        if cs in _CLOSERS:
+            return ""
+
+        # Comma / semicolon: never a space before, exactly one after.
+        if cs == "," or cs == ";":
+            return ""
+        if ps == "," or ps == ";":
+            return " "
+
+        # ``:`` rules. Annotations / dict entries / lambda terminators
+        # never want a space *before* the colon. Slice colons (inside
+        # ``[]``) glue on both sides; everything else gets a space
+        # after.
+        if cs == ":":
+            return ""
+        if ps == ":":
+            if self._brackets and self._brackets[-1] == "[":
+                return ""
+            return " "
+
+        # ``=`` rule. At statement level (no enclosing parens, no open
+        # lambda parameter list) it's always an assignment and gets
+        # spaces; otherwise it's a kwarg / default / annotated default
+        # and stays glued. Suppressed in subprocess context, where
+        # ``--flag=value`` is one argument and a user-written
+        # ``--flag = value`` should stay as-typed — fall through to
+        # the original-gap default below.
+        if (
+            (ps == "=" or cs == "=")
+            and self._paren_depth == 0
+            and self._lambda_depth == 0
+            and not self._subproc_line
+        ):
+            return " "
+
+        # Always-spaced operators (==, !=, augmented assigns, …).
+        if ps in _ALWAYS_SPACED or cs in _ALWAYS_SPACED:
+            return " "
+
+        # Force a space after a Python keyword so ``if(x):`` becomes
+        # ``if (x):`` — but not before ``:`` or a closer (handled
+        # earlier).
+        if pt == NAME and ps in _PY_KEYWORDS:
+            return " "
+
+        # Default: preserve the original gap, normalized to exactly
+        # one space (collapses runs of whitespace) or none.
+        if prev.end[0] != cur.start[0]:
+            return " "
+        return " " if cur.start[1] > prev.end[1] else ""
+
+    # ---------------------------------------------------------------
+    # Token rendering
+    # ---------------------------------------------------------------
+    def _render_token(self, tok) -> str:
+        if tok.type == COMMENT:
+            return _format_comment(tok.string)
+        if tok.type == FSTRING_MIDDLE:
+            # ``tok.string`` for ``FSTRING_MIDDLE`` is the *decoded*
+            # value: source ``{{`` collapses to ``{``, ``}}`` to ``}``,
+            # ``\n`` to a real newline, and so on. Re-emitting the
+            # decoded form would silently change the f-string's value
+            # (``f"{{x}}"`` → ``f"{x}"`` is a different format string).
+            # When the tokenizer's reported source span is large enough
+            # to actually contain the decoded value, we extract the
+            # original characters and round-trip is exact. xonsh's
+            # tokenizer reports bogus end positions for multi-line
+            # ``FSTRING_MIDDLE`` tokens (the entire fragment is
+            # squashed onto one logical line), so in that case fall
+            # back to re-escaping braces on the decoded value —
+            # preserves ``{{``/``}}`` for multi-line triple-quoted
+            # literals at the cost of not preserving rarer ``\``
+            # escapes inside them.
+            if self._fstring_span_reliable(tok):
+                src = self._source_slice(tok)
+                if src is not None:
+                    return src
+            return tok.string.replace("{", "{{").replace("}", "}}")
+        return tok.string
+
+    # ---------------------------------------------------------------
+    # Subprocess-statement / macro detection
+    # ---------------------------------------------------------------
+    def _is_alias_macro_line(self, tokens: list, start_idx: int) -> bool:
+        """``name! raw text`` form — a NAME directly followed by a
+        ``!`` ``ERRORTOKEN`` (no whitespace between them) treats the
+        rest of the logical line as raw macro arguments."""
+        if start_idx >= len(tokens):
+            return False
+        first = tokens[start_idx]
+        if first.type != NAME:
+            return False
+        if first.string in _LINE_START_PYTHON_NAMES:
+            return False
+        for j in range(start_idx + 1, len(tokens)):
+            t = tokens[j]
+            if t.type in (COMMENT, NL):
+                continue
+            return t.type == ERRORTOKEN and t.string == "!" and t.start == first.end
+        return False
+
+    def _is_subproc_statement(self, tokens: list, start_idx: int) -> bool:
+        """Heuristic: does the logical line starting at ``tokens[start_idx]``
+        look like a *bare* subprocess command (``echo 1 2 --flag=val``)
+        rather than a Python statement?
+
+        The xonsh parser performs the real subprocess-vs-Python decision
+        based on the runtime ``aliases`` table and ``$PATH`` — neither
+        is available to a static formatter. The static heuristic here
+        only catches the bare-command form: a NAME at line start that
+        is *not* a Python keyword/literal/soft-keyword AND whose next
+        non-trivial token is something a Python statement wouldn't put
+        there (another NAME, a NUMBER, a STRING, ``-flag``, alias-macro
+        ``!``, …).
+
+        Lines that *begin* with a subprocess capture (``$(...)``,
+        ``!(...)``, ``${...}``, ``@$(...)``, …) are intentionally
+        excluded — those are Python expressions whose value happens to
+        be a captured pipeline. Their *contents* get normalized by the
+        regular paren-aware rules (multi-space inside ``$(...)``
+        collapses to one), while nothing meaningful is gained from
+        forcing the entire enclosing statement into verbatim mode.
+
+        Anything else (assignment, function call, attribute access,
+        infix operator, bare expression, decorated def, …) is left to
+        the Python formatter.
+        """
+        if start_idx >= len(tokens):
+            return False
+        first = tokens[start_idx]
+        if first.type != NAME:
+            return False
+        if first.string in _LINE_START_PYTHON_NAMES:
+            return False
+        # Find the next non-trivial token on the same statement.
+        second = None
+        for j in range(start_idx + 1, len(tokens)):
+            t = tokens[j]
+            if t.type in (COMMENT, NL):
+                continue
+            second = t
+            break
+        if second is None or second.type == NEWLINE:
+            return False  # bare ``name`` — Python expression statement
+        if second.type == OP:
+            if second.string in _PY_AFTER_LEADING_NAME:
+                return False
+            if second.string == "-":
+                return self._dash_looks_like_subproc_flag(tokens, j, second)
+            # ``name!(`` macro-call opens here; the call itself is a
+            # Python expression at the outer level (the body becomes
+            # raw via :attr:`_macro_until_depth` once entered).
+            if second.string in {"!(", "![", "?", "??"}:
+                return False
+        if second.type == ERRORTOKEN and second.string == "!":
+            # Alias macro form: ``echo! raw stuff`` — subprocess.
+            return True
+        if second.type == NAME:
+            # Python infix word operators (``x and y``, ``x is None``,
+            # ``x in s``, ``x not in s``) keep the line in Python mode.
+            if second.string in _PY_INFIX_KEYWORDS:
+                return False
+            return True
+        if second.type in (NUMBER, STRING, FSTRING_START, SEARCHPATH, DOLLARNAME):
+            return True
+        return False
+
+    def _dash_looks_like_subproc_flag(
+        self, tokens: list, dash_idx: int, dash_tok
+    ) -> bool:
+        """``cmd -flag`` vs ``x - 1``: peek at the token after ``-``."""
+        for j in range(dash_idx + 1, len(tokens)):
+            t = tokens[j]
+            if t.type in (COMMENT, NL):
+                continue
+            if t.type == OP and t.string == "-":
+                return True  # ``--flag``
+            if t.type == NAME and t.start == dash_tok.end:
+                return True  # ``-flag`` (no space — attached short flag)
+            return False
+        return False
+
+    def _raw_between(self, prev, cur) -> str:
+        """Original source text between ``prev``'s emitted end and
+        ``cur.start``.
+
+        We compute ``prev``'s effective end from its ``string`` rather
+        than blindly trusting ``prev.end``: tokens whose value carries
+        an embedded newline (notably the ``\\\\\\n`` line-continuation
+        ``ERRORTOKEN`` xonsh emits in subprocess context) report an
+        end position that lies on the *previous* logical line. Without
+        this adjustment the multi-line branch below would re-emit the
+        line break that the token already wrote.
+
+        Special case: a subprocess line-continuation backslash-newline
+        ``\\\\\\n`` arrives as an ``ERRORTOKEN``. Its value already
+        ends with a real newline, so we're now positioned at column 0
+        of the continuation line; whatever leading whitespace the user
+        typed there is just visual indent. Replace it with one level
+        past the statement's base indent so multi-line subprocess
+        commands look consistently indented regardless of how the user
+        aligned them in the source.
+        """
+        if prev.type == ERRORTOKEN and prev.string in ("\\\n", "\\\r\n"):
+            return self._indent_str * (self._indent_level + 1)
+
+        s_line, s_col = self._real_end(prev)
+        e_line, e_col = cur.start
+        if s_line == e_line:
+            if e_col < s_col:
+                return ""
+            return self._src_lines[s_line - 1][s_col:e_col]
+        if e_line < s_line:
+            return " "
+        parts = [self._src_lines[s_line - 1][s_col:]]
+        for ln in range(s_line, e_line - 1):
+            parts.append("\n")
+            parts.append(self._src_lines[ln])
+        parts.append("\n")
+        parts.append(self._src_lines[e_line - 1][:e_col])
+        return "".join(parts)
+
+    @staticmethod
+    def _real_end(tok) -> tuple[int, int]:
+        """Position immediately after ``tok.string`` is fully emitted,
+        accounting for embedded newlines in the value."""
+        s_line, s_col = tok.start
+        nl = tok.string.count("\n")
+        if nl == 0:
+            return (s_line, s_col + len(tok.string))
+        tail = tok.string.rsplit("\n", 1)[-1]
+        return (s_line + nl, len(tail))
+
+    def _fstring_span_reliable(self, tok) -> bool:
+        """True if the token's reported source span is at least as
+        wide as its decoded value — the simplest cross-check that
+        catches the xonsh multi-line ``FSTRING_MIDDLE`` quirk."""
+        s_line, s_col = tok.start
+        e_line, e_col = tok.end
+        if e_line < s_line:
+            return False
+        if e_line > s_line:
+            return True
+        return e_col - s_col >= len(tok.string)
+
+    def _source_slice(self, tok) -> str | None:
+        """Return the original source text covered by a token, or
+        ``None`` if the token's reported span is incoherent (a known
+        quirk for multi-line f-string fragments — see callers)."""
+        s_line, s_col = tok.start
+        e_line, e_col = tok.end
+        if s_line == e_line:
+            if e_col < s_col:
+                return None
+            return self._src_lines[s_line - 1][s_col:e_col]
+        if e_line < s_line:
+            return None
+        parts = [self._src_lines[s_line - 1][s_col:]]
+        for ln in range(s_line, e_line - 1):
+            parts.append(self._src_lines[ln])
+        parts.append(self._src_lines[e_line - 1][:e_col])
+        return "\n".join(parts)
+
+    # ---------------------------------------------------------------
+    # Final cleanup
+    # ---------------------------------------------------------------
+    def _finalize(self, text: str) -> str:
+        # Strip trailing whitespace from each line without disturbing
+        # line endings inside string literals (those came through as
+        # part of STRING token text and are emitted unchanged here).
+        lines = text.split("\n")
+        # ``split`` keeps a trailing empty element when the text ended
+        # with ``\n``; rstrip-ing it is harmless.
+        cleaned = [ln.rstrip(" \t") for ln in lines]
+        text = "\n".join(cleaned)
+        # Collapse any trailing blank lines down to a single newline.
+        text = text.rstrip("\n") + "\n"
+        return text
+
+
+def _format_comment(text: str) -> str:
+    """Return a comment token's text unchanged, save for one defensive
+    cleanup.
+
+    The formatter intentionally does not rewrite the body of a comment
+    — including not inserting a space after ``#`` for ``#text`` style
+    comments. Users routinely keep commented-out code verbatim
+    (``#def foo():``) and expect the formatter to leave it alone.
+
+    The only adjustment is an ``lstrip``: xonsh's tokenizer
+    occasionally emits a COMMENT token whose value carries a stray
+    leading space (a state-contamination quirk after a ``$(...)``
+    capture inside a string literal). The caller has already inserted
+    the correct preceding whitespace via
+    :meth:`_Formatter._space_between`, so any leading space on the
+    value would double-count.
+    """
+    return text.lstrip()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -1093,6 +1093,19 @@ def _failback_to_other_shells(args, err):
 
 
 def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Subcommand dispatch. ``xonsh format ...`` does not need a shell
+    # session, xontribs, rc files, or even a TTY handshake — bypass
+    # premain entirely and hand off to the formatter CLI. Add new
+    # subcommands here when their lifecycle differs from the regular
+    # shell entry point.
+    if argv and argv[0] == "format":
+        from xonsh.formatter.cli import main as format_main
+
+        sys.exit(format_main(argv[1:]))
+
     # Run the TTY startup handshake *before* premain so that xontrib
     # loading and xonshrc execution happen with xonsh already as the
     # foreground process group. rc files are arbitrary user code and


### PR DESCRIPTION
Xonsh code formatter

Format file:
```xsh
xonsh format file.xsh
# file.xsh: reformatted
```
Format 1 save output to 2:
```
xonsh format - < 1.xsh > 2.xsh
```

Closes https://github.com/xonsh/xonsh/issues/2691


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
