### PR TITLE
fix(tests): forward $PATH in foreign shell tests so they work in Nix sandbox (#6430)

### DIFF
--- a/tests/test_foreign_shells_llm.py
+++ b/tests/test_foreign_shells_llm.py
@@ -117,9 +117,13 @@ def test_foreign_shell_data_show_output_forwards_script_stdout(capfd, xession):
         )
         script_name = script.name
     try:
+        # Forward ``$PATH`` so the bash subprocess can resolve itself, ``env``,
+        # and friends — Nix sandboxes have no ``/bin/bash`` fallback and the
+        # default ``_PATH_DEFPATH`` (``/bin:/usr/bin``) used when ``env`` lacks
+        # ``PATH`` doesn't exist there.
         env, aliases = foreign_shell_data(
             shell="bash",
-            currenv=(),
+            currenv=(("PATH", os.environ.get("PATH", "")),),
             interactive=False,
             sourcer="source",
             prevcmd=f"source {script_name}\n",
@@ -154,7 +158,7 @@ def test_foreign_shell_data_default_silently_swallows_script_output(capfd, xessi
     try:
         env, _ = foreign_shell_data(
             shell="bash",
-            currenv=(),
+            currenv=(("PATH", os.environ.get("PATH", "")),),
             interactive=False,
             sourcer="source",
             prevcmd=f"source {script_name}\n",


### PR DESCRIPTION
## Summary

Fixes #6430. `nix build` fails with:

```
FAILED tests/test_foreign_shells_llm.py::test_foreign_shell_data_show_output_forwards_script_stdout - FileNotFoundError: [Errno 2] No such file or directory: 'bash'
FAILED tests/test_foreign_shells_llm.py::test_foreign_shell_data_default_silently_swallows_script_output - FileNotFoundError: [Errno 2] No such file or directory: 'bash'
```

### Why it fails only in Nix

Both tests call `foreign_shell_data(shell="bash", currenv=(), ...)`. With `currenv=()` the helper produces `env={}` for the `subprocess.run(['bash', ...])` call. POSIX `execvp` then looks up `bash` using the `PATH` from the child env — if there's no `PATH`, it falls back to `_PATH_DEFPATH` (`/bin:/usr/bin`). On normal Linux/macOS hosts `/bin/bash` exists and the lookup succeeds despite the empty child env; in a Nix sandbox neither `/bin` nor `/usr/bin` exists, so the spawn raises `FileNotFoundError: 'bash'`.

Verified inside `nixos/nix` Docker:

```
bash via shutil:        /nix/store/.../bash-interactive-5.3p3/bin/bash
/bin/bash exists:       False
/usr/bin/bash exists:   False
subprocess(env={})            FAIL: [Errno 2] No such file or directory: 'bash'
subprocess(env={PATH: ...})   OK: 'hi\n'
```

### Fix

Forward the parent's `PATH` explicitly: `currenv=(("PATH", os.environ.get("PATH", "")),)`. That's all bash and its `env`/`declare` invocations inside the `COMMAND` template need to be resolvable. Production callers go through `XSH.env.detype()`, which already carries `PATH`, so this change is test-isolation only.

The sibling test `test_foreign_function_alias_streams_to_caller_stdout` already works because the `ForeignShellFunctionAlias.__call__` path uses `XSH.env.detype()` for `env=`, not the test's `currenv`.

## Test plan

- [x] `python -m pytest tests/test_foreign_shells_llm.py -v` — all 8 tests pass locally.
- [x] Reproduced the original failure with `docker run --rm -v "$PWD:/src:ro" nixos/nix:latest sh -c 'nix … build /src'` — same `FileNotFoundError: 'bash'` as the report.
- [x] Re-ran the same `nix build` after the fix — now succeeds, producing `/nix/store/.../xonsh-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)