### PR TITLE
feat: Add `@xml` and `@lxml` (if installed) command decorator e.g. `data = $(@xml cat file.xml)`

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -266,8 +266,25 @@ with ``.tag``, ``.attrib``, ``.text``, ``.find()``, ``.findall()``, etc.
 
 .. code-block:: xonshcon
 
-    @ root = $(@xml curl -s https://example.com/feed.xml)
-      [item.find('title').text for item in root.findall('.//item')]
+    @ feed = $(@xml curl -s https://github.com/xonsh/xonsh/releases.atom)
+      ns = {'a': 'http://www.w3.org/2005/Atom'}
+      [e.find('a:title', ns).text for e in feed.findall('a:entry', ns)[:5]]
+    ['v0.23.6', 'v0.23.5', 'v0.23.4', 'v0.23.3', 'v0.23.2']
+
+
+``@lxml``
+----------
+Parses XML with `lxml <https://lxml.de/>`_ and returns an ``lxml.etree._Element``.
+Adds full XPath, richer error messages, and faster parsing on top of the
+stdlib ``@xml``. Registered only when ``lxml`` is installed
+(``xpip install lxml``).
+
+.. code-block:: xonshcon
+
+    @ feed = $(@lxml curl -s https://github.com/xonsh/xonsh/releases.atom)
+      ns = {'a': 'http://www.w3.org/2005/Atom'}
+      feed.xpath('//a:entry/a:title/text()', namespaces=ns)[:5]
+    ['v0.23.6', 'v0.23.5', 'v0.23.4', 'v0.23.3', 'v0.23.2']
 
 
 Directory Stack

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -259,6 +259,17 @@ Parses YAML and returns a dict.
     @ config = $(@yaml cat config.yaml)
 
 
+``@xml``
+---------
+Parses XML and returns an :class:`xml.etree.ElementTree.Element`. Navigate it
+with ``.tag``, ``.attrib``, ``.text``, ``.find()``, ``.findall()``, etc.
+
+.. code-block:: xonshcon
+
+    @ root = $(@xml curl -s https://example.com/feed.xml)
+      [item.find('title').text for item in root.findall('.//item')]
+
+
 Directory Stack
 ====================
 

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -183,6 +183,8 @@ Provides an interface to printing lines of source code prior to their execution.
 .. command-help:: xonsh.aliases.xexec
 
 
+.. _command-decorators:
+
 Command Decorators (Decorator Aliases)
 ======================================
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1423,6 +1423,9 @@ In xonsh you can decorate the command to transform output into desired object:
     @ $(@yaml echo 'a: 1')
     {'a': 1}
 
+    @ $(@xml echo '<a x="1"/>').attrib
+    {'x': '1'}
+
 See the full list of command decorators in Aliases article or build the new one.
 
 Using ``DecoratorAlias`` and ``SpecAttrDecoratorAlias`` and callable ``output_format`` you can

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1423,16 +1423,8 @@ In xonsh you can decorate the command to transform output into desired object:
     @ $(@jsonl echo '{"a":1}\n{"b":2}')
     [{'a': 1}, {'b': 2}]
 
-    @ $(@yaml echo 'a: 1')
-    {'a': 1}
 
-    @ $(@toml echo 'a = 1')
-    {'a': 1}
-
-    @ $(@xml echo '<a x="1"/>').attrib
-    {'x': '1'}
-
-See the full list of command decorators in Aliases article or build the new one.
+See the full list of :ref:`Command Decorators <command-decorators>` (``@yaml``, ``@toml``, ``@xml``, ``@lxml``, etc.) or build the new one.
 
 Using ``DecoratorAlias`` and ``SpecAttrDecoratorAlias`` and callable ``output_format`` you can
 convert subprocess command output into Python object with your own logic:

--- a/tests/aliases/test_xml_decorator_llm.py
+++ b/tests/aliases/test_xml_decorator_llm.py
@@ -1,0 +1,44 @@
+"""Tests for the ``@xml`` command decorator.
+
+The ``@xml`` decorator captures subprocess output and parses it with
+``xml.etree.ElementTree.fromstring`` so that ``$(@xml cmd)`` yields an
+``Element`` instance ready for ``.find()`` / ``.findall()`` traversal.
+"""
+
+from xml.etree.ElementTree import Element
+
+from xonsh.aliases import make_default_aliases
+from xonsh.procs.specs import SpecAttrDecoratorAlias
+
+
+def _xml_output_format():
+    return make_default_aliases()["@xml"].set_attributes["output_format"]
+
+
+def test_xml_decorator_registered(xession):
+    aliases = make_default_aliases()
+    assert "@xml" in aliases
+    assert isinstance(aliases["@xml"], SpecAttrDecoratorAlias)
+
+
+def test_xml_decorator_parses_element_tree(xession):
+    output_format = _xml_output_format()
+    root = output_format(
+        ['<root attr="v">', "  <item>1</item>", "  <item>2</item>", "</root>"]
+    )
+
+    assert isinstance(root, Element)
+    assert root.tag == "root"
+    assert root.attrib == {"attr": "v"}
+    assert [item.text for item in root.findall("item")] == ["1", "2"]
+
+
+def test_xml_decorator_invalid_input_raises(xession):
+    import xml.etree.ElementTree as ET
+
+    output_format = _xml_output_format()
+    try:
+        output_format(["not xml"])
+    except ET.ParseError:
+        return
+    raise AssertionError("expected ParseError on non-XML input")

--- a/tests/test_aliases_llm.py
+++ b/tests/test_aliases_llm.py
@@ -1,8 +1,14 @@
-"""Unit tests for ``win_sudo`` — the Windows UAC sudo fallback alias.
+"""LLM-generated unit tests for :mod:`xonsh.aliases`.
 
-The function under test is platform-independent enough to exercise on any host:
-``xonsh.platforms.winutils.sudo`` is mocked out so the elevation API is never
-actually called. See issue #5706 for the original bug.
+Currently covers:
+
+* ``win_sudo`` — the Windows UAC sudo fallback alias. The function under
+  test is platform-independent enough to exercise on any host:
+  ``xonsh.platforms.winutils.sudo`` is mocked out so the elevation API is
+  never actually called. See issue #5706 for the original bug.
+* ``@lxml`` — the optional command decorator that is only registered in
+  ``make_default_aliases()`` when the third-party ``lxml`` package is
+  importable.
 """
 
 import os
@@ -10,7 +16,8 @@ import os
 import pytest
 
 from xonsh import aliases
-from xonsh.aliases import WINDOWS_CMD_ALIASES, win_sudo
+from xonsh.aliases import WINDOWS_CMD_ALIASES, make_default_aliases, win_sudo
+from xonsh.procs.specs import SpecAttrDecoratorAlias
 
 
 @pytest.fixture
@@ -95,3 +102,53 @@ def test_windows_cmd_aliases_is_frozen():
     assert isinstance(WINDOWS_CMD_ALIASES, frozenset)
     assert "dir" in WINDOWS_CMD_ALIASES
     assert "echo" in WINDOWS_CMD_ALIASES
+
+
+# ---------------------------------------------------------------------------
+# ``@lxml`` decorator — optional, gated on third-party ``lxml`` being present.
+# ---------------------------------------------------------------------------
+
+lxml_etree = pytest.importorskip("lxml.etree")
+
+
+def _lxml_output_format():
+    return make_default_aliases()["@lxml"].set_attributes["output_format"]
+
+
+def test_lxml_decorator_registered_when_lxml_available(xession):
+    aliases_ = make_default_aliases()
+    assert "@lxml" in aliases_
+    assert isinstance(aliases_["@lxml"], SpecAttrDecoratorAlias)
+
+
+def test_lxml_decorator_parses_and_supports_xpath(xession):
+    output_format = _lxml_output_format()
+    root = output_format(
+        [
+            '<root attr="v">',
+            "  <item>1</item>",
+            "  <item>2</item>",
+            "</root>",
+        ]
+    )
+
+    assert root.tag == "root"
+    assert dict(root.attrib) == {"attr": "v"}
+    assert [i.text for i in root.findall("item")] == ["1", "2"]
+    assert root.xpath("//item/text()") == ["1", "2"]
+
+
+def test_lxml_decorator_unavailable(xession, monkeypatch):
+    """When ``lxml`` cannot be located, ``@lxml`` is not registered."""
+    import importlib.util as _util
+
+    real_find_spec = _util.find_spec
+    monkeypatch.setattr(
+        _util,
+        "find_spec",
+        lambda name, *a, **kw: (
+            None if name == "lxml" else real_find_spec(name, *a, **kw)
+        ),
+    )
+    aliases_ = make_default_aliases()
+    assert "@lxml" not in aliases_

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -2,6 +2,7 @@
 
 import argparse
 import functools
+import importlib.util
 import inspect
 import operator
 import os
@@ -1732,6 +1733,16 @@ def make_default_aliases():
             "Command decorator. Parses XML and returns ElementTree Element.",
         ),
     }
+
+    if importlib.util.find_spec("lxml") is not None:
+        default_aliases["@lxml"] = SpecAttrDecoratorAlias(
+            {
+                "output_format": lambda lines: __import__(
+                    "lxml.etree", fromlist=["fromstring"]
+                ).fromstring("\n".join(lines).encode())
+            },
+            "Command decorator. Parses XML with lxml and returns lxml Element.",
+        )
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.
         for alias in WINDOWS_CMD_ALIASES:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1723,6 +1723,14 @@ def make_default_aliases():
             {"output_format": lambda lines: XSH.imp.yaml.safe_load("\n".join(lines))},
             "Command decorator. Parses YAML and returns dict.",
         ),
+        "@xml": SpecAttrDecoratorAlias(
+            {
+                "output_format": lambda lines: __import__(
+                    "xml.etree.ElementTree", fromlist=["fromstring"]
+                ).fromstring("\n".join(lines))
+            },
+            "Command decorator. Parses XML and returns ElementTree Element.",
+        ),
     }
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.


### PR DESCRIPTION
```xsh
$(@xml echo '<a x="1"/>').attrib
# {'x': '1'}
```

```xsh
feed = $(@lxml curl -s https://github.com/xonsh/xonsh/releases.atom)
ns = {'a': 'http://www.w3.org/2005/Atom'}
feed.xpath('//a:entry/a:title/text()', namespaces=ns)[:5]
# ['v0.23.6', 'v0.23.5', 'v0.23.4', 'v0.23.3', 'v0.23.2']
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
