### PR TITLE
fix: xcontext: Show both path and resolved path

### DIFF
--- a/tests/xoreutils/test_xcontext.py
+++ b/tests/xoreutils/test_xcontext.py
@@ -38,13 +38,17 @@ def _make_unexecutable(path):
 @skip_if_on_windows
 def test_resolve_one_passthrough_when_disabled(tmp_path):
     """``resolve=False`` never follows symlinks. The accessibility check
-    still runs, so an executable symlink target returns ``bad=False``."""
+    still runs, so an executable symlink target returns ``bad=False``,
+    and ``original == resolved`` so the colored output collapses to a
+    single line.
+    """
     target = tmp_path / "target"
     _make_executable(target)
     link = tmp_path / "link"
     link.symlink_to(target)
 
-    resolved, bad = _resolve_one(str(link), resolve=False)
+    original, resolved, bad = _resolve_one(str(link), resolve=False)
+    assert original == str(link)
     assert resolved == str(link)  # not resolved
     assert bad is False  # but still passes the executable check
 
@@ -52,13 +56,16 @@ def test_resolve_one_passthrough_when_disabled(tmp_path):
 @skip_if_on_windows
 def test_resolve_one_follows_symlink(tmp_path):
     """A non-cyclic symlink pointing at an executable file is followed to
-    its real target and reported as NOT bad."""
+    its real target and reported as NOT bad. The input is preserved on
+    ``original`` so the colored renderer can show both rows.
+    """
     target = tmp_path / "target"
     _make_executable(target)
     link = tmp_path / "link"
     link.symlink_to(target)
 
-    resolved, bad = _resolve_one(str(link), resolve=True)
+    original, resolved, bad = _resolve_one(str(link), resolve=True)
+    assert original == str(link)
     assert resolved == os.path.realpath(str(link))
     assert resolved == os.path.realpath(str(target))
     assert bad is False
@@ -67,14 +74,15 @@ def test_resolve_one_follows_symlink(tmp_path):
 def test_resolve_one_nonexistent_is_bad(tmp_path):
     """Dangling / missing paths can't be executed — bad=True."""
     missing = tmp_path / "does_not_exist"
-    resolved, bad = _resolve_one(str(missing), resolve=True)
+    original, resolved, bad = _resolve_one(str(missing), resolve=True)
+    assert original == str(missing)
     assert resolved == os.path.realpath(str(missing))
     assert bad is True
 
 
 def test_resolve_one_directory_is_bad(tmp_path):
     """A directory is not a runnable file — bad=True."""
-    resolved, bad = _resolve_one(str(tmp_path), resolve=True)
+    _, _, bad = _resolve_one(str(tmp_path), resolve=True)
     assert bad is True
 
 
@@ -90,7 +98,8 @@ def test_resolve_one_not_executable_is_bad(tmp_path):
     """
     f = tmp_path / "foo.py"
     _make_unexecutable(f)
-    resolved, bad = _resolve_one(str(f), resolve=True)
+    original, resolved, bad = _resolve_one(str(f), resolve=True)
+    assert original == str(f)
     assert resolved == os.path.realpath(str(f))
     assert bad is True
 
@@ -106,7 +115,8 @@ def test_resolve_one_main_py_is_not_bad(tmp_path):
     main = pkg / "__main__.py"
     _make_unexecutable(main)  # not +x, as __main__.py conventionally is
 
-    resolved, bad = _resolve_one(str(main), resolve=True)
+    original, resolved, bad = _resolve_one(str(main), resolve=True)
+    assert original == str(main)
     assert resolved == os.path.realpath(str(main))
     assert bad is False
 
@@ -115,7 +125,7 @@ def test_resolve_one_missing_main_py_is_bad(tmp_path):
     """A non-existent ``__main__.py`` is still bad — the ``+x`` exemption
     only applies when the file actually exists."""
     missing = tmp_path / "nopkg" / "__main__.py"
-    _, bad = _resolve_one(str(missing), resolve=True)
+    _, _, bad = _resolve_one(str(missing), resolve=True)
     assert bad is True
 
 
@@ -123,7 +133,8 @@ def test_resolve_one_executable_file_is_ok(tmp_path):
     """An existing, accessible, ``+x`` file is not bad."""
     f = tmp_path / "runnable"
     _make_executable(f)
-    resolved, bad = _resolve_one(str(f), resolve=True)
+    original, resolved, bad = _resolve_one(str(f), resolve=True)
+    assert original == str(f)
     assert resolved == os.path.realpath(str(f))
     assert bad is False
 
@@ -136,7 +147,7 @@ def test_resolve_one_not_executable_bad_even_without_resolve(tmp_path):
     """
     f = tmp_path / "foo.py"
     _make_unexecutable(f)
-    _, bad = _resolve_one(str(f), resolve=False)
+    _, _, bad = _resolve_one(str(f), resolve=False)
     assert bad is True
 
 
@@ -147,22 +158,25 @@ def test_resolve_one_dangling_symlink_is_bad(tmp_path):
     link = tmp_path / "dangling"
     link.symlink_to(target)
 
-    _, bad = _resolve_one(str(link), resolve=True)
+    _, _, bad = _resolve_one(str(link), resolve=True)
     assert bad is True
 
 
 @skip_if_on_windows
 def test_resolve_one_detects_cycle(tmp_path):
-    """A symlink pair A → B → A must be flagged bad and leave the
-    original path untouched so the caller can display it."""
+    """A symlink pair A → B → A must be flagged bad and leave the input
+    path untouched on both ``original`` and ``resolved`` so the colored
+    renderer collapses to a single (red) row.
+    """
     a = tmp_path / "a"
     b = tmp_path / "b"
     a.symlink_to(b)
     b.symlink_to(a)
 
-    resolved, bad = _resolve_one(str(a), resolve=True)
+    original, resolved, bad = _resolve_one(str(a), resolve=True)
     assert bad is True
-    assert resolved == str(a)  # original preserved
+    assert original == str(a)
+    assert resolved == str(a)  # cycle: chain not followed
 
 
 @skip_if_on_windows
@@ -171,49 +185,55 @@ def test_resolve_one_detects_self_cycle(tmp_path):
     a = tmp_path / "selfloop"
     a.symlink_to(a)
 
-    resolved, bad = _resolve_one(str(a), resolve=True)
+    original, resolved, bad = _resolve_one(str(a), resolve=True)
     assert bad is True
+    assert original == str(a)
     assert resolved == str(a)
 
 
 def test_resolve_path_accepts_none():
-    assert _resolve_path(None, resolve=True) == (None, False)
+    assert _resolve_path(None, resolve=True) == (None, None, False)
 
 
 def test_resolve_path_accepts_non_path_list():
-    """A list whose first element is not a string is returned as-is."""
+    """A list whose first element is not a string is returned as-is on
+    both sides (no probing happens)."""
     value = [object(), "-m", "pip"]
-    assert _resolve_path(value, resolve=True) == (value, False)
+    assert _resolve_path(value, resolve=True) == (value, value, False)
 
 
 @skip_if_on_windows
 def test_resolve_path_list_with_cyclic_head(tmp_path):
     """For list values (e.g. xpip alias), only the first element is resolved.
-    If it cycles, the list is kept and the bad flag is True."""
+    If it cycles, the list is kept verbatim on both sides and the bad
+    flag is True."""
     a = tmp_path / "a"
     b = tmp_path / "b"
     a.symlink_to(b)
     b.symlink_to(a)
 
     value = [str(a), "-m", "pip"]
-    resolved, bad = _resolve_path(value, resolve=True)
+    original, resolved, bad = _resolve_path(value, resolve=True)
     assert bad is True
-    # Original head preserved so the display still works; tail unchanged.
+    # Head kept verbatim on both sides; tail unchanged.
+    assert original == [str(a), "-m", "pip"]
     assert resolved == [str(a), "-m", "pip"]
 
 
 @skip_if_on_windows
 def test_resolve_path_list_with_good_head(tmp_path):
-    """For list values with an executable head, the head is resolved in
-    place and the tail is kept intact."""
+    """For list values with an executable head, the head is resolved on
+    the ``resolved`` side while ``original`` keeps the input verbatim;
+    the tail is kept intact on both sides."""
     target = tmp_path / "real"
     _make_executable(target)
     link = tmp_path / "link"
     link.symlink_to(target)
 
     value = [str(link), "-m", "pip"]
-    resolved, bad = _resolve_path(value, resolve=True)
+    original, resolved, bad = _resolve_path(value, resolve=True)
     assert bad is False
+    assert original == [str(link), "-m", "pip"]
     assert resolved[0] == os.path.realpath(str(link))
     assert resolved[1:] == ["-m", "pip"]
 
@@ -227,8 +247,9 @@ def test_resolve_path_list_with_bad_head_not_executable(tmp_path):
     f = tmp_path / "foo.py"
     _make_unexecutable(f)
     value = [str(f), "-m", "pip"]
-    resolved, bad = _resolve_path(value, resolve=True)
+    original, resolved, bad = _resolve_path(value, resolve=True)
     assert bad is True
+    assert original == [str(f), "-m", "pip"]
     assert resolved == [os.path.realpath(str(f)), "-m", "pip"]
 
 

--- a/tests/xoreutils/test_xcontext_llm.py
+++ b/tests/xoreutils/test_xcontext_llm.py
@@ -3,7 +3,9 @@
 import io
 import json
 import os
+import re
 import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -18,7 +20,9 @@ from xonsh.xoreutils import xcontext
 
 def test_resolve_one_bare_script_resolves_to_exe_on_windows(tmp_path, xession):
     """Windows-only: ``C:\\...\\Scripts\\xonsh`` must resolve to
-    ``xonsh.exe`` so ``xxonsh`` isn't red and matches the PATH row.
+    ``xonsh.exe`` on the ``resolved`` side; the input is preserved on
+    ``original`` so the colored renderer can show the unresolved form
+    that the user actually typed.
     """
     if not ON_WINDOWS:
         pytest.skip("Windows-only — relies on PATHEXT executable check")
@@ -32,7 +36,8 @@ def test_resolve_one_bare_script_resolves_to_exe_on_windows(tmp_path, xession):
     bare = str(scripts / "xonsh")
     assert not os.path.exists(bare)
 
-    resolved, bad = xcontext._resolve_one(bare, resolve=True)
+    original, resolved, bad = xcontext._resolve_one(bare, resolve=True)
+    assert original == bare
     assert os.path.samefile(resolved, str(real))
     assert bad is False
 
@@ -40,7 +45,8 @@ def test_resolve_one_bare_script_resolves_to_exe_on_windows(tmp_path, xession):
 def test_resolve_one_bare_script_no_resolve_still_probes(tmp_path, xession):
     """With ``--no-resolve`` the ext probe still runs, so the row
     isn't mistakenly flagged as missing just because symlink
-    resolution was disabled.
+    resolution was disabled. The PATHEXT-resolved name is still on
+    ``resolved``; the bare input stays on ``original``.
     """
     if not ON_WINDOWS:
         pytest.skip("Windows-only — relies on PATHEXT executable check")
@@ -52,15 +58,16 @@ def test_resolve_one_bare_script_no_resolve_still_probes(tmp_path, xession):
     xession.env["PATHEXT"] = [".EXE"]
 
     bare = str(scripts / "xonsh")
-    resolved, bad = xcontext._resolve_one(bare, resolve=False)
+    original, resolved, bad = xcontext._resolve_one(bare, resolve=False)
+    assert original == bare
     assert os.path.samefile(resolved, str(real))
     assert bad is False
 
 
 def test_resolve_one_existing_file_untouched(tmp_path, xession):
-    """If the value already exists on disk, we keep it as-is (this is
-    what preserves the ``__main__.py`` entry-point case used by
-    ``python -m xonsh``).
+    """If the value already exists on disk, we keep it as-is on both
+    sides (this is what preserves the ``__main__.py`` entry-point case
+    used by ``python -m xonsh``).
     """
     entry = tmp_path / "xonsh"
     entry.mkdir()
@@ -68,7 +75,8 @@ def test_resolve_one_existing_file_untouched(tmp_path, xession):
     main_py.write_text("")
     xession.env["PATHEXT"] = [".EXE"]
 
-    resolved, bad = xcontext._resolve_one(str(main_py), resolve=True)
+    original, resolved, bad = xcontext._resolve_one(str(main_py), resolve=True)
+    assert original == str(main_py)
     assert resolved == str(main_py)
     # ``__main__.py`` is never +x but is treated as good by the
     # special case in ``_is_executable_file``.
@@ -79,7 +87,7 @@ def test_resolve_one_missing_path_still_bad(tmp_path, xession):
     """Completely missing path stays flagged."""
     xession.env["PATHEXT"] = [".EXE"]
     missing = str(tmp_path / "ghost")
-    _, bad = xcontext._resolve_one(missing, resolve=True)
+    _, _, bad = xcontext._resolve_one(missing, resolve=True)
     assert bad is True
 
 
@@ -204,7 +212,7 @@ def _run_xcontext_main(xession):
         mock.patch.object(xcontext.subprocess, "run", return_value=fake_completed),
         mock.patch.object(xcontext, "locate_executable", return_value="/fake/bin"),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
         mock.patch.object(
@@ -251,10 +259,173 @@ def test_current_environment_shown_when_conda_set(xession):
     assert "VIRTUAL_ENV" not in out
 
 
+# ---------------------------------------------------------------------------
+# xcontext_main — secondary ``name resolved:`` row
+# ---------------------------------------------------------------------------
+
+
+_COLOR_TOKENS_RE = re.compile(r"\{[A-Z_]+\}")
+
+
+def _strip_color_tokens(text):
+    """Drop the ``{PURPLE}``/``{RESET}``/etc. format tokens from a
+    ``xcontext_main`` text dump so substring asserts can match the
+    user-visible content directly.
+    """
+    return _COLOR_TOKENS_RE.sub("", text)
+
+
+def _run_xcontext_main_with_resolve(xession, resolve_map):
+    """Run ``xcontext_main`` with a stubbed ``_resolve_path`` that
+    returns a custom ``resolved`` value for selected inputs, and return
+    the rendered output with color tokens stripped.
+
+    ``resolve_map`` is a dict mapping the input value (string or list,
+    lists must be passed as tuples for hashability) to the resolved
+    value the stub should report. Inputs absent from the map pass
+    through unchanged (original == resolved).
+    """
+    buf = io.StringIO()
+    fake_completed = subprocess.CompletedProcess(
+        args=["python", "--version"],
+        returncode=0,
+        stdout="Python 3.13.3\n",
+        stderr="",
+    )
+    xession.aliases["xpip"] = ["/fake/python", "-m", "pip"]
+
+    def fake_resolve(value, resolve):
+        key = tuple(value) if isinstance(value, list) else value
+        target = resolve_map.get(key, value)
+        return value, target, False
+
+    with (
+        mock.patch.object(xcontext.subprocess, "run", return_value=fake_completed),
+        mock.patch.object(xcontext, "locate_executable", return_value="/fake/bin"),
+        mock.patch.object(xcontext, "_resolve_path", side_effect=fake_resolve),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+        mock.patch.object(
+            xcontext,
+            "print_color",
+            side_effect=lambda s, file=None: print(s, file=file),
+        ),
+    ):
+        xcontext.xcontext_main(_stdout=buf)
+    return _strip_color_tokens(buf.getvalue())
+
+
+def test_text_no_resolved_row_when_identical(xession):
+    """When the resolved path is identical to the input, no second
+    ``name resolved:`` row appears — it would just duplicate the line.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    out = _run_xcontext_main_with_resolve(xession, resolve_map={})
+    # No row in the output starts with "xxonsh resolved" / etc.
+    assert "xxonsh resolved" not in out
+    assert "xpython resolved" not in out
+    assert "xpip resolved" not in out
+    assert "xonsh resolved" not in out
+    assert "python resolved" not in out
+    assert "pip resolved" not in out
+
+
+def test_text_resolved_row_emitted_when_xxonsh_differs(xession):
+    """When the resolved xxonsh path differs from the input, a
+    secondary ``xxonsh resolved:`` row appears with the resolved path.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    out = _run_xcontext_main_with_resolve(
+        xession, resolve_map={"/fake/xonsh": "/real/xonsh"}
+    )
+    # Original row carries the input path; resolved row carries the
+    # symlink target.
+    assert "xxonsh: /fake/xonsh" in out
+    assert "xxonsh resolved: /real/xonsh" in out
+    # The other families weren't remapped, so their resolved rows are
+    # suppressed.
+    assert "xpython resolved" not in out
+    assert "xpip resolved" not in out
+
+
+def test_text_resolved_row_emitted_for_xpip_list(xession):
+    """A list-valued xpip whose head was symlink-resolved emits a
+    secondary row with the joined resolved list.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    out = _run_xcontext_main_with_resolve(
+        xession,
+        resolve_map={
+            ("/fake/python", "-m", "pip"): ["/real/python", "-m", "pip"],
+        },
+    )
+    assert "xpip: /fake/python -m pip" in out
+    assert "xpip resolved: /real/python -m pip" in out
+
+
+def test_text_resolved_row_repeats_version(xession):
+    """The ``# Python X.Y.Z`` annotation is shown on BOTH the input row
+    and the resolved row — the version describes the binary, not the
+    spelling of the path.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    out = _run_xcontext_main_with_resolve(
+        xession, resolve_map={sys.executable: "/real/python3"}
+    )
+    # The ``xpython:`` row uses sys.executable, and the resolved row
+    # carries our remap. Both should carry the version comment.
+    version_lines = [ln for ln in out.splitlines() if "Python 3.13.3" in ln]
+    # xpython input + xpython resolved + commands.python input + commands.python resolved
+    # commands.python wasn't remapped (resolve_map keyed by sys.executable
+    # only matches the session getter), so we expect at least 2 — the
+    # session pair.
+    assert len(version_lines) >= 2
+    # Both session lines (xpython: ... # Python 3.13.3) and the
+    # resolved variant carry the trailing comment.
+    assert any(ln.lstrip().startswith("xpython:") for ln in version_lines)
+    assert any(ln.lstrip().startswith("xpython resolved:") for ln in version_lines)
+
+
+def test_text_no_resolved_row_when_path_missing(xession):
+    """A missing entry (xpip with no alias) renders ``not found`` once;
+    no spurious ``name resolved:`` row is emitted.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    xession.aliases.pop("xpip", None)
+    buf = io.StringIO()
+    fake_completed = subprocess.CompletedProcess(
+        args=["python", "--version"],
+        returncode=0,
+        stdout="Python 3.13.3\n",
+        stderr="",
+    )
+    with (
+        mock.patch.object(xcontext.subprocess, "run", return_value=fake_completed),
+        mock.patch.object(xcontext, "locate_executable", return_value="/fake/bin"),
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
+        ),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+        mock.patch.object(
+            xcontext,
+            "print_color",
+            side_effect=lambda s, file=None: print(s, file=file),
+        ),
+    ):
+        xcontext.xcontext_main(_stdout=buf)
+    out = _strip_color_tokens(buf.getvalue())
+    assert "xpip: not found" in out
+    assert "xpip resolved" not in out
+
+
 def test_resolve_path_list_head_uses_pathext_probe(tmp_path, xession):
     """List-valued aliases (``xpip = [python, -m, pip]``) have only
     their head element probed — trailing args are passed through
-    unchanged.
+    unchanged on both the original and the resolved side.
     """
     if not ON_WINDOWS:
         pytest.skip("Windows-only — relies on PATHEXT executable check")
@@ -266,7 +437,8 @@ def test_resolve_path_list_head_uses_pathext_probe(tmp_path, xession):
     xession.env["PATHEXT"] = [".EXE"]
 
     bare = str(scripts / "python")
-    resolved, bad = xcontext._resolve_path([bare, "-m", "pip"], resolve=True)
+    original, resolved, bad = xcontext._resolve_path([bare, "-m", "pip"], resolve=True)
+    assert original == [bare, "-m", "pip"]
     assert os.path.samefile(resolved[0], str(real))
     assert resolved[1:] == ["-m", "pip"]
     assert bad is False
@@ -297,7 +469,7 @@ def _run_xcontext_json(xession, locate=None):
             xcontext, "locate_executable", side_effect=lambda c: locate_map.get(c)
         ),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
     ):
@@ -314,8 +486,10 @@ def test_json_output_has_expected_top_level_keys(xession):
 
 
 def test_json_session_carries_xpython_xxonsh_xpip(xession):
-    """``session`` joins list-valued ``xpip`` with spaces — same flat
-    string the colored output shows for the ``xpip:`` row.
+    """``session`` carries each entry under its base key; ``xpip`` joins
+    its list with spaces — same flat string the colored output shows
+    for the ``xpip:`` row. With the stubbed ``_resolve_path``, original
+    equals resolved, so no ``_resolved`` siblings appear.
     """
     xession.env.pop("CONDA_DEFAULT_ENV", None)
     xession.env.pop("VIRTUAL_ENV", None)
@@ -330,19 +504,24 @@ def test_json_session_carries_xpython_xxonsh_xpip(xession):
 
 def test_json_commands_includes_all_probed_names(xession):
     """``commands`` always lists every probed name (xonsh/python/pip/
-    pytest/uv) so consumers don't have to special-case missing keys.
+    pytest/uv) so consumers don't have to special-case missing base
+    keys. ``_resolved`` siblings are absent when the value matches —
+    see :func:`test_json_resolved_keys_carry_distinct_values` for the
+    differing case.
     """
     xession.env.pop("CONDA_DEFAULT_ENV", None)
     xession.env.pop("VIRTUAL_ENV", None)
     report, _ = _run_xcontext_json(xession)
-    assert set(report["commands"]) == {"xonsh", "python", "pip", "pytest", "uv"}
-    for cmd, path in report["commands"].items():
-        assert path == f"/fake/{cmd}"
+    bases = {"xonsh", "python", "pip", "pytest", "uv"}
+    assert set(report["commands"]) == bases
+    for cmd in bases:
+        assert report["commands"][cmd] == f"/fake/{cmd}"
 
 
 def test_json_commands_null_when_not_on_path(xession):
-    """A name absent from ``$PATH`` shows up as JSON ``null``, not as a
-    missing key — the schema is stable.
+    """A name absent from ``$PATH`` shows up as JSON ``null`` for its
+    base key. The ``_resolved`` sibling is omitted (no resolution to
+    add) — there's no key at all, not a ``null`` placeholder.
     """
     xession.env.pop("CONDA_DEFAULT_ENV", None)
     xession.env.pop("VIRTUAL_ENV", None)
@@ -350,6 +529,11 @@ def test_json_commands_null_when_not_on_path(xession):
     assert report["commands"]["pytest"] is None
     assert report["commands"]["uv"] is None
     assert report["commands"]["xonsh"] == "/fake/xonsh"
+    # No ``_resolved`` siblings — stubbed ``_resolve_path`` returns
+    # ``original == resolved`` for every value, including the ``None``s.
+    assert "pytest_resolved" not in report["commands"]
+    assert "uv_resolved" not in report["commands"]
+    assert "xonsh_resolved" not in report["commands"]
 
 
 def test_json_env_empty_when_no_vars_set(xession):
@@ -408,6 +592,93 @@ def test_json_skips_print_color_calls(xession):
     assert "\x1b[" not in raw  # no ANSI escape sequences
 
 
+def test_json_resolved_keys_carry_distinct_values(xession):
+    """When resolution rewrites a path, the ``_resolved`` JSON key
+    carries the new value while the base key keeps the input. Names
+    that weren't rewritten ship without a ``_resolved`` sibling.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    buf = io.StringIO()
+    xession.aliases["xpip"] = ["/fake/python", "-m", "pip"]
+    locate_map = {
+        "xonsh": "/fake/xonsh",
+        "python": "/fake/python",
+        "pip": "/fake/pip",
+        "pytest": "/fake/pytest",
+        "uv": "/fake/uv",
+    }
+    rewrite = {
+        "/fake/xonsh": "/real/xonsh",
+        "/fake/python": "/real/python",
+        ("/fake/python", "-m", "pip"): ["/real/python", "-m", "pip"],
+    }
+
+    def fake_resolve(value, resolve):
+        key = tuple(value) if isinstance(value, list) else value
+        return value, rewrite.get(key, value), False
+
+    with (
+        mock.patch.object(
+            xcontext, "locate_executable", side_effect=lambda c: locate_map.get(c)
+        ),
+        mock.patch.object(xcontext, "_resolve_path", side_effect=fake_resolve),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+    ):
+        rc = xcontext.xcontext_main(as_json=True, _stdout=buf)
+    assert rc == 0
+    report = json.loads(buf.getvalue())
+    # session: input vs resolved diverge for xxonsh and xpip; xpython
+    # (sys.executable) is untouched by the rewrite map → no
+    # xpython_resolved key.
+    assert report["session"]["xxonsh"] == "/fake/xonsh"
+    assert report["session"]["xxonsh_resolved"] == "/real/xonsh"
+    assert report["session"]["xpip"] == "/fake/python -m pip"
+    assert report["session"]["xpip_resolved"] == "/real/python -m pip"
+    assert "xpython_resolved" not in report["session"]
+    # commands: xonsh and python diverge; pip/pytest/uv aren't in the
+    # rewrite map → no ``_resolved`` siblings.
+    assert report["commands"]["xonsh"] == "/fake/xonsh"
+    assert report["commands"]["xonsh_resolved"] == "/real/xonsh"
+    assert report["commands"]["python"] == "/fake/python"
+    assert report["commands"]["python_resolved"] == "/real/python"
+    assert report["commands"]["pip"] == "/fake/pip"
+    assert "pip_resolved" not in report["commands"]
+    assert "pytest_resolved" not in report["commands"]
+    assert "uv_resolved" not in report["commands"]
+
+
+def test_json_no_resolve_flag_skips_resolved_keys(xession):
+    """``xcontext -n --json`` (no_resolve=True) suppresses every
+    ``_resolved`` sibling because the resolver leaves paths verbatim —
+    matches the colored output's behavior under ``--no-resolve``.
+    """
+    xession.env.pop("CONDA_DEFAULT_ENV", None)
+    xession.env.pop("VIRTUAL_ENV", None)
+    xession.aliases["xpip"] = ["/fake/python", "-m", "pip"]
+    buf = io.StringIO()
+    locate_map = {
+        cmd: f"/fake/{cmd}" for cmd in ("xonsh", "python", "pip", "pytest", "uv")
+    }
+    with (
+        mock.patch.object(
+            xcontext, "locate_executable", side_effect=lambda c: locate_map.get(c)
+        ),
+        # Pass the value through unchanged on both sides — the real
+        # ``_resolve_path`` does the same in ``-n`` mode when nothing
+        # needs the PATHEXT fallback.
+        mock.patch.object(
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
+        ),
+        mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
+    ):
+        rc = xcontext.xcontext_main(no_resolve=True, as_json=True, _stdout=buf)
+    assert rc == 0
+    report = json.loads(buf.getvalue())
+    for section in ("session", "commands"):
+        assert not any(k.endswith("_resolved") for k in report[section])
+
+
 # ---------------------------------------------------------------------------
 # Resolved dataclass — display rendering
 # ---------------------------------------------------------------------------
@@ -449,13 +720,81 @@ def test_resolved_display_list_with_non_string_passthrough():
 
 def test_resolved_defaults_are_safe():
     """Default ``Resolved()`` is a "nothing found" placeholder — bad is
-    False, version is empty, path is None. Lets callers construct from
-    optional fields without juggling sentinels.
+    False, version is empty, path and resolved are None. Lets callers
+    construct from optional fields without juggling sentinels.
     """
     r = xcontext.Resolved()
     assert r.path is None
+    assert r.resolved is None
     assert r.bad is False
     assert r.version == ""
+
+
+def test_resolved_resolved_display_string():
+    """``resolved_display`` renders the ``resolved`` field the same way
+    ``display`` renders ``path`` — a plain string passes through.
+    """
+    r = xcontext.Resolved(path="/bin/python", resolved="/usr/bin/python3.13")
+    assert r.resolved_display == "/usr/bin/python3.13"
+
+
+def test_resolved_resolved_display_list_joined_with_spaces():
+    """A list ``resolved`` (xpip alias) joins with spaces the same way
+    ``display`` does for ``path``.
+    """
+    r = xcontext.Resolved(
+        path=["/bin/python", "-m", "pip"],
+        resolved=["/usr/bin/python3.13", "-m", "pip"],
+    )
+    assert r.resolved_display == "/usr/bin/python3.13 -m pip"
+
+
+def test_resolved_resolved_display_none():
+    """``resolved=None`` renders as ``None`` so callers can detect
+    "no resolution available" without re-checking the field.
+    """
+    assert xcontext.Resolved(path="/x").resolved_display is None
+    assert xcontext.Resolved().resolved_display is None
+
+
+def test_resolved_differs_false_when_equal():
+    """When the input and the resolved path are the same string, the
+    colored renderer must collapse to a single ``name:`` row.
+    """
+    r = xcontext.Resolved(path="/bin/python", resolved="/bin/python")
+    assert r.differs is False
+
+
+def test_resolved_differs_true_when_distinct():
+    """A symlink resolution produces distinct input/resolved values —
+    the colored renderer emits the secondary ``name resolved:`` row.
+    """
+    r = xcontext.Resolved(path="/bin/python", resolved="/usr/bin/python3.13")
+    assert r.differs is True
+
+
+def test_resolved_differs_false_when_resolved_none():
+    """``resolved=None`` (the "not found / placeholder" shape) must not
+    drive the secondary row — there's nothing to render.
+    """
+    assert xcontext.Resolved(path="/x").differs is False
+    assert xcontext.Resolved().differs is False
+
+
+def test_resolved_differs_for_list_compares_elementwise():
+    """Two list values with different head executables differ; equal
+    lists do not. Drives the ``xpip resolved:`` row.
+    """
+    r_same = xcontext.Resolved(
+        path=["/bin/python", "-m", "pip"],
+        resolved=["/bin/python", "-m", "pip"],
+    )
+    r_diff = xcontext.Resolved(
+        path=["/bin/python", "-m", "pip"],
+        resolved=["/usr/bin/python3.13", "-m", "pip"],
+    )
+    assert r_same.differs is False
+    assert r_diff.differs is True
 
 
 # ---------------------------------------------------------------------------
@@ -470,7 +809,7 @@ def test_xcontext_get_session_xxonsh_returns_resolved(xession):
     """
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch("xonsh.main.get_current_xonsh", return_value="/fake/xonsh"),
     ):
@@ -488,7 +827,7 @@ def test_xcontext_get_session_xxonsh_passes_resolve_flag(xession):
 
     def fake(value, resolve):
         seen.append(resolve)
-        return value, False
+        return value, value, False
 
     with (
         mock.patch.object(xcontext, "_resolve_path", side_effect=fake),
@@ -507,7 +846,7 @@ def test_xcontext_get_session_xxonsh_caches_when_enabled(xession):
     calls = mock.MagicMock(return_value="/fake/xonsh")
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch("xonsh.main.get_current_xonsh", side_effect=calls),
     ):
@@ -526,7 +865,7 @@ def test_xcontext_default_does_not_cache(xession):
     calls = mock.MagicMock(return_value="/fake/xonsh")
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch("xonsh.main.get_current_xonsh", side_effect=calls),
     ):
@@ -551,7 +890,7 @@ def test_xcontext_get_session_xpython_records_version(xession):
     )
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(xcontext.subprocess, "run", return_value=completed) as run,
     ):
@@ -568,7 +907,7 @@ def test_xcontext_get_session_xpython_marks_bad_on_spawn_error(xession):
     """
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(
             xcontext.subprocess,
@@ -592,7 +931,7 @@ def test_xcontext_get_session_xpython_caches_subprocess_when_enabled(xession):
     )
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(xcontext.subprocess, "run", return_value=completed) as run,
     ):
@@ -612,7 +951,7 @@ def test_xcontext_default_reruns_subprocess(xession):
     )
     with (
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(xcontext.subprocess, "run", return_value=completed) as run,
     ):
@@ -630,10 +969,11 @@ def test_xcontext_get_session_xpip_returns_alias(xession):
     """
     xession.aliases["xpip"] = ["/fake/python", "-m", "pip"]
     with mock.patch.object(
-        xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
     ):
         r = xcontext.XContext().get_session_xpip()
     assert r.path == ["/fake/python", "-m", "pip"]
+    assert r.resolved == ["/fake/python", "-m", "pip"]
     assert r.display == "/fake/python -m pip"
     assert r.bad is False
 
@@ -645,10 +985,11 @@ def test_xcontext_get_session_xpip_missing_alias(xession):
     """
     xession.aliases.pop("xpip", None)
     with mock.patch.object(
-        xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+        xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
     ):
         r = xcontext.XContext().get_session_xpip()
     assert r.path is None
+    assert r.resolved is None
     assert r.display is None
 
 
@@ -663,7 +1004,7 @@ def test_xcontext_get_commands_xonsh_uses_locate_executable(xession):
     with (
         mock.patch.object(xcontext, "locate_executable", return_value="/path/xonsh"),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
     ):
         r = xcontext.XContext().get_commands_xonsh()
@@ -684,7 +1025,7 @@ def test_xcontext_get_commands_python_records_version(xession):
     with (
         mock.patch.object(xcontext, "locate_executable", return_value="/path/python"),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(xcontext.subprocess, "run", return_value=completed),
     ):
@@ -700,7 +1041,7 @@ def test_xcontext_get_commands_python_skips_probe_when_missing(xession):
     with (
         mock.patch.object(xcontext, "locate_executable", return_value=None),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(xcontext.subprocess, "run") as run,
     ):
@@ -716,7 +1057,7 @@ def test_xcontext_get_commands_python_marks_bad_on_spawn_error(xession):
     with (
         mock.patch.object(xcontext, "locate_executable", return_value="/store/python"),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
         mock.patch.object(
             xcontext.subprocess, "run", side_effect=OSError(1920, "WinError 1920")
@@ -737,7 +1078,7 @@ def test_xcontext_get_commands_pip_pytest_uv(xession):
             xcontext, "locate_executable", side_effect=lambda c: locate_map.get(c)
         ),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
     ):
         xc = xcontext.XContext()
@@ -753,7 +1094,7 @@ def test_xcontext_get_commands_missing_returns_none(xession):
     with (
         mock.patch.object(xcontext, "locate_executable", return_value=None),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
     ):
         r = xcontext.XContext().get_commands_pytest()
@@ -769,7 +1110,7 @@ def test_xcontext_get_commands_caches_when_enabled(xession):
     with (
         mock.patch.object(xcontext, "locate_executable", side_effect=locate),
         mock.patch.object(
-            xcontext, "_resolve_path", side_effect=lambda v, r: (v, False)
+            xcontext, "_resolve_path", side_effect=lambda v, r: (v, v, False)
         ),
     ):
         xc = xcontext.XContext(cache=True)

--- a/xonsh/xoreutils/xcontext.py
+++ b/xonsh/xoreutils/xcontext.py
@@ -128,20 +128,29 @@ def _is_executable_file(path):
 def _resolve_one(value, resolve):
     """Resolve a single string path and report whether it's "bad".
 
-    Returns ``(resolved_value, is_bad)``. A path is considered bad — and
-    the caller renders its whole row in RED — if any of:
+    Returns ``(original, resolved, is_bad)``. ``original`` is the input
+    value preserved verbatim — the caller renders it on the ``name:``
+    row. ``resolved`` is the same value after the Windows PATHEXT lookup
+    and, when ``resolve`` is True, ``os.path.realpath`` — the caller
+    renders it on the optional ``name resolved:`` row when it differs
+    from ``original``. A path is considered bad — and the caller renders
+    its whole row in RED — if any of:
 
-    * a symlink cycle is detected (original path is preserved as the
-      display value; the caller can't meaningfully resolve further),
+    * a symlink cycle is detected (both ``original`` and ``resolved``
+      keep the input verbatim because the chain can't be followed),
     * the resolved path is not an accessible executable file (missing,
       not a regular file, or lacks the ``+x`` bit).
 
     If ``resolve`` is False, symlinks are NOT followed, but the
     accessibility / executable check still runs on the raw value, so
-    ``--no-resolve`` still reports broken entries in red.
+    ``--no-resolve`` still reports broken entries in red. The Windows
+    PATHEXT fallback also still runs, so ``resolved`` can legitimately
+    differ from ``original`` even in ``--no-resolve`` mode.
     """
     if not value:
-        return value, False
+        return value, value, False
+
+    original = value
 
     if not os.path.exists(value):
         located = locate_relative_path(value, use_pathext=True, check_executable=True)
@@ -154,10 +163,10 @@ def _resolve_one(value, resolve):
         except OSError as e:
             # POSIX reliably uses ELOOP for cycles.
             if getattr(e, "errno", None) == errno.ELOOP:
-                return value, True
+                return original, value, True
             # Windows / edge cases: walk the chain ourselves before giving up.
             if os.path.islink(value) and _has_symlink_cycle(value):
-                return value, True
+                return original, value, True
             # Non-cyclic failure (dangling link, missing target, permission
             # error, etc.) — fall back to the lenient ``realpath``, which
             # never raises but may return a non-existent path.
@@ -166,55 +175,89 @@ def _resolve_one(value, resolve):
         resolved = value
 
     # ----- Accessibility / executable phase --------------------------------
-    return resolved, not _is_executable_file(resolved)
+    return original, resolved, not _is_executable_file(resolved)
 
 
 def _resolve_path(value, resolve):
-    """Return ``(resolved_value, is_bad)`` for the given alias value.
+    """Return ``(original_value, resolved_value, is_bad)`` for an alias value.
 
     Accepts ``None`` (passed through), a string path (resolved via
     :func:`_resolve_one`), or a list whose first element is an executable
     path (only the first element is resolved — the remaining args are
-    kept as-is). ``is_bad`` is True if the resolved (or, for lists, the
-    first-element) path is a symlink loop or is missing / not executable.
+    kept as-is on both the original and the resolved side). ``is_bad`` is
+    True if the resolved (or, for lists, the first-element) path is a
+    symlink loop or is missing / not executable.
     """
     if value is None:
-        return None, False
+        return None, None, False
     if isinstance(value, str):
         return _resolve_one(value, resolve)
     if isinstance(value, list) and value and isinstance(value[0], str):
-        head, bad = _resolve_one(value[0], resolve)
-        return [head] + list(value[1:]), bad
-    return value, False
+        orig_head, resolved_head, bad = _resolve_one(value[0], resolve)
+        tail = list(value[1:])
+        return [orig_head] + tail, [resolved_head] + tail, bad
+    return value, value, False
 
 
 @dataclass(frozen=True)
 class Resolved:
-    """A resolved binary path probed by :class:`XContext`.
+    """A binary path probed by :class:`XContext`.
 
-    ``path`` may be a string (resolved file path), a list (alias args
-    where ``path[0]`` is the executable), or ``None`` (not found / no
-    such alias). ``bad`` is True when the entry is unusable: symlink
-    loop, missing file, not a regular file, lacks ``+x``, or its
-    ``--version`` probe failed (Windows Store ``python.exe`` alias).
-    ``version`` is the trimmed ``--version`` output, populated only
-    for python-family entries.
+    ``path`` is the input value as discovered (whatever
+    :func:`locate_executable`, :func:`get_current_xonsh`,
+    :data:`sys.executable`, or the alias lookup returned) — preserved
+    verbatim so the colored output and the JSON consumer can show the
+    user the path they would actually type. ``resolved`` is the same
+    value after PATHEXT lookup and (in default mode) ``os.path.realpath``;
+    when symlinks weren't followed *and* no PATHEXT substitution
+    happened, it equals ``path``. Both may be a string, a list (alias
+    args where ``[0]`` is the executable), or ``None`` (not found / no
+    such alias).
 
-    The :attr:`display` property renders the entry as a single string —
-    list paths are space-joined the way the CLI shows them, plain
-    strings pass through, and ``None`` becomes ``None`` so callers can
-    detect "not found" without re-checking ``path``.
+    ``bad`` is True when the entry is unusable: symlink loop, missing
+    file, not a regular file, lacks ``+x``, or its ``--version`` probe
+    failed (Windows Store ``python.exe`` alias). ``version`` is the
+    trimmed ``--version`` output, populated only for python-family
+    entries.
+
+    :attr:`display` renders ``path`` for the colored row; list paths
+    are space-joined the way the CLI shows them, plain strings pass
+    through, and ``None`` becomes ``None`` so callers can detect "not
+    found" without re-checking ``path``. :attr:`resolved_display`
+    renders the same thing for ``resolved``. :attr:`differs` reports
+    whether the resolved value is meaningfully different from the
+    input — when it's False, the colored renderer suppresses the
+    ``name resolved:`` row.
     """
 
     path: object = None
+    resolved: object = None
     bad: bool = False
     version: str = ""
 
     @property
     def display(self):
-        if isinstance(self.path, list) and all(isinstance(x, str) for x in self.path):
-            return " ".join(self.path)
-        return str(self.path) if self.path else None
+        return self._render(self.path)
+
+    @property
+    def resolved_display(self):
+        return self._render(self.resolved)
+
+    @property
+    def differs(self):
+        """True when ``resolved`` is set and is not identical to ``path``.
+
+        Drives whether the colored renderer emits the secondary
+        ``name resolved:`` row — same value on both sides would just
+        duplicate the line.
+        """
+        return self.resolved is not None and self.resolved != self.path
+
+    @staticmethod
+    def _render(value):
+        if isinstance(value, list) and all(isinstance(x, str) for x in value):
+            return " ".join(value)
+        return str(value) if value else None
 
 
 def _cached_method(method):
@@ -270,8 +313,8 @@ class XContext:
         # Local import: ``xonsh.main`` pulls in heavy modules.
         from xonsh.main import get_current_xonsh
 
-        path, bad = _resolve_path(get_current_xonsh(), self._resolve)
-        return Resolved(path=path, bad=bad)
+        original, resolved, bad = _resolve_path(get_current_xonsh(), self._resolve)
+        return Resolved(path=original, resolved=resolved, bad=bad)
 
     @_cached_method
     def get_session_xpython(self) -> Resolved:
@@ -283,23 +326,28 @@ class XContext:
         invoke.
         """
         appimage_python = XSH.env.get("_") if IN_APPIMAGE else None
-        path, bad = _resolve_path(
+        original, resolved, bad = _resolve_path(
             appimage_python if appimage_python else sys.executable, self._resolve
         )
-        ver, ver_ok = _get_version(path)
-        return Resolved(path=path, bad=bad or not ver_ok, version=ver)
+        # Probe the resolved binary — the original may be a symlink or
+        # a non-existent shim (PATHEXT case) that can't be executed
+        # directly.
+        ver, ver_ok = _get_version(resolved)
+        return Resolved(
+            path=original, resolved=resolved, bad=bad or not ver_ok, version=ver
+        )
 
     @_cached_method
     def get_session_xpip(self) -> Resolved:
         """Return the ``xpip`` alias value (typically ``[python, -m, pip]``)."""
-        path, bad = _resolve_path(XSH.aliases.get("xpip"), self._resolve)
-        return Resolved(path=path, bad=bad)
+        original, resolved, bad = _resolve_path(XSH.aliases.get("xpip"), self._resolve)
+        return Resolved(path=original, resolved=resolved, bad=bad)
 
     # ---- commands: what ``$PATH`` lookup currently resolves to --------
 
     def _get_command(self, name: str) -> Resolved:
-        path, bad = _resolve_path(locate_executable(name), self._resolve)
-        return Resolved(path=path, bad=bad)
+        original, resolved, bad = _resolve_path(locate_executable(name), self._resolve)
+        return Resolved(path=original, resolved=resolved, bad=bad)
 
     @_cached_method
     def get_commands_xonsh(self) -> Resolved:
@@ -318,8 +366,13 @@ class XContext:
         base = self._get_command("python")
         if not base.path:
             return base
-        ver, ver_ok = _get_version(base.path)
-        return Resolved(path=base.path, bad=base.bad or not ver_ok, version=ver)
+        ver, ver_ok = _get_version(base.resolved)
+        return Resolved(
+            path=base.path,
+            resolved=base.resolved,
+            bad=base.bad or not ver_ok,
+            version=ver,
+        )
 
     @_cached_method
     def get_commands_pip(self) -> Resolved:
@@ -350,24 +403,32 @@ class XContext:
 def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None):
     """Report information about the current xonsh environment.
 
-    By default, all displayed binary paths (xxonsh, xpython, xpip and the
-    ``$PATH``-resolved ``xonsh``/``python``/``pip``/``pytest``) have their
-    symlinks followed to the real underlying files. This also makes the
-    match check that decides the label color (GREEN for match, BLUE for
-    mismatch) more accurate, because two paths that ultimately point to
-    the same file compare equal after resolution.
+    The colored text report shows the input path of each binary on a
+    ``name:`` row and — when symlink resolution (or, on Windows, the
+    PATHEXT lookup) changes it — the resolved path on a second
+    ``name resolved:`` row. The label-color match check (GREEN/BLUE)
+    uses the resolved paths so two entries that ultimately point to the
+    same underlying file compare equal even when their input paths
+    differ.
 
     Parameters
     ----------
     no_resolve : -n, --no-resolve
         Show raw paths as-is without following symlinks (turns off the
-        default resolution).
+        default resolution). The accessibility / executable check still
+        runs, so broken entries are still flagged in red.
     as_json : -j, --json
-        Emit the resolved paths as a JSON object on stdout instead of the
-        colored text report. Top-level keys mirror the text sections
-        (``session``, ``commands``, ``env``); ``commands`` always
-        includes every probed name with ``null`` for entries not on
-        ``$PATH``; ``env`` only contains variables that are set.
+        Emit the paths as a JSON object on stdout instead of the colored
+        text report. Top-level keys mirror the text sections
+        (``session``, ``commands``, ``env``). Each entry in ``session``
+        and ``commands`` carries the input path under its base key
+        (e.g. ``xxonsh``) — and, **only when the resolved path differs
+        from the input**, an additional sibling key with a ``_resolved``
+        suffix (e.g. ``xxonsh_resolved``). This mirrors the colored
+        output's secondary row: with ``--no-resolve`` (or when paths
+        already match their realpath) the ``_resolved`` keys are
+        omitted entirely instead of duplicating the value. ``env`` only
+        contains variables that are set.
     """
     stdout = _stdout or sys.stdout
     # cache=True so each ``--version`` subprocess runs at most once
@@ -383,25 +444,41 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
     cmd_uv = xc.get_commands_uv()
 
     if as_json:
-        # Skip color/version probes — JSON consumers want raw paths only.
-        # ``commands`` keeps every probed key (None for not-on-PATH) so the
-        # shape is predictable; ``env`` mirrors the text section and omits
-        # unset variables. Use ``_get_command`` for python here so we don't
-        # spawn a subprocess just to throw the version away.
+        # Skip the version probe — JSON consumers can call ``--version``
+        # themselves if they need it. ``commands`` always lists every
+        # probed name (``null`` for not-on-PATH) so the base schema is
+        # stable; the ``_resolved`` siblings, however, are only emitted
+        # when ``r.differs`` is True — same rule as the colored output's
+        # secondary row. That way ``--no-resolve`` (and the common case
+        # where the input is already a realpath) produce a clean JSON
+        # without echoing every path twice.
         cmd_python_raw = xc._get_command("python")
+
+        def _section(items):
+            out: dict = {}
+            for key, r in items:
+                out[key] = r.display
+                if r.differs:
+                    out[f"{key}_resolved"] = r.resolved_display
+            return out
+
         report = {
-            "session": {
-                "xxonsh": session_xxonsh.path,
-                "xpython": session_xpython.path,
-                "xpip": session_xpip.display,
-            },
-            "commands": {
-                "xonsh": cmd_xonsh.path,
-                "python": cmd_python_raw.path,
-                "pip": cmd_pip.path,
-                "pytest": cmd_pytest.path,
-                "uv": cmd_uv.path,
-            },
+            "session": _section(
+                [
+                    ("xxonsh", session_xxonsh),
+                    ("xpython", session_xpython),
+                    ("xpip", session_xpip),
+                ]
+            ),
+            "commands": _section(
+                [
+                    ("xonsh", cmd_xonsh),
+                    ("python", cmd_python_raw),
+                    ("pip", cmd_pip),
+                    ("pytest", cmd_pytest),
+                    ("uv", cmd_uv),
+                ]
+            ),
             "env": {
                 ev: val
                 for ev, val in (
@@ -420,12 +497,14 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
 
     # Color tokens: section headers are purple; within a family (xonsh/xxonsh,
     # python/xpython, pip/xpip) both labels go GREEN when the session binary
-    # matches what ``$PATH`` resolves to, otherwise BLUE. Labels outside any
-    # family (pytest, ``[Current environment]`` vars) stay YELLOW. Any row
-    # whose path is "bad" — symlink loop, missing, inaccessible, or not
-    # executable — is rendered entirely in RED, overriding the row color.
-    # Printed via print_color, which dispatches to the active shell's own
-    # color renderer.
+    # matches what ``$PATH`` resolves to, otherwise BLUE. The match check
+    # compares the *resolved* paths so two entries that point at the same
+    # underlying file via different symlinks still register as the same.
+    # Labels outside any family (pytest, ``[Current environment]`` vars)
+    # stay YELLOW. Any row whose path is "bad" — symlink loop, missing,
+    # inaccessible, or not executable — is rendered entirely in RED,
+    # overriding the row color. Printed via print_color, which dispatches
+    # to the active shell's own color renderer.
     PURPLE = "{PURPLE}"
     GREEN = "{GREEN}"
     BLUE = "{BLUE}"
@@ -433,9 +512,17 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
     RED = "{RED}"
     RESET = "{RESET}"
 
-    xonsh_color = GREEN if session_xxonsh.path == cmd_xonsh.path else BLUE
-    python_color = GREEN if session_xpython.path == cmd_python.path else BLUE
-    pip_color = GREEN if session_xpip.display == cmd_pip.path else BLUE
+    xonsh_color = GREEN if session_xxonsh.resolved == cmd_xonsh.resolved else BLUE
+    python_color = GREEN if session_xpython.resolved == cmd_python.resolved else BLUE
+    # ``xpip`` is a ``[python, -m, pip]`` list while the PATH-resolved ``pip``
+    # is a plain string, so a direct equality compare wouldn't match by
+    # construction. Compare the executable head element instead.
+    xpip_head = (
+        session_xpip.resolved[0]
+        if isinstance(session_xpip.resolved, list) and session_xpip.resolved
+        else None
+    )
+    pip_color = GREEN if xpip_head == cmd_pip.resolved else BLUE
 
     label_color = {
         "xonsh": xonsh_color,
@@ -455,34 +542,41 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
         wrapped in :data:`RED` to flag the problem (cycle, missing file,
         or not executable) — the label's normal color is overridden.
         Otherwise the label uses its family color and the value is
-        rendered in the default terminal color.
+        rendered in the default terminal color. ``name`` may carry the
+        trailing ``" resolved"`` suffix used by the secondary row; the
+        family color is looked up against the base name so both rows
+        share the same color.
         """
         if bad:
             return f"{RED}{name}: {value}{ver}{RESET}"
-        color = label_color.get(name, YELLOW)
+        base = name.removesuffix(" resolved")
+        color = label_color.get(base, YELLOW)
         return f"{color}{name}:{RESET} {value}{ver}"
 
+    def _print_pair(name, r, show_not_found=True):
+        """Print the row for ``r`` and, when its resolved path differs
+        from the input, a second ``name resolved:`` row.
+
+        The version line (``# Python 3.13.3``) is repeated on both rows
+        — it describes the binary regardless of which spelling of its
+        path the reader is looking at.
+        """
+        ver = f"  # {r.version}" if r.version else ""
+        if r.display is None:
+            if show_not_found:
+                print_color(_format_row(name, "not found"), file=stdout)
+            return
+        print_color(_format_row(name, r.display, ver=ver, bad=r.bad), file=stdout)
+        if r.differs:
+            print_color(
+                _format_row(f"{name} resolved", r.resolved_display, ver=ver, bad=r.bad),
+                file=stdout,
+            )
+
     print_color(f"{PURPLE}[Current xonsh session]{RESET}", file=stdout)
-    print_color(
-        _format_row("xxonsh", session_xxonsh.path, bad=session_xxonsh.bad),
-        file=stdout,
-    )
-    print_color(
-        _format_row(
-            "xpython",
-            session_xpython.path,
-            ver=f"  # {session_xpython.version}",
-            bad=session_xpython.bad,
-        ),
-        file=stdout,
-    )
-    if session_xpip.display is not None:
-        print_color(
-            _format_row("xpip", session_xpip.display, bad=session_xpip.bad),
-            file=stdout,
-        )
-    else:
-        print_color(_format_row("xpip", "not found"), file=stdout)
+    _print_pair("xxonsh", session_xxonsh)
+    _print_pair("xpython", session_xpython)
+    _print_pair("xpip", session_xpip)
 
     print("", file=stdout)
     print_color(f"{PURPLE}[Current commands environment]{RESET}", file=stdout)
@@ -496,11 +590,7 @@ def xcontext_main(no_resolve: bool = False, as_json: bool = False, _stdout=None)
     if cmd_uv.path:
         cmd_rows.append(("uv", cmd_uv))
     for name, r in cmd_rows:
-        if r.path:
-            ver = f"  # {r.version}" if r.version else ""
-            print_color(_format_row(name, r.path, ver=ver, bad=r.bad), file=stdout)
-        else:
-            print_color(_format_row(name, "not found"), file=stdout)
+        _print_pair(name, r)
 
     env_rows = [
         (ev, val)


### PR DESCRIPTION
After using `xcontext` with real life with `uv` I see that much more useful to have both e.g. python and python-resolved, uv and uv-resolved.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
