### PR TITLE
fix: `exit N` aborts execution immediately

### DIFF
--- a/tests/shell/test_ptk_shell.py
+++ b/tests/shell/test_ptk_shell.py
@@ -110,7 +110,10 @@ def test_tokenize_ansi(prompt_tokens, ansi_string_parts):
 def test_ptk_prompt(line, exp, ptk_shell, capsys):
     inp, out, shell = ptk_shell
     inp.send_text(f"{line}\nexit\n")  # note: terminate with '\n'
-    shell.cmdloop()
+    # ``exit`` now propagates SystemExit out of the loop (issue #6426); in
+    # production ``main_xonsh`` catches it.
+    with pytest.raises(SystemExit):
+        shell.cmdloop()
     screen = pyte.Screen(80, 24)
     stream = pyte.Stream(screen)
 

--- a/tests/shell/test_readline_shell.py
+++ b/tests/shell/test_readline_shell.py
@@ -167,7 +167,10 @@ def test_rl_prompt_cmdloop(line, exp, readline_shell, capsys):
     shell.use_rawinput = False
     shell.stdin.write(f"{line}\nexit\n")  # note: terminate with '\n'
     shell.stdin.seek(0)
-    shell.cmdloop()
+    # ``exit`` now propagates SystemExit out of the loop (issue #6426); in
+    # production ``main_xonsh`` catches it.
+    with pytest.raises(SystemExit):
+        shell.cmdloop()
     # xonsh, doesn't write all its output to shell.stdout
     # so capture sys.stdout
     out, err = capsys.readouterr()

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -1067,6 +1067,17 @@ def test_single_command_return_code(cmd, exp_rtn):
         ("exit 2", "", 2),
         ("echo 1 && exit 2 && echo 3", "1\n", 2),
         ("__xonsh__.exit=5; echo no", "", 5),
+        (
+            "@aliases.register\n"
+            "def _a():\n"
+            "    print(1)\n"
+            "    exit 2\n"
+            "    print(2)\n"
+            "a\n"
+            "print(3)\n",
+            "1\n",
+            2,
+        ),
     ],
 )
 def test_exit_aborts_execution(cmd, exp_out, exp_rtn):

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -1056,6 +1056,25 @@ def test_single_command_return_code(cmd, exp_rtn):
     assert rtn == exp_rtn
 
 
+# issue 6426 — ``exit N`` must stop execution, not just record the rc.
+@skip_if_on_windows
+@pytest.mark.parametrize(
+    "cmd, exp_out, exp_rtn",
+    [
+        ("echo 1; exit 2; echo 3", "1\n", 2),
+        ("print(1); exit 2; print(3)", "1\n", 2),
+        ("exit 0; echo no", "", 0),
+        ("exit 2", "", 2),
+        ("echo 1 && exit 2 && echo 3", "1\n", 2),
+        ("__xonsh__.exit=5; echo no", "", 5),
+    ],
+)
+def test_exit_aborts_execution(cmd, exp_out, exp_rtn):
+    out, _, rtn = run_xonsh(cmd, single_command=True)
+    assert out == exp_out
+    assert rtn == exp_rtn
+
+
 @skip_if_on_msys
 @skip_if_on_windows
 @skip_if_on_darwin

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -974,7 +974,6 @@ def xonsh_exit(args, stdin=None):
     else:
         code = 0
     XSH.exit = code
-    print()  # gimme a newline
     return None, None
 
 

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -1351,6 +1351,11 @@ def run_subproc(cmds, captured=False, envs=None, in_boolop=False):
     (e.g. let a non-zero return short-circuit instead of raising).
     """
 
+    # ``exit N`` only sets ``XSH.exit``; raise SystemExit on either side of
+    # the pipeline so subsequent statements (subproc *or* Python) do not run.
+    if XSH.exit is not None:
+        raise SystemExit(XSH.exit)
+
     specs = cmds_to_specs(cmds, captured=captured, envs=envs, in_boolop=in_boolop)
 
     if trace := XSH.env.get("XONSH_SUBPROC_TRACE", False):
@@ -1360,7 +1365,12 @@ def run_subproc(cmds, captured=False, envs=None, in_boolop=False):
         _flatten_cmd_redirects(cmd) if isinstance(cmd, list) else cmd for cmd in cmds
     ]
     _shell_set_title(cmds)
-    return _run_specs(specs, cmds)
+    result = _run_specs(specs, cmds)
+
+    if XSH.exit is not None:
+        raise SystemExit(XSH.exit)
+
+    return result
 
 
 def _run_command_pipeline(specs, cmds):

--- a/xonsh/pytest/plugin.py
+++ b/xonsh/pytest/plugin.py
@@ -250,7 +250,7 @@ def mock_xonsh_session(monkeypatch, xonsh_events, xonsh_session, env):
             ("env", env),
             ("shell", DummyShell()),
             ("help", lambda x: x),
-            ("exit", False),
+            ("exit", None),
             ("history", DummyHistory()),
             (
                 "commands_cache",


### PR DESCRIPTION
* Fixes #6426