### PR TITLE
Include commit authors in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": false,
+  "include-commit-authors": true,
   "release-search-depth": 10,
   "commit-search-depth": 2000,
   "packages": {


### PR DESCRIPTION
## Summary

- enable release-please to include commit authors in generated release note entries
- keep the existing tag, package, and changelog configuration unchanged

## Why

The project already tracks release notes through release-please. Including commit authors gives contributors visible credit in generated changelog entries.

## Validation

- `python -m json.tool release-please-config.json`
- `git diff --check`
