### PR TITLE
feat: Parser: Allow comments in multiline commands

### DIFF
--- a/tests/test_execer_llm.py
+++ b/tests/test_execer_llm.py
@@ -1,20 +1,38 @@
-"""End-to-end tests for ``CtxAwareTransformer.try_subproc_toks`` in eval mode.
+"""LLM-generated end-to-end regression tests for the execer.
 
-Regression coverage for GH-6386: with the ``coconut`` xontrib loaded,
-``CtxAwareTransformer.mode`` is forced to ``"eval"`` so the whole
-stripped logical line is fed to ``subproc_toks``.  When phase 1 has
-already wrapped part of the line as ``![…]`` (e.g. for
-``echo && echo hi`` → ``echo && ![echo hi]``), the eval-mode wrap of
-the remaining bare ``Name`` used to produce ``![![echo hi]]`` (invalid
-xonsh), the parser raised ``SyntaxError``, ``try_subproc_toks``
-swallowed it, and the bare ``Name('echo')`` survived to runtime as a
-``NameError``.  A second variant silently miscompiled
-``cmd1 && cmd2`` (both bare, both single-token) into ``cmd2 && cmd2``.
+GH-6386 — ``CtxAwareTransformer.try_subproc_toks`` in eval mode
+===============================================================
+
+With the ``coconut`` xontrib loaded, ``CtxAwareTransformer.mode`` is
+forced to ``"eval"`` so the whole stripped logical line is fed to
+``subproc_toks``.  When phase 1 has already wrapped part of the line as
+``![…]`` (e.g. for ``echo && echo hi`` → ``echo && ![echo hi]``), the
+eval-mode wrap of the remaining bare ``Name`` used to produce
+``![![echo hi]]`` (invalid xonsh), the parser raised ``SyntaxError``,
+``try_subproc_toks`` swallowed it, and the bare ``Name('echo')``
+survived to runtime as a ``NameError``.  A second variant silently
+miscompiled ``cmd1 && cmd2`` (both bare, both single-token) into
+``cmd2 && cmd2``.
 
 The tests reproduce both classes without depending on coconut by
 driving ``CtxAwareTransformer`` in eval mode directly via the same
 ``mode = "eval"`` flip the coconut xontrib performs (see
 ``coconut.integrations.CoconutXontribLoader.new_try_subproc_toks``).
+
+GH-6414 — fish-style continuation comments
+==========================================
+
+A multi-line command joined with backslash continuation may contain
+comment-only lines in between; the continuation extends through them.
+These tests drive the public ``Execer.parse`` path so they exercise
+both the source preprocessor (``strip_continuation_comments``) and
+every downstream consumer that depends on a coherent continuation
+chain — ``tokenize``, ``_ends_with_line_continuation``,
+``get_logical_line``, ``subproc_toks``, and the context-aware
+transformer's recovery loop.  Without the preprocessor these snippets
+either fail to parse outright (``SyntaxError: unexpected indent``) or
+hit the recovery loop's safety bail-out as the comment-only line
+repeatedly breaks the logical line.
 """
 
 import ast as pyast
@@ -76,3 +94,27 @@ def test_andor_chain_eval_mode(line, xession):
         f"  exec: {exec_unparsed}\n"
         f"  eval: {eval_unparsed}"
     )
+
+
+# --- GH-6414: fish-style continuation comments -------------------------
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # Issue #6414: original example
+        "echo 1 \\\n    # 2 \\\n    3 \\\n    4\n",
+        # Comment with no trailing backslash is also transparent
+        "echo 1 \\\n    # 2\n    3\n",
+        # Multiple consecutive comment-only lines
+        "echo a \\\n    # c1\n    # c2 \\\n    b\n",
+        # Mixed: one comment with `\\`, one without
+        "echo a \\\n    # c1 \\\n    # c2\n    b\n",
+        # Inside a function body
+        "def f():\n    echo 1 \\\n        # inner comment\n        2\nf()\n",
+        # Inside a $() substitution
+        "x = $(echo 1 \\\n    # 2 \\\n    3)\n",
+    ],
+)
+def test_line_cont_with_comment(code, xonsh_execer_parse):
+    assert xonsh_execer_parse(code)

--- a/tests/test_tools_llm.py
+++ b/tests/test_tools_llm.py
@@ -162,4 +162,10 @@ def test_subproc_toks_already_wrapped_chain(line, expected):
     ],
 )
 def test_strip_continuation_comments(src, exp, xession):
+    # Pin the line-continuation marker to ``\\`` so expectations stay
+    # platform-agnostic. On Windows, ``get_line_continuation()`` returns
+    # ``" \\"`` whenever ``XONSH_INTERACTIVE`` is true, which the preprocessor
+    # would faithfully use as the replacement marker — but the unit-test
+    # expectations encode the non-interactive shape.
+    xession.env["XONSH_INTERACTIVE"] = False
     assert strip_continuation_comments(src) == exp

--- a/tests/test_tools_llm.py
+++ b/tests/test_tools_llm.py
@@ -1,26 +1,44 @@
-"""Tests for ``xonsh.tools.subproc_toks`` against already-wrapped lines.
+"""LLM-generated regression coverage for ``xonsh.tools`` parsing helpers.
 
-Regression coverage for GH-6386: ``subproc_toks`` called on a line that
-has already been partially wrapped by an earlier parse pass (e.g. xonsh
-phase 1 turning ``echo && echo hi`` into ``echo && ![echo hi]``) used
-to re-wrap the existing ``![…]`` block, producing ``![![…]]`` — which
-is not valid xonsh, since neither ``![…]`` nor ``&&``/``||`` may appear
-inside ``![…]``.  The bug surfaced in xontribs that force
-``CtxAwareTransformer.mode = "eval"`` to compensate for shifted column
-numbers in their compiled output (the ``coconut`` xontrib being the
-canonical example), making the whole-line wrap reach phase-1 output.
+GH-6386 — ``subproc_toks`` against already-wrapped lines
+========================================================
+
+``subproc_toks`` called on a line that has already been partially wrapped
+by an earlier parse pass (e.g. xonsh phase 1 turning ``echo && echo hi``
+into ``echo && ![echo hi]``) used to re-wrap the existing ``![…]`` block,
+producing ``![![…]]`` — which is not valid xonsh, since neither ``![…]``
+nor ``&&``/``||`` may appear inside ``![…]``.  The bug surfaced in
+xontribs that force ``CtxAwareTransformer.mode = "eval"`` to compensate
+for shifted column numbers in their compiled output (the ``coconut``
+xontrib being the canonical example), making the whole-line wrap reach
+phase-1 output.
 
 These tests pin the corrected behaviour at the ``subproc_toks`` layer
 without depending on coconut: skip already-wrapped ``![…]``/``$[…]``
 blocks, fall back to the bare region preceding the skip when the
 trailing region is fully wrapped, and decline (return ``None``) when
 every region in the chain is already wrapped.
+
+GH-6414 — ``strip_continuation_comments`` (fish-style)
+======================================================
+
+A physical line that is "just a comment" sitting inside a multi-line
+command joined by backslash continuation should be transparent — the
+continuation extends through it to the next physical line, mirroring
+fish-shell behaviour. ``strip_continuation_comments`` normalises this
+at source-level so the rest of the pipeline (``tokenize``,
+``_ends_with_line_continuation``, ``get_logical_line``,
+``subproc_toks``) sees a uniform continuation chain. Tests pin both the
+success cases and the boundaries that must remain unchanged: ``#``
+inside a string literal, an inline ``# \\`` at the end of a regular
+code line (#6294 regression), and lines inside an open triple-quoted
+string.
 """
 
 import pytest
 
 from xonsh.parsers.lexer import Lexer
-from xonsh.tools import subproc_toks
+from xonsh.tools import strip_continuation_comments, subproc_toks
 
 LEXER = Lexer()
 LEXER.build()
@@ -74,3 +92,74 @@ def test_subproc_toks_already_wrapped_chain(line, expected):
     """
     obs = subproc_toks(line, mincol=0, maxcol=None, lexer=LEXER, returnline=False)
     assert obs == expected
+
+
+# --- GH-6414: fish-style continuation comments -------------------------
+
+
+@pytest.mark.parametrize(
+    "src, exp",
+    [
+        # Issue #6414 example: comment with trailing ``\`` between
+        # continued lines is consumed, continuation extends through.
+        (
+            "echo 1 \\\n    # 2 \\\n    3 \\\n    4\n",
+            "echo 1 \\\n\\\n    3 \\\n    4\n",
+        ),
+        # Comment without trailing ``\`` is also transparent inside a
+        # continuation chain (matches fish-shell semantics).
+        (
+            "echo 1 \\\n    # 2\n    3\n",
+            "echo 1 \\\n\\\n    3\n",
+        ),
+        # Multiple comment-only lines in a row are all consumed.
+        (
+            "echo a \\\n    # c1\n    # c2 \\\n    b\n",
+            "echo a \\\n\\\n\\\n    b\n",
+        ),
+        # A blank line breaks the continuation; the comment-only line
+        # preceding it is replaced, but the blank line ends the chain.
+        (
+            "echo 1 \\\n    # comment\n\n    3\n",
+            "echo 1 \\\n\\\n\n    3\n",
+        ),
+        # Top-level comment with no preceding ``\`` continuation is
+        # left untouched.
+        (
+            "echo first\n# comment\necho second\n",
+            "echo first\n# comment\necho second\n",
+        ),
+        # Inline ``# \\`` at the end of a regular code line must NOT
+        # set in_continuation -- regression for #6294 follow-up.
+        ("a = 1 # \\\necho 1\n", "a = 1 # \\\necho 1\n"),
+        # Lines inside an open triple-quoted string are not touched
+        # even if they look like comment-only physical lines.
+        (
+            's = """foo\n# in string\nbar"""\n',
+            's = """foo\n# in string\nbar"""\n',
+        ),
+        # ``#`` inside a string literal does not start a comment, so a
+        # ``\\`` at end of that line is a real continuation.
+        (
+            'echo "1 # not comment" \\\n    2\n',
+            'echo "1 # not comment" \\\n    2\n',
+        ),
+        # Source without any newlines is returned as-is.
+        ("echo hi", "echo hi"),
+        # CRLF line endings are preserved.
+        (
+            "echo 1 \\\r\n    # 2\r\n    3\r\n",
+            "echo 1 \\\r\n\\\r\n    3\r\n",
+        ),
+        # Comment-only line at the very start (no preceding ``\``)
+        # remains unchanged.
+        ("# header\necho 1\n", "# header\necho 1\n"),
+        # Tab/whitespace-prefixed comment also matches.
+        (
+            "echo 1 \\\n\t# tabbed\n    2\n",
+            "echo 1 \\\n\\\n    2\n",
+        ),
+    ],
+)
+def test_strip_continuation_comments(src, exp, xession):
+    assert strip_continuation_comments(src) == exp

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -16,6 +16,7 @@ from xonsh.tools import (
     get_logical_line,
     replace_logical_line,
     starting_whitespace,
+    strip_continuation_comments,
     subproc_toks,
 )
 
@@ -247,6 +248,7 @@ class Execer:
             filename = self.filename
         if mode != "eval" and not input.endswith("\n"):
             input += "\n"
+        input = strip_continuation_comments(input)
 
         def _try_parse(input, greedy):
             last_error_line = last_error_col = -1

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -667,6 +667,56 @@ def _ends_with_line_continuation(line, linecont):
     return True
 
 
+def strip_continuation_comments(src):
+    """Strip comment-only lines that fall inside a backslash-continuation chain.
+
+    Within a multi-line command joined by ``\\<NL>``, a physical line that
+    consists only of optional whitespace followed by a ``#`` comment is
+    transparent: the continuation extends through it to the next physical
+    line. This mirrors fish-shell behaviour (see issue #6414)::
+
+        echo 1 \\
+            # comment
+            2 \\
+            3
+
+    yields ``echo 1 2 3``. Each such comment-only line is replaced by a
+    bare ``\\<NL>`` continuation marker, preserving line numbers so error
+    locations remain accurate.
+
+    A ``#`` inside a string literal does not start a comment, and a line
+    inside an open triple-quoted string is left untouched. Comment-only
+    lines that are NOT preceded by an active backslash continuation are
+    also left untouched, so a top-level ``# comment`` keeps its current
+    semantics.
+    """
+    if "\n" not in src and "\r" not in src:
+        return src
+    linecont = get_line_continuation()
+    out = []
+    in_cont = False  # previous "active" line ended with continuation
+    accumulated = ""  # used only to track open triple-quoted strings
+    in_triple = False
+    for raw in src.splitlines(keepends=True):
+        if raw.endswith("\r\n"):
+            body, eol = raw[:-2], "\r\n"
+        elif raw[-1:] in ("\n", "\r"):
+            body, eol = raw[:-1], raw[-1:]
+        else:
+            body, eol = raw, ""
+        is_comment_only = not in_triple and body.lstrip(" \t\f").startswith("#")
+        if in_cont and is_comment_only:
+            replacement = linecont + eol
+            out.append(replacement)
+            accumulated += replacement
+            continue
+        out.append(raw)
+        accumulated += raw
+        in_triple = bool(_have_open_triple_quotes(accumulated))
+        in_cont = False if in_triple else _ends_with_line_continuation(body, linecont)
+    return "".join(out)
+
+
 def get_logical_line(lines, idx):
     """Returns a single logical line (i.e. one without line continuations)
     from a list of lines.  This line should begin at index idx. This also


### PR DESCRIPTION
* Closes https://github.com/xonsh/xonsh/issues/6414

### Before

```xsh
echo 1 \
   # 2 \
    3
# Error
```


### Afer

```xsh
echo 1 \
   # 2 \
    3
# 1 3
```

### Real life example

<img width="908" height="395" alt="image" src="https://github.com/user-attachments/assets/2a67b508-60dc-4547-916b-1098b006646a" />


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
