### PR TITLE
test: Fix test_bash_completion_paths in case of bash built without readline in Nix

### DIFF
--- a/tests/completers/test_bash_completion_paths_llm.py
+++ b/tests/completers/test_bash_completion_paths_llm.py
@@ -18,6 +18,7 @@ again.
 import os
 import pathlib
 import shutil
+import subprocess
 
 import pytest
 
@@ -78,6 +79,12 @@ def test_bash_completions_executes_user_dir_scripts(tmp_path):
     command = bc_mod._bash_command()
     if shutil.which(command) is None:
         pytest.skip("bash not found on PATH")
+    if subprocess.run([command, "-c", "complete -p"], capture_output=True).returncode:
+        # Bash built without readline (e.g. the stdenv bash in the Nix
+        # build sandbox) has programmable completion compiled out — the
+        # ``complete`` builtin does not exist, so the bridge can only
+        # ever return an empty set. Nothing to test against.
+        pytest.skip("bash lacks programmable completion")
 
     framework = tmp_path / "bash_completion"
     user_dir = tmp_path / ".bash_completions"


### PR DESCRIPTION
<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
