### PR TITLE
docs(events): add usage examples to all event handlers missing them

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -138,6 +138,19 @@ on_envvar_new(name: str, value: Any) -> None
 Fires after a new environment variable is created.
 Note: Setting envvars inside the handler might
 cause a recursion until the limit.
+
+Parameters:
+
+* ``name``: The name of the new environment variable.
+* ``value``: The value assigned to it.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_envvar_new
+    def log_new_var(name, value, **kw):
+        print(f"New env var created: {name}={value!r}")
 """,
 )
 
@@ -168,6 +181,20 @@ on_pre_spec_run_ls(spec: xonsh.built_ins.SubprocSpec) -> None
 
 Fires right before a SubprocSpec.run() is called for the ls
 command.
+
+Parameters:
+
+* ``spec``: The ``SubprocSpec`` object for the ``ls`` invocation.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_pre_spec_run_ls
+    def inject_color_flag(spec, **kw):
+        # Automatically add --color=auto if not already present
+        if "--color" not in spec.args:
+            spec.args.append("--color=auto")
 """,
 )
 
@@ -182,6 +209,25 @@ LS_COLORS values must be (ANSI color) strings, None is unambiguous.
 Does not fire when the whole environment variable changes (see on_envvar_change).
 Does not fire for each value when LS_COLORS is first instantiated.
 Normal usage is to arm the event handler, then read (not modify) all existing values.
+
+Parameters:
+
+* ``key``: The LS_COLORS key that changed (e.g. ``"di"`` for directories).
+* ``oldvalue``: Previous ANSI color string, or ``None`` if the key is new.
+* ``newvalue``: New ANSI color string, or ``None`` if the key was deleted.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_lscolors_change
+    def log_lscolors_change(key, oldvalue, newvalue, **kw):
+        if newvalue is None:
+            print(f"LS_COLORS: removed key {key!r}")
+        elif oldvalue is None:
+            print(f"LS_COLORS: added {key!r}={newvalue!r}")
+        else:
+            print(f"LS_COLORS: changed {key!r} from {oldvalue!r} to {newvalue!r}")
 """,
 )
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -193,7 +193,7 @@ Example:
     @events.on_pre_spec_run_ls
     def _event_inject_color_flag(spec, **kw):
         # Automatically add --color=auto if not already present
-        if "--color" not in spec.args:
+        if not any(arg.startswith("--color") for arg in spec.args):
             spec.args.append("--color=auto")
 """,
 )

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -146,7 +146,7 @@ Parameters:
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_envvar_new
     def _event_log_new_var(name, value, **kw):
@@ -163,7 +163,7 @@ Fires after an environment variable is changed.
 Note: Setting envvars inside the handler might
 cause a recursion until the limit.
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_envvar_change
     def _on_env_path_change(name, oldvalue, newvalue):
@@ -188,7 +188,7 @@ Parameters:
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_pre_spec_run_ls
     def _event_inject_color_flag(spec, **kw):
@@ -218,7 +218,7 @@ Parameters:
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_lscolors_change
     def _event_log_lscolors_change(key, oldvalue, newvalue, **kw):
@@ -1447,7 +1447,7 @@ class SubprocessSetting(Xettings):
         "``specs`` is the list of :class:`SubprocSpec` objects about to be executed; "
         "``CommandPipeline`` is not yet built at this point.",
         doc_default="By default it just prints ``cmds`` like below.\n\n"
-        ".. code-block:: python\n\n"
+        ".. code-block:: xonsh\n\n"
         "    def _tracer(cmds, captured, specs):\n"
         "        # ``specs`` is a list of SubprocSpec — use e.g. ``s.args``,\n"
         "        # ``s.alias``, ``s.binary_loc``, ``s.threadable`` for details.\n"

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -149,7 +149,7 @@ Example:
 .. code-block:: python
 
     @events.on_envvar_new
-    def log_new_var(name, value, **kw):
+    def _event_log_new_var(name, value, **kw):
         print(f"New env var created: {name}={value!r}")
 """,
 )
@@ -191,7 +191,7 @@ Example:
 .. code-block:: python
 
     @events.on_pre_spec_run_ls
-    def inject_color_flag(spec, **kw):
+    def _event_inject_color_flag(spec, **kw):
         # Automatically add --color=auto if not already present
         if "--color" not in spec.args:
             spec.args.append("--color=auto")
@@ -221,7 +221,7 @@ Example:
 .. code-block:: python
 
     @events.on_lscolors_change
-    def log_lscolors_change(key, oldvalue, newvalue, **kw):
+    def _event_log_lscolors_change(key, oldvalue, newvalue, **kw):
         if newvalue is None:
             print(f"LS_COLORS: removed key {key!r}")
         elif oldvalue is None:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -144,9 +144,9 @@ Example:
 
     @events.on_xontribs_loaded
     def _event_check_xontribs(**kw):
-        from xonsh.built_ins import XSH
-        loaded = list(XSH.builtins.__xonsh__.xontribs_loaded)
-        print(f"Loaded xontribs: {loaded}")
+        from xonsh.xontribs import xontribs_loaded
+        if "coreutils" not in xontribs_loaded():
+            print("Hint: 'xontrib load coreutils' adds cross-platform cp, mv, rm, ...")
 """,
 )
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -53,7 +53,7 @@ NOTE: This is fired before the wizard is automatically started.
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_post_init
     def _event_greet(**kw):
@@ -79,7 +79,7 @@ Parameters:
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_exit
     def _event_save_session_log(exit_code, **kw):
@@ -100,7 +100,7 @@ Fired just before the command loop is started, if it is.
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_pre_cmdloop
     def _event_show_tip(**kw):
@@ -122,7 +122,7 @@ NOTE: All the caveats of the ``atexit`` module also apply to this event.
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_post_cmdloop
     def _event_session_summary(**kw):
@@ -140,7 +140,7 @@ Fired after external xontribs with ``entrypoints defined`` are loaded.
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_xontribs_loaded
     def _event_check_xontribs(**kw):
@@ -160,7 +160,7 @@ Fired just before rc files are loaded, if they are.
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_pre_rc
     def _event_announce_rc(**kw):
@@ -178,7 +178,7 @@ Fired just after rc files are loaded, if they are.
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_post_rc
     def _event_rc_loaded(**kw):

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -56,7 +56,7 @@ Example:
 .. code-block:: python
 
     @events.on_post_init
-    def greet(**kw):
+    def _event_greet(**kw):
         from xonsh.built_ins import XSH
         name = XSH.env.get("USER", "user")
         print(f"Welcome back, {name}!")
@@ -82,7 +82,7 @@ Example:
 .. code-block:: python
 
     @events.on_exit
-    def save_session_log(exit_code, **kw):
+    def _event_save_session_log(exit_code, **kw):
         import datetime
         with open("/tmp/xonsh_sessions.log", "a") as f:
             f.write(f"{datetime.datetime.now()}: exited with code {exit_code}\\n")
@@ -103,7 +103,7 @@ Example:
 .. code-block:: python
 
     @events.on_pre_cmdloop
-    def show_tip(**kw):
+    def _event_show_tip(**kw):
         import random
         tips = ["Use Tab for completion", "Try 'xonfig' to configure xonsh"]
         print("Tip:", random.choice(tips))
@@ -125,7 +125,7 @@ Example:
 .. code-block:: python
 
     @events.on_post_cmdloop
-    def farewell(**kw):
+    def _event_farewell(**kw):
         print("Goodbye!")
 """,
 )
@@ -143,7 +143,7 @@ Example:
 .. code-block:: python
 
     @events.on_xontribs_loaded
-    def check_xontribs(**kw):
+    def _event_check_xontribs(**kw):
         from xonsh.built_ins import XSH
         loaded = list(XSH.builtins.__xonsh__.xontribs_loaded)
         print(f"Loaded xontribs: {loaded}")
@@ -163,7 +163,7 @@ Example:
 .. code-block:: python
 
     @events.on_pre_rc
-    def announce_rc(**kw):
+    def _event_announce_rc(**kw):
         print("Loading rc files...")
 """,
 )
@@ -181,7 +181,7 @@ Example:
 .. code-block:: python
 
     @events.on_post_rc
-    def rc_loaded(**kw):
+    def _event_rc_loaded(**kw):
         print("RC files loaded successfully.")
 """,
 )

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -126,8 +126,7 @@ Example:
 
     @events.on_post_cmdloop
     def _event_session_summary(**kw):
-        from xonsh.built_ins import XSH
-        print(f"Session ended after {len(XSH.history)} commands.")
+        print(f"Session ended after {len(@.history)} commands.")
 """,
 )
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -50,6 +50,16 @@ on_post_init() -> None
 Fired after all initialization is finished and we're ready to do work.
 
 NOTE: This is fired before the wizard is automatically started.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_post_init
+    def greet(**kw):
+        from xonsh.built_ins import XSH
+        name = XSH.env.get("USER", "user")
+        print(f"Welcome back, {name}!")
 """,
 )
 
@@ -62,6 +72,20 @@ on_exit(exit_code : int) -> None
 Fired after all commands have been executed, before tear-down occurs.
 
 NOTE: All the caveats of the ``atexit`` module also apply to this event.
+
+Parameters:
+
+* ``exit_code``: The shell's exit code (``0`` for success).
+
+Example:
+
+.. code-block:: python
+
+    @events.on_exit
+    def save_session_log(exit_code, **kw):
+        import datetime
+        with open("/tmp/xonsh_sessions.log", "a") as f:
+            f.write(f"{datetime.datetime.now()}: exited with code {exit_code}\\n")
 """,
 )
 
@@ -73,6 +97,16 @@ events.doc(
 on_pre_cmdloop() -> None
 
 Fired just before the command loop is started, if it is.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_pre_cmdloop
+    def show_tip(**kw):
+        import random
+        tips = ["Use Tab for completion", "Try 'xonfig' to configure xonsh"]
+        print("Tip:", random.choice(tips))
 """,
 )
 
@@ -85,6 +119,14 @@ on_post_cmdloop() -> None
 Fired just after the command loop finishes, if it is.
 
 NOTE: All the caveats of the ``atexit`` module also apply to this event.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_post_cmdloop
+    def farewell(**kw):
+        print("Goodbye!")
 """,
 )
 
@@ -95,6 +137,16 @@ events.doc(
 on_xontribs_loaded() -> None
 
 Fired after external xontribs with ``entrypoints defined`` are loaded.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_xontribs_loaded
+    def check_xontribs(**kw):
+        from xonsh.built_ins import XSH
+        loaded = list(XSH.builtins.__xonsh__.xontribs_loaded)
+        print(f"Loaded xontribs: {loaded}")
 """,
 )
 
@@ -105,6 +157,14 @@ events.doc(
 on_pre_rc() -> None
 
 Fired just before rc files are loaded, if they are.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_pre_rc
+    def announce_rc(**kw):
+        print("Loading rc files...")
 """,
 )
 
@@ -115,6 +175,14 @@ events.doc(
 on_post_rc() -> None
 
 Fired just after rc files are loaded, if they are.
+
+Example:
+
+.. code-block:: python
+
+    @events.on_post_rc
+    def rc_loaded(**kw):
+        print("RC files loaded successfully.")
 """,
 )
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -125,8 +125,9 @@ Example:
 .. code-block:: python
 
     @events.on_post_cmdloop
-    def _event_farewell(**kw):
-        print("Goodbye!")
+    def _event_session_summary(**kw):
+        from xonsh.built_ins import XSH
+        print(f"Session ended after {len(XSH.history)} commands.")
 """,
 )
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -31,7 +31,7 @@ Only done for interactive sessions.
 This may be fired multiple times per command, with other transformers input or
 output, so design any handlers for this carefully.
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_transform_command
     def _pipe_prev_command(cmd, **kw):
@@ -59,7 +59,7 @@ Parameters:
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_precommand
     def _audit(cmd, **kw):
@@ -87,7 +87,7 @@ Parameters:
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_postcommand
     def _prompt_err_command_again(cmd, rtn, out, ts):
@@ -121,7 +121,7 @@ Note: If the replacement command also fails, the original error is shown.
 
 Examples:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_command_not_found
     def _vim_to_vi(cmd, **kwargs):
@@ -147,7 +147,7 @@ Fires before the prompt will be formatted
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_pre_prompt_format
     def _event_update_vcs_status(**kw):
@@ -166,7 +166,7 @@ Fires just before showing the prompt
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_pre_prompt
     def _event_ring_bell(**kw):
@@ -184,7 +184,7 @@ Fires just after the prompt returns
 
 Example:
 
-.. code-block:: python
+.. code-block:: xonsh
 
     @events.on_post_prompt
     def _event_log_session_time(**kw):

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -144,6 +144,16 @@ events.doc(
 on_pre_prompt_format() -> None
 
 Fires before the prompt will be formatted
+
+Example:
+
+.. code-block:: python
+
+    @events.on_pre_prompt_format
+    def update_vcs_status(**kw):
+        # refresh any cached VCS info before the prompt template is rendered
+        import os
+        os.environ.pop("GIT_STATUS_CACHE", None)
 """,
 )
 
@@ -153,6 +163,14 @@ events.doc(
 on_pre_prompt() -> None
 
 Fires just before showing the prompt
+
+Example:
+
+.. code-block:: python
+
+    @events.on_pre_prompt
+    def ring_bell(**kw):
+        print("\\a", end="", flush=True)
 """,
 )
 
@@ -163,6 +181,15 @@ events.doc(
 on_post_prompt() -> None
 
 Fires just after the prompt returns
+
+Example:
+
+.. code-block:: python
+
+    @events.on_post_prompt
+    def log_session_time(**kw):
+        import time
+        print(f"[session time: {time.strftime('%H:%M:%S')}]")
 """,
 )
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -150,7 +150,7 @@ Example:
 .. code-block:: python
 
     @events.on_pre_prompt_format
-    def update_vcs_status(**kw):
+    def _event_update_vcs_status(**kw):
         # refresh any cached VCS info before the prompt template is rendered
         import os
         os.environ.pop("GIT_STATUS_CACHE", None)
@@ -169,7 +169,7 @@ Example:
 .. code-block:: python
 
     @events.on_pre_prompt
-    def ring_bell(**kw):
+    def _event_ring_bell(**kw):
         print("\\a", end="", flush=True)
 """,
 )
@@ -187,7 +187,7 @@ Example:
 .. code-block:: python
 
     @events.on_post_prompt
-    def log_session_time(**kw):
+    def _event_log_session_time(**kw):
         import time
         print(f"[session time: {time.strftime('%H:%M:%S')}]")
 """,


### PR DESCRIPTION
## Summary

Closes #5964.

Adds a `.. code-block:: python` usage example to every event docstring that lacked one. These docstrings power the [events page](https://xon.sh/events.html) and the [tutorial](https://xon.sh/tutorial_events.html).

## Events updated

**`xonsh/shell.py`**
- `on_pre_prompt_format`
- `on_pre_prompt`
- `on_post_prompt`

**`xonsh/main.py`**
- `on_post_init`
- `on_exit` (also added `exit_code` parameter docs)
- `on_pre_cmdloop`
- `on_post_cmdloop`
- `on_xontribs_loaded`
- `on_pre_rc`
- `on_post_rc`

**`xonsh/environ.py`**
- `on_envvar_new` (also added parameter docs)
- `on_pre_spec_run_ls` (also added parameter docs)
- `on_lscolors_change` (also added parameter docs)

## Test plan

- [ ] `make docs` / `sphinx-build docs docs/_build/html` — events page renders with examples
- [ ] Each example follows the `@events.<name>` decorator pattern used in the codebase