### PR TITLE
fix: AppImage: Remove legacy logic from entrypoint

### DIFF
--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -1,2 +1,2 @@
-#! /bin/bash -i
-{{ python-executable }} -u "${APPDIR}/opt/python{{ python-version }}/bin/xonsh" "$@"
+#! /bin/bash
+exec {{ python-executable }} -u "${APPDIR}/opt/python{{ python-version }}/bin/xonsh" "$@"


### PR DESCRIPTION
The logic with `bash -i` was legacy. After https://github.com/xonsh/xonsh/pull/6290 we can remove it.

* Fixes https://github.com/xonsh/xonsh/issues/5807

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
