### PR TITLE
fix: Support ANSI sequences in `repr`

### DIFF
--- a/tests/test_main_llm.py
+++ b/tests/test_main_llm.py
@@ -1,0 +1,92 @@
+"""LLM-authored tests for :mod:`xonsh.main`.
+
+Module-mirroring home for generated tests of ``xonsh/main.py``. Each test
+documents the specific behavior it pins down in its own docstring.
+"""
+
+import builtins
+
+import pytest
+
+import xonsh.main
+from xonsh.platform import HAS_PYGMENTS
+
+
+@pytest.fixture
+def restore_underscore():
+    """``_pprint_displayhook`` writes the value to ``builtins._``.
+
+    Snapshot and restore it so the displayed value does not leak into other
+    tests through the ``_`` builtin.
+    """
+    sentinel = object()
+    prev = getattr(builtins, "_", sentinel)
+    yield
+    if prev is sentinel:
+        if hasattr(builtins, "_"):
+            del builtins._
+    else:
+        builtins._ = prev
+
+
+class _AnsiRepr:
+    """Helper whose repr is colored with raw ANSI escape sequences."""
+
+    def __repr__(self):
+        return "\x1b[31mhello\x1b[0m"
+
+
+def test_displayhook_passes_ansi_repr_through_verbatim(
+    xession, capsys, mocker, restore_underscore
+):
+    """An ANSI-colored repr is shown verbatim, not re-highlighted (gh-6503).
+
+    When ``__repr__`` already emits terminal escapes, re-lexing the string as
+    xonsh source splits the escapes into separate tokens and prompt_toolkit then
+    sanitizes the raw ESC bytes, so the color never renders. The displayhook must
+    instead pass it straight through, like CPython's default ``sys.displayhook``.
+    """
+    print_color = mocker.patch("xonsh.main.print_color")
+    xession.env["COLOR_RESULTS"] = True
+    xession.env["PRETTY_PRINT_RESULTS"] = True
+
+    xonsh.main._pprint_displayhook(_AnsiRepr())
+
+    out, _ = capsys.readouterr()
+    # The escape sequence survives byte-for-byte (matching print(repr(foo))) ...
+    assert out == "\x1b[31mhello\x1b[0m\n"
+    # ... and the pygments + prompt_toolkit highlighting path was skipped.
+    print_color.assert_not_called()
+
+
+def test_displayhook_passes_ansi_repr_with_pretty_print_off(
+    xession, capsys, mocker, restore_underscore
+):
+    """Passthrough also applies when PRETTY_PRINT_RESULTS falls back to repr()."""
+    print_color = mocker.patch("xonsh.main.print_color")
+    xession.env["COLOR_RESULTS"] = True
+    xession.env["PRETTY_PRINT_RESULTS"] = False
+
+    xonsh.main._pprint_displayhook(_AnsiRepr())
+
+    out, _ = capsys.readouterr()
+    assert out == "\x1b[31mhello\x1b[0m\n"
+    print_color.assert_not_called()
+
+
+@pytest.mark.skipif(not HAS_PYGMENTS, reason="pygments not installed")
+def test_displayhook_highlights_plain_repr(xession, capsys, mocker, restore_underscore):
+    """A normal repr (no embedded escapes) still goes through highlighting."""
+    print_color = mocker.patch("xonsh.main.print_color")
+    xession.env["COLOR_RESULTS"] = True
+    xession.env["PRETTY_PRINT_RESULTS"] = True
+
+    xonsh.main._pprint_displayhook([1, 2, 3])
+
+    # Highlighting path taken: print_color receives the lexed tokens ...
+    print_color.assert_called_once()
+    tokens = print_color.call_args.args[0]
+    assert "".join(text for _, text in tokens).rstrip("\n") == "[1, 2, 3]"
+    # ... and nothing was emitted through the raw print branch.
+    out, _ = capsys.readouterr()
+    assert out == ""

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -969,12 +969,17 @@ def _pprint_displayhook(value):
     if not isinstance(printed_val, str):
         # pretty may fail (i.e for unittest.mock.Mock)
         printed_val = repr(value)
-    if HAS_PYGMENTS and env.get("COLOR_RESULTS"):
+    # A repr that already carries its own terminal escapes (e.g. a __repr__
+    # that emits ANSI colors) must not be re-highlighted: the lexer would
+    # split the escapes into separate tokens and the raw ESC bytes would be
+    # mangled when re-colored, so pass it through raw like CPython's default
+    # displayhook does. See https://github.com/xonsh/xonsh/issues/6503.
+    if HAS_PYGMENTS and env.get("COLOR_RESULTS") and "\x1b" not in printed_val:
         tokens = list(pygments.lex(printed_val, lexer=pyghooks.XonshLexer()))
         end = "" if env.get("SHELL_TYPE") == "prompt_toolkit" else "\n"
         print_color(tokens, end=end)
     else:
-        print(printed_val)  # black & white case
+        print(printed_val)  # black & white case, or an already-colored repr
     builtins._ = value
 
 


### PR DESCRIPTION
Fixes #6503

Test:
```xsh
class Foo:
    def __repr__(self):
        return '\x1b[31mhello\x1b[0m'

Foo()
# hello (red)
print(repr(Foo()))
# hello (red)
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
