### PR TITLE
fix: Readline: Completer: Fix file with space in name

### DIFF
--- a/tests/shell/test_readline_shell.py
+++ b/tests/shell/test_readline_shell.py
@@ -8,6 +8,7 @@ from xonsh.shells.readline_shell import (
     _ensure_newline,
     _parse_dsr_cursor_column,
     _render_completions,
+    _rendered_keeps_prefix,
 )
 
 
@@ -44,10 +45,39 @@ def test_render_completions_filters_substring_matches():
     completions = {"json", "jsonrpc", "_json"}
     rendered = _render_completions(completions, prefix, plen)
     # _json renders to @.imp._json which does NOT start with @.imp.jso
-    safe = [c for c in rendered if c.startswith(prefix)]
-    assert all(c.startswith(prefix) for c in safe)
+    safe = [c for c in rendered if _rendered_keeps_prefix(c, prefix)]
     assert "@.imp._json" not in safe
     assert "@.imp.json" in safe
+    assert "@.imp.jsonrpc" in safe
+
+
+@pytest.mark.parametrize(
+    "rendered, prefix, expected",
+    [
+        # #2865 — quoted path completions for an unquoted prefix must pass.
+        # Without the leading-quote allowance, readline ends up with nothing
+        # to insert (bell) when the user tabs `cat file<TAB>`.
+        ("'file with different name.txt' ", "file", True),
+        ("'file with spaces in name.txt' ", "file", True),
+        ('"file with spaces.txt" ', "file", True),
+        # #6209 — substring match starting with `_` would shrink the GCP
+        # below the typed prefix and must be filtered.
+        ("@.imp._json", "@.imp.jso", False),
+        ("@.imp.json", "@.imp.jso", True),
+        # Plain (non-quoted) prefix match — the common case.
+        ("abc", "ab", True),
+        # Empty prefix accepts everything.
+        ("anything", "", True),
+        # Leading quote on the rendered form, but the content does not
+        # actually match the typed prefix.
+        ("'other.txt'", "file", False),
+        # Both prefix and rendered start with a quote.
+        ('"hello world"', '"hel', True),
+        ('"_hello"', '"hel', False),
+    ],
+)
+def test_rendered_keeps_prefix(rendered, prefix, expected):
+    assert _rendered_keeps_prefix(rendered, prefix) is expected
 
 
 @pytest.mark.parametrize(

--- a/xonsh/shells/readline_shell.py
+++ b/xonsh/shells/readline_shell.py
@@ -389,6 +389,30 @@ def _render_completions(completions, prefix, prefix_len):
     return rendered_completions
 
 
+def _rendered_keeps_prefix(rendered, prefix):
+    """Return True if a rendered completion is compatible with readline's
+    word-replacement (i.e. won't shrink readline's Greatest Common Prefix
+    below what the user already typed).
+
+    A rendered completion is compatible when:
+
+    * it begins with the typed ``prefix`` (the common case), OR
+    * a quoted path completer prepended a single leading ``'`` or ``"`` so
+      the rendered form looks like ``'file with spaces' `` for a typed
+      ``file``. The completion is still valid — readline will replace
+      ``file`` with ``'file with `` (the LCP) on the first tab — but the
+      simple ``startswith`` test would otherwise reject it.
+
+    True substring matches (e.g. ``_json`` for prefix ``jso``) are still
+    filtered out, which is what motivated the original check (#6209).
+    """
+    if rendered.startswith(prefix):
+        return True
+    if rendered[:1] in ("'", '"') and rendered[1:].startswith(prefix):
+        return True
+    return False
+
+
 DEDENT_TOKENS = LazyObject(
     lambda: frozenset(["raise", "return", "pass", "break", "continue"]),
     globals(),
@@ -537,13 +561,14 @@ class ReadlineShell(BaseShell, cmd.Cmd):
             cursor_index=len(prev_text) + endidx,
         )
         rtn_completions = _render_completions(completions, prefix, plen)
-        # Filter out completions that don't start with the readline prefix.
-        # Substring matches (e.g. _json for prefix "jso") would cause readline's
-        # Greatest Common Prefix to shrink below what was typed.
+        # Filter out completions that would shrink readline's Greatest
+        # Common Prefix below what was typed (e.g. ``_json`` for prefix
+        # ``jso``, issue #6209), while still allowing quoted path forms
+        # like ``'file with spaces.txt' `` for an unquoted prefix (#2865).
         filtered = [
             (r, c)
             for r, c in zip(rtn_completions, completions, strict=True)
-            if r.startswith(prefix)
+            if _rendered_keeps_prefix(r, prefix)
         ]
         if filtered:
             rtn_completions, completions = zip(*filtered, strict=True)


### PR DESCRIPTION
* Fixes https://github.com/xonsh/xonsh/issues/2865

### Before

```xsh
xonsh -st readline
cd /tmp
touch '1 2 3'
ls 1<Tab>
# Nothing
```

### After
```xsh
ls 1<Tab>
ls '1 2 3'
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
