### PR TITLE
fix(docs): Fix code highlighting

### DIFF
--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -1,8 +1,11 @@
 Run Control File
 =========================
 Xonsh allows you to customize your shell behavior with run control files, called "xonshrc" files.
-These files are written either in the Xonsh language (a superset of Python) or in Python and are executed
+These files are written either in the Xonsh language or in Python and are executed
 exactly once at startup.
+
+Xonsh RC Basics
+---------------
 
 The control file usually contains:
 

--- a/tests/test_pyghooks_llm.py
+++ b/tests/test_pyghooks_llm.py
@@ -8,6 +8,12 @@ Currently covers:
   https://github.com/xonsh/xonsh/issues/6387 (``LS_COLORS`` carrying ANSI
   blink/reverse/hidden/strike codes used to crash pygments' ``StyleMeta``
   with ``AssertionError: wrong color format 'blink'`` at shell startup).
+* Plugin-mode lenient highlighting — when ``XonshLexer`` is loaded as a
+  pygments entry point outside a live xonsh session (Sphinx,
+  nbconvert, jupyter), runtime checks for ``$VAR`` / subprocess
+  commands / ``@()`` names cannot succeed, so the lexer must emit the
+  optimistic token instead of flooding rendered output with Error
+  markers.
 """
 
 from unittest.mock import MagicMock, patch
@@ -15,7 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from xonsh.environ import LsColors
-from xonsh.pyghooks import XonshStyle
+from xonsh.pyghooks import Token, XonshLexer, XonshStyle
 
 
 @pytest.fixture(autouse=True)
@@ -154,3 +160,63 @@ def test_xonsh_style_proxy_strips_ptk_modifiers_from_ls_colors(xs_LS_COLORS):
             )
         # Color information must be preserved
         assert "ansired" in sanitized
+
+
+@pytest.fixture
+def plugin_mode_lexer(xession, monkeypatch):
+    """Reproduce the state the lexer sees when loaded as a pygments
+    plugin outside a live xonsh session (Sphinx, nbconvert, jupyter):
+    ``XSH.commands_cache`` is None, ``XSH.env`` is the empty mock, and
+    ``XSH.ctx`` is None. ``_is_plugin_mode`` keys off
+    ``commands_cache is None``."""
+    monkeypatch.setattr(xession, "commands_cache", None)
+    monkeypatch.setattr(xession, "env", None)
+    monkeypatch.setattr(xession, "ctx", None)
+    return XonshLexer()
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "$THIS_VAR_DOES_NOT_EXIST = 1",
+        "$ANOTHER_UNKNOWN.append('/x')",
+        "$(unknown_cmd_xyz arg1 arg2)",
+        "echo @(undefined_name)",
+    ],
+)
+def test_plugin_mode_no_error_tokens(plugin_mode_lexer, code):
+    """Without a live session, runtime checks for ``$VAR`` / subprocess
+    commands / ``@()`` names cannot succeed (no env, no commands cache,
+    no ctx).  In that mode the lexer must fall back to the optimistic
+    token instead of marking everything as Error — otherwise rendered
+    docs / notebooks are flooded with red error markers around tokens
+    that are perfectly valid xonsh code (regression for Sphinx-rendered
+    ``.xsh`` snippets in the docs build)."""
+    tokens = list(plugin_mode_lexer.get_tokens(code))
+    err_values = [v for t, v in tokens if t is Token.Error]
+    assert err_values == [], f"{code!r}: unexpected Error tokens {err_values!r}"
+
+
+def test_plugin_mode_keeps_python_lexing(plugin_mode_lexer):
+    """Plugin-mode lenience must not switch the lexer into ``subproc``
+    state for plain Python source.  The leading ``#`` of a comment
+    matches ``COMMAND_TOKEN_RE`` and would otherwise be promoted to
+    ``Name.Builtin``, leaving the rest of the file lexed as a
+    subprocess command line (brackets become Error, etc.)."""
+    code = "# adjust some paths\n$PATH.append('/foo')\n"
+    tokens = list(plugin_mode_lexer.get_tokens(code))
+    assert any(t is Token.Comment.Single for t, _ in tokens), (
+        f"comment was not preserved: {tokens!r}"
+    )
+    assert all(t is not Token.Error for t, _ in tokens), tokens
+
+
+def test_unknown_env_var_still_error_in_live_session(xession):
+    """In a real session ``XSH.commands_cache`` is set, so the lexer
+    keeps the strict check — a typo in a ``$VAR`` reference is still
+    surfaced as Error.  Regression guard for the plugin-mode fix."""
+    assert getattr(xession, "commands_cache", None) is not None
+    lexer = XonshLexer()
+    tokens = list(lexer.get_tokens("$THIS_VAR_DOES_NOT_EXIST = 1\n"))
+    err_values = [v for t, v in tokens if t is Token.Error]
+    assert "$THIS_VAR_DOES_NOT_EXIST" in err_values

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1654,6 +1654,24 @@ _ptk_app: object | None = None  # Captured on the main thread for bg invalidatio
 _validation_gen: int = 0  # Generation token — incremented on each new input
 
 
+def _is_plugin_mode():
+    """True when XonshLexer runs without a live xonsh session.
+
+    The lexer is registered as a pygments entry point and gets imported by
+    Sphinx, nbconvert, jupyter console, and other tools that never call
+    ``xonsh.main.setup()``.  In those contexts the singleton is bare —
+    ``XSH.commands_cache`` is None, ``XSH.env`` is the mock ``{}`` set by
+    ``XonshLexer.__init__``, ``XSH.ctx`` is None — so runtime checks
+    against env / commands cache / context return False for everything
+    and would mark every ``$VAR``, every subprocess command, and every
+    ``@()``-substituted name as Error.  When this returns True, callbacks
+    emit the optimistic token (``Name.Variable`` / ``Name.Builtin`` /
+    ``Name``) instead of Error, so rendered xonsh code reads as plain
+    syntax highlighting rather than a sea of red error markers.
+    """
+    return getattr(XSH, "commands_cache", None) is None
+
+
 @events.on_pre_prompt
 def _clear_cmd_caches(**kwargs):
     global _validation_gen
@@ -1830,6 +1848,9 @@ def _at_bracket_name_cb(_, match):
     name = match.group()
     if _at_bracket_check:
         _at_bracket_check = False
+        if _is_plugin_mode():
+            yield match.start(), Name, name
+            return
         ctx = getattr(XSH, "ctx", None) or {}
         found = name in ctx or hasattr(builtins, name) or iskeyword(name)
         yield match.start(), Name if found else Error, name
@@ -1849,7 +1870,7 @@ def _env_var_cb(_, match):
     text = match.group()
     name = text[1:]  # strip leading $
     env = getattr(XSH, "env", None)
-    found = env is not None and name in env
+    found = (env is not None and name in env) or _is_plugin_mode()
     yield match.start(), Name.Variable if found else Error, text
 
 
@@ -1858,7 +1879,8 @@ def subproc_cmd_callback(_, match):
     otherwise fallback to fallback lexer.
     """
     cmd = match.group()
-    yield match.start(), Name.Builtin if _command_is_valid(cmd) else Error, cmd
+    valid = _is_plugin_mode() or _command_is_valid(cmd)
+    yield match.start(), Name.Builtin if valid else Error, cmd
 
 
 def subproc_arg_callback(_, match):
@@ -2062,7 +2084,18 @@ class XonshLexer(Python3Lexer):
 
     def get_tokens_unprocessed(self, text, **_):
         """Check first command, then call super.get_tokens_unprocessed
-        with root or subproc state"""
+        with root or subproc state.
+
+        Plugin mode (no live session — Sphinx, nbconvert, jupyter) keeps
+        the original strict check here on purpose: ``_command_is_valid``
+        rejects keywords, so a Python source line like ``from foo import
+        bar`` correctly falls through to root state and is highlighted as
+        Python.  Treating *every* leading token as a valid command would
+        switch the lexer into ``subproc`` state for any input whose first
+        non-whitespace character matches ``COMMAND_TOKEN_RE`` (including
+        ``#`` for plain comments), wrecking highlighting for the rest of
+        the file.
+        """
         start = 0
         state = ("root",)
         m = re.match(rf"(\s*)({COMMAND_TOKEN_RE})", text)


### PR DESCRIPTION

The code highlighting is not working because pygments has empty xonsh session. In this case we need to ignore error in names.

<img width="767" height="581" alt="image" src="https://github.com/user-attachments/assets/e26ab567-d967-45f6-a8a1-9f8a4c719929" />


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
