### PR TITLE
test: Fix FreeBSD CI: Unset SSH_TTY/SSH_CONNECTION in fake_tty fixture

### DIFF
--- a/tests/shell/test_ptk_shell_llm.py
+++ b/tests/shell/test_ptk_shell_llm.py
@@ -10,8 +10,29 @@ def restore_vt100_cpr():
     """Snapshot Vt100_Output.{ask_for_cpr,responds_to_cpr} and restore
     them after the test. The CPR-suppression patch in ptk_shell runs at
     import time and mutates the class globally, so tests that
-    deliberately trigger it must clean up."""
+    deliberately trigger it must clean up.
+
+    On CI runners that invoke pytest inside an SSH session (FreeBSD VM),
+    ``ptk_shell``'s first import — triggered by some collected test's
+    import chain — already runs with ``SSH_TTY``/``SSH_CONNECTION`` set
+    and replaces both attributes with the no-op lambda.  Naively
+    snapshotting at fixture entry would therefore record the lambda as
+    "original" and ``test_ptk_does_not_touch_cpr_outside_ssh`` would
+    fail because its assertion expects the truly-original method name.
+
+    Drop any leftover lambda overrides from the class *before* taking
+    the snapshot so that ``type(...).__delattr__`` falls back to the
+    method body defined in ``prompt_toolkit.output.vt100.Vt100_Output``.
+    """
     from prompt_toolkit.output.vt100 import Vt100_Output
+
+    for attr in ("ask_for_cpr", "responds_to_cpr"):
+        cur = vars(Vt100_Output).get(attr)
+        if cur is not None and getattr(cur, "__name__", "") == "<lambda>":
+            try:
+                delattr(Vt100_Output, attr)
+            except AttributeError:
+                pass
 
     orig_ask = Vt100_Output.ask_for_cpr
     orig_responds = Vt100_Output.responds_to_cpr

--- a/tests/shell/test_readline_shell.py
+++ b/tests/shell/test_readline_shell.py
@@ -121,6 +121,12 @@ def fake_tty(monkeypatch):
     import termios
 
     state = {"chunks": []}
+    # ``_ensure_newline`` returns early if ``SSH_TTY``/``SSH_CONNECTION``
+    # is set (issue #5686 — DSR reply through ssh client breaks ``~.``).
+    # CI runs FreeBSD tests inside an SSH-attached VM where those env
+    # vars are inherited, so clear them before exercising the DSR path.
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
     monkeypatch.setattr(sys, "stdin", _FakeStdin())
     monkeypatch.setattr("os.isatty", lambda fd: True)
     monkeypatch.setattr(termios, "tcgetattr", lambda fd: object())


### PR DESCRIPTION
## Problem

The FreeBSD CI job has been failing on four ``test_ensure_newline_*`` parametrizations in ``tests/shell/test_readline_shell.py``:

\`\`\`
FAILED tests/shell/test_readline_shell.py::test_ensure_newline_col_gt_1_prints_newline - AssertionError: assert '' == '\x1b[6n\n'
FAILED tests/shell/test_readline_shell.py::test_ensure_newline_col_1_does_not_print_newline - AssertionError: assert '' == '\x1b[6n'
FAILED tests/shell/test_readline_shell.py::test_ensure_newline_split_reply - AssertionError: assert '' == '\x1b[6n\n'
FAILED tests/shell/test_readline_shell.py::test_ensure_newline_no_reply - AssertionError: assert '' == '\x1b[6n'
\`\`\`

The same four failures occur on every recent run, on every commit landed in ``main``, so they are not a regression — they have just been ignored as flaky.

## Cause

``_ensure_newline`` in ``xonsh/shells/readline_shell.py`` returns early when ``SSH_TTY`` or ``SSH_CONNECTION`` is set in the environment.  This is a legitimate runtime guard (issue #5686 — the DSR reply travels through the ssh client and breaks tilde escape sequences).

The CI matrix runs FreeBSD tests inside an SSH-attached VM, so those env vars are inherited by ``python3.11 -m pytest``.  The ``fake_tty`` fixture mocks termios/tty/select but does not clear the env, so under SSH the test process hits the early-return path, nothing is written to stdout, and the assertions fail.

## Reproduction

Connecting to a FreeBSD 16.0-CURRENT VM via SSH:

\`\`\`
$ env | grep SSH
SSH_CONNECTION=10.0.2.2 54593 10.0.2.15 22
$ python3.11 -m pytest tests/shell/test_readline_shell.py -v --timeout=60
# ... 4 failures, same as CI

$ env -u SSH_CONNECTION -u SSH_TTY python3.11 -m pytest tests/shell/test_readline_shell.py
# ... 36 passed
\`\`\`

## Fix

Clear both env vars in the ``fake_tty`` fixture so the SSH guard does not kick in during the test:

\`\`\`python
monkeypatch.delenv("SSH_TTY", raising=False)
monkeypatch.delenv("SSH_CONNECTION", raising=False)
\`\`\`

## Test plan

- [x] Reproduced 4 failures locally on FreeBSD 16.0-CURRENT VM via SSH.
- [x] With the fix all 36 tests in ``test_readline_shell.py`` pass on that VM.
- [x] Tests still pass on macOS / Linux (no SSH env vars present).

Closes the persistent FreeBSD CI red on every PR.