### PR TITLE
fix: Add repr to DecoratorAlias and ArgParserAlias

### DIFF
--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -532,6 +532,14 @@ def test_spec_decorator_alias_output_format(xession):
     assert p.output == ["1", "2", "3"]
 
 
+def test_spec_decorator_alias_repr():
+    named = SpecAttrDecoratorAlias({"raise_subproc_error": True}, name="@error_raise")
+    assert repr(named) == "xonsh.procs.specs.SpecAttrDecoratorAlias('@error_raise')"
+
+    unnamed = SpecAttrDecoratorAlias({"raise_subproc_error": True})
+    assert repr(unnamed) == "xonsh.procs.specs.SpecAttrDecoratorAlias()"
+
+
 @pytest.mark.parametrize("thread_subprocs", [False, True])
 def test_callable_alias_cls(thread_subprocs, xession):
     class Cls:

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -89,3 +89,23 @@ def test_parser_default_func(mocker):
 
     mocker.patch.object(xx, "xontribs_list", func)
     assert alias([]) is True
+
+
+def test_repr():
+    from xonsh.completers._aliases import CompleterAlias
+
+    def _fn():
+        pass
+
+    alias = cli_utils.ArgParserAlias(func=_fn, has_args=True, prog="myprog")
+    assert repr(alias) == "xonsh.cli_utils.ArgParserAlias('myprog')"
+
+    bare = cli_utils.ArgParserAlias()
+    assert repr(bare) == "xonsh.cli_utils.ArgParserAlias()"
+
+    # Subclass without `prog` in kwargs falls back to the bare class form
+    # until its parser is built, then uses the parser's prog.
+    completer = CompleterAlias()
+    assert repr(completer) == "xonsh.completers._aliases.CompleterAlias()"
+    assert completer.parser is not None  # trigger lazy build
+    assert repr(completer) == "xonsh.completers._aliases.CompleterAlias('completer')"

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -163,7 +163,8 @@ class FuncAlias:
             for attr in self.attributes_show
             if (val := getattr(self, attr, None)) is not None
         }
-        return f"FuncAlias({repr(r)})"
+        cls = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return f"{cls}({r!r})"
 
     def __call__(
         self,
@@ -739,7 +740,8 @@ class ExecAlias:
         return thread_local.get("returncode", 0)
 
     def __repr__(self):
-        return f"ExecAlias({self.src!r}, filename={self.filename!r})"
+        cls = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        return f"{cls}({self.src!r}, filename={self.filename!r})"
 
 
 ALIAS_PARAMS_DEFAULT = {

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1687,46 +1687,57 @@ def make_default_aliases():
         "@error_raise": SpecAttrDecoratorAlias(
             {"raise_subproc_error": True},
             "Command decorator. Raise an exception if the command returns a non-zero exit code.",
+            name="@error_raise",
         ),
         "@error_ignore": SpecAttrDecoratorAlias(
             {"raise_subproc_error": False},
             "Command decorator. Do not raise an exception if the command returns a non-zero exit code.",
+            name="@error_ignore",
         ),
         "@thread": SpecAttrDecoratorAlias(
             {"threadable": True, "force_threadable": True},
             "Command decorator. Mark current command as threadable.",
+            name="@thread",
         ),
         "@unthread": SpecAttrDecoratorAlias(
             {"threadable": False, "force_threadable": False},
             "Command decorator. Mark current command as unthreadable.",
+            name="@unthread",
         ),
         "@lines": SpecAttrDecoratorAlias(
             {"output_format": "list_lines"},
             "Command decorator. Return output as list of lines.",
+            name="@lines",
         ),
         "@path": SpecAttrDecoratorAlias(
             {"output_format": _output_to_path_object},
             "Command decorator. Return Path object for the first line in output.",
+            name="@path",
         ),
         "@paths": SpecAttrDecoratorAlias(
             {"output_format": _output_to_path_objects},
             "Command decorator. Return Path objects for the lines in output.",
+            name="@paths",
         ),
         "@json": SpecAttrDecoratorAlias(
             {"output_format": lambda lines: XSH.imp.json.loads("\n".join(lines))},
             "Command decorator. Parses JSON and returns JSON object.",
+            name="@json",
         ),
         "@jsonl": SpecAttrDecoratorAlias(
             {"output_format": lambda lines: [XSH.imp.json.loads(lj) for lj in lines]},
             "Command decorator. Parses JSON strings and returns list of JSON objects.",
+            name="@jsonl",
         ),
         "@yaml": SpecAttrDecoratorAlias(
             {"output_format": lambda lines: XSH.imp.yaml.safe_load("\n".join(lines))},
             "Command decorator. Parses YAML and returns dict.",
+            name="@yaml",
         ),
         "@toml": SpecAttrDecoratorAlias(
             {"output_format": lambda lines: XSH.imp.tomllib.loads("\n".join(lines))},
             "Command decorator. Parses TOML and returns dict.",
+            name="@toml",
         ),
         "@xml": SpecAttrDecoratorAlias(
             {
@@ -1735,6 +1746,7 @@ def make_default_aliases():
                 ).fromstring("\n".join(lines))
             },
             "Command decorator. Parses XML and returns ElementTree Element.",
+            name="@xml",
         ),
     }
 
@@ -1746,6 +1758,7 @@ def make_default_aliases():
                 ).fromstring("\n".join(lines).encode())
             },
             "Command decorator. Parses XML with lxml and returns lxml Element.",
+            name="@lxml",
         )
     if ON_WINDOWS:
         # Borrow builtin commands from cmd.exe.

--- a/xonsh/cli_utils.py
+++ b/xonsh/cli_utils.py
@@ -601,6 +601,15 @@ class ArgParserAlias:
         self.stdout = None
         self.stderr = None
 
+    def __repr__(self):
+        cls = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        prog = self.kwargs.get("prog")
+        if prog is None and self._parser is not None:
+            prog = getattr(self._parser, "prog", None)
+        if prog:
+            return f"{cls}({prog!r})"
+        return f"{cls}()"
+
     def build(self) -> "ArgParser":
         """Sub-classes should return constructed ArgumentParser"""
         if self.kwargs:

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -366,6 +366,13 @@ class DecoratorAlias:
     """Decorator alias base class."""
 
     descr = "DecoratorAlias base."
+    name = ""
+
+    def __repr__(self):
+        cls = f"{self.__class__.__module__}.{self.__class__.__name__}"
+        if self.name:
+            return f"{cls}({self.name!r})"
+        return f"{cls}()"
 
     def __call__(
         self,
@@ -391,10 +398,11 @@ class DecoratorAlias:
 class SpecAttrDecoratorAlias(DecoratorAlias):
     """Decorator Alias for spec attributes."""
 
-    def __init__(self, set_attributes: dict, descr=""):
+    def __init__(self, set_attributes: dict, descr="", name=""):
         self.set_attributes = set_attributes
         self.descr = descr
         self.__doc__ = descr
+        self.name = name
         super().__init__()
 
     def decorate_spec(self, spec):


### PR DESCRIPTION
Before

```xsh
aliases
'@error_raise': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x105c7a270>,
 '@error_ignore': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x1055ce210>,
 '@thread': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x1055ce350>,
 '@unthread': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x105cade00>,
 '@lines': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x105cadf30>,
 '@path': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x1055670b0>,
 '@paths': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x105c889e0>,
 '@json': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x105c88d10>,
 '@jsonl': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x1055b2650>,
 '@yaml': <xonsh.procs.specs.SpecAttrDecoratorAlias at 0x106010150>,
```

After

```xsh
aliases
'@error_raise': xonsh.procs.specs.SpecAttrDecoratorAlias('@error_raise'),
 '@error_ignore': xonsh.procs.specs.SpecAttrDecoratorAlias('@error_ignore'),
 '@thread': xonsh.procs.specs.SpecAttrDecoratorAlias('@thread'),
 '@unthread': xonsh.procs.specs.SpecAttrDecoratorAlias('@unthread'),
 '@lines': xonsh.procs.specs.SpecAttrDecoratorAlias('@lines'),
 '@path': xonsh.procs.specs.SpecAttrDecoratorAlias('@path'),
 '@paths': xonsh.procs.specs.SpecAttrDecoratorAlias('@paths'),
 '@json': xonsh.procs.specs.SpecAttrDecoratorAlias('@json'),
 '@jsonl': xonsh.procs.specs.SpecAttrDecoratorAlias('@jsonl'),
 '@yaml': xonsh.procs.specs.SpecAttrDecoratorAlias('@yaml'),
 '@toml': xonsh.procs.specs.SpecAttrDecoratorAlias('@toml'),
 '@xml': xonsh.procs.specs.SpecAttrDecoratorAlias('@xml'),
 '@lxml': xonsh.procs.specs.SpecAttrDecoratorAlias('@lxml'),

```
## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
