### PR TITLE
feat: Support SSH escape sequences

### DIFF
--- a/tests/shell/test_ptk_shell_llm.py
+++ b/tests/shell/test_ptk_shell_llm.py
@@ -1,6 +1,72 @@
 """LLM-generated tests for the prompt_toolkit shell."""
 
+import importlib
+import os
+
 import pytest
+
+
+@pytest.fixture
+def restore_vt100_cpr():
+    """Snapshot Vt100_Output.{ask_for_cpr,responds_to_cpr} and restore
+    them after the test. The CPR-suppression patch in ptk_shell runs at
+    import time and mutates the class globally, so tests that
+    deliberately trigger it must clean up."""
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    orig_ask = Vt100_Output.ask_for_cpr
+    orig_responds = Vt100_Output.responds_to_cpr
+    yield
+    Vt100_Output.ask_for_cpr = orig_ask
+    Vt100_Output.responds_to_cpr = orig_responds
+
+
+@pytest.mark.parametrize("ssh_var", ["SSH_TTY", "SSH_CONNECTION"])
+def test_ptk_suppresses_cpr_inside_ssh(monkeypatch, ssh_var, restore_vt100_cpr):
+    """Inside an SSH session, prompt_toolkit must not issue Cursor
+    Position Report (``\\x1b[6n``) queries — see issue #5686.
+
+    The terminal's reply travels back through stdin and is observed by
+    the local ssh client's tilde-escape filter; a reply arriving
+    between the user's Enter and the following ``~`` resets
+    ``last_was_cr`` to 0, so ssh never sees ``\\r~`` and ``~.`` etc.
+    silently fail.
+
+    We re-import ``xonsh.shells.ptk_shell`` with the SSH env var set so
+    the module-level guard runs, then check that
+    ``Vt100_Output.ask_for_cpr`` is the no-op installed by the guard.
+    """
+    for v in ("SSH_TTY", "SSH_CONNECTION"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv(ssh_var, "/dev/pts/0")
+
+    import xonsh.shells.ptk_shell as ptk_shell_module
+
+    importlib.reload(ptk_shell_module)
+
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    # The monkey-patch installs a one-line lambda — both checks
+    # together pin down that it really is our no-op.
+    assert Vt100_Output.ask_for_cpr.__name__ == "<lambda>"
+    # Confirm the responds_to_cpr override is the False-returning
+    # property (so renderer code paths skip waiting for a reply).
+    assert isinstance(Vt100_Output.responds_to_cpr, property)
+
+
+def test_ptk_does_not_touch_cpr_outside_ssh(monkeypatch, restore_vt100_cpr):
+    """Outside SSH the CPR machinery must be untouched so prompt_toolkit
+    can render correctly against the real terminal."""
+    for v in ("SSH_TTY", "SSH_CONNECTION"):
+        monkeypatch.delenv(v, raising=False)
+
+    import xonsh.shells.ptk_shell as ptk_shell_module
+
+    importlib.reload(ptk_shell_module)
+
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    assert Vt100_Output.ask_for_cpr.__name__ != "<lambda>"
 
 
 def test_singleline_eoferror_propagates(ptk_shell):

--- a/tests/shell/test_ptk_shell_llm.py
+++ b/tests/shell/test_ptk_shell_llm.py
@@ -1,7 +1,6 @@
 """LLM-generated tests for the prompt_toolkit shell."""
 
 import importlib
-import os
 
 import pytest
 

--- a/tests/shell/test_readline_shell_llm.py
+++ b/tests/shell/test_readline_shell_llm.py
@@ -1,0 +1,39 @@
+"""LLM-generated tests for the readline shell."""
+
+import sys
+
+import pytest
+
+from xonsh.pytest.tools import skip_if_on_windows
+from xonsh.shells.readline_shell import _ensure_newline
+
+
+class _FakeStdin:
+    """Stand-in for sys.stdin with a fileno — pytest's capture replaces
+    the real stdin with a pseudofile that raises on fileno()."""
+
+    def fileno(self):
+        return 0
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize("var", ["SSH_TTY", "SSH_CONNECTION"])
+def test_ensure_newline_skipped_inside_ssh(monkeypatch, capsys, var):
+    """No DSR (``\\x1b[6n``) query when running inside an SSH session.
+
+    The terminal's reply to DSR travels back through stdin and is
+    observed by the local ssh client's tilde-escape filter; a reply
+    arriving between the user's Enter and the following ``~`` resets
+    ``last_was_cr`` to 0, silently breaking ssh ``~.`` etc. (#5686).
+    """
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    monkeypatch.setattr("os.isatty", lambda fd: True)
+    for v in ("SSH_TTY", "SSH_CONNECTION"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv(var, "/dev/pts/0")
+
+    _ensure_newline()
+
+    # No DSR query and no newline written to stdout — the function
+    # short-circuited before reaching the ``sys.stdout.write("\\033[6n")``.
+    assert capsys.readouterr().out == ""

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -23,6 +23,7 @@ from prompt_toolkit.application.current import get_app
 if os.environ.get("SSH_TTY") or os.environ.get("SSH_CONNECTION"):
     try:
         from prompt_toolkit.output.vt100 import Vt100_Output as _XPtkVt100Output
+
         _XPtkVt100Output.ask_for_cpr = lambda self: None
         _XPtkVt100Output.responds_to_cpr = property(lambda self: False)
     except Exception:

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -8,6 +8,25 @@ from types import MethodType
 
 from prompt_toolkit import ANSI
 from prompt_toolkit.application.current import get_app
+
+# When xonsh runs inside an SSH session, suppress prompt-toolkit's Cursor
+# Position Report (CPR) query — see issue #5686. CPR (`\x1b[6n`) asks the
+# terminal to report the cursor position, and the terminal answers by
+# sending bytes back through *stdin*. Those bytes pass through the local
+# ssh client, which uses byte-stream state (`last_was_cr`) to detect tilde
+# escape sequences. A CPR response arriving between the user's Enter and
+# the following `~` resets `last_was_cr` to 0, so ssh never sees `\r~` and
+# the escape (`~.`, `~^Z`, `~?`…) silently fails. Disabling CPR makes
+# prompt-toolkit fall back to assuming the cursor is at column 0, which
+# is correct in almost all cases (we just wrote a newline) and is the
+# same assumption bash's readline makes.
+if os.environ.get("SSH_TTY") or os.environ.get("SSH_CONNECTION"):
+    try:
+        from prompt_toolkit.output.vt100 import Vt100_Output as _XPtkVt100Output
+        _XPtkVt100Output.ask_for_cpr = lambda self: None
+        _XPtkVt100Output.responds_to_cpr = property(lambda self: False)
+    except Exception:
+        pass
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory, Suggestion
 from prompt_toolkit.clipboard import InMemoryClipboard
 from prompt_toolkit.document import Document

--- a/xonsh/shells/readline_shell.py
+++ b/xonsh/shells/readline_shell.py
@@ -96,6 +96,13 @@ def _ensure_newline():
     fd = sys.stdin.fileno()
     if not os.isatty(fd):
         return
+    # When running inside an SSH session, do not issue the DSR query.
+    # The terminal's reply travels through stdin and is observed by the
+    # local ssh client, which uses byte-stream state to detect tilde
+    # escape sequences; a DSR reply arriving between the user's Enter
+    # and a following `~` silently breaks ssh's `~.` etc. (issue #5686).
+    if os.environ.get("SSH_TTY") or os.environ.get("SSH_CONNECTION"):
+        return
     old = termios.tcgetattr(fd)
     try:
         tty.setcbreak(fd)


### PR DESCRIPTION
* Closes https://github.com/xonsh/xonsh/issues/5686 - https://medium.com/@rmolsen/ssh-tricks-escape-sequences-4a7a5d889d70

Before

```xsh
ssh host
xonsh
# <Enter><~><.>
# Typing ~.
```

After
```xsh
# <Enter><~><.>
# SSH closed as expected
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
