### PR TITLE
fix!: Procs: Run scripts without shebang using `sh`

### DIFF
--- a/tests/aliases/test_xexec.py
+++ b/tests/aliases/test_xexec.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from xonsh.aliases import xexec
+from xonsh.pytest.tools import skip_if_on_windows
 
 
 @pytest.fixture(autouse=True)
@@ -150,7 +151,7 @@ def test_exec_script_shebang_fallback(monkeypatch, tmp_path):
 
 
 def test_exec_script_no_shebang_defaults_to_xonsh(monkeypatch, tmp_path):
-    """exec on a script without shebang should default to xonsh."""
+    """exec on a .xsh script without shebang should default to xonsh."""
     calls = []
 
     def mocked_execvpe(command, args, env):
@@ -169,6 +170,29 @@ def test_exec_script_no_shebang_defaults_to_xonsh(monkeypatch, tmp_path):
     assert len(calls) == 1
     # Must not try to execute the script directly again
     assert calls[0]["command"] != str(script)
+
+
+@skip_if_on_windows
+def test_exec_script_no_shebang_sh_fallback(monkeypatch, tmp_path):
+    """exec on a shebang-less non-xonsh script should fall back to sh (#5843)."""
+    calls = []
+
+    def mocked_execvpe(command, args, env):
+        if command.endswith("test.sh"):
+            raise OSError(8, "Exec format error")
+        calls.append({"command": command, "args": args})
+
+    monkeypatch.setattr(os, "execvpe", mocked_execvpe)
+
+    script = tmp_path / "test.sh"
+    script.write_text('echo "$@"\n')
+    script.chmod(0o755)
+
+    xexec([str(script)])
+
+    assert len(calls) == 1
+    assert calls[0]["command"] == "/bin/sh"
+    assert calls[0]["args"][:2] == ["/bin/sh", str(script)]
 
 
 def test_exec_nonexistent_file(monkeypatch):

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1,4 +1,5 @@
 import builtins
+import os
 from unittest.mock import mock_open
 
 import pytest
@@ -30,6 +31,59 @@ def test_path_default_non_empty_on_supported_platforms():
     if not (xp.ON_LINUX or xp.ON_DARWIN or xp.ON_BSD or xp.ON_WINDOWS):
         pytest.skip("PATH_DEFAULT is intentionally empty on this platform")
     assert tuple(xp.PATH_DEFAULT)
+
+
+def test_path_bshell_posix_default(monkeypatch):
+    monkeypatch.setattr(xp, "ON_TERMUX", False)
+    monkeypatch.setattr(xp, "ON_ANDROID", False)
+    monkeypatch.setattr(os, "access", lambda p, m: p == "/bin/sh")
+    assert xp.path_bshell() == "/bin/sh"
+
+
+def test_path_bshell_termux(monkeypatch, tmp_path):
+    sh = tmp_path / "usr" / "bin" / "sh"
+    sh.parent.mkdir(parents=True)
+    sh.touch()
+    sh.chmod(0o755)
+    monkeypatch.setattr(xp, "ON_TERMUX", True)
+    monkeypatch.setattr(xp, "ON_ANDROID", True)
+    monkeypatch.setenv("PREFIX", str(tmp_path / "usr"))
+    assert xp.path_bshell() == str(sh)
+
+
+def test_path_bshell_android_stock(monkeypatch):
+    monkeypatch.setattr(xp, "ON_TERMUX", False)
+    monkeypatch.setattr(xp, "ON_ANDROID", True)
+    monkeypatch.setattr(os, "access", lambda p, m: p == "/system/bin/sh")
+    assert xp.path_bshell() == "/system/bin/sh"
+
+
+def test_path_bshell_android_proot_prefers_fhs(monkeypatch):
+    # FHS userland on top of Android (proot-distro, UserLAnd, ...): its
+    # own /bin/sh wins over the bionic /system/bin/sh.
+    monkeypatch.setattr(xp, "ON_TERMUX", False)
+    monkeypatch.setattr(xp, "ON_ANDROID", True)
+    monkeypatch.setattr(os, "access", lambda p, m: p in ("/bin/sh", "/system/bin/sh"))
+    assert xp.path_bshell() == "/bin/sh"
+
+
+def test_path_bshell_path_fallback(monkeypatch):
+    # No candidate exists: fall back to ``sh`` from $PATH.
+    monkeypatch.setattr(xp, "ON_TERMUX", False)
+    monkeypatch.setattr(xp, "ON_ANDROID", False)
+    monkeypatch.setattr(os, "access", lambda p, m: False)
+    monkeypatch.setattr(
+        xp.shutil, "which", lambda cmd: "/opt/bin/sh" if cmd == "sh" else None
+    )
+    assert xp.path_bshell() == "/opt/bin/sh"
+
+
+def test_path_bshell_last_resort(monkeypatch):
+    monkeypatch.setattr(xp, "ON_TERMUX", False)
+    monkeypatch.setattr(xp, "ON_ANDROID", False)
+    monkeypatch.setattr(os, "access", lambda p, m: False)
+    monkeypatch.setattr(xp.shutil, "which", lambda cmd: None)
+    assert xp.path_bshell() == "/bin/sh"
 
 
 def test_path_default_freebsd_covers_system_and_ports():

--- a/tests/procs/test_specs.py
+++ b/tests/procs/test_specs.py
@@ -1085,7 +1085,9 @@ def test_auto_cd(xession, tmpdir):
 @pytest.mark.parametrize(
     "inp,exp",
     [
-        ["echo command", ["xonsh", "{file}", "--arg", "1"]],
+        # No shebang: POSIX convention — run with sh (#5843).
+        ["echo command", ["/bin/sh", "{file}", "--arg", "1"]],
+        ["#!", ["/bin/sh", "{file}", "--arg", "1"]],
         ["#!/bin/bash", ["/bin/bash", "{file}", "--arg", "1"]],
         ["#!/bin/bash\necho 1", ["/bin/bash", "{file}", "--arg", "1"]],
         ["#!/bin/bash\n\necho 1", ["/bin/bash", "{file}", "--arg", "1"]],
@@ -1104,6 +1106,17 @@ def test_get_script_subproc_command_shebang(tmpdir, inp, exp):
     file.chmod(0o755)
     cmd = get_script_subproc_command(file_str, ["--arg", "1"])
     assert [c if c != file_str else "{file}" for c in cmd] == exp
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize("ext", [".xsh", ".py", ".pyw"])
+def test_get_script_subproc_command_no_shebang_xonsh_exts(tmpdir, ext):
+    """Shebang-less xonsh/Python scripts run with the current xonsh."""
+    file = tmpdir / f"script{ext}"
+    file.write_text("echo command", encoding="utf-8")
+    file.chmod(0o755)
+    cmd = get_script_subproc_command(str(file), ["--arg", "1"])
+    assert cmd == [sys.executable, "-m", "xonsh", str(file), "--arg", "1"]
 
 
 def test_redirect_without_left_part(tmpdir):

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -10,6 +10,7 @@ import importlib.util
 import os
 import pathlib
 import platform
+import shutil
 import signal
 import subprocess
 import sys
@@ -116,6 +117,31 @@ IN_FLATPAK = LazyBool(
     "IN_FLATPAK",
 )
 """``True`` if in Flastpak, else ``False``."""
+
+
+def path_bshell():
+    """Absolute path to the system Bourne shell, like libc ``_PATH_BSHELL``.
+
+    ``/bin/sh`` everywhere except Android: Termux ships ``sh`` under
+    ``$PREFIX/bin`` and stock Android under ``/system/bin`` (bionic's
+    ``_PATH_BSHELL``); plain ``/bin/sh`` may not exist on either.
+    Candidates are checked for existence, so FHS userlands running on top
+    of Android (proot-distro, UserLAnd, ...) keep their own ``/bin/sh``.
+    NixOS needs no special casing — ``/bin/sh`` is its single ``/bin``
+    FHS concession. If no candidate exists, fall back to ``sh`` from
+    ``$PATH`` (POSIX mandates the *utility*, not a fixed path).
+    """
+    candidates = []
+    if ON_TERMUX:
+        prefix = os.environ.get("PREFIX", "/data/data/com.termux/files/usr")
+        candidates.append(os.path.join(prefix, "bin", "sh"))
+    candidates.append("/bin/sh")
+    if ON_ANDROID:
+        candidates.append("/system/bin/sh")
+    for sh in candidates:
+        if os.access(sh, os.X_OK):
+            return sh
+    return shutil.which("sh") or "/bin/sh"
 
 
 @lazybool

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -160,18 +160,27 @@ def get_script_subproc_command(fname, args):
             return o + [fname] + args
         # 5) Unknown file type — no recognised extension, no shebang
         return None
-    # --- POSIX path (unchanged) ---
+    # --- POSIX path ---
     shebang = parse_shebang_from_file(fname)
     m = RE_SHEBANG.match(shebang)
-    # xonsh is the default interpreter
-    if m is None:
-        interp = ["xonsh"]
-    else:
-        interp = m.group(1).strip()
-        if len(interp) > 0:
-            interp = shlex.split(interp)
-        else:
+    interp = shlex.split(m.group(1).strip()) if m is not None else []
+    if not interp:
+        # No shebang (or an empty one).
+        _, ext = os.path.splitext(fname)
+        if ext.lower() in {".xsh", ".py", ".pyw"}:
+            # xonsh/Python scripts run with the current xonsh interpreter,
+            # mirroring the Windows branch above.
             interp = ["xonsh"]
+        else:
+            # Any other text file follows the POSIX ENOEXEC convention used
+            # by bash, zsh, dash, ksh, fish and tcsh alike: an executable
+            # text file without a shebang is run as a ``sh`` script
+            # (https://github.com/xonsh/xonsh/issues/5843).
+            interp = ["/bin/sh"]
+    if interp[:1] == ["xonsh"]:
+        # Run with the current xonsh rather than whatever ``xonsh`` happens
+        # to be first on $PATH (which may belong to a different Python).
+        interp = [sys.executable, "-m", "xonsh"] + interp[1:]
     return interp + [fname] + args
 
 

--- a/xonsh/procs/specs.py
+++ b/xonsh/procs/specs.py
@@ -176,7 +176,7 @@ def get_script_subproc_command(fname, args):
             # by bash, zsh, dash, ksh, fish and tcsh alike: an executable
             # text file without a shebang is run as a ``sh`` script
             # (https://github.com/xonsh/xonsh/issues/5843).
-            interp = ["/bin/sh"]
+            interp = [xp.path_bshell()]
     if interp[:1] == ["xonsh"]:
         # Run with the current xonsh rather than whatever ``xonsh`` happens
         # to be first on $PATH (which may belong to a different Python).


### PR DESCRIPTION
### Motivation

Closes https://github.com/xonsh/xonsh/issues/5843

After research we see that most of the shells interpret scripts without shebang as `/bin/sh`.

### Normative and supporting documents

#### Normative (POSIX)

- **POSIX.1-2017, XCU §2.9.1 "Command Search and Execution"** — <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_01_01>
  When `execve()` fails with `[ENOEXEC]`, the shell *"shall execute a command equivalent to having a shell invoked with the pathname resulting from the search as its first operand"* — i.e. run the file as an `sh` script. This is the requirement for shells.

- **POSIX.1-2017, XSH `exec` family** — <https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html>
  Where other `exec*` functions must fail with `[ENOEXEC]`, `execlp()`/`execvp()` must instead execute the file *as if the process invoked the `sh` utility*. This is the requirement for libc — the path through which nushell inherits the behavior.

  Note: POSIX literally mandates "the `sh` utility", not the path `/bin/sh` (it does not even guarantee `sh` lives in `/bin`). `/bin/sh` (`_PATH_BSHELL`) is how every practical implementation realizes it.

#### Shell manuals (how each shell documents its ENOEXEC fallback)

- **bash Reference Manual, §3.7.2 "Command Search and Execution"** — <https://www.gnu.org/software/bash/manual/html_node/Command-Search-and-Execution.html>
  *"If that function is not defined ... the file is assumed to be a shell script"* — bash executes it in a forked copy of **itself** (bash ⊃ sh, so this satisfies POSIX).

- **zsh manual, zshmisc "COMMAND EXECUTION"** — <https://zsh.sourceforge.io/Doc/Release/Command-Execution.html>
  *"If execution fails because the file is not in executable format, and the file is not a directory, it is assumed to be a shell script. `/bin/sh` is spawned to execute it."*

- **Linux man-pages, `exec(3)`** — <https://man7.org/linux/man-pages/man3/exec.3.html>
  Documents the libc side on Linux: if `execve(2)` fails with `ENOEXEC`, `execlp()`/`execvp()`/`execvpe()` *"execute the shell (`/bin/sh`) with the path of the file as its first argument"*.

## Implementation sources (verified behavior, not formal docs)

- **dash, `src/exec.c` (`tryexec`)** — <https://git.kernel.org/pub/scm/utils/dash/dash.git/tree/src/exec.c>
  On `ENOEXEC`, retries the file with `_PATH_BSHELL` (`/bin/sh`).

- **glibc, `sysdeps/unix/sysv/linux/spawni.c` + `posix/execvp.c` (`maybe_script_execute`)** — <https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/spawni.c>
  Both `execvp()` and `posix_spawnp()` fall back to `/bin/sh` on `ENOEXEC`. This is why nushell (Rust `std::process::Command`) runs shebang-less scripts as sh on glibc systems despite having no fallback code of its own.

- **Apple Libc, `gen/FreeBSD/exec.c`** — <https://github.com/apple-oss-distributions/Libc>
  macOS `execvp()`/`posix_spawnp()` retry with `_PATH_BSHELL`, preserving the caller's `argv[0]` (the source of the doubled-script-path `ps` signature observed in testing).

- **musl libc, `src/process/execvp.c`** — <https://git.musl-libc.org/cgit/musl/tree/src/process/execvp.c>
  Deliberately implements **no** `ENOEXEC` fallback — counter-example: programs relying on libc (e.g. nushell on Alpine) get a bare `Exec format error`. Shells that implement the fallback themselves (bash, zsh, dash, fish) are unaffected, which is the argument for xonsh doing it explicitly in `get_script_subproc_command` rather than relying on the spawn layer.

- **fish** — no documentation of the fallback; behavior verified empirically (shebang-less file runs via `/bin/sh`, `ps` shows `/bin/sh ./script`). Relevant precedent: fish is, like xonsh, a non-POSIX-syntax shell and still delegates to `/bin/sh`.


### Other shells

| Shell | Result | Who actually interprets the file | Mechanism |
|---|---|---|---|
| bash | ✅ `hello world` | bash itself (fork, no exec; bash ⊃ sh) | own ENOEXEC fallback in the shell |
| ksh93 | ✅ `hello world` | ksh itself (re-exec, argv[0] = script; ksh ⊃ sh) | own ENOEXEC fallback in the shell |
| zsh | ✅ `hello world` | spawns `sh` | own ENOEXEC fallback in the shell |
| dash | ✅ `hello world` | `/bin/sh` | own ENOEXEC fallback (`tryexec` → `_PATH_BSHELL`) |
| fish | ✅ `hello world` | `/bin/sh` | own ENOEXEC fallback in the shell |
| tcsh | ✅ `hello world` | `/bin/sh` | own ENOEXEC fallback in the shell |
| nushell | ✅ `hello world` | `/bin/sh` | **inherited from libc**, not nushell code: Apple libc / glibc retry `posix_spawnp`/`execvp` with `/bin/sh` on ENOEXEC. Breaks on musl (Alpine): bare `Exec format error` |

### Before

```xsh
cd /tmp
echo 'echo @(2+2)' > qwe && chmod +x qwe
cp qwe qwe.xsh
./qwe
# Run in xonsh 🔴 
./qwe.xsh
# Run in xonsh 🟢 
```

### After

```xsh
./qwe
# Run in sh 🟢  
./qwe.xsh
# Run in xonsh 🟢 
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
