### PR TITLE
docs: Cross-platform: Add `osquery` to cross-platform tooling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,10 +103,11 @@ Xonsh
             xontrib load sh \
                          fish_completer
 
+            osqueryi ! SELECT platform FROM os_version
+
             def nudf(cmd):
                 return @.imp.pandas.DataFrame(
-                  @.imp.json.loads(
-                    $(nu -c @(cmd+'| to json'))))
+                  $(@json nu -c @(cmd+'| to json')))
             nudf!(ls -la)
 
             aliases['ai'] = 'ollama run llama3'

--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -409,7 +409,7 @@
 <span unselectable-text="@ "></span><b>xontrib</b> load sh \
 <span unselectable-text="  "></span>             fish_completer
 
-<span unselectable-text="@ "></span><b>osqueryi !</b> SELECT platform FROM os_version
+            <span unselectable-text="@ "></span><b>osqueryi <span style="color: lightsalmon;">!</span></b> <span style="color: lightblue;">SELECT</span> platform <span style="color: lightblue;">FROM</span> os_version
 
 <span unselectable-text="@ "></span><b>def</b> nudf(cmd):
 <span unselectable-text="  "></span>    <b>return</b> <b>@</b>.imp.pandas.DataFrame(

--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -409,10 +409,11 @@
 <span unselectable-text="@ "></span><b>xontrib</b> load sh \
 <span unselectable-text="  "></span>             fish_completer
 
+<span unselectable-text="@ "></span><b>osqueryi !</b> SELECT platform FROM os_version
+
 <span unselectable-text="@ "></span><b>def</b> nudf(cmd):
 <span unselectable-text="  "></span>    <b>return</b> <b>@</b>.imp.pandas.DataFrame(
-<span unselectable-text="  "></span>      <b>@</b>.imp.json.loads(
-<span unselectable-text="  "></span>          <span style="color: lightgreen;">$(nu -c <span style="color: lightsalmon;">@(cmd + <span style="color: lightblue;">'| to json'</span>)</span>)</span>))
+<span unselectable-text="  "></span>      <span style="color: lightgreen;">$(<span style="color: lightsalmon;">@json</span> nu -c <span style="color: lightsalmon;">@(cmd + <span style="color: lightblue;">'| to json'</span>)</span>)</span>)
 
 <span unselectable-text="  "></span>nudf!(<span style="color: lightgreen;">ls -la</span>)
 

--- a/docs/platforms.rst
+++ b/docs/platforms.rst
@@ -208,6 +208,8 @@ Unset the affected functions in your ``~/.bashrc``:
     $ unset scl
 
 
+.. _open_terminal_here:
+
 "Open Terminal Here" action in Thunar (XFCE)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -708,8 +710,37 @@ Most modern Windows applications accept forward-slash paths, but not all do
 other tools work fine with ``/``.
 
 
-.. _open_terminal_here:
+Cross-platform tooling
+----------------------
 
+Query the system
+^^^^^^^^^^^^^^^^
+
+`osquery <https://www.osquery.io>`_ exposes the operating system as a
+relational database. It ships hundreds of tables — ``processes``,
+``listening_ports``, ``users``, ``system_info``, ``os_version`` and many more (see
+the `schema <https://osquery.io/schema>`_) — that you read with plain SQL, and
+the same query returns the same columns on Linux, macOS, and Windows. Its
+``osqueryi`` shell runs a single query and exits when you pass the SQL as an
+argument:
+
+.. code-block:: xonshcon
+
+    @ osqueryi! SELECT platform FROM os_version
+    +----------+
+    | platform |
+    +----------+
+    | darwin   |
+    +----------+
+
+Because ``osqueryi --json`` prints a table as a JSON array, the ``@json``
+:doc:`output decorator <aliases>` hands it back as a list of dicts you can loop
+over directly:
+
+.. code-block:: xonsh
+
+    for proc in $(@json osqueryi --json "SELECT pid, name FROM processes ORDER BY pid LIMIT 5"):
+        print(proc['pid'], proc['name'])
 
 
 See Also


### PR DESCRIPTION
`osquery <https://www.osquery.io>`_ exposes the operating system as a
relational database. It ships hundreds of tables — ``processes``,
``listening_ports``, ``users``, ``system_info``, ``os_version`` and many more (see
the `schema <https://osquery.io/schema>`_) — that you read with plain SQL, and
the same query returns the same columns on Linux, macOS, and Windows.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
