### PR TITLE
test: Make inspector and xontribs smoke tests robust to shell selection

### DIFF
--- a/tests/lib/test_inspectors_llm.py
+++ b/tests/lib/test_inspectors_llm.py
@@ -332,5 +332,8 @@ def test_inspector_noinfo_without_oname(capsys):
 def test_inspector_format_fields_str_smoke():
     insp = Inspector()
     out = insp._format_fields_str([("Title", "value")])
-    assert "Title" in out
-    assert "value" in out
+    # ``format_color`` yields a token list when pygments is installed and a
+    # plain string otherwise; normalise to text before asserting.
+    text = out if isinstance(out, str) else "".join(tok[1] for tok in out)
+    assert "Title" in text
+    assert "value" in text

--- a/tests/test_xontribs_smoke_llm.py
+++ b/tests/test_xontribs_smoke_llm.py
@@ -127,10 +127,10 @@ def test_xontribs_list_json(xession):
     assert isinstance(parsed, dict)
 
 
-def test_xontribs_list_human_format(capsys):
+def test_xontribs_list_human_format(capfd):
     """The non-JSON branch prints colored lines for each xontrib."""
     xontribs_list(to_json=False)
-    captured = capsys.readouterr().out
+    captured = capfd.readouterr().out
     # we got at least one printed line and it mentions "loaded" or "not-loaded"
     assert "loaded" in captured.lower() or "not-loaded" in captured.lower()
 


### PR DESCRIPTION
## Motivation

The xonsh pytest plugin calls `xonsh.main.setup()` in `pytest_configure`,
which assigns `XSH.shell` a real `Shell`. Which concrete implementation ends
up in `XSH.shell.shell` is resolved from the environment by
`Shell.choose_shell_type` / `construct_shell_cls` — `$TERM`, whether stdin is
a terminal, prompt_toolkit availability.

These two LLM-generated smoke tests take no session fixture, so
`format_color()` / `print_color()` dispatch into whatever shell that
resolution produced. Shell implementations disagree on the result:
`BaseShell.format_color` returns a plain `str`, while a tokenizing shell
(e.g. `PromptToolkitShell`) returns a pygments token list, and
shell-dispatched output is written at the file-descriptor level rather than
to `sys.stdout`.

The tests assumed the string-shell outcome, so they pass under some
environments and fail under others. This surfaced as a hard test failure
in a downstream distro build whose chroot resolves to a tokenizing shell:

\`\`\`
test_inspector_format_fields_str_smoke
  assert 'Title' in [(Token.Color.BOLD_RED, 'Title:'), (Token.Color.RESET, '  value\n')]
test_xontribs_list_human_format
  assert ('loaded' in '' or 'not-loaded' in '')   # capsys saw nothing
\`\`\`

## Changes

| Test | Before | After |
|------|--------|-------|
| `test_inspector_format_fields_str_smoke` | `assert "Title" in out` — fails when `out` is a token list | normalize `out` to text first, then assert |
| `test_xontribs_list_human_format` | `capsys` — empty when output goes through the shell | `capfd` — captures fd-level output |

Both make the tests pass regardless of which shell the environment resolves
to. Test-only change; no product behavior or public API affected, so no docs
update is needed.