### PR TITLE
fix(environ): pop __THREAD_LOCAL__ from inherited os.environ in default_env

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -413,6 +413,32 @@ def test_no_lines_columns():
         del os.environ["COLUMNS"]
 
 
+def test_no_thread_local_inherited_from_os_environ():
+    # If a parent xonsh leaked __THREAD_LOCAL__ into os.environ (stringified
+    # by detype), the child must strip it before populating XSH.env —
+    # otherwise CommandPipeline._apply_to_thread_local reads a str instead
+    # of a dict and every pipeline crashes.
+    os.environ["__THREAD_LOCAL__"] = "{}"
+    try:
+        env = default_env()
+        assert "__THREAD_LOCAL__" not in env
+    finally:
+        del os.environ["__THREAD_LOCAL__"]
+
+
+def test_thread_local_not_detyped():
+    # __THREAD_LOCAL__ is an internal overlay set by ExecAlias via env.swap.
+    # It must never appear in env.detype() — that dict is the env passed to
+    # subprocess.Popen, and stringifying the overlay (via ensure_string) is
+    # what leaks the bogus value to child processes in the first place.
+    env = Env()
+    env["__THREAD_LOCAL__"] = {"returncode": 0}
+    assert "__THREAD_LOCAL__" not in env.detype()
+    # Same for the swap path that ExecAlias actually uses.
+    with env.swap(__THREAD_LOCAL__={"returncode": 0}):
+        assert "__THREAD_LOCAL__" not in env.detype()
+
+
 def test_make_args_env():
     obs = make_args_env(["script", "1", "2", "3"])
     exp = {

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -3282,6 +3282,7 @@ def default_env(env=None):
     # These can cause problems for programs (#2543)
     ctx.pop("LINES", None)
     ctx.pop("COLUMNS", None)
+    ctx.pop("__THREAD_LOCAL__", None)
     # other shells' PROMPT definitions generally don't work in XONSH:
     try:
         del ctx["PROMPT"]

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2430,6 +2430,21 @@ class Env(cabc.MutableMapping):
         # during alias execution. See push_overlay()/pop_overlay().
         self._overlay_local = threading.local()
         self._vars = {k: v for k, v in DEFAULT_VARS.items()}
+        # ``__THREAD_LOCAL__`` is an internal overlay used by ExecAlias to
+        # carry the alias return code out of the pipeline thread. Register it
+        # here with ``detype=None`` so it is excluded from ``Env.detype()``
+        # and never reaches a child process via ``subprocess.Popen(env=...)``
+        # or ``os.environ``. Not exposed through ``Xettings``:
+        # the ``__`` prefix already hides it from ``Xettings.get_settings``,
+        # so the docs generator won't pick it up.
+        self._vars["__THREAD_LOCAL__"] = Var(
+            validate=always_true,
+            convert=None,
+            detype=None,
+            default=DefaultNotGiven,
+            doc="",
+            is_configurable=False,
+        )
 
         if len(args) == 0 and len(kwargs) == 0:
             args = (os_environ,)


### PR DESCRIPTION
When a parent xonsh process serializes its environment for a subprocess, `__THREAD_LOCAL__` (added in https://github.com/xonsh/xonsh/commit/e237d9f1da3c12178d936295a40ca9fa2c2fcf7d) gets stringified by detype() and ends up in the child's os.environ. The child then inherits the string instead of a dict, causing:

`TypeError: 'str' object does not support item assignment`

The fix is to pop `__THREAD_LOCAL__` in default_env(), so it never enters a child XSH.env.

Example in the wild, with [any-nix-shell](https://github.com/haslersn/any-nix-shell):
```bash
$ nix-shell -p xmake

To log full traceback to a file set:
$XONSH_TRACEBACK_LOGFILE = 'error.log'

Traceback (most recent call last):
  File "/home/zack/.config/xonsh/rc.xsh", line 23, in <module>
    _any_nix_shell_source = $(any-nix-shell xonsh --info-right)

  File "/nix/store/w6r8afxany30c14h0rz0zaiv4f794zkg-python3-3.13.12-env/lib/python3.13/site-packages/xonsh/built_ins.py", line 430, in subproc_captured_stdout
    r = xonsh.procs.specs.run_subproc(
        cmds, captured="stdout", envs=envs, in_boolop=in_boolop
    )

  File "/nix/store/w6r8afxany30c14h0rz0zaiv4f794zkg-python3-3.13.12-env/lib/python3.13/site-packages/xonsh/procs/specs.py", line 1363, in run_subproc
    return _run_specs(specs, cmds)

  File "/nix/store/w6r8afxany30c14h0rz0zaiv4f794zkg-python3-3.13.12-env/lib/python3.13/site-packages/xonsh/procs/specs.py", line 1414, in _run_specs
    cp.end()
    ~~~~~~^^

  File "/nix/store/w6r8afxany30c14h0rz0zaiv4f794zkg-python3-3.13.12-env/lib/python3.13/site-packages/xonsh/procs/pipelines.py", line 602, in end
    self._end(tee_output=tee_output)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^

  File "/nix/store/w6r8afxany30c14h0rz0zaiv4f794zkg-python3-3.13.12-env/lib/python3.13/site-packages/xonsh/procs/pipelines.py", line 630, in _end
    self._apply_to_thread_local()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^

  File "/nix/store/w6r8afxany30c14h0rz0zaiv4f794zkg-python3-3.13.12-env/lib/python3.13/site-packages/xonsh/procs/pipelines.py", line 884, in _apply_to_thread_local
    tl["returncode"] = 1 if self.proc is None else self.proc.returncode
    ~~^^^^^^^^^^^^^^

TypeError: 'str' object does not support item assignment

error running xonsh run control file '/home/zack/.config/xonsh/rc.xsh':
'str' object does not support item assignment

WARNING: your terminal doesn't support cursor position requests (CPR).
```

with rc.xsh:
```xonsh
if $XONSH_INTERACTIVE:
    # Interactive shell initialisation
    _any_nix_shell_source = $(any-nix-shell xonsh --info-right)
    execx(_any_nix_shell_source)
```

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
