### PR TITLE
feat: Introduce Xonsh linter `xonsh lint`

### DIFF
--- a/docs/launch.rst
+++ b/docs/launch.rst
@@ -270,6 +270,9 @@ Subcommands
 * ``xonsh check`` -- check xonsh source files for syntax errors without
   running them; the ``-n`` / ``--no-execute`` flag does the same for a
   ``-c`` command, a script file, or piped stdin. Run ``xonsh check --help``.
+* ``xonsh lint`` -- lint xonsh source files for likely mistakes (env-var
+  typos, bad env-var values, deprecated vars, unused imports), without
+  running them. Run ``xonsh lint --help``.
 
 
 See also

--- a/tests/lint/test_linter_cli_llm.py
+++ b/tests/lint/test_linter_cli_llm.py
@@ -1,0 +1,228 @@
+"""Tests for ``xonsh lint`` and the lint rules.
+
+The linter runs over the transformed xonsh AST (no execution) and ships four
+MVP rules: XSH001 (env-var typo), XSH002 (bad env-var literal), XSH003
+(deprecated env var), XSH101 (unused import).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from xonsh.linter import cli as lcli
+
+
+def codes(src):
+    return [f.code for f in lcli.lint_source(src)]
+
+
+def _run(argv, capsys, monkeypatch, stdin_text=None):
+    if stdin_text is not None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
+    rc = lcli.main(argv)
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+# ---------------------------------------------------------------------
+# XSH001 — env-var typo
+# ---------------------------------------------------------------------
+
+
+def test_xsh001_typo_read():
+    fs = lcli.lint_source("x = $XONSH_COLOR_STYL")
+    assert [f.code for f in fs] == ["XSH001"]
+    assert "XONSH_COLOR_STYLE" in fs[0].message
+
+
+def test_xsh001_typo_write():
+    fs = lcli.lint_source('$XONSH_HISTROY_BACKEND = "json"')
+    assert [f.code for f in fs] == ["XSH001"]
+    assert "XONSH_HISTORY_BACKEND" in fs[0].message
+
+
+def test_xsh001_custom_var_silent():
+    # A genuinely custom env var (no close match) must not be flagged.
+    assert codes('$DATABASE_URL = "postgres://x"') == []
+
+
+# ---------------------------------------------------------------------
+# XSH002 — bad env-var literal value
+# ---------------------------------------------------------------------
+
+
+def test_xsh002_quoted_bool():
+    fs = lcli.lint_source('$XONSH_STORE_STDOUT = "yes"')
+    assert [f.code for f in fs] == ["XSH002"]
+    assert "XONSH_STORE_STDOUT" in fs[0].message
+
+
+def test_xsh002_valid_value_silent():
+    assert codes("$XONSH_STORE_STDOUT = True") == []
+
+
+def test_xsh002_string_var_silent():
+    # A string value for a string-typed var is fine.
+    assert "XSH002" not in codes('$TITLE = "{current_job:{} | }{cwd}"')
+
+
+# ---------------------------------------------------------------------
+# XSH003 — deprecated env var
+# ---------------------------------------------------------------------
+
+
+def test_xsh003_deprecated_write():
+    fs = lcli.lint_source("$RAISE_SUBPROC_ERROR = True")
+    assert [f.code for f in fs] == ["XSH003"]
+
+
+def test_xsh003_deprecated_read():
+    assert codes("x = $AUTO_SUGGEST") == ["XSH003"]
+
+
+# ---------------------------------------------------------------------
+# XSH101 — unused import
+# ---------------------------------------------------------------------
+
+
+def test_xsh101_unused_import():
+    fs = lcli.lint_source("import os\nx = 1")
+    assert [f.code for f in fs] == ["XSH101"]
+    assert "'os'" in fs[0].message
+
+
+def test_xsh101_used_in_pyeval_silent():
+    assert codes("import json\necho @(json.dumps(1))") == []
+
+
+def test_xsh101_from_import_unused():
+    fs = lcli.lint_source("from os import path\nx = 1")
+    assert [f.code for f in fs] == ["XSH101"]
+    assert "os.path" in fs[0].message
+
+
+def test_xsh101_future_import_silent():
+    assert codes("from __future__ import annotations\nx = 1") == []
+
+
+def test_xsh101_dunder_all_counts_as_used():
+    assert codes('import os\n__all__ = ["os"]') == []
+
+
+def test_xsh101_star_import_silent():
+    assert codes("from os import *\nx = 1") == []
+
+
+# ---------------------------------------------------------------------
+# Engine behaviour
+# ---------------------------------------------------------------------
+
+
+def test_clean_source_no_findings():
+    assert codes("x = 1\nls -l | grep foo\necho @(x)") == []
+
+
+def test_comment_only_no_findings():
+    assert codes("# just a note") == []
+
+
+def test_findings_sorted_by_position():
+    src = "import os\nimport sys\n"  # two unused imports
+    fs = lcli.lint_source(src)
+    assert [f.line for f in fs] == [1, 2]
+    assert all(f.code == "XSH101" for f in fs)
+
+
+def test_syntax_error_propagates():
+    with pytest.raises(SyntaxError):
+        lcli.lint_source("x = (1 +")
+
+
+def test_ignore_filters_codes():
+    src = "import os\nx = 1"
+    assert lcli.lint_source(src, ignore={"XSH101"}) == []
+
+
+# ---------------------------------------------------------------------
+# CLI: xonsh lint FILE...
+# ---------------------------------------------------------------------
+
+
+def test_cli_clean_file(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x = 1\n")
+    rc, out, err = _run([str(f)], capsys, monkeypatch)
+    assert rc == lcli.EXIT_OK
+    assert f"{f}: clean" in err
+
+
+def test_cli_file_with_findings(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "bad.xsh"
+    f.write_text("import os\n")
+    rc, out, err = _run([str(f)], capsys, monkeypatch)
+    assert rc == lcli.EXIT_LINT
+    assert "XSH101" in err
+    assert str(f) in err
+
+
+def test_cli_quiet_suppresses_clean(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "a.xsh"
+    f.write_text("x = 1\n")
+    rc, out, err = _run([str(f), "-q"], capsys, monkeypatch)
+    assert rc == lcli.EXIT_OK
+    assert err == ""
+
+
+def test_cli_ignore_flag(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "imp.xsh"
+    f.write_text("import os\n")
+    rc, out, err = _run([str(f), "--ignore", "XSH101"], capsys, monkeypatch)
+    assert rc == lcli.EXIT_OK
+
+
+def test_cli_missing_file(tmp_path, capsys, monkeypatch):
+    rc, out, err = _run([str(tmp_path / "nope.xsh")], capsys, monkeypatch)
+    assert rc == lcli.EXIT_ERROR
+    assert "error" in err
+
+
+def test_cli_syntax_error_file(tmp_path, capsys, monkeypatch):
+    f = tmp_path / "broken.xsh"
+    f.write_text("x = (1 +\n")
+    rc, out, err = _run([str(f)], capsys, monkeypatch)
+    assert rc == lcli.EXIT_ERROR
+    assert str(f) in err
+
+
+def test_cli_stdin(capsys, monkeypatch):
+    rc, out, err = _run(["-"], capsys, monkeypatch, stdin_text="import os\n")
+    assert rc == lcli.EXIT_LINT
+    assert "<stdin>" in err and "XSH101" in err
+
+
+# ---------------------------------------------------------------------
+# Wiring: main() dispatch
+# ---------------------------------------------------------------------
+
+
+def test_main_dispatches_lint(tmp_path):
+    import xonsh.main
+
+    f = tmp_path / "a.xsh"
+    f.write_text("x = 1\n")
+    with pytest.raises(SystemExit) as ei:
+        xonsh.main.main(["lint", str(f), "-q"])
+    assert ei.value.code == lcli.EXIT_OK
+
+
+def test_main_dispatches_lint_findings(tmp_path):
+    import xonsh.main
+
+    f = tmp_path / "imp.xsh"
+    f.write_text("import os\n")
+    with pytest.raises(SystemExit) as ei:
+        xonsh.main.main(["lint", str(f)])
+    assert ei.value.code == lcli.EXIT_LINT

--- a/xonsh/linter/__init__.py
+++ b/xonsh/linter/__init__.py
@@ -1,0 +1,20 @@
+"""Static lint rules for xonsh source code.
+
+Where :mod:`xonsh.checker` answers "does it parse?" and :mod:`xonsh.formatter`
+answers "is it formatted?", :mod:`xonsh.linter` answers "is it likely *wrong*?"
+— without executing the code. It runs a small set of rules over the transformed
+xonsh AST, drawing on xonsh's own registries (the environment-variable table in
+:mod:`xonsh.environ`) for checks no generic linter could make.
+
+Public API:
+
+- :func:`lint_source` — lint a string of xonsh source, returning ``Finding``\\ s.
+- :class:`Finding` — one diagnostic (line, col, code, message).
+
+The CLI entry point used by ``xonsh lint ...`` lives in :mod:`xonsh.linter.cli`.
+"""
+
+from xonsh.linter.cli import lint_source
+from xonsh.linter.rules import Finding
+
+__all__ = ["lint_source", "Finding"]

--- a/xonsh/linter/cli.py
+++ b/xonsh/linter/cli.py
@@ -1,0 +1,151 @@
+"""Command-line interface for ``xonsh lint``.
+
+The dispatcher in :mod:`xonsh.main` peeks at ``sys.argv`` and, if the first
+non-option argument is ``lint``, hands the rest off to :func:`main` here. As
+with ``xonsh check`` / ``xonsh format`` we bypass xonsh's own argparse: linting
+needs no shell session, xontribs or rc files.
+
+``xonsh lint`` is the *correctness* sibling of the *style* tool ``xonsh format``
+and the *syntax* tool ``xonsh check``. It reuses the checker's parser/session
+(:func:`xonsh.checker.cli._get_execer`) to obtain the transformed xonsh AST,
+then runs the rules in :mod:`xonsh.linter.rules` over it.
+
+Exit codes
+----------
+* ``0`` — every file parsed and produced no findings;
+* ``1`` — at least one file had a lint finding;
+* ``123`` — at least one path could not be read or parsed (syntax error).
+"""
+
+from __future__ import annotations
+
+import argparse
+import builtins
+import sys
+
+from xonsh.linter.rules import ALL_RULES, Finding
+
+_PROG = "xonsh lint"
+EXIT_OK = 0
+EXIT_LINT = 1
+EXIT_ERROR = 123
+
+
+def lint_source(
+    src: str, filename: str = "<lint>", execer=None, ignore=()
+) -> list[Finding]:
+    """Parse *src* and return the lint findings, sorted by position.
+
+    Raises ``SyntaxError`` (propagated from the parser) if *src* does not parse;
+    callers should handle that the same way ``xonsh check`` does. No code is
+    executed. Comment-only / empty input yields ``[]``.
+    """
+    from xonsh.checker.cli import _get_execer
+
+    if execer is None:
+        execer = _get_execer()
+    if not src.endswith("\n"):
+        src += "\n"
+    # Mirror Execer.compile's parse step (empty user context, builtins only) but
+    # keep the transformed AST instead of compiling it.
+    tree = execer.parse(
+        src,
+        set(dir(builtins)),
+        mode="exec",
+        filename=filename,
+        transform=True,
+        user_names=set(),
+    )
+    if tree is None:
+        return []
+    findings: list[Finding] = []
+    for rule in ALL_RULES:
+        findings.extend(rule(tree))
+    if ignore:
+        findings = [f for f in findings if f.code not in ignore]
+    findings.sort(key=lambda f: (f.line, f.col, f.code))
+    return findings
+
+
+def _lint_one(src: str, name: str, execer, quiet: bool, ignore) -> str:
+    """Lint one source string. Return 'ok', 'lint', or 'error'."""
+    try:
+        findings = lint_source(src, filename=name, execer=execer, ignore=ignore)
+    except (SyntaxError, ValueError) as exc:
+        from xonsh.checker.cli import _diagnostic_lines
+
+        for line in _diagnostic_lines(name, exc):
+            print(line, file=sys.stderr)
+        return "error"
+    if findings:
+        for f in findings:
+            print(f"{name}:{f.line}:{f.col}: {f.code} {f.message}", file=sys.stderr)
+        return "lint"
+    if not quiet:
+        print(f"{name}: clean", file=sys.stderr)
+    return "ok"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog=_PROG,
+        description="Lint xonsh source files for likely mistakes "
+        "(env-var typos, bad env-var values, deprecated vars, unused imports).",
+    )
+    p.add_argument(
+        "files",
+        nargs="+",
+        metavar="FILE",
+        help="One or more files to lint. Use '-' to read from stdin.",
+    )
+    p.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only report files with findings; suppress per-file 'clean' output.",
+    )
+    p.add_argument(
+        "--ignore",
+        metavar="CODES",
+        default="",
+        help="Comma-separated rule codes to silence, e.g. --ignore XSH001,XSH101.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``xonsh lint FILE...``."""
+    args = build_parser().parse_args(argv)
+    ignore = {c.strip().upper() for c in args.ignore.split(",") if c.strip()}
+
+    from xonsh.checker.cli import _get_execer
+
+    execer = _get_execer()
+
+    had_lint = False
+    had_error = False
+    for path in args.files:
+        try:
+            if path == "-":
+                src, name = sys.stdin.read(), "<stdin>"
+            else:
+                with open(path, encoding="utf-8") as fh:
+                    src = fh.read()
+                name = path
+        except OSError as exc:
+            print(f"{path}: error: {exc.strerror or exc}", file=sys.stderr)
+            had_error = True
+            continue
+        result = _lint_one(src, name, execer, args.quiet, ignore)
+        if result == "lint":
+            had_lint = True
+        elif result == "error":
+            had_error = True
+
+    # Unprocessable files (read/parse failures) take precedence, mirroring the
+    # exit-code ordering of the sibling ``xonsh check`` subcommand.
+    if had_error:
+        return EXIT_ERROR
+    if had_lint:
+        return EXIT_LINT
+    return EXIT_OK

--- a/xonsh/linter/rules.py
+++ b/xonsh/linter/rules.py
@@ -1,0 +1,197 @@
+"""Lint rules for xonsh source code.
+
+Each rule is a plain function ``(tree) -> list[Finding]`` operating on the
+*transformed* xonsh AST (a standard :mod:`ast` ``Module`` in which subprocess
+lines have been lowered to ``__xonsh__.subproc_*`` calls, so shell command
+words are opaque string constants and never masquerade as Python names).
+
+The MVP ships four rules:
+
+* ``XSH001`` — a ``$VAR`` whose name is unknown but is a close match for a real
+  xonsh environment variable (likely a typo).
+* ``XSH002`` — a string literal assigned to a ``$VAR`` whose registered
+  validator rejects it (e.g. ``$XONSH_STORE_STDOUT = 'yes'`` instead of
+  ``True``).
+* ``XSH003`` — use of a deprecated environment variable.
+* ``XSH101`` — an import bound name that is never used (pyflakes' F401).
+
+The env-var rules draw their source of truth from :data:`xonsh.environ.DEFAULT_VARS`
+(~157 vars, each a ``Var`` carrying ``validate`` / ``deprecated`` metadata),
+which is something no generic Python or shell linter can know about.
+"""
+
+from __future__ import annotations
+
+import ast
+import difflib
+from typing import NamedTuple
+
+
+class Finding(NamedTuple):
+    line: int
+    col: int  # 1-based, to match the syntax-checker's diagnostics
+    code: str
+    message: str
+
+
+# Only flag an unknown ``$VAR`` as a typo when it is *this* close to a real
+# variable name. High cutoff keeps legitimately-custom env vars silent.
+_CLOSE_CUTOFF = 0.8
+
+
+def _known_env_vars():
+    # Imported lazily: keeps ``import xonsh.linter`` cheap and avoids paying the
+    # environ import cost unless a file is actually linted.
+    from xonsh.environ import DEFAULT_VARS
+
+    return DEFAULT_VARS
+
+
+def _env_var_name(node):
+    """If *node* is ``__xonsh__.env['NAME']`` (a ``$VAR`` / ``${'NAME'}`` in
+    Python mode), return ``'NAME'``; otherwise ``None``.
+
+    Dynamic forms like ``${expr}`` with a non-constant subscript return ``None``
+    — there is no static name to check.
+    """
+    if not isinstance(node, ast.Subscript):
+        return None
+    val = node.value
+    if not (
+        isinstance(val, ast.Attribute)
+        and val.attr == "env"
+        and isinstance(val.value, ast.Name)
+        and val.value.id == "__xonsh__"
+    ):
+        return None
+    sl = node.slice
+    if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+        return sl.value
+    return None
+
+
+def _pos(node):
+    return getattr(node, "lineno", 0), getattr(node, "col_offset", 0) + 1
+
+
+def check_env_vars(tree) -> list[Finding]:
+    """XSH001 (typo), XSH002 (bad literal value), XSH003 (deprecated)."""
+    dv = _known_env_vars()
+    known = list(dv)
+    out: list[Finding] = []
+
+    # Pass 1: every $VAR read or write — typo (unknown but close) or deprecated.
+    for node in ast.walk(tree):
+        name = _env_var_name(node)
+        if name is None:
+            continue
+        line, col = _pos(node)
+        if name not in dv:
+            match = difflib.get_close_matches(name, known, n=1, cutoff=_CLOSE_CUTOFF)
+            if match:
+                out.append(
+                    Finding(
+                        line,
+                        col,
+                        "XSH001",
+                        f"unknown environment variable ${name}; "
+                        f"did you mean ${match[0]}?",
+                    )
+                )
+        elif getattr(dv[name], "deprecated", False):
+            out.append(
+                Finding(
+                    line, col, "XSH003", f"environment variable ${name} is deprecated"
+                )
+            )
+
+    # Pass 2: ``$KNOWN_VAR = <str literal>`` whose validator rejects the value.
+    # Restricted to *string* literals on purpose — a quoted bool/number is the
+    # classic mistake (``$XONSH_STORE_STDOUT = 'yes'``), while bare ``0``/``1``
+    # ints stay unflagged so we don't fight users who spell bools that way.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        val = node.value
+        if not (isinstance(val, ast.Constant) and isinstance(val.value, str)):
+            continue
+        for tgt in node.targets:
+            name = _env_var_name(tgt)
+            if name is None or name not in dv:
+                continue
+            validate = getattr(dv[name], "validate", None)
+            if validate is None:
+                continue
+            try:
+                ok = bool(validate(val.value))
+            except Exception:
+                # Inconclusive — stay silent rather than risk a false positive.
+                ok = True
+            if not ok:
+                line, col = _pos(tgt)
+                out.append(
+                    Finding(
+                        line,
+                        col,
+                        "XSH002",
+                        f"invalid value {val.value!r} for ${name} "
+                        f"(failed {getattr(validate, '__name__', 'validation')})",
+                    )
+                )
+    return out
+
+
+def _dunder_all_names(tree) -> set[str]:
+    """Names listed in a module-level ``__all__`` count as 'used'."""
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets
+        ):
+            if isinstance(node.value, (ast.List, ast.Tuple)):
+                for elt in node.value.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        out.add(elt.value)
+    return out
+
+
+def check_unused_imports(tree) -> list[Finding]:
+    """XSH101 — an imported name that is never loaded anywhere in the module."""
+    imports = []  # (bound_name, lineno, col, label)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                bound = a.asname or a.name.partition(".")[0]
+                label = f"{a.name} as {a.asname}" if a.asname else a.name
+                imports.append((bound, *_pos(node), label))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "__future__":
+                continue  # __future__ imports are directives, never "used"
+            mod = node.module or ""
+            for a in node.names:
+                if a.name == "*":
+                    continue  # star imports bind unknown names — can't track
+                bound = a.asname or a.name
+                label = f"{mod}.{a.name}" if mod else a.name
+                if a.asname:
+                    label += f" as {a.asname}"
+                imports.append((bound, *_pos(node), label))
+    if not imports:
+        return []
+
+    used = {
+        n.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+    }
+    used |= _dunder_all_names(tree)
+
+    return [
+        Finding(line, col, "XSH101", f"{label!r} imported but unused")
+        for bound, line, col, label in imports
+        if bound not in used
+    ]
+
+
+#: All rules run by :func:`xonsh.linter.cli.lint_source`, in order.
+ALL_RULES = (check_env_vars, check_unused_imports)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -770,6 +770,8 @@ def parser():
             "Run `xonsh format --help` for options.\n"
             "  check           Check xonsh source files for syntax errors "
             "without running them. Run `xonsh check --help` for options.\n"
+            "  lint            Lint xonsh source files for likely mistakes. "
+            "Run `xonsh lint --help` for options.\n"
         ),
     )
     p.add_argument(
@@ -1203,6 +1205,11 @@ def main(argv=None):
         from xonsh.checker.cli import main as check_main
 
         sys.exit(check_main(argv[1:]))
+
+    if argv and argv[0] == "lint":
+        from xonsh.linter.cli import main as lint_main
+
+        sys.exit(lint_main(argv[1:]))
 
     # Run the TTY startup handshake *before* premain so that xontrib
     # loading and xonshrc execution happen with xonsh already as the


### PR DESCRIPTION
First version of Xonsh linter.

```
  ┌────────┬──────────────────────────┬─────────────────────────────────────────────────────────┐
  │  Code  │           Name           │                       Description                       │
  ├────────┼──────────────────────────┼─────────────────────────────────────────────────────────┤
  │        │ Unknown environment      │ A $VAR whose name is not a registered xonsh variable    │
  │ XSH001 │ variable                 │ but is a close match for one — i.e. a likely typo.      │
  │        │                          │ Custom/OS variables (no close match) are not flagged.   │
  ├────────┼──────────────────────────┼─────────────────────────────────────────────────────────┤
  │        │ Invalid                  │ A string literal assigned to a known $VAR whose         │
  │ XSH002 │ environment-variable     │ registered validator rejects it (e.g. a quoted          │
  │        │ value                    │ bool/number where a typed value is expected).           │
  ├────────┼──────────────────────────┼─────────────────────────────────────────────────────────┤
  │ XSH003 │ Deprecated environment   │ Use (read or write) of an environment variable marked   │
  │        │ variable                 │ deprecated in xonsh's registry.                         │
  ├────────┼──────────────────────────┼─────────────────────────────────────────────────────────┤
  │ XSH101 │ Unused import            │ An imported name that is never used anywhere in the     │
  │        │                          │ file (pyflakes' F401).                                  │
  └────────┴──────────────────────────┴─────────────────────────────────────────────────────────┘

```
Examples:

```xsh
# XSH001 — unknown environment variable $XONSH_HISTROY_BACKEND; did you mean
$XONSH_HISTRY_BACKEND?
$XONSH_HISTROY_BACKEND = "json"

# XSH002 — invalid value 'yes' for $XONSH_STORE_STDOUT (failed is_bool)
$XONSH_STORE_STDOUT = "yes"        # should be True

# XSH003 — environment variable $RAISE_SUBPROC_ERROR is deprecated
$RAISE_SUBPROC_ERROR = True

# XSH101 — 'os' imported but unused
import os

```

Closes https://github.com/xonsh/xonsh/issues/2420

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
