### PR TITLE
fix(Completer): Fix completer in case of xontrib load with unknown arg

### DIFF
--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -85,6 +85,18 @@ def test_argparse_completer_after_option(check_completer, tmp_path):
     assert check_completer("xonsh --no-rc", prefix)
 
 
+def test_argparse_completer_unknown_option(check_completer):
+    """Completer must not crash on an unknown option that looks like a flag.
+
+    Regression: ``xontrib load -p <TAB>`` raised
+    ``AttributeError: 'NoneType' object has no attribute 'nargs'`` because
+    ``argparse._parse_optional`` returns ``(None, arg, None, None)`` when the
+    token starts with a prefix char but matches no known option.
+    """
+    # Should not raise. Result may be empty — we only assert no crash.
+    check_completer("xontrib load -p", prefix="")
+
+
 @skip_if_on_windows
 def test_complete_command_substring(completion_context_parse):
     """Completers should match by substring, not just prefix (xonsh#6082)."""

--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -85,6 +85,22 @@ def test_argparse_completer_after_option(check_completer, tmp_path):
     assert check_completer("xonsh --no-rc", prefix)
 
 
+def test_argparse_completer_description_no_ansi(check_completer, xession):
+    """Completion descriptions must be plain text — no ANSI escape codes.
+
+    Regression: ``xontrib load -<TAB>`` returned descriptions formatted by
+    ``RstHelpFormatter`` (the parser's own help formatter), which wraps
+    ``code`` spans in pygments ANSI color escapes. Those escapes leak as
+    literal characters into the prompt-toolkit completion menu.
+    """
+    xession.env["XONSH_INTERACTIVE"] = True
+    completions = check_completer("xontrib load", prefix="-")
+    assert completions
+    for comp in completions:
+        desc = getattr(comp, "description", "") or ""
+        assert "\x1b[" not in desc, f"ANSI escape leaked into description: {desc!r}"
+
+
 def test_argparse_completer_unknown_option(check_completer):
     """Completer must not crash on an unknown option that looks like a flag.
 

--- a/tests/completers/test_path_dotdot_llm.py
+++ b/tests/completers/test_path_dotdot_llm.py
@@ -73,9 +73,7 @@ def test_cd_dotdot_slash_lists_parent_subdirs(completer_env, monkeypatch):
         monkeypatch.chdir(work)
 
         results, _ = cd_xonsh_complete(_cd_command_ctx("../"))
-        basenames = {
-            os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results
-        }
+        basenames = {os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results}
         assert {"sib1", "sib2", "work"}.issubset(basenames)
         # Plain files in the parent must not appear — cd filters to dirs.
         assert "file.txt" not in basenames
@@ -93,9 +91,7 @@ def test_cd_dotdot_dotdot_slash_lists_grandparent(completer_env, monkeypatch):
         monkeypatch.chdir(ab)
 
         results, _ = cd_xonsh_complete(_cd_command_ctx("../../"))
-        basenames = {
-            os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results
-        }
+        basenames = {os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results}
         # Both the grandparent's children must show up.
         assert {"a", "sib_of_a"}.issubset(basenames)
 
@@ -115,9 +111,7 @@ def test_path_completer_dotdot_lists_files_too(completer_env, monkeypatch):
         prefix = "../"
         line = f"cat {prefix}"
         paths, _ = xcp._complete_path_raw(prefix, line, 4, len(line), {})
-        basenames = {
-            os.path.basename(str(p).rstrip().rstrip(os.sep)) for p in paths
-        }
+        basenames = {os.path.basename(str(p).rstrip().rstrip(os.sep)) for p in paths}
         # Both file and dir siblings should be offered.
         assert "sib" in basenames
         assert "note.txt" in basenames
@@ -135,9 +129,7 @@ def test_cd_dotdot_in_absolute_path(completer_env, monkeypatch):
         prefix = os.path.join(target, "..", "target") + os.sep
 
         results, _ = cd_xonsh_complete(_cd_command_ctx(prefix))
-        basenames = {
-            os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results
-        }
+        basenames = {os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results}
         assert {"child_a", "child_b"}.issubset(basenames)
 
 
@@ -156,7 +148,5 @@ def test_cd_dotdot_does_not_break_pipeline(completer_env, monkeypatch):
 
         # 'subdir/../' must list cwd's directories.
         results, _ = cd_xonsh_complete(_cd_command_ctx("subdir/../"))
-        basenames = {
-            os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results
-        }
+        basenames = {os.path.basename(str(r).rstrip().rstrip(os.sep)) for r in results}
         assert "subdir" in basenames

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -525,13 +525,17 @@ class ArgparseCompleter:
                 return
 
         # in the end after positionals show remaining unfilled options
+        # Use a plain HelpFormatter for descriptions: the parser's own
+        # formatter may be ``RstHelpFormatter``, which wraps text in ANSI
+        # color escapes — those leak as literal escape codes into the
+        # prompt-toolkit completion menu.
+        plain_formatter = ap.HelpFormatter(self.parser.prog)
         for act in options:
             for flag in sorted(act.option_strings, key=len, reverse=True):
                 desc = ""
                 if act.help:
-                    formatter = self.parser._get_formatter()
                     try:
-                        desc = formatter._expand_help(act)
+                        desc = plain_formatter._expand_help(act)
                     except KeyError:
                         desc = act.help
                 yield RichCompletion(flag, description=desc)

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -552,6 +552,12 @@ class ArgparseCompleter:
             self.remaining_args = self.remaining_args[1:]
             act, *_, value = act_res
 
+            if act is None:
+                # argparse returns ``(None, arg_string, ...)`` when the token
+                # looks like an option (starts with a prefix char) but does
+                # not match any known option in this parser. Skip it.
+                continue
+
             # remove the found option
             # todo: not remove if append/extend
             options.pop(act, None)


### PR DESCRIPTION
Reported by @goodboy :

1. 
```xsh
xontrib load -p <TAB>

Unhandled exception in event loop:
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/prompt_toolkit/buffer.py", line 1923, in new_coroutine
    await coroutine(*a, **kw)
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/prompt_toolkit/buffer.py", line 1740, in async_completer
    async for completion in async_generator:
    ...<12 lines>...
            break
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/prompt_toolkit/completion/base.py", line 310, in get_completions_async
    async for completion in completer.get_completions_async(
    ...<2 lines>...
        yield completion
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/prompt_toolkit/completion/base.py", line 186, in get_completions_async
    for item in self.get_completions(document, complete_event):
                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/shells/ptk_shell/completer.py", line 167, in get_completions
    completions, plen = self.completer.complete(
                        ~~~~~~~~~~~~~~~~~~~~~~~^
        prefix,
        ^^^^^^^
    ...<5 lines>...
        cursor_index=cursor_index,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/completer.py", line 129, in complete
    return self.complete_from_context(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        completion_context,
        ^^^^^^^^^^^^^^^^^^^
        (prefix, line, begidx, endidx, ctx),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/completer.py", line 373, in complete_from_context
    for comp in gen:
                ^^^
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/completer.py", line 283, in generate_completions
    for comp in res:
                ^^^
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/cli_utils.py", line 622, in xonsh_complete
    yield from completer.complete()
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/cli_utils.py", line 500, in complete
    opt_completions = self._complete_options(options)
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/cli_utils.py", line 559, in _complete_options
    if self.filled(act):
       ~~~~~~~~~~~^^^^^
  File "/home/goodboy/repos/tractor/py313/lib/python3.13/site-packages/xonsh/cli_utils.py", line 457, in filled
    if isinstance(act.nargs, int)
                  ^^^^^^^^^

Exception 'NoneType' object has no attribute 'nargs'
Press ENTER to continue...
```
2. ansi esc leaking
```xsh
xontrib load --<Tab>
# --full  indicates that the names are fully qualified module paths and not inside ^[[33m``^[[39;49;00m^[[33mxontrib^[[39;49;00m^[[33m``^[[39;49;00m
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
