### PR TITLE
feat: Add sentinel `@.env.DELETE_VAR` to removing env variables using env swap/layouts/specs

### DIFF
--- a/docs/env.rst
+++ b/docs/env.rst
@@ -193,6 +193,48 @@ Multiple variables can be swapped at once:
     with @.env.swap(LANG='C', LC_ALL='C'):
         sort data.txt
 
+Unsetting a Variable
+--------------------
+
+Sometimes you need to remove an environment variable for a single command
+or a single scope, not just override it. Assigning the sentinel
+``@.env.DELETE_VAR`` does exactly that — the variable behaves as if it
+was never set for the duration of the surrounding scope:
+
+.. code-block:: xonshcon
+
+    @ $HOSTNAME='myhost'
+    @ $HOSTNAME=@.env.DELETE_VAR env | grep -c '^HOSTNAME='
+    0
+    @ echo $HOSTNAME
+    myhost
+
+The sentinel works on every path where a variable can be set:
+
+.. code-block:: xonsh
+
+    # Inline prefix for a single subprocess
+    $HTTPS_PROXY=@.env.DELETE_VAR curl https://example.com
+
+    # `swap` block — mask a variable for a multi-statement scope
+    with @.env.swap(LD_PRELOAD=@.env.DELETE_VAR):
+        # Run something that misbehaves with LD_PRELOAD
+
+    # Inside a callable alias — mask for any subprocess it spawns
+    @aliases.register
+    def _clean_env(env):
+        env['HOSTNAME'] = @.env.DELETE_VAR
+        # ...
+
+    # In an `on_pre_spec_run` handler — mask per-spec at runtime
+    @events.on_pre_spec_run
+    def _strip_secrets(spec, **_):
+        spec.env = (spec.env or {}) | {'SECRET_TOKEN': @.env.DELETE_VAR}
+
+Reading a masked variable raises ``KeyError``, ``in`` returns ``False``,
+and iteration / ``detype`` skip the key — so nothing leaks the sentinel
+into a subprocess as a stringified value.
+
 Callable Environment Variables
 ------------------------------
 

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -28,6 +28,17 @@ if we wanted to intercept all specs, we could write:
     def print_when_ls(spec=None, **kwargs):
         print("Running a command")
 
+To mask an environment variable for the subprocess this spec is about to
+run, set ``spec.env[name] = @.env.DELETE_VAR``. The variable will not
+appear in the environment passed to the child process, even if it is set
+in the session env:
+
+.. code-block:: python
+
+    @events.on_pre_spec_run
+    def strip_secrets(spec, **_):
+        spec.env = (spec.env or {}) | {'SECRET_TOKEN': @.env.DELETE_VAR}
+
 
 ``on_pre_spec_run_<cmd-name>(spec: SubprocSpec) -> None``
 .........................................................

--- a/tests/test_environ_llm.py
+++ b/tests/test_environ_llm.py
@@ -1,8 +1,11 @@
 import os
 import pathlib
+import pickle
 from collections.abc import Iterable
 
-from xonsh.environ import Env, EnvPath
+import pytest
+
+from xonsh.environ import DELETE_VAR, Env, EnvPath, _DeleteVarSentinel
 from xonsh.tools import env_path_to_str
 
 
@@ -77,3 +80,293 @@ def test_env_windows_does_not_strip_other_path_vars(monkeypatch):
     raw = os.pathsep.join(["", "manuals"])
     env = Env(MANPATH=raw)
     assert env["MANPATH"]._l == ["", "manuals"]
+
+
+# ═══ DELETE_VAR sentinel ═══════════════════════════════════════════════
+#
+# Covers the sentinel value that masks an environment variable for the
+# duration of the surrounding scope: the public surface (direct assign,
+# ``swap``, overlays, detype, iteration, ``in``-checks, event firing)
+# and the two integration points where the sentinel must be honored —
+# the ``spec.env`` override dict used by ``prep_env_subproc`` (inline
+# ``$VAR=…`` prefix and ``on_pre_spec_run`` handlers) and the overlay
+# dict passed to callable aliases.
+
+
+# ── singleton & exposure ───────────────────────────────────────────────
+
+
+def test_delete_var_is_singleton():
+    assert DELETE_VAR is _DeleteVarSentinel()
+    assert DELETE_VAR is _DeleteVarSentinel()
+
+
+def test_delete_var_exposed_on_env_class_and_instance():
+    assert Env.DELETE_VAR is DELETE_VAR
+    env = Env()
+    # The attribute path used by `@.env.DELETE_VAR` resolves via class
+    # lookup, in parallel with the mapping `__getitem__`.
+    assert env.DELETE_VAR is DELETE_VAR
+
+
+def test_delete_var_repr_is_stable():
+    assert repr(DELETE_VAR) == "<XSH.env.DELETE_VAR>"
+
+
+def test_delete_var_pickle_roundtrip():
+    # Spec.env can travel through machinery that pickles things (e.g.
+    # multiprocessing); the sentinel must survive a round trip as the
+    # same singleton, not become a distinct object that fails `is` checks.
+    restored = pickle.loads(pickle.dumps(DELETE_VAR))
+    assert restored is DELETE_VAR
+
+
+# ── direct assignment ─────────────────────────────────────────────────
+
+
+def test_direct_assign_removes_existing_var():
+    env = Env(FOO="bar")
+    assert env["FOO"] == "bar"
+    env["FOO"] = DELETE_VAR
+    assert "FOO" not in env
+    with pytest.raises(KeyError):
+        env["FOO"]
+
+
+def test_direct_assign_on_absent_var_is_noop():
+    env = Env()
+    # Must not raise even though FOO is not a known var: the user's
+    # intent ("make sure FOO is absent") is already satisfied.
+    env["FOO"] = DELETE_VAR
+    assert "FOO" not in env
+
+
+def test_get_returns_default_for_masked_var():
+    env = Env(FOO="bar")
+    env["FOO"] = DELETE_VAR
+    assert env.get("FOO", "fallback") == "fallback"
+    assert env.get("FOO") is None
+
+
+# ── swap (thread-local) ───────────────────────────────────────────────
+
+
+def test_swap_with_delete_var_masks_then_restores():
+    env = Env(FOO="bar")
+    with env.swap(FOO=DELETE_VAR):
+        assert "FOO" not in env
+        with pytest.raises(KeyError):
+            env["FOO"]
+    assert env["FOO"] == "bar"
+
+
+def test_swap_with_delete_var_on_absent_key_stays_absent_after_exit():
+    env = Env()
+    with env.swap(FOO=DELETE_VAR):
+        assert "FOO" not in env
+    assert "FOO" not in env
+
+
+def test_nested_swap_inner_delete_does_not_leak():
+    env = Env(FOO="orig")
+    with env.swap(FOO="middle"):
+        with env.swap(FOO=DELETE_VAR):
+            assert "FOO" not in env
+        # Inner swap restores middle's value, not the original.
+        assert env["FOO"] == "middle"
+    assert env["FOO"] == "orig"
+
+
+def test_swap_with_delete_var_then_inner_override_re_introduces():
+    env = Env(FOO="orig")
+    with env.swap(FOO=DELETE_VAR):
+        assert "FOO" not in env
+        with env.swap(FOO="new"):
+            assert env["FOO"] == "new"
+        assert "FOO" not in env
+    assert env["FOO"] == "orig"
+
+
+# ── overlay parameter (used by callable aliases) ──────────────────────
+
+
+def test_overlay_delete_var_masks():
+    # `Env.swap(overlay=…)` is the API used by ProcProxy to expose an
+    # `env` parameter to callable aliases. Putting DELETE_VAR there
+    # must mask the underlying var both for reads and for `detype`.
+    env = Env(FOO="bar", BAZ="qux")
+    overlay = {}
+    with env.swap(overlay=overlay):
+        overlay["FOO"] = DELETE_VAR
+        assert "FOO" not in env
+        assert env.get("BAZ") == "qux"
+        d = env.detype()
+        assert "FOO" not in d
+        assert d.get("BAZ") == "qux"
+    assert env["FOO"] == "bar"
+
+
+def test_overlay_value_wins_over_underlying_delete_var():
+    # If `swap` masks FOO via DELETE_VAR but a later overlay sets FOO
+    # to a real value, that real value wins on read and in detype.
+    env = Env(FOO="orig")
+    overlay = {"FOO": "new"}
+    with env.swap({"FOO": DELETE_VAR}, overlay=overlay):
+        assert env["FOO"] == "new"
+        assert env.detype().get("FOO") == "new"
+
+
+# ── detype ────────────────────────────────────────────────────────────
+
+
+def test_detype_skips_delete_var_keys():
+    env = Env(FOO="bar", BAZ="qux")
+    with env.swap(FOO=DELETE_VAR):
+        d = env.detype()
+        assert "FOO" not in d
+        assert d.get("BAZ") == "qux"
+
+
+def test_detype_does_not_leak_sentinel_as_string():
+    # Regression guard: a naive implementation would let `ensure_string`
+    # render the sentinel as "<XSH.env.DELETE_VAR>" and put that into
+    # the env dict passed to Popen.
+    env = Env(FOO="bar")
+    with env.swap(FOO=DELETE_VAR):
+        d = env.detype()
+        assert "<XSH.env.DELETE_VAR>" not in d.values()
+
+
+def test_detype_cache_invalidated_by_delete_var_transitions():
+    env = Env(FOO="bar")
+    assert env.detype().get("FOO") == "bar"  # primes the cache
+    env["FOO"] = DELETE_VAR
+    assert "FOO" not in env.detype()
+    env["FOO"] = "back"
+    assert env.detype().get("FOO") == "back"
+
+
+# ── iteration & membership ────────────────────────────────────────────
+
+
+def test_iter_skips_delete_var_keys():
+    env = Env(A="1", B="2", C="3")
+    with env.swap(B=DELETE_VAR):
+        keys = {k for k in env if k in {"A", "B", "C"}}
+        assert keys == {"A", "C"}
+
+
+def test_contains_returns_false_for_delete_var():
+    env = Env(FOO="bar")
+    with env.swap(FOO=DELETE_VAR):
+        assert "FOO" not in env
+
+
+# ── events ────────────────────────────────────────────────────────────
+
+
+def test_no_event_fires_on_delete_var_transitions():
+    # User-facing handlers should not receive DELETE_VAR as a value:
+    # neither when the mask is applied nor when it is lifted.
+    import xonsh.environ as environ_mod
+
+    env = Env(FOO="bar")
+    seen = []
+
+    def _on_new(name, value, **_):
+        seen.append(("new", name, value))
+
+    def _on_change(name, oldvalue, newvalue, **_):
+        seen.append(("change", name, oldvalue, newvalue))
+
+    environ_mod.events.on_envvar_new(_on_new)
+    environ_mod.events.on_envvar_change(_on_change)
+    try:
+        with env.swap(FOO=DELETE_VAR):
+            pass
+        # The transition into the mask and back is invisible to handlers.
+        assert seen == [], f"unexpected events fired: {seen}"
+    finally:
+        environ_mod.events.on_envvar_new.discard(_on_new)
+        environ_mod.events.on_envvar_change.discard(_on_change)
+
+
+# ── integration: SubprocSpec.prep_env_subproc ─────────────────────────
+
+
+def test_prep_env_subproc_drops_delete_var_key(xession):
+    """The dict passed to ``subprocess.Popen(env=…)`` must not contain
+    a key that was masked via DELETE_VAR — neither as an empty value nor
+    as a stringified sentinel.
+    """
+    from xonsh.procs.specs import SubprocSpec
+
+    xession.env["MY_TEST_VAR"] = "leaked_value"
+    spec = SubprocSpec(
+        cmd=["/bin/true"],
+        env={"MY_TEST_VAR": DELETE_VAR},
+    )
+    kwargs = {}
+    spec.prep_env_subproc(kwargs)
+    assert "MY_TEST_VAR" not in kwargs["env"]
+    # The session env still has the original — only this subprocess
+    # sees the mask.
+    assert xession.env["MY_TEST_VAR"] == "leaked_value"
+
+
+def test_prep_env_subproc_drops_delete_var_but_keeps_override(xession):
+    from xonsh.procs.specs import SubprocSpec
+
+    xession.env["KEEP_ME"] = "session_value"
+    xession.env["DROP_ME"] = "leaked"
+    spec = SubprocSpec(
+        cmd=["/bin/true"],
+        env={"KEEP_ME": "override", "DROP_ME": DELETE_VAR},
+    )
+    kwargs = {}
+    spec.prep_env_subproc(kwargs)
+    assert kwargs["env"].get("KEEP_ME") == "override"
+    assert "DROP_ME" not in kwargs["env"]
+
+
+def test_on_pre_spec_run_handler_can_mask_via_delete_var(xession):
+    """Issue #5782: the handler must be able to remove a variable from
+    the subprocess env. Doing so via ``spec.env[name] = DELETE_VAR`` is
+    the supported pattern.
+    """
+    from xonsh.procs.specs import SubprocSpec
+
+    xession.env["FOO"] = "session_value"
+
+    def _mask(spec, **_):
+        spec.env = (spec.env or {}) | {"FOO": DELETE_VAR}
+
+    xession.builtins.events.on_pre_spec_run(_mask)
+    try:
+        spec = SubprocSpec(cmd=["/bin/true"])
+        spec._pre_run_event_fire("true")
+        kwargs = {}
+        spec.prep_env_subproc(kwargs)
+        assert "FOO" not in kwargs["env"]
+    finally:
+        xession.builtins.events.on_pre_spec_run.discard(_mask)
+
+
+def test_callable_alias_can_mask_via_overlay(xession):
+    """The user's example: writing ``env[k] = DELETE_VAR`` from inside a
+    callable alias must mask the variable for any read inside the alias
+    and for any subprocess spawned from the alias body. ``proxies.py``
+    runs the alias inside ``XSH.env.swap(spec.env, overlay=alias_env)``,
+    so we reproduce the same overlay protocol here.
+    """
+    xession.env["HOSTNAME"] = "myhost"
+    alias_env = {}
+    with xession.env.swap(overlay=alias_env):
+        # The alias body would do exactly this:
+        alias_env["HOSTNAME"] = DELETE_VAR
+        # From inside the alias, the variable is gone.
+        assert "HOSTNAME" not in xession.env
+        # And `detype` (called by any nested `prep_env_subproc`) omits it.
+        assert "HOSTNAME" not in xession.env.detype()
+    # Outside the alias scope the original value is intact.
+    assert xession.env["HOSTNAME"] == "myhost"

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -795,6 +795,45 @@ def test_single_command_no_windows(cmd, fmt, exp):
 
 
 @skip_if_on_windows
+@pytest.mark.parametrize(
+    "script, expected",
+    [
+        # Inline `$VAR=@.env.DELETE_VAR cmd` masks the variable for the
+        # immediate subprocess even when it is set in the session env.
+        # The inline-prefix form requires no whitespace around `=`.
+        (
+            f"$XONSH_DELETE_VAR_TEST = 'leaked_value'\n"
+            f"$XONSH_DELETE_VAR_TEST=@.env.DELETE_VAR {sys.executable} -c "
+            f"\"import os; print('XONSH_DELETE_VAR_TEST' not in os.environ)\"\n",
+            "True\n",
+        ),
+        # A callable alias can mask a variable for any subprocess it
+        # spawns by writing the sentinel into its overlay `env`
+        # parameter — the canonical example from the issue.
+        # `@aliases.register` strips the leading underscore, so the
+        # registered alias name is `check`, not `_check`.
+        (
+            f"""
+$XONSH_DELETE_VAR_TEST = 'leaked_value'
+
+@aliases.register
+def _check(env):
+    env['XONSH_DELETE_VAR_TEST'] = @.env.DELETE_VAR
+    {sys.executable} -c "import os; print('XONSH_DELETE_VAR_TEST' not in os.environ)"
+
+check
+""",
+            "True\n",
+        ),
+    ],
+)
+def test_env_delete_var(script, expected):
+    out, err, rtn = run_xonsh(script)
+    assert out == expected, err
+    assert rtn == 0, err
+
+
+@skip_if_on_windows
 def test_stdin_script_reopens_tty_for_children():
     """When xonsh reads a script from stdin and /dev/tty is available,
     it should reopen fd 0 on /dev/tty so child processes see a real

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2366,6 +2366,39 @@ def DEFAULT_VARS():
 #
 
 
+class _DeleteVarSentinel:
+    """Singleton marker used as a value to mask an environment variable.
+
+    Storing this value in :class:`Env` (directly, via :meth:`Env.swap`, via
+    a ``$VAR=<sentinel> cmd`` inline prefix, or via ``spec.env`` inside an
+    ``on_pre_spec_run`` handler) is treated as "this variable is unset" on
+    every read path: ``__getitem__``, ``__contains__``, ``get``, iteration,
+    and ``detype``. The original value reappears when the masking scope
+    ends (e.g. on ``swap`` exit). Exposed publicly as ``XSH.env.DELETE_VAR``.
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        return "<XSH.env.DELETE_VAR>"
+
+    def __reduce__(self):
+        # Pickle-safe: re-resolves to the same singleton on unpickle.
+        return (_resolve_delete_var, ())
+
+
+def _resolve_delete_var():
+    return DELETE_VAR
+
+
+DELETE_VAR = _DeleteVarSentinel()
+
+
 class Env(cabc.MutableMapping):
     """A xonsh environment, whose variables have limited typing.
     Most variables are, by default, strings.
@@ -2379,6 +2412,12 @@ class Env(cabc.MutableMapping):
     An Env instance may be converted to an untyped version suitable for
     use in a subprocess.
     """
+
+    # Public sentinel: assigning this value to a key (directly, via swap,
+    # inline `$VAR=@.env.DELETE_VAR cmd`, or `spec.env[k] = ...` in an
+    # `on_pre_spec_run` handler) hides the variable for the duration of
+    # the surrounding scope. See `_DeleteVarSentinel` for details.
+    DELETE_VAR = DELETE_VAR
 
     def __init__(self, *args, **kwargs):
         """If no initial environment is given, os_environ is used."""
@@ -2446,6 +2485,10 @@ class Env(cabc.MutableMapping):
         for overlay in self._overlay_stack:
             items.update(overlay)
         for key, val in items.items():
+            # Skip variables masked by DELETE_VAR — they must not reach
+            # subprocess.Popen as a stringified sentinel.
+            if val is DELETE_VAR:
+                continue
             if not isinstance(key, str):
                 key = str(key)
             detyper = self.get_detyper(key)
@@ -2476,7 +2519,11 @@ class Env(cabc.MutableMapping):
                 continue
             if not isinstance(key, str):
                 key = str(key)
-            val = self.__getitem__(key)
+            try:
+                val = self.__getitem__(key)
+            except KeyError:
+                # Masked by DELETE_VAR in `_d` or in an overlay.
+                continue
             detyper = self.get_detyper(key)
             if detyper is not None:
                 val = detyper(val)
@@ -2641,6 +2688,21 @@ class Env(cabc.MutableMapping):
         """
         return varname in self._d
 
+    def _capture_for_swap(self, key, local):
+        """Capture `key`'s pre-swap state so the outer scope can be
+        restored on exit. We probe the thread-local layer directly
+        instead of going through ``get`` so that a DELETE_VAR mask
+        survives a nested ``swap`` that overrides the same key with
+        a value — otherwise the mask would be silently dropped when
+        the inner ``swap`` exits.
+        """
+        if key in local:
+            return local[key]
+        try:
+            return self[key]
+        except KeyError:
+            return NotImplemented
+
     @contextlib.contextmanager
     def swap(self, other=None, overlay=None, **kwargs):
         """Provides a context manager for temporarily swapping out certain
@@ -2654,14 +2716,15 @@ class Env(cabc.MutableMapping):
         Callable aliases use this to provide scoped ``env`` variables.
         """
         old = {}
+        local = self._d._local
         # single positional argument should be a dict-like object
         if other is not None:
             for k, v in other.items():
-                old[k] = self.get(k, NotImplemented)
+                old[k] = self._capture_for_swap(k, local)
                 self._set_item(k, v, thread_local=True)
         # kwargs could also have been sent in
         for k, v in kwargs.items():
-            old[k] = self.get(k, NotImplemented)
+            old[k] = self._capture_for_swap(k, local)
             self._set_item(k, v, thread_local=True)
 
         if overlay is not None:
@@ -2704,12 +2767,21 @@ class Env(cabc.MutableMapping):
     def __getitem__(self, key):
         if key is Ellipsis:
             return self
-        # Check overlay stack top-down (most recent first)
+        # Check overlay stack top-down (most recent first). A DELETE_VAR
+        # in an overlay masks the key entirely — don't fall through to
+        # deeper overlays or to `_d`/defaults.
         for overlay in reversed(self._overlay_stack):
             if key in overlay:
-                return overlay[key]
+                val = overlay[key]
+                if val is DELETE_VAR:
+                    raise KeyError(
+                        f"Environment variable ${key} is masked by DELETE_VAR"
+                    )
+                return val
         if key in self._d:
             val = self._d[key]
+            if val is DELETE_VAR:
+                raise KeyError(f"Environment variable ${key} is masked by DELETE_VAR")
         elif key in self._vars and self._vars[key].default is not DefaultNotGiven:
             val = self.get_default(key)
             if is_callable_default(val):
@@ -2734,6 +2806,20 @@ class Env(cabc.MutableMapping):
         return self._d[key]
 
     def _set_item(self, key, val, thread_local=False, check_sync=True):
+        if val is DELETE_VAR:
+            # Bypass validator/converter/detyper — none of them accept
+            # the sentinel. Two modes:
+            #   - thread_local (swap): store the sentinel in the local
+            #     layer so swap's restore step can put the original
+            #     value back when the scope ends.
+            #   - direct: equivalent to ``del env[key]``; if the key
+            #     was not set, silently no-op (matches "absent" intent).
+            if thread_local:
+                self._d.set_locally(key, DELETE_VAR)
+                self._detyped = None
+            elif key in self._d:
+                self._del_item(key)
+            return
         if check_sync and key in self._vars:
             if self._vars[key].deprecated:
                 sync_txt = (
@@ -2802,6 +2888,14 @@ class Env(cabc.MutableMapping):
                     os_environ[key] = deval
         if old_value is self._no_value:
             events.on_envvar_new.fire(name=key, value=val)
+        elif old_value is DELETE_VAR:
+            # No observable transition for the event API — DELETE_VAR is
+            # an internal masking state, not a user-visible value, so
+            # `on_envvar_change` would surface a sentinel to handlers
+            # that are not prepared for it. Stay silent here; the most
+            # common path (swap exit restoring the original value)
+            # really is a no-op from the user's point of view.
+            pass
         elif old_value != val:
             events.on_envvar_change.fire(name=key, oldvalue=old_value, newvalue=val)
 
@@ -2825,11 +2919,9 @@ class Env(cabc.MutableMapping):
         """The environment will look up default values from its own defaults if a
         default is not given here.
         """
-        if key in self._d or (
-            key in self._vars and self._vars[key].default is not DefaultNotGiven
-        ):
+        try:
             return self[key]
-        else:
+        except KeyError:
             return default
 
     def get_stringified(self, key, default=None):
@@ -2851,17 +2943,30 @@ class Env(cabc.MutableMapping):
         )
 
     def __iter__(self):
+        # Compute the set of keys masked by DELETE_VAR. An overlay layer
+        # may mask either an underlying overlay or `_d`/defaults; `_d`
+        # itself may also hold the sentinel (set via swap thread-local).
+        masked = set()
+        for overlay in reversed(self._overlay_stack):
+            for k, v in overlay.items():
+                if v is DELETE_VAR and k not in masked:
+                    masked.add(k)
         for key in self.rawkeys():
-            if isinstance(key, str):
-                yield key
+            if not isinstance(key, str):
+                continue
+            if key in masked:
+                continue
+            if key in self._d and self._d[key] is DELETE_VAR:
+                continue
+            yield key
 
     def __contains__(self, item):
         for overlay in reversed(self._overlay_stack):
             if item in overlay:
-                return True
-        return item in self._d or (
-            item in self._vars and self._vars[item].default is not DefaultNotGiven
-        )
+                return overlay[item] is not DELETE_VAR
+        if item in self._d:
+            return self._d[item] is not DELETE_VAR
+        return item in self._vars and self._vars[item].default is not DefaultNotGiven
 
     def __len__(self):
         # Counts only explicitly-set vars (not defaults from self._vars).


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/5782

Description see in docs changes.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
