### PR TITLE
feat: Add dedicated `sudo` completer

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1207,7 +1207,10 @@ One of the most interesting application is expanding an alias:
       @aliases.return_command
       def _xsudo(args):
           """Sudo with expanding aliases."""
-          return ['sudo', '--', *aliases.eval_alias(args)]
+          if args:
+              return ['sudo', '--', *aliases.eval_alias(args)]
+          else:
+              return ['sudo', '--']  # Allows completion to work properly.
 
     @ aliases['install'] = "apt install cowsay"
     @ xsudo install

--- a/tests/completers/test_command_completers.py
+++ b/tests/completers/test_command_completers.py
@@ -35,7 +35,7 @@ def test_complete_command(completion_context_parse, tmp_path, xession):
 @skip_if_on_windows
 def test_skipper_command(completion_context_parse):
     assert "grep" in completions_from_result(
-        complete_skipper(completion_context_parse("sudo gre", 8))
+        complete_skipper(completion_context_parse("time gre", 8))
     )
 
 
@@ -48,7 +48,7 @@ def test_skipper_arg(completion_context_parse, xession, monkeypatch):
     bash_completer_mock.return_value = {"--count "}
 
     assert "--count " in completions_from_result(
-        complete_skipper(completion_context_parse("sudo grep --coun", 16))
+        complete_skipper(completion_context_parse("time grep --coun", 16))
     )
 
     call_args = bash_completer_mock.call_args[0]

--- a/tests/completers/test_sudo_llm.py
+++ b/tests/completers/test_sudo_llm.py
@@ -1,0 +1,176 @@
+"""Tests for the ``sudo`` xompletion."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from xompletions.sudo import _find_inner_command_position, xonsh_complete
+from xonsh.completer import Completer
+from xonsh.parsers.completion_context import (
+    CommandArg,
+    CommandContext,
+    CompletionContext,
+)
+from xonsh.pytest.tools import completions_from_result, skip_if_on_windows
+
+
+def _args(*vals):
+    return tuple(CommandArg(v) for v in vals)
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        # Inner command not yet typed.
+        (_args("sudo"), 1),
+        (_args("sudo", "-E"), 2),
+        (_args("sudo", "-u", "root"), 3),
+        (_args("sudo", "--"), 2),
+        # Inner command present.
+        (_args("sudo", "ls"), 1),
+        (_args("sudo", "-E", "ls"), 2),
+        (_args("sudo", "--", "ls"), 2),
+        (_args("sudo", "-u", "root", "ls"), 3),
+        (_args("sudo", "--user=root", "ls"), 2),
+        (_args("sudo", "--user", "root", "ls"), 3),
+        (_args("sudo", "VAR=1", "ls"), 2),
+        (_args("sudo", "VAR=1", "OTHER=2", "ls"), 3),
+        # Composite: flag + env-var + flag-with-arg + inner command.
+        (_args("sudo", "-E", "VAR=1", "-u", "root", "ls"), 5),
+        # Multiple flags without args.
+        (_args("sudo", "-E", "-H", "ls"), 3),
+        # ``--`` terminates options even if more dashes follow inside the inner command.
+        (_args("sudo", "--", "ls", "--color"), 2),
+    ],
+)
+def test_find_inner_command_position(args, expected):
+    assert _find_inner_command_position(args) == expected
+
+
+def test_no_completion_for_flag_prefix(completion_context_parse):
+    """``sudo -<Tab>`` defers to the man completer."""
+    ctx = completion_context_parse("sudo -", 6).command
+    assert xonsh_complete(ctx) is None
+
+
+def test_no_completion_for_long_flag_prefix(completion_context_parse):
+    """``sudo --u<Tab>`` defers — long flags are man's job."""
+    ctx = completion_context_parse("sudo --u", 8).command
+    assert xonsh_complete(ctx) is None
+
+
+def test_no_completion_for_flag_value_slot(completion_context_parse):
+    """``sudo -u <Tab>`` — username slot, not the inner command."""
+    ctx = completion_context_parse("sudo -u ", 8).command
+    assert xonsh_complete(ctx) is None
+
+
+def test_no_completion_for_long_flag_value_slot(completion_context_parse):
+    """``sudo --user <Tab>`` — same as the short form."""
+    ctx = completion_context_parse("sudo --user ", 12).command
+    assert xonsh_complete(ctx) is None
+
+
+@skip_if_on_windows
+def test_complete_inner_command_plain(completion_context_parse, xession):
+    """``sudo gre<Tab>`` lists commands matching ``gre`` (regression coverage
+    for the path that used to live in ``complete_skipper``)."""
+    ctx = completion_context_parse("sudo gre", 8).command
+    assert "grep" in completions_from_result(xonsh_complete(ctx))
+
+
+@skip_if_on_windows
+def test_complete_inner_command_after_double_dash(completion_context_parse, xession):
+    """``sudo -- gre<Tab>`` — the ``--`` must not be treated as the command."""
+    ctx = completion_context_parse("sudo -- gre", 11).command
+    assert "grep" in completions_from_result(xonsh_complete(ctx))
+
+
+@skip_if_on_windows
+def test_complete_inner_command_after_double_dash_empty(
+    completion_context_parse, xession
+):
+    """``sudo -- <Tab>`` — empty prefix after the option terminator still offers commands."""
+    ctx = completion_context_parse("sudo -- ", 8).command
+    completions = completions_from_result(xonsh_complete(ctx))
+    assert "grep" in completions
+
+
+@skip_if_on_windows
+def test_complete_inner_command_after_flag_with_value(
+    completion_context_parse, xession
+):
+    """``sudo -u root gre<Tab>`` — flag and its value are skipped."""
+    ctx = completion_context_parse("sudo -u root gre", 16).command
+    assert "grep" in completions_from_result(xonsh_complete(ctx))
+
+
+@skip_if_on_windows
+def test_complete_inner_command_after_long_flag_with_value(
+    completion_context_parse, xession
+):
+    """``sudo --user=root gre<Tab>`` — embedded ``=`` consumes the value."""
+    ctx = completion_context_parse("sudo --user=root gre", 20).command
+    assert "grep" in completions_from_result(xonsh_complete(ctx))
+
+
+@skip_if_on_windows
+def test_complete_inner_command_after_env_assign(completion_context_parse, xession):
+    """``sudo VAR=1 gre<Tab>`` — env-var assignments are not commands."""
+    ctx = completion_context_parse("sudo VAR=1 gre", 14).command
+    assert "grep" in completions_from_result(xonsh_complete(ctx))
+
+
+@skip_if_on_windows
+def test_delegate_to_inner_command_args(completion_context_parse, xession, monkeypatch):
+    """``sudo grep --coun<Tab>`` re-enters the pipeline with ``grep`` as the head."""
+    monkeypatch.setattr(xession.shell.shell, "completer", Completer(), raising=False)
+    bash_completer_mock = Mock(return_value={"--count "})
+    monkeypatch.setattr(xession, "_completers", {"bash": bash_completer_mock})
+
+    ctx = completion_context_parse("sudo grep --coun", 16).command
+    assert "--count " in completions_from_result(xonsh_complete(ctx))
+
+    call_args = bash_completer_mock.call_args[0]
+    assert len(call_args) == 1
+    inner_ctx = call_args[0]
+    assert isinstance(inner_ctx, CompletionContext)
+    assert inner_ctx.command == CommandContext(
+        args=(CommandArg("grep"),), arg_index=1, prefix="--coun"
+    )
+
+
+@skip_if_on_windows
+def test_delegate_after_double_dash_to_inner_command_args(
+    completion_context_parse, xession, monkeypatch
+):
+    """``sudo -- grep --coun<Tab>`` — both sudo and ``--`` are stripped before delegation."""
+    monkeypatch.setattr(xession.shell.shell, "completer", Completer(), raising=False)
+    bash_completer_mock = Mock(return_value={"--count "})
+    monkeypatch.setattr(xession, "_completers", {"bash": bash_completer_mock})
+
+    ctx = completion_context_parse("sudo -- grep --coun", 19).command
+    assert "--count " in completions_from_result(xonsh_complete(ctx))
+
+    inner_ctx = bash_completer_mock.call_args[0][0]
+    assert inner_ctx.command == CommandContext(
+        args=(CommandArg("grep"),), arg_index=1, prefix="--coun"
+    )
+
+
+@skip_if_on_windows
+def test_delegate_after_flag_with_value_to_inner_command_args(
+    completion_context_parse, xession, monkeypatch
+):
+    """``sudo -u root grep --coun<Tab>`` — flag, value, and sudo are all stripped."""
+    monkeypatch.setattr(xession.shell.shell, "completer", Completer(), raising=False)
+    bash_completer_mock = Mock(return_value={"--count "})
+    monkeypatch.setattr(xession, "_completers", {"bash": bash_completer_mock})
+
+    ctx = completion_context_parse("sudo -u root grep --coun", 24).command
+    assert "--count " in completions_from_result(xonsh_complete(ctx))
+
+    inner_ctx = bash_completer_mock.call_args[0][0]
+    assert inner_ctx.command == CommandContext(
+        args=(CommandArg("grep"),), arg_index=1, prefix="--coun"
+    )

--- a/xompletions/sudo.py
+++ b/xompletions/sudo.py
@@ -1,0 +1,115 @@
+"""Completer for ``sudo``.
+
+``sudo`` is more than a transparent command wrapper: it has its own flag
+grammar, accepts ``VAR=value`` environment assignments before the command,
+and honours the POSIX ``--`` end-of-options sentinel. The generic
+command-token skipper in :mod:`xonsh.completers.commands` only knows how to
+strip the literal ``sudo`` token, which leaves ``sudo -- foo``,
+``sudo -u root foo`` and similar invocations without useful completions.
+
+This module walks ``ctx.args`` past every token that belongs to ``sudo``'s
+own prefix (flags, their values, ``VAR=value`` assignments, ``--``) and
+then either offers command names (when the cursor sits on the inner
+command word) or re-enters the full completion pipeline with the inner
+command at ``args[0]`` so the inner command's own completers
+(``man``, paths, ``pip``'s xompletion, …) surface.
+"""
+
+import re
+
+from xonsh.built_ins import XSH
+from xonsh.completers.commands import complete_command
+from xonsh.parsers.completion_context import CommandContext, CompletionContext
+
+# Short-form sudo flags whose next argument is the flag's value
+# (``sudo -u root cmd``). Long-form variants are tracked separately below
+# because they can also appear as ``--user=root`` in a single token.
+_SUDO_OPTS_WITH_ARG = frozenset(
+    {"-C", "-D", "-R", "-T", "-U", "-c", "-g", "-h", "-p", "-r", "-t", "-u"}
+)
+
+# Long-form sudo flags whose next argument is the flag's value when used
+# without an embedded ``=`` (``--user root`` vs ``--user=root``).
+_SUDO_LONG_OPTS_WITH_ARG = frozenset(
+    {
+        "--chdir",
+        "--chroot",
+        "--class",
+        "--close-from",
+        "--command-timeout",
+        "--group",
+        "--host",
+        "--other-user",
+        "--prompt",
+        "--role",
+        "--type",
+        "--user",
+    }
+)
+
+# ``VAR=value`` env-var assignments that sudo accepts before the command.
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _find_inner_command_position(args) -> int:
+    """Return the index in ``args`` where the inner command begins.
+
+    Walks past ``sudo`` itself, every flag (consuming the next token when
+    the flag is known to take a value), every ``VAR=value`` env-var
+    assignment, and the ``--`` end-of-options sentinel. Stops at the first
+    bare positional — that's the inner command. The return value can be
+    greater than ``len(args)`` when a value-taking flag (``-u``,
+    ``--user``) sits at the end without its value yet typed; callers
+    interpret that as "the inner command hasn't been reached".
+    """
+    i = 1  # skip ``sudo`` itself
+    while i < len(args):
+        v = args[i].value
+        if v == "--":
+            return i + 1
+        if v.startswith("-"):
+            # ``--user=root`` carries its value inside the same token.
+            if v.startswith("--") and "=" in v:
+                i += 1
+            elif v in _SUDO_OPTS_WITH_ARG or v in _SUDO_LONG_OPTS_WITH_ARG:
+                # Flag consumes the next arg as its value.
+                i += 2
+            else:
+                # Unknown / value-less flag (``-E``, ``-H``, …).
+                i += 1
+            continue
+        if _ENV_ASSIGN_RE.match(v):
+            i += 1
+            continue
+        return i
+    return i
+
+
+def xonsh_complete(ctx: CommandContext):
+    """Complete arguments to ``sudo``."""
+    inner = _find_inner_command_position(ctx.args)
+
+    if ctx.arg_index < inner:
+        # Cursor sits on the value-slot of a sudo flag (``sudo -u <Tab>``)
+        # or some other token that still belongs to sudo's own prefix.
+        # Defer to the rest of the completer pipeline.
+        return None
+
+    if ctx.arg_index == inner:
+        # Cursor is on the inner-command slot. A ``-`` prefix here means
+        # the user is still typing one of sudo's own flags (e.g.
+        # ``sudo -E -<Tab>``) — defer to the man-page completer instead
+        # of returning command names that start with ``-``.
+        if ctx.prefix.startswith("-"):
+            return None
+        return complete_command(ctx)
+
+    # Cursor is past the inner command's name, inside its own arguments.
+    # Re-enter the completer pipeline with the inner command at args[0]
+    # so its completers (paths, man flags, xompletions, …) fire.
+    skipped = ctx._replace(
+        args=ctx.args[inner:],
+        arg_index=ctx.arg_index - inner,
+    )
+    completer = XSH.shell.shell.completer  # type: ignore[union-attr]
+    return completer.complete_from_context(CompletionContext(skipped))

--- a/xonsh/completers/commands.py
+++ b/xonsh/completers/commands.py
@@ -17,7 +17,10 @@ from xonsh.completers.tools import (
 from xonsh.lib.modules import ModuleFinder
 from xonsh.parsers.completion_context import CommandContext, CompletionContext
 
-SKIP_TOKENS = {"sudo", "time", "timeit", "which", "showcmd", "man"}
+# Wrapper commands whose completions delegate to the inner command. ``sudo``
+# is intentionally absent — it has its own flag grammar (``-u root``,
+# ``VAR=value``, ``--``) handled by ``xompletions/sudo.py``.
+SKIP_TOKENS = {"time", "timeit", "which", "showcmd", "man"}
 END_PROC_TOKENS = ("|", ";", "&&")  # includes ||
 END_PROC_KEYWORDS = {"and", "or"}
 


### PR DESCRIPTION
Fixes the issue reported by @Infinidoge

### Implementation

We've added `xompletions/sudo.py` with extended logic.

### Before 
Example from tutorial:

```xsh
@aliases.register
@aliases.return_command
def _xsudo(args):
    """Sudo with expanding aliases."""
    return ['sudo', '--', *aliases.eval_alias(args)]

xsudo <Tab> 
# Wrong completer list
```

### After

New example and fixed behavior:

```xsh
@aliases.register
@aliases.return_command
def _xsudo(args):
    """Sudo with expanding aliases."""
    if args:
        return ['sudo', '--', *aliases.eval_alias(args)]
    else:
        return ['sudo', '--']  # Allows completion to work properly.

xsudo <Tab>
# Working as expected.
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
