### PR TITLE
fix: Foreign shell function aliases now stream their output through the caller-supplied stdout/stderr instead of inheriting xonsh's terminal fds

### DIFF
--- a/tests/test_foreign_shells_llm.py
+++ b/tests/test_foreign_shells_llm.py
@@ -1,0 +1,63 @@
+"""LLM-generated tests for foreign shell aliases (issue #5043 and friends)."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import warnings
+
+import pytest
+
+from xonsh.pytest.tools import skip_if_on_windows
+
+
+@skip_if_on_windows
+@pytest.mark.skipif(not shutil.which("bash"), reason="bash is not available")
+def test_foreign_function_alias_streams_to_caller_stdout(xession):
+    """Issue #5043: in streaming mode the foreign shell must write to the
+    ``stdout`` argument supplied by the caller (e.g. xonsh's ``$()`` pipe),
+    not inherit xonsh's own terminal fd."""
+    from xonsh.foreign_shells import ForeignShellFunctionAlias
+
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as bashrc:
+        bashrc.write("function printstuff() { echo printing stuff; }\n")
+        bashrc_name = bashrc.name
+    try:
+        alias = ForeignShellFunctionAlias(
+            funcname="printstuff",
+            shell="bash",
+            sourcer="source",
+            files=(bashrc_name,),
+        )
+        with tempfile.TemporaryFile("w+") as out_file:
+            alias([], stdout=out_file, stderr=subprocess.DEVNULL)
+            out_file.seek(0)
+            captured = out_file.read()
+        assert "printing stuff" in captured
+    finally:
+        os.unlink(bashrc_name)
+
+
+def test_foreign_shell_nostream_flag_is_deprecated():
+    """``--xonsh-nostream`` is a legacy opt-out from the streaming mode.
+    Streaming now captures correctly via $(...) / !(...), so the flag is
+    redundant and should warn on use."""
+    from xonsh.foreign_shells import ForeignShellBaseAlias
+
+    with pytest.warns(DeprecationWarning, match="xonsh-nostream"):
+        args, streaming = ForeignShellBaseAlias._is_streaming(
+            ["foo", "--xonsh-nostream", "bar"]
+        )
+    assert streaming is False
+    assert args == ["foo", "bar"]
+
+
+def test_foreign_shell_streaming_default_does_not_warn():
+    """No ``--xonsh-nostream`` → no warning, streaming stays the default."""
+    from xonsh.foreign_shells import ForeignShellBaseAlias
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would raise
+        args, streaming = ForeignShellBaseAlias._is_streaming(["foo", "bar"])
+    assert streaming is True
+    assert args == ["foo", "bar"]

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -481,7 +481,11 @@ class ForeignShellBaseAlias:
         env = XSH.env
         denv = env.detype()
         if streaming:
-            subprocess.check_call(cmd, env=denv)
+            # Pass the alias's stdout/stderr through to the foreign shell so
+            # subprocess captures (e.g. ``$(foo)``) work. Without this, the
+            # foreign shell inherits xonsh's terminal fds and writes around
+            # the pipe xonsh set up for capture (issue #5043).
+            subprocess.check_call(cmd, env=denv, stdout=stdout, stderr=stderr)
             out = None
         else:
             out = subprocess.check_output(cmd, env=denv, stderr=subprocess.STDOUT)
@@ -502,9 +506,16 @@ class ForeignShellBaseAlias:
 
     @staticmethod
     def _is_streaming(args):
-        """Test and modify args if --xonsh-stream is present."""
+        """Test and modify args if ``--xonsh-nostream`` is present."""
         if "--xonsh-nostream" not in args:
             return args, True
+        warnings.warn(
+            "--xonsh-nostream is deprecated and will be removed in a future "
+            "release. Streaming mode (the default) now captures correctly "
+            "via $(...) and !(...) — drop the flag.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         args = list(args)
         args.remove("--xonsh-nostream")
         return args, False


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/5043

Changes:

* Foreign shell function aliases (e.g. bash functions loaded via `source-bash`) now stream their output through the caller-supplied `stdout`/`stderr` instead of inheriting xonsh's terminal fds, so `$(funcname)` and `!(funcname)` correctly capture what the function prints. 
* The legacy `--xonsh-nostream` opt-out is preserved for backward compatibility but now emits a `DeprecationWarning` since streaming captures correctly on its own.


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
