### PR TITLE
feat(Completer): Show alias body in description if no docstring

### DIFF
--- a/tests/completers/test_alias_doc_llm.py
+++ b/tests/completers/test_alias_doc_llm.py
@@ -169,18 +169,42 @@ def test_docstring_shows_regardless_of_show_desc(xession, completion_context_par
         assert completion.description == "always shown"
 
 
-def test_string_and_list_aliases_have_no_description(xession, completion_context_parse):
-    """Plain string and list aliases carry no docstring; description falls
-    back to the legacy behaviour."""
+def test_string_and_list_aliases_show_contents(xession, completion_context_parse):
+    """Plain string and list aliases without a docstring fall back to
+    showing the alias *contents* — so users can recall what an alias
+    expands to without typing ``which`` or ``cmd?``."""
 
     xession.aliases["lsx"] = ["ls", "-G"]
     xession.aliases["greppy"] = "echo hi"
+    # Single-line ``ExecAlias`` (pipe forces ExecAlias path).
+    xession.aliases["pyg"] = "ls -la | grep py"
 
-    xession.env["CMD_COMPLETIONS_SHOW_DESC"] = True
     comps = list(complete_command(completion_context_parse("ls", 2).command))
-    assert _completion(comps, "lsx").description == "Alias"
+    assert _completion(comps, "lsx").description == "ls -G"
     comps = list(complete_command(completion_context_parse("gre", 3).command))
-    assert _completion(comps, "greppy").description == "Alias"
+    assert _completion(comps, "greppy").description == "echo hi"
+    comps = list(complete_command(completion_context_parse("py", 2).command))
+    assert _completion(comps, "pyg").description == "ls -la | grep py"
+
+
+def test_multiline_string_alias_uses_repr(xession, completion_context_parse):
+    """Multi-line aliases can't be displayed verbatim on a single
+    ``display_meta`` line, so fall back to ``repr`` of the source — the
+    user still sees the full content with ``\\n``/``\\t`` escapes."""
+
+    xession.aliases["multil"] = "echo a\necho b"
+
+    comps = list(complete_command(completion_context_parse("mu", 2).command))
+    assert _completion(comps, "multil").description == "echo a\\necho b"
+
+
+def test_explicit_doc_overrides_contents_fallback(xession, completion_context_parse):
+    """When the user attaches an explicit ``doc`` via the dict-form,
+    the docstring wins over the contents fallback."""
+
+    xession.aliases["ll"] = {"alias": "ls -la", "doc": "long listing"}
+    comps = list(complete_command(completion_context_parse("ll", 2).command))
+    assert _completion(comps, "ll").description == "long listing"
 
 
 def test_alias_completion_description_helper_handles_missing_aliases():

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -573,7 +573,12 @@ class Aliases(cabc.MutableMapping):
         func = getattr(alias, "func", None)
         if func is not None:
             doc = getattr(func, "__doc__", None)
-        elif isinstance(alias, (list, str)):
+        elif isinstance(alias, (list, str, ExecAlias)):
+            # ``ExecAlias`` has a class docstring ("Provides an exec alias
+            # for xonsh source code.") that would otherwise leak through as
+            # the description for every plain string alias with shell
+            # syntax — same pitfall as ``FuncAlias`` above. Treat it like
+            # list/str: no implicit description.
             return ""
         else:
             doc = getattr(alias, "__doc__", None)

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -23,23 +23,54 @@ END_PROC_KEYWORDS = {"and", "or"}
 
 
 def _alias_completion_description(aliases, name: str) -> str:
-    """Return the first non-empty line of the alias docstring, or ``""``.
+    """Return a one-line description for an alias entry in the dropdown.
 
     The completion dropdown's ``display_meta`` is rendered as a single line
     (prompt-toolkit replaces newlines with spaces in
     ``PromptToolkitCompleter.get_completions``), so a multi-line docstring is
     summarised down to its first non-empty line — typically the docstring's
     one-line summary in PEP 257 style.
+
+    When the alias has no docstring, fall back to the alias *contents* for
+    plain string-/list-form aliases — `aliases['ll'] = 'ls -la'` should show
+    ``ls -la`` next to ``ll`` in the menu so the user remembers what it
+    expands to. Only single-line content is shown; multi-line / callable /
+    Click aliases keep an empty description (their behaviour can't be
+    meaningfully summarised in one line without a docstring).
     """
     if aliases is None:
         return ""
     doc = aliases.get_doc(name)
-    if not doc:
+    if doc:
+        for line in doc.splitlines():
+            line = line.strip()
+            if line:
+                return line
         return ""
-    for line in doc.splitlines():
-        line = line.strip()
-        if line:
-            return line
+    # No docstring — fall back to alias contents.
+    try:
+        raw = aliases[name]
+    except KeyError:
+        return ""
+    if isinstance(raw, list):
+        # Plain string aliases (``aliases['ll'] = 'ls -la'``) are stored as
+        # a token list after being run through the lexer. Re-join for
+        # display; lists by construction have no newlines.
+        return " ".join(str(tok) for tok in raw)
+    src = getattr(raw, "src", None)
+    if isinstance(src, str):
+        # ``ExecAlias`` — the original source string is on ``.src``. For
+        # single-line sources show the source as-is; for multi-line ones
+        # fall back to ``repr`` so newlines/tabs render as ``\n`` / ``\t``
+        # and the whole body can still fit on one ``display_meta`` line.
+        src = src.strip()
+        if not src:
+            return ""
+        if "\n" in src:
+            # ``repr`` to surface ``\n``/``\t`` as visible escapes, then
+            # strip the outer quotes — they're noise in a description slot.
+            return repr(src)[1:-1]
+        return src
     return ""
 
 


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

cc https://github.com/xonsh/xonsh/issues/5998

```xsh
aliases['tst'] = 'echo 1'
t<Tab>
# tst - echo 1
```
## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
