### PR TITLE
fix: Parser: treat `!` inside f-string `{…}` as conversion

### DIFF
--- a/tests/test_execer_llm.py
+++ b/tests/test_execer_llm.py
@@ -172,10 +172,10 @@ def test_fstring_conversion_in_pyeval(src, xession):
     [
         # Bare macro at top level still wraps; the ``!`` is outside any
         # f-string.  These are existing baselines pinned for regression.
-        '$[echo ! arg]\n',
-        '![echo ! arg]\n',
-        '$(echo ! arg)\n',
-        '!(echo ! arg)\n',
+        "$[echo ! arg]\n",
+        "![echo ! arg]\n",
+        "$(echo ! arg)\n",
+        "!(echo ! arg)\n",
         # Macro with multi-line triple-quoted argument.
         '![echo ! """a\nb"""]\n',
     ],

--- a/tests/test_execer_llm.py
+++ b/tests/test_execer_llm.py
@@ -118,3 +118,76 @@ def test_andor_chain_eval_mode(line, xession):
 )
 def test_line_cont_with_comment(code, xonsh_execer_parse):
     assert xonsh_execer_parse(code)
+
+
+# --- f-string conversion (``{x!r}``/``{x!s}``/``{x!a}``) -----------------
+#
+# In subproc mode the xonsh lexer emits ``BANG`` for ``!``.  Without
+# f-string awareness, ``subproc_toks`` and ``find_next_break`` treat
+# any ``BANG`` as the start of a macro call, swallowing the rest of
+# the line into a single ``![…]`` wrap that then fails to re-parse
+# (``code: @(``).  ``f"{name!r}"`` and friends use ``!`` as a
+# *conversion specifier* — purely textual, with no relation to xonsh
+# macros — so the fix tracks f-string nesting (``FSTRING_START`` /
+# ``FSTRING_END``) and replacement-field depth (``LBRACE`` /
+# ``RBRACE``) and ignores ``BANG`` while ``fstring_expr_depth > 0``.
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # Plain ``!r`` conversion in ``@()`` followed by ``&&``.
+        'echo @(f"hi {name!r}") && echo z\n',
+        # ``!s`` and ``!a`` are the other two conversions.
+        'echo @(f"x {y!s}") && echo z\n',
+        'echo @(f"x {y!a}") && echo z\n',
+        # Triple-quoted f-string with conversion.
+        'echo @(f"""hi {name!r}""") && echo z\n',
+        # Conversion + format spec (``:>10``).
+        'echo @(f"x {y!r:>10}") && echo z\n',
+        # PEP 701 nested f-string with conversion in the inner one.
+        'echo @(f"""a {f"{x!r}"} b""") && echo z\n',
+        # Plain Python statement with conversion — should never have
+        # touched recovery, but covers the path nonetheless.
+        'x = "world"\nprint(f"hi {x!r}")\n',
+    ],
+)
+def test_fstring_conversion_in_pyeval(src, xession):
+    """f-string conversion (``{x!r}``/``{x!s}``/``{x!a}``) inside an
+    ``@()`` argument used to break recovery because the subproc-mode
+    lexer reported the ``!`` as a ``BANG`` token, which
+    ``subproc_toks`` / ``find_next_break`` interpreted as the start of
+    a macro call.  The fix tracks f-string nesting and ignores
+    ``BANG`` while inside a replacement field.
+    """
+    execer = xession.execer
+    ctx = {"__xonsh__": object()}
+    tree = execer.parse(src, ctx=ctx, mode="exec")
+    assert tree is not None
+    assert tree.body, f"expected non-empty AST for {src!r}"
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # Bare macro at top level still wraps; the ``!`` is outside any
+        # f-string.  These are existing baselines pinned for regression.
+        '$[echo ! arg]\n',
+        '![echo ! arg]\n',
+        '$(echo ! arg)\n',
+        '!(echo ! arg)\n',
+        # Macro with multi-line triple-quoted argument.
+        '![echo ! """a\nb"""]\n',
+    ],
+)
+def test_macro_still_works_after_fstring_fix(src, xession):
+    """Pin the macro-call paths: the f-string-conversion guard only
+    suppresses ``BANG``-as-macro detection while ``fstring_expr_depth
+    > 0``.  Top-level macros (and macros inside ``$[…]``/``![…]``)
+    must continue to be recognised.
+    """
+    execer = xession.execer
+    ctx = {"__xonsh__": object()}
+    tree = execer.parse(src, ctx=ctx, mode="exec")
+    assert tree is not None
+    assert tree.body, f"expected non-empty AST for {src!r}"

--- a/tests/test_tools_llm.py
+++ b/tests/test_tools_llm.py
@@ -33,12 +33,27 @@ success cases and the boundaries that must remain unchanged: ``#``
 inside a string literal, an inline ``# \\`` at the end of a regular
 code line (#6294 regression), and lines inside an open triple-quoted
 string.
+
+f-string conversion ``!r``/``!s``/``!a`` inside ``{…}``
+========================================================
+
+In subproc mode the xonsh lexer emits ``BANG`` for ``!``, regardless of
+whether it sits inside an f-string replacement field (where ``!r``,
+``!s``, ``!a`` are *conversion specifiers* — purely textual, with no
+relation to xonsh macros) or at top level (where ``!`` is the macro
+operator).  Without f-string awareness, ``subproc_toks`` and
+``find_next_break`` treated any ``BANG`` as macro-start: the former
+swallowed the rest of the line into a single wrap that then failed to
+re-parse (``code: @(``), the latter returned ``maxcol = end-of-line``
+which prevented wrapping the LHS before a combinator.  The fix tracks
+``FSTRING_START`` / ``FSTRING_END`` nesting and ``LBRACE`` /
+``RBRACE`` depth, ignoring ``BANG`` while inside a replacement field.
 """
 
 import pytest
 
 from xonsh.parsers.lexer import Lexer
-from xonsh.tools import strip_continuation_comments, subproc_toks
+from xonsh.tools import find_next_break, strip_continuation_comments, subproc_toks
 
 LEXER = Lexer()
 LEXER.build()
@@ -169,3 +184,114 @@ def test_strip_continuation_comments(src, exp, xession):
     # expectations encode the non-interactive shape.
     xession.env["XONSH_INTERACTIVE"] = False
     assert strip_continuation_comments(src) == exp
+
+# --- f-string conversion ``!r``/``!s``/``!a`` inside ``{…}`` ---------------
+#
+# In subproc mode the lexer emits ``BANG`` for ``!``, regardless of
+# whether it sits inside an f-string replacement field (where it means
+# "conversion specifier") or at top level (where it means "macro call").
+# Without f-string awareness, ``subproc_toks`` and ``find_next_break``
+# treat any ``BANG`` as macro-start: the former swallows the rest of
+# the line into a single wrap that then fails to re-parse, the latter
+# returns ``maxcol = end-of-line`` which prevents wrapping the LHS
+# before a combinator.  The fix tracks ``FSTRING_START`` / ``FSTRING_END``
+# nesting and ``LBRACE`` / ``RBRACE`` depth, ignoring ``BANG`` while
+# inside a replacement field.
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        # ``!r`` conversion — the wrap must cover the whole ``@()``
+        # subproc segment up to the ``&&``, not stop at the ``!``.
+        (
+            'echo @(f"hi {name!r}") && echo z',
+            '![echo @(f"hi {name!r}")] && echo z',
+        ),
+        # ``!s`` and ``!a``.
+        (
+            'echo @(f"x {y!s}") && echo z',
+            '![echo @(f"x {y!s}")] && echo z',
+        ),
+        (
+            'echo @(f"x {y!a}") && echo z',
+            '![echo @(f"x {y!a}")] && echo z',
+        ),
+        # Conversion plus a format spec — the ``:`` introduces a
+        # ``FSTRING_MIDDLE`` for the spec text, ``BANG`` still must be
+        # treated as conversion.
+        (
+            'echo @(f"x {y!r:>10}") && echo z',
+            '![echo @(f"x {y!r:>10}")] && echo z',
+        ),
+    ],
+)
+def test_subproc_toks_fstring_conversion(line, expected):
+    """Wrap up to ``&&`` even though the f-string contains ``{x!r}``."""
+    maxcol = find_next_break(line, mincol=-1, lexer=LEXER)
+    obs = subproc_toks(line, lexer=LEXER, maxcol=maxcol, returnline=True)
+    assert obs == expected
+
+
+@pytest.mark.parametrize(
+    "line, expected_maxcol",
+    [
+        # ``find_next_break`` returns the lexpos of the combinator
+        # token (with ``mincol=-1`` the per-mincol shift cancels out).
+        # For ``&&`` / ``||`` / ``;`` at lexpos 23 this is ``23``.
+        # Without the f-string guard, the ``BANG`` inside ``{x!r}``
+        # would trigger an early break and return ``len(line)``
+        # instead.
+        (
+            'echo @(f"hi {name!r}") && echo z',
+            23,
+        ),
+        (
+            'echo @(f"hi {name!r}") || echo z',
+            23,
+        ),
+        (
+            'echo @(f"hi {name!r}") ; echo z',
+            23,
+        ),
+        # Without any ``!``, the position shifts because the f-string
+        # is shorter — sanity check that the value is still the
+        # combinator position, not end-of-line.
+        (
+            'echo @(f"hi {name}") && echo z',
+            21,
+        ),
+    ],
+)
+def test_find_next_break_fstring_conversion(line, expected_maxcol):
+    """``find_next_break`` must not treat ``!`` inside an f-string
+    replacement field as a macro break — only top-level ``BANG``
+    qualifies.
+    """
+    obs = find_next_break(line, mincol=-1, lexer=LEXER)
+    assert obs == expected_maxcol
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Bare macro at top level — ``!`` IS a macro operator here.
+        # ``subproc_toks`` must still recognise it (saw_macro behaviour).
+        "echo ! something",
+        "cmd ! arg with spaces",
+        # Macro inside an already-wrapped block.
+        "$[echo ! arg]",
+        "![echo ! arg]",
+    ],
+)
+def test_subproc_toks_macro_outside_fstring_still_works(line):
+    """Pin the inverse: ``BANG`` outside an f-string replacement field
+    is still the xonsh macro operator and ``subproc_toks`` must accept
+    it (i.e., not decline by mistake after the f-string-conversion
+    guard).
+    """
+    obs = subproc_toks(line, lexer=LEXER, returnline=True)
+    # Either the function wraps the line (placing ``![…]`` around it)
+    # or, for an already-wrapped input, leaves it alone — but never
+    # crashes and never collapses to a comment-only ``None`` return.
+    assert obs is None or "!" in obs

--- a/tests/test_tools_llm.py
+++ b/tests/test_tools_llm.py
@@ -185,6 +185,7 @@ def test_strip_continuation_comments(src, exp, xession):
     xession.env["XONSH_INTERACTIVE"] = False
     assert strip_continuation_comments(src) == exp
 
+
 # --- f-string conversion ``!r``/``!s``/``!a`` inside ``{…}`` ---------------
 #
 # In subproc mode the lexer emits ``BANG`` for ``!``, regardless of

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -330,8 +330,27 @@ def find_next_break(line, mincol=0, lexer=None):
         return None
     maxcol = None
     lparens = []
+    # Track f-string state so a ``!`` conversion specifier inside ``{…}``
+    # (e.g. ``f"{name!r}"``) is not mistaken for the xonsh macro operator
+    # and does not trigger an early ``BANG`` break.  See ``subproc_toks``
+    # for the matching logic.
+    in_fstring = 0
+    fstring_expr_depth = 0
     lexer.input(line, is_subproc=True)
     for tok in lexer:
+        if tok.type == "FSTRING_START":
+            in_fstring += 1
+            continue
+        elif tok.type == "FSTRING_END" and in_fstring > 0:
+            in_fstring -= 1
+            continue
+        elif in_fstring > 0:
+            if tok.type == "LBRACE":
+                fstring_expr_depth += 1
+                continue
+            elif tok.type == "RBRACE" and fstring_expr_depth > 0:
+                fstring_expr_depth -= 1
+                continue
         if tok.type in LPARENS:
             lparens.append(tok.type)
         elif tok.type in END_TOK_TYPES:
@@ -343,7 +362,7 @@ def find_next_break(line, mincol=0, lexer=None):
         elif tok.type == "ERRORTOKEN" and ")" in tok.value:
             maxcol = tok.lexpos + mincol + 1
             break
-        elif tok.type == "BANG":
+        elif tok.type == "BANG" and fstring_expr_depth == 0:
             maxcol = mincol + len(line) + 1
             break
     return maxcol
@@ -403,6 +422,14 @@ def subproc_toks(
     saved_toks = None
     saved_lparens = None
     saved_leading_paren_skipped = False
+    # Track f-string state so ``!`` conversion specifiers (``!r``/``!s``/
+    # ``!a``) inside ``{…}`` are not mistaken for the xonsh macro
+    # operator.  ``in_fstring`` counts nested ``FSTRING_START``/``END``
+    # pairs (PEP 701 allows ``f"{f"…"}"``); ``fstring_expr_depth`` counts
+    # ``LBRACE``/``RBRACE`` pairs while inside an f-string.  A ``BANG``
+    # token is the xonsh macro operator only when both counters are zero.
+    in_fstring = 0
+    fstring_expr_depth = 0
     for tok in lexer:
         pos = tok.lexpos
         if skip_depth > 0:
@@ -411,9 +438,19 @@ def subproc_toks(
             elif tok.type == "RBRACKET":
                 skip_depth -= 1
             continue
+        # Update f-string nesting state before any BANG / END_TOK checks.
+        if tok.type == "FSTRING_START":
+            in_fstring += 1
+        elif tok.type == "FSTRING_END" and in_fstring > 0:
+            in_fstring -= 1
+        elif in_fstring > 0:
+            if tok.type == "LBRACE":
+                fstring_expr_depth += 1
+            elif tok.type == "RBRACE" and fstring_expr_depth > 0:
+                fstring_expr_depth -= 1
         if tok.type not in END_TOK_TYPES and pos >= maxcol:
             break
-        if tok.type == "BANG":
+        if tok.type == "BANG" and fstring_expr_depth == 0:
             saw_macro = True
         if saw_macro and tok.type not in ("NEWLINE", "DEDENT"):
             toks.append(tok)


### PR DESCRIPTION
## Problem

In subproc mode the xonsh lexer emits ``BANG`` for ``!`` regardless of context, so ``f"{name!r}"`` inside an ``@()`` argument breaks phase-1 recovery:

\`\`\`xsh
@ name = "world"
@ echo @(f"{name!r}") && echo z
xonsh: SyntaxError: code: @(
\`\`\`

``subproc_toks`` sees ``BANG`` and enters macro mode, swallowing the rest of the line into a single ``![…]`` wrap that then fails to re-parse. ``find_next_break`` does the matching thing, returning ``maxcol = len(line)+1`` and preventing any wrap of the LHS before a shell combinator.

``!r``, ``!s``, ``!a`` inside ``{…}`` of an f-string are **conversion specifiers** — purely textual, with no relation to xonsh macros.

## Fix

Track f-string nesting in both helpers via two counters:

- ``in_fstring`` — depth of ``FSTRING_START`` / ``FSTRING_END`` pairs (PEP 701 permits ``f"{f"…"}"``).
- ``fstring_expr_depth`` — depth of ``LBRACE`` / ``RBRACE`` pairs while inside an f-string.

A ``BANG`` token is the xonsh macro operator only when both counters are zero. Inside a replacement field (``fstring_expr_depth > 0``) it is the conversion specifier and passes through to the normal token-collection path.

## After fix

\`\`\`xsh
@ name = "world"
@ echo @(f"hi {name!r}") && echo z
hi 'world'
z
\`\`\`

## Test plan

- [x] Unit tests in ``tests/test_tools_llm.py`` cover ``subproc_toks`` wrap output, ``find_next_break`` return values, format specs (``{x!r:>10}``), PEP-701 nested f-strings (``f"{f'{x!r}'}"``).
- [x] Integration tests in ``tests/test_execer_llm.py`` exercise ``Execer.compile`` end-to-end.
- [x] Regression pin that bare macro syntax (``$[cmd ! arg]``, ``![cmd ! arg]``, ``$(cmd ! arg)``, ``!(cmd ! arg)``) still works.
- [x] Full local test suite: 7204 passed, 0 failed.