### PR TITLE
fix: Proc: Fix alias with pipe backgrounding

### DIFF
--- a/tests/procs/test_pipeline_llm.py
+++ b/tests/procs/test_pipeline_llm.py
@@ -4,12 +4,17 @@ Regression tests for:
 - ValueError "I/O operation on closed file" when Ctrl+C interrupts a
   pipeline of alias commands like `!(a | a | a)`.
 - ProcProxy.wait() called twice causing duplicated output.
+- Deadlock when an ExecAlias whose source already contains a pipe is
+  itself used inside an outer pipeline.
 """
 
 import io
 from types import SimpleNamespace
 
+import pytest
+
 from xonsh.procs.proxies import ProcProxy, parse_proxy_return
+from xonsh.pytest.tools import skip_if_on_windows
 
 
 def test_parse_proxy_return_writes_str_once():
@@ -46,3 +51,36 @@ def test_close_proc_skips_non_thread_procs():
     proc = ProcProxy.__new__(ProcProxy)
     # ProcProxy has no join — _close_proc's `hasattr(p, 'join')` guard must skip it
     assert not hasattr(proc, "join")
+
+
+@skip_if_on_windows
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+def test_exec_alias_with_inner_pipe_in_outer_pipe(xonsh_session):
+    """ExecAlias whose source already contains a pipe, used inside an outer
+    pipeline, must not deadlock.
+
+    Reproducer::
+
+        aliases['aaa'] = 'seq 1 100000 | grep 5'
+        aaa | head -3
+
+    The inner pipeline runs inside the ExecAlias's ProcProxyThread.  When
+    the outer downstream (head) exits early, the inner pipeline must still
+    be able to terminate.  The deadlock surfaced because ``iterraw`` only
+    closed pipe-writer fds of finished upstream procs while
+    ``check_prev_done`` was False — and any byte of downstream output
+    flipped it True, leaving the parent's copy of the inner pipe writer
+    open and preventing the inner downstream from ever observing EOF.
+    """
+    xonsh_session.env["XONSH_SUBPROC_CMD_RAISE_ERROR"] = False
+    xonsh_session.aliases["aaa"] = "seq 1 100000 | grep 5"
+
+    # Early-close downstream
+    out = xonsh_session.execer.eval("$(aaa | head -3)")
+    assert out.strip().splitlines() == ["5", "15", "25"]
+
+    # Full-drain downstream — would also hang under the bug because the
+    # inner pipeline never reaches its own _close_prev_procs() while the
+    # parent still holds the seq→grep write fd.
+    out = xonsh_session.execer.eval("$(aaa | wc -l)")
+    assert out.strip() == "40951"  # count of numbers 1..100000 containing '5'

--- a/xonsh/procs/pipelines.py
+++ b/xonsh/procs/pipelines.py
@@ -401,6 +401,10 @@ class CommandPipeline:
             if not prev_procs_closed and proc.poll() is not None:
                 self._close_prev_procs()
                 prev_procs_closed = True
+            # Drain pipe-writer fds of any upstream proc
+            # that has finished, so the downstream proc can observe EOF on
+            # its stdin.
+            all_prev_done = self._prev_procs_done()
             if not check_prev_done:
                 # if we are piping...
                 if stdout_lines or stderr_lines:
@@ -409,7 +413,7 @@ class CommandPipeline:
                 elif prev_end_time is None:
                     # or see if we already know that the next-to-last
                     # proc in the pipeline has ended.
-                    if self._prev_procs_done():
+                    if all_prev_done:
                         # if it has, record the time
                         prev_end_time = time.time()
                 elif time.time() - prev_end_time >= 0.1:


### PR DESCRIPTION
This is the case that wasn't covered during massive refactoring in 0.23.0.

### Before

```xsh
aliases['a'] = 'echo 1 | grep 1'
a | grep 1
# Backgrounded and hanging 🔴 
```

### After

```xsh
aliases['a'] = 'echo 1 | grep 1'
a | grep 1
# 1 🟢 
```


## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
