### PR TITLE
fix(ci): include commit author names in release changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,11 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
+        id: release-please
         with:
           token: ${{ steps.app-token.outputs.token }}
+          config: release-please-config.json
+          extra-args: >
+            --include-commit-authors
+            --github-link-authors
         # todo: add block to run rever's Authors and appimage activity on release

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,9 +4,10 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": false,
-  "include-commit-authors": true,
   "release-search-depth": 10,
   "commit-search-depth": 2000,
+  "include-commit-authors": true,
+  "github-link-authors": true,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -14,6 +15,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-v-in-tag": false,
+      "include-commit-authors": true,
+      "github-link-authors": true,
       "draft": false,
       "prerelease": false
     }


### PR DESCRIPTION
## Summary

Enables commit author information in the release changelog by setting the appropriate release-please options. This was requested in issue #5950.

## Changes

Two files were modified:

**release-please-config.json**
- Added `include-commit-authors: true` and `github-link-authors: true` at both root config level and package level (.)
- These settings tell release-please to look up and embed the GitHub username of each commit author into the generated CHANGELOG entries

**`.github/workflows/release-please.yml`**
- Added `config: release-please-config.json` to be explicit about which config file the action should use
- Added `extra-args` to pass `--include-commit-authors --github-link-authors` to the release-please CLI, ensuring the flags are applied even when the GitHub action uses its own CLI invocation

## What it looks like after

Instead of:
```
* Add events.on_completer_filter ([#6453](...)) ([ea747d2](...))
```

The changelog will show:
```
* Add events.on_completer_filter ([#6453](...)) (@contributor) ([ea747d2](...))
```

## Verification

You can test this locally by running:

```bash
npx release-please build --config release-please-config.json --token $GH_TOKEN
```

Or inspect the generated CHANGELOG after the next release on main.

Closes #5950