### PR TITLE
fix: Conda on Windows: `conda init xonsh` produces TypeError. Also fixed conda activate/deactivate aliases when conda is on $PATH

### DIFF
--- a/tests/aliases/test_conda_aliases_llm.py
+++ b/tests/aliases/test_conda_aliases_llm.py
@@ -1,0 +1,52 @@
+"""Tests for conda activate/deactivate alias detection on Windows.
+
+See xonsh/xonsh#3676 — `conda init xonsh` is broken on Windows, so the
+`activate`/`deactivate` aliases are the practical fallback. They were
+previously gated on ``ON_ANACONDA`` only, which requires xonsh itself to
+be installed inside the conda env. This file covers the extended detection
+that also fires when ``conda`` is reachable on ``$PATH``.
+"""
+
+import shutil
+
+import pytest
+
+from xonsh.aliases import make_default_aliases
+
+
+def _activate_aliases(aliases):
+    return aliases.get("activate"), aliases.get("deactivate")
+
+
+@pytest.fixture
+def force_windows(monkeypatch, xession):
+    monkeypatch.setattr("xonsh.aliases.ON_WINDOWS", True)
+    monkeypatch.setattr("xonsh.aliases.ON_ANACONDA", False)
+    monkeypatch.setattr("xonsh.aliases._find_cmd_exe", lambda: "cmd.exe")
+    return monkeypatch
+
+
+def test_no_conda_no_activate_alias(force_windows, xession):
+    force_windows.setattr(shutil, "which", lambda name, **kw: None)
+    aliases = make_default_aliases()
+    assert _activate_aliases(aliases) == (None, None)
+
+
+def test_conda_on_path_sets_activate_alias(force_windows, xession):
+    def fake_which(name, **kw):
+        return r"C:\miniconda3\Scripts\conda.exe" if name == "conda" else None
+
+    force_windows.setattr(shutil, "which", fake_which)
+    aliases = make_default_aliases()
+    activate, deactivate = _activate_aliases(aliases)
+    assert activate == ["source-cmd", "activate.bat"]
+    assert deactivate == ["source-cmd", "deactivate.bat"]
+
+
+def test_on_anaconda_sets_activate_alias(force_windows, xession):
+    force_windows.setattr("xonsh.aliases.ON_ANACONDA", True)
+    force_windows.setattr(shutil, "which", lambda name, **kw: None)
+    aliases = make_default_aliases()
+    activate, deactivate = _activate_aliases(aliases)
+    assert activate == ["source-cmd", "activate.bat"]
+    assert deactivate == ["source-cmd", "deactivate.bat"]

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1732,8 +1732,14 @@ def make_default_aliases():
         default_aliases["call"] = ["source-cmd"]
         default_aliases["source-bat"] = ["source-cmd"]
         default_aliases["clear"] = "cls"
-        if ON_ANACONDA:
-            # Add aliases specific to the Anaconda python distribution.
+        if ON_ANACONDA or shutil.which(
+            "conda", path=XSH.env.get_detyped("PATH")
+        ):
+            # ON_ANACONDA only fires when xonsh itself is installed inside the
+            # conda env (sys.prefix has conda-meta/). Pip-installed xonsh +
+            # standalone Miniconda3 leaves it False, so also probe $PATH for
+            # a `conda` launcher to give those users a working fallback while
+            # `conda init xonsh` on Windows is broken — see xonsh/xonsh#3676.
             default_aliases["activate"] = ["source-cmd", "activate.bat"]
             default_aliases["deactivate"] = ["source-cmd", "deactivate.bat"]
         if not shutil.which("sudo", path=XSH.env.get_detyped("PATH")):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1732,9 +1732,7 @@ def make_default_aliases():
         default_aliases["call"] = ["source-cmd"]
         default_aliases["source-bat"] = ["source-cmd"]
         default_aliases["clear"] = "cls"
-        if ON_ANACONDA or shutil.which(
-            "conda", path=XSH.env.get_detyped("PATH")
-        ):
+        if ON_ANACONDA or shutil.which("conda", path=XSH.env.get_detyped("PATH")):
             # ON_ANACONDA only fires when xonsh itself is installed inside the
             # conda env (sys.prefix has conda-meta/). Pip-installed xonsh +
             # standalone Miniconda3 leaves it False, so also probe $PATH for


### PR DESCRIPTION
## Summary

Closes part of #3676 from the xonsh side.

The Windows-only `activate` / `deactivate` aliases in `xonsh/aliases.py` were gated on `ON_ANACONDA`, which only fires when xonsh itself is installed inside the conda env (`sys.prefix/conda-meta/`). The common setup of pip-installed xonsh + standalone Miniconda3 leaves them unset, so users have no working activation path — and `conda init xonsh` on Windows is independently broken (also #3676), so they're stuck.

This adds a `shutil.which("conda")` probe so those users get the same `source-cmd`-based fallback automatically.

## Waiting

- [ ] https://github.com/conda/conda/pull/16065
- [ ] https://github.com/conda/conda/pull/16064