### PR TITLE
feat: Add `events.on_completer_filter` to skip certain completer if needed

### DIFF
--- a/tests/test_completer_filter_llm.py
+++ b/tests/test_completer_filter_llm.py
@@ -1,0 +1,214 @@
+"""Tests for the ``on_completer_filter`` event (xonsh/completer.py)."""
+
+import pytest
+
+from xonsh.completer import Completer
+from xonsh.completers.tools import contextual_command_completer
+from xonsh.events import events
+from xonsh.parsers.completion_context import CommandContext
+
+
+@pytest.fixture(scope="session")
+def completer():
+    return Completer()
+
+
+@pytest.fixture
+def completers_mock(xession, monkeypatch):
+    completers = {}
+    monkeypatch.setattr(xession, "_completers", completers)
+    return completers
+
+
+def test_filter_false_skips_completer(completer, completers_mock):
+    called = []
+
+    def comp(*a):
+        called.append("ran")
+        return {"x"}
+
+    completers_mock["bash"] = comp
+
+    @events.on_completer_filter
+    def _veto(completer, context, **_):
+        return False
+
+    assert completer.complete("", "", 0, 0) == ((), 0)
+    assert called == []
+
+
+def test_filter_true_lets_completer_run(completer, completers_mock):
+    called = []
+
+    def comp(*a):
+        called.append("ran")
+        return {"x"}
+
+    completers_mock["bash"] = comp
+
+    @events.on_completer_filter
+    def _allow(completer, context, **_):
+        return True
+
+    res, _ = completer.complete("", "", 0, 0)
+    assert res == ("x",)
+    assert called == ["ran"]
+
+
+def test_filter_none_lets_completer_run(completer, completers_mock):
+    called = []
+
+    def comp(*a):
+        called.append("ran")
+        return {"x"}
+
+    completers_mock["bash"] = comp
+
+    @events.on_completer_filter
+    def _noop(completer, context, **_):
+        return None
+
+    res, _ = completer.complete("", "", 0, 0)
+    assert res == ("x",)
+    assert called == ["ran"]
+
+
+def test_filter_any_false_vetoes(completer, completers_mock):
+    called = []
+
+    def comp(*a):
+        called.append("ran")
+        return {"x"}
+
+    completers_mock["bash"] = comp
+
+    @events.on_completer_filter
+    def _allow(completer, context, **_):
+        return True
+
+    @events.on_completer_filter
+    def _veto(completer, context, **_):
+        return False
+
+    assert completer.complete("", "", 0, 0) == ((), 0)
+    assert called == []
+
+
+def test_filter_no_handlers_is_passthrough(completer, completers_mock):
+    completers_mock["bash"] = lambda *a: {"x"}
+    res, _ = completer.complete("", "", 0, 0)
+    assert res == ("x",)
+
+
+def test_filter_handler_exception_does_not_block(completer, completers_mock):
+    called = []
+
+    def comp(*a):
+        called.append("ran")
+        return {"x"}
+
+    completers_mock["bash"] = comp
+
+    @events.on_completer_filter
+    def _boom(completer, context, **_):
+        raise RuntimeError("boom")
+
+    res, _ = completer.complete("", "", 0, 0)
+    assert res == ("x",)
+    assert called == ["ran"]
+
+
+def test_filter_receives_completer_name_command_and_context(completer, completers_mock):
+    seen = []
+
+    @contextual_command_completer
+    def comp(context: CommandContext):
+        return {"x"}
+
+    completers_mock["bash"] = comp
+
+    @events.on_completer_filter
+    def _capture(completer, command, context, **_):
+        seen.append((completer, command, context))
+        return True
+
+    completer.complete("p", "ls p", 3, 4, {}, multiline_text="ls p", cursor_index=4)
+    assert len(seen) == 1
+    name, command, ctx = seen[0]
+    assert name == "bash"
+    assert command == "ls"
+    assert ctx is not None
+    assert ctx.command is not None
+    assert ctx.command.args[0].value == "ls"
+
+
+def test_filter_command_is_basename_of_full_path(completer, completers_mock):
+    """``/usr/bin/kubectl`` should arrive at the handler as ``kubectl``."""
+    seen = []
+
+    completers_mock["bash"] = lambda *a: {"x"}
+
+    @events.on_completer_filter
+    def _capture(command, **_):
+        seen.append(command)
+        return True
+
+    completer.complete(
+        "p",
+        "/usr/bin/kubectl p",
+        17,
+        18,
+        {},
+        multiline_text="/usr/bin/kubectl p",
+        cursor_index=18,
+    )
+    assert seen and seen[0] == "kubectl"
+
+
+def test_filter_command_is_empty_when_no_command(completer, completers_mock):
+    seen = []
+
+    completers_mock["bash"] = lambda *a: {"x"}
+
+    @events.on_completer_filter
+    def _capture(command, **_):
+        seen.append(command)
+        return True
+
+    completer.complete("", "", 0, 0)
+    assert seen and seen[0] == ""
+
+
+def test_filter_per_completer_selectivity(completer, completers_mock):
+    """Returning False for one completer must not affect the others."""
+    completers_mock["bash"] = lambda *a: {"from-bash"}
+    completers_mock["path"] = lambda *a: {"from-path"}
+
+    @events.on_completer_filter
+    def _no_bash(completer, context, **_):
+        if completer == "bash":
+            return False
+
+    res, _ = completer.complete("", "", 0, 0)
+    assert "from-bash" not in res
+    assert "from-path" in res
+
+
+def test_filter_trace_reports_skip_with_handler_name(
+    completer, completers_mock, xession, monkeypatch
+):
+    monkeypatch.setitem(xession.env, "XONSH_COMPLETER_TRACE", True)
+    completers_mock["bash"] = lambda *a: {"x"}
+
+    @events.on_completer_filter
+    def _veto_for_test(completer, context, **_):
+        return False
+
+    messages = []
+    monkeypatch.setattr(
+        "xonsh.completer.print_above_prompt", lambda msg: messages.append(msg)
+    )
+
+    completer.complete("", "", 0, 0)
+    assert any("Skipped 'bash' by on_completer_filter handler" in m for m in messages)
+    assert any("_veto_for_test" in m for m in messages)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -46,6 +46,37 @@ def test_event_returns(events):
     assert set(vals) == {1, 2}
 
 
+def test_fire_iter_yields_handler_and_result(events):
+    @events.on_test
+    def first(**_):
+        return "a"
+
+    @events.on_test
+    def second(**_):
+        return "b"
+
+    pairs = list(events.on_test.fire_iter())
+    handlers = {h for h, _ in pairs}
+    results = {rv for _, rv in pairs}
+
+    assert handlers == {first, second}
+    assert results == {"a", "b"}
+
+
+def test_fire_iter_skips_raising_handler(events):
+    @events.on_test
+    def good(**_):
+        return "ok"
+
+    @events.on_test
+    def bad(**_):
+        raise RuntimeError("boom")
+
+    pairs = list(events.on_test.fire_iter())
+
+    assert pairs == [(good, "ok")]
+
+
 def test_validator(events):
     called = None
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -1,6 +1,7 @@
 """A (tab-)completer for xonsh."""
 
 import collections.abc as cabc
+import os
 import sys
 import typing as tp
 
@@ -14,8 +15,47 @@ from xonsh.completers.tools import (
     is_contextual_completer,
     is_exclusive_completer,
 )
+from xonsh.events import events
 from xonsh.parsers.completion_context import CompletionContext, CompletionContextParser
 from xonsh.tools import print_above_prompt, print_exception
+
+events.doc(
+    "on_completer_filter",
+    """
+on_completer_filter(completer: str, command: str, context: CompletionContext) -> bool | None
+
+Fires once for every registered completer just before it is invoked,
+allowing handlers to veto the call. Return ``False`` to skip the
+completer; return ``True``, ``None`` (or nothing) to let it run. If any
+handler returns ``False``, the completer is skipped.
+
+Parameters:
+
+* ``completer``: the registered name of the completer about to run
+  (e.g. ``'bash'``, ``'path'``).
+* ``command``: the basename of the command being completed
+  (e.g. ``'kubectl'`` even when the user typed ``/usr/bin/kubectl``).
+  Empty string when no command has been typed yet, or when the
+  completion happens outside the command-line context.
+* ``context``: the full :class:`CompletionContext` for the current
+  completion request.
+
+Use this to short-circuit completers such as ``bash`` on commands
+where the user does not need bash-supplied completions:
+
+.. code-block:: xonsh
+
+    @events.on_completer_filter
+    def _only_bash_for_some(completer, command, context, **_):
+        if completer != 'bash':
+            return True
+        return command in {'kubectl', 'docker'}
+
+Handlers run on the completion thread; exceptions raised inside a
+handler are logged and treated as if no value was returned (i.e. the
+completer is still allowed to run).
+""",
+)
 
 
 class Completer:
@@ -220,7 +260,31 @@ class Completer:
     ) -> tp.Iterator[tuple[Completion, int]]:
         filter_func = get_filter_function()
 
+        if (
+            completion_context is not None
+            and completion_context.command is not None
+            and completion_context.command.args
+        ):
+            command = os.path.basename(completion_context.command.args[0].value)
+        else:
+            command = ""
+
         for name, func in XSH.completers.items():
+            veto_by = None
+            for handler, rv in events.on_completer_filter.fire_iter(
+                completer=name, command=command, context=completion_context
+            ):
+                if rv is False:
+                    veto_by = handler
+            if veto_by is not None:
+                if trace:
+                    hmod = getattr(veto_by, "__module__", "unknown")
+                    hname = getattr(veto_by, "__name__", repr(veto_by))
+                    print_above_prompt(
+                        f"TRACE COMPLETIONS: Skipped '{name}' by on_completer_filter "
+                        f"handler '{hmod}.{hname}'."
+                    )
+                continue
             try:
                 if is_contextual_completer(func):
                     if completion_context is None:

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -47,9 +47,7 @@ where the user does not need bash-supplied completions:
 
     @events.on_completer_filter
     def _only_bash_for_some(completer, command, context, **_):
-        if completer != 'bash':
-            return True
-        return command in {'kubectl', 'docker'}
+        return command in {'kubectl', 'docker'} if completer == 'bash' else True
 
 Handlers run on the completion thread; exceptions raised inside a
 handler are logged and treated as if no value was returned (i.e. the

--- a/xonsh/events.py
+++ b/xonsh/events.py
@@ -199,7 +199,20 @@ class Event(AbstractEvent):
             Return values of each handler. If multiple handlers return the same value, it will
             appear multiple times.
         """
-        vals = []
+        return [rv for _h, rv in self.fire_iter(**kwargs)]
+
+    def fire_iter(self, **kwargs):
+        """Iterator variant of :meth:`fire`.
+
+        Yields ``(handler, return_value)`` lazily as each registered,
+        validation-passing handler runs. Mirrors :meth:`fire`'s
+        exception handling — handlers that raise are logged and
+        skipped (no pair is yielded for them).
+
+        Use this when the caller needs to correlate each result with
+        the handler that produced it (e.g. to trace which handler
+        vetoed in a scatter-gather event).
+        """
         self._firing_depth += 1
         try:
             for handler in self._filterhandlers(self._handlers.values(), **kwargs):
@@ -208,7 +221,7 @@ class Event(AbstractEvent):
                 except Exception:
                     print_exception("Exception raised in event handler; ignored.")
                 else:
-                    vals.append(rv)
+                    yield handler, rv
         finally:
             self._firing_depth -= 1
             if self._firing_depth == 0:
@@ -219,7 +232,6 @@ class Event(AbstractEvent):
                     for key in self._delayed_discards:
                         self._handlers.pop(key, None)
                     self._delayed_discards = None
-        return vals
 
 
 class LoadEvent(AbstractEvent):


### PR DESCRIPTION
* Closes https://github.com/xonsh/xonsh/issues/3488

Filter any completer:
```xsh
@events.on_completer_filter
def _only_bash_for_some(completer, command, context, **_):
    return command in {'kubectl', 'docker'} if completer == 'bash' else True
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
