### PR TITLE
fix(completer): Allow completion of explicit dot-dirs

### DIFF
--- a/tests/test_tools_iglob_llm.py
+++ b/tests/test_tools_iglob_llm.py
@@ -147,18 +147,43 @@ def test_empty_pattern_returns_empty():
 
 
 @skip_on_windows
-def test_dotfiles_excluded_by_default(tree):
-    # '.*' matches nothing because dotfiles are filtered out before
-    # the casefold compare. (Note: this differs from glob.iglob, which
-    # includes dotfiles when explicitly anchored at '.'; the helper
-    # follows xonsh's $DOTGLOB semantics.)
-    out = sorted(_case_insensitive_iglob(".*"))
+def test_bare_wildcard_excludes_dotfiles_by_default(tree):
+    # Bare '*' (no leading '.') hides dotfiles by default — matches
+    # stdlib glob with include_hidden=False.
+    out = sorted(_case_insensitive_iglob("*"))
     assert ".hidden" not in out
+    assert "README.md" in out
+
+
+@skip_on_windows
+def test_explicit_dot_wildcard_matches_dotfiles(tree):
+    # A wildcard segment whose pattern starts with '.' is an explicit
+    # request for hidden names, so the dotfile filter is bypassed even
+    # with include_dotfiles=False. Mirrors stdlib glob, where
+    # glob.glob('.*', include_hidden=False) returns dotfile entries.
+    out = sorted(_case_insensitive_iglob(".*"))
+    assert ".hidden" in out
+
+
+@skip_on_windows
+def test_literal_hidden_segment_is_traversed(tmp_path):
+    # A literal segment that happens to start with '.' (no glob meta)
+    # must always be traversed — otherwise paths like '~/.config/<Tab>'
+    # cannot be completed without flipping a global flag.
+    hidden = tmp_path / ".foo"
+    hidden.mkdir()
+    (hidden / "a.txt").touch()
+    (hidden / "b.txt").touch()
+    pattern = str(hidden / "*")
+    out = sorted(_case_insensitive_iglob(pattern, include_dotfiles=False))
+    assert out == [str(hidden / "a.txt"), str(hidden / "b.txt")]
 
 
 @skip_on_windows
 def test_dotfiles_included_when_requested(tree):
-    out = sorted(_case_insensitive_iglob(".*", include_dotfiles=True))
+    # include_dotfiles=True shows hidden names even when the wildcard
+    # itself doesn't anchor at '.'.
+    out = sorted(_case_insensitive_iglob("*", include_dotfiles=True))
     assert ".hidden" in out
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2782,12 +2782,16 @@ def _case_insensitive_iglob(pattern, *, include_dotfiles=False, recursive=False)
         # itself started with one.
         strip_dot_prefix = not pattern.startswith("." + os.sep)
 
-    def _entries(d):
+    def _entries(d, part):
         try:
             entries = os.listdir(d)
         except OSError:
             return None
-        if not include_dotfiles:
+        # Mirror stdlib glob: a segment that starts with '.' is treated as
+        # an explicit request for hidden names (literal '.foo' or wildcard
+        # '.x*'), so the dotfile filter does not apply. Bare wildcards
+        # ('*', '**', 'foo*') still hide dotfiles unless include_dotfiles.
+        if not include_dotfiles and not part.startswith("."):
             entries = [e for e in entries if not e.startswith(".")]
         return entries
 
@@ -2811,7 +2815,7 @@ def _case_insensitive_iglob(pattern, *, include_dotfiles=False, recursive=False)
                     continue
                 seen.add(d)
                 nxt.append(d)
-                entries = _entries(d)
+                entries = _entries(d, part)
                 if entries is None:
                     continue
                 for e in entries:
@@ -2822,7 +2826,7 @@ def _case_insensitive_iglob(pattern, *, include_dotfiles=False, recursive=False)
             continue
         has_meta = any(c in part for c in _GLOB_META)
         for d in cur:
-            entries = _entries(d)
+            entries = _entries(d, part)
             if entries is None:
                 # Parent unreadable (sandbox, EACCES) — keep the literal
                 # name if it actually exists on disk, otherwise drop


### PR DESCRIPTION
### Motivation

If user explicitly ask about dot-directory completion we need to show.

### Before

```xsh
$DOTGLOB
# False by default

cd /tmp
mkdir .qwe
echo 123 > .qwe/asd

ls .q<Tab>
# Not working 🔴 
ls .qwe/<Tab>
# Not working 🔴 
```

### After

```xsh
ls .q<Tab>
# Working 🟢 
ls .qwe/<Tab>
# Working 🟢 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
