### PR TITLE
fix(tools): preserve env var tildes in subprocess args

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1845,6 +1845,16 @@ def test_expand_path(expand_user, inp, expand_env_vars, exp_end, xession):
         assert path == "~" + exp_end
 
 
+def test_expand_path_preserves_tilde_from_envvar_value(xession):
+    tilde_path = os.path.join("~", "docs")
+    xession.env.update({"tilde": "~", "tilde_path": tilde_path})
+    xession.env["EXPAND_ENV_VARS"] = True
+
+    assert expand_path("$tilde") == "~"
+    assert expand_path("$tilde_path") == tilde_path
+    assert expand_path("x=$tilde_path") == f"x={tilde_path}"
+
+
 @pytest.mark.parametrize(
     "inp, exp_expanded, exp_literal",
     [

--- a/tests/xintegration/test_integrations.py
+++ b/tests/xintegration/test_integrations.py
@@ -776,6 +776,16 @@ def test_script_stderr(case):
     assert exp_rtn == rtn
 
 
+def test_env_var_tilde_is_not_expanduser_in_subproc():
+    script = """
+with @.env.swap(QWE="~"):
+    echo $QWE
+"""
+    out, err, rtn = run_xonsh(script, stderr=sp.PIPE)
+    assert out == "~\n", err
+    assert rtn == 0, err
+
+
 @skip_if_on_windows
 @pytest.mark.parametrize(
     "cmd, fmt, exp",

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -165,9 +165,15 @@ def expand_path(s, expand_user=True):
     """Takes a string path and expands ~ to home if expand_user is set
     and environment vars if EXPAND_ENV_VARS is set."""
     env = xsh.env or os_environ
-    if env.get("EXPAND_ENV_VARS", False):
-        s = expandvars(s)
+    if isinstance(s, bytes):
+        s = s.decode(
+            encoding=env.get("XONSH_ENCODING"), errors=env.get("XONSH_ENCODING_ERRORS")
+        )
+    elif isinstance(s, pathlib.Path):
+        s = str(s)
     if expand_user and env.get("XONSH_SUBPROC_ARG_EXPANDUSER", True):
+        # Match shell expansion order: only literal tildes are expanded here.
+        # Tildes introduced later by environment expansion should stay literal.
         # expand ~ according to Bash unquoted rules "Each variable assignment is
         # checked for unquoted tilde-prefixes immediately following a ':' or the
         # first '='". See the following for more details.
@@ -178,6 +184,8 @@ def expand_path(s, expand_user=True):
             s += os.pathsep.join(map(expanduser, post.split(os.pathsep)))
         else:
             s = expanduser(s)
+    if env.get("EXPAND_ENV_VARS", False):
+        s = expandvars(s)
     return s
 
 


### PR DESCRIPTION
## Summary
- Preserve tildes that come from environment variable expansion in subprocess arguments.
- Normalize `bytes` and `pathlib.Path` inputs before the reordered expansion path.
- Add unit and integration coverage for the reported `$QWE="~"` behavior.

## Root cause
`expand_path()` expanded environment variables before running expanduser, so `$QWE` with value `~` became a literal `~` and was immediately expanded to the home directory. Shell expansion order expands literal tildes before parameter expansion, so tildes introduced by env expansion should remain literal.

## Validation
- `python -m pytest tests\test_tools.py -q`
- `python -m pytest tests\xintegration\test_integrations.py::test_env_var_tilde_is_not_expanduser_in_subproc -q`
- `python -m ruff check xonsh\tools.py tests\test_tools.py tests\xintegration\test_integrations.py`
- `python -m ruff format --check xonsh\tools.py tests\test_tools.py tests\xintegration\test_integrations.py`
- `git diff --check`

Fixes #5970