### PR TITLE
fix: Completer: Fix `sometool --arg=path/<Tab>` completion

### DIFF
--- a/tests/completers/test_path_llm.py
+++ b/tests/completers/test_path_llm.py
@@ -64,75 +64,70 @@ def test_option_value_completes_path_after_equals(
         assert all(a.startswith(f"app {opt}={td}{os.sep}") for a in applied)
 
 
-def test_option_value_empty_lists_cwd(path_env, completion_context_parse, monkeypatch):
+# The cwd-relative tests below use the ``tmp_path`` fixture rather than
+# ``tempfile.TemporaryDirectory``: they ``chdir`` into the directory, and on
+# Windows a directory can't be removed while it is the current working
+# directory.  ``TemporaryDirectory`` rmtree's on ``with`` exit — before
+# ``monkeypatch`` restores the cwd — raising ``WinError 32``.  pytest cleans
+# ``tmp_path`` lazily, after the cwd has been restored.
+def test_option_value_empty_lists_cwd(
+    path_env, completion_context_parse, tmp_path, monkeypatch
+):
     """``app --out=<TAB>`` (empty value) lists the current directory."""
-    with tempfile.TemporaryDirectory() as td:
-        os.makedirs(os.path.join(td, "subdir"))
-        open(os.path.join(td, "afile"), "w").close()
-        monkeypatch.chdir(td)
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "afile").touch()
+    monkeypatch.chdir(tmp_path)
 
-        line = "app --out="
-        applied = _apply(
-            line, xcp.complete_path(completion_context_parse(line, len(line)))
-        )
+    line = "app --out="
+    applied = _apply(line, xcp.complete_path(completion_context_parse(line, len(line))))
 
-        assert f"app --out=subdir{os.sep}" in applied
-        assert "app --out=afile" in applied
+    assert f"app --out=subdir{os.sep}" in applied
+    assert "app --out=afile" in applied
 
 
 def test_real_dir_containing_equals_is_not_split(
-    path_env, completion_context_parse, monkeypatch
+    path_env, completion_context_parse, tmp_path, monkeypatch
 ):
     """A real directory named ``qwe=asd`` is completed whole, not split.
 
     ``app qwe=asd/<TAB>`` must list the contents of ``qwe=asd/`` rather than
     treating ``qwe=`` as an option and completing ``asd/`` in the cwd.
     """
-    with tempfile.TemporaryDirectory() as td:
-        os.makedirs(os.path.join(td, "qwe=asd", "inside1"))
-        os.makedirs(os.path.join(td, "qwe=asd", "inside2"))
-        monkeypatch.chdir(td)
+    (tmp_path / "qwe=asd" / "inside1").mkdir(parents=True)
+    (tmp_path / "qwe=asd" / "inside2").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
 
-        # complete inside the real 'qwe=asd' directory
-        line = "app qwe=asd/"
-        applied = _apply(
-            line, xcp.complete_path(completion_context_parse(line, len(line)))
-        )
-        assert applied == [
-            f"app qwe=asd{os.sep}inside1{os.sep}",
-            f"app qwe=asd{os.sep}inside2{os.sep}",
-        ]
+    # complete inside the real 'qwe=asd' directory
+    line = "app qwe=asd/"
+    applied = _apply(line, xcp.complete_path(completion_context_parse(line, len(line))))
+    assert applied == [
+        f"app qwe=asd{os.sep}inside1{os.sep}",
+        f"app qwe=asd{os.sep}inside2{os.sep}",
+    ]
 
-        # partial inside the directory
-        line = "app qwe=asd/in"
-        applied = _apply(
-            line, xcp.complete_path(completion_context_parse(line, len(line)))
-        )
-        assert f"app qwe=asd{os.sep}inside1{os.sep}" in applied
-        assert f"app qwe=asd{os.sep}inside2{os.sep}" in applied
+    # partial inside the directory
+    line = "app qwe=asd/in"
+    applied = _apply(line, xcp.complete_path(completion_context_parse(line, len(line))))
+    assert f"app qwe=asd{os.sep}inside1{os.sep}" in applied
+    assert f"app qwe=asd{os.sep}inside2{os.sep}" in applied
 
-        # partial of the directory name itself (still contains '=')
-        line = "app qwe=as"
-        applied = _apply(
-            line, xcp.complete_path(completion_context_parse(line, len(line)))
-        )
-        assert f"app qwe=asd{os.sep}" in applied
+    # partial of the directory name itself (still contains '=')
+    line = "app qwe=as"
+    applied = _apply(line, xcp.complete_path(completion_context_parse(line, len(line))))
+    assert f"app qwe=asd{os.sep}" in applied
 
 
 def test_real_file_containing_equals_is_not_split(
-    path_env, completion_context_parse, monkeypatch
+    path_env, completion_context_parse, tmp_path, monkeypatch
 ):
     """A real file named ``qwe=asd`` completes whole from a partial name."""
-    with tempfile.TemporaryDirectory() as td:
-        open(os.path.join(td, "qwe=asd"), "w").close()
-        monkeypatch.chdir(td)
+    (tmp_path / "qwe=asd").touch()
+    monkeypatch.chdir(tmp_path)
 
-        line = "app qwe=as"
-        applied = _apply(
-            line, xcp.complete_path(completion_context_parse(line, len(line)))
-        )
-        # completes the literal 'qwe=asd' name, not a split 'as'
-        assert any(a.startswith("app qwe=asd") for a in applied)
+    line = "app qwe=as"
+    applied = _apply(line, xcp.complete_path(completion_context_parse(line, len(line))))
+    # completes the literal 'qwe=asd' name, not a split 'as'
+    assert any(a.startswith("app qwe=asd") for a in applied)
 
 
 def test_plain_path_completion_unaffected(path_env, completion_context_parse):

--- a/tests/completers/test_path_llm.py
+++ b/tests/completers/test_path_llm.py
@@ -1,0 +1,147 @@
+"""Tests for ``option=value`` path completion in ``xonsh/completers/path.py``.
+
+When an argument looks like ``--opt=/some/path`` or ``var=/some/path`` the
+path completer should complete only the value after the first ``=`` while
+preserving the ``opt=`` part.  A real filesystem path that itself contains
+``=`` (a file/dir literally named ``qwe=asd``) must still be completed as a
+whole and never split.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import xonsh.completers.path as xcp
+
+
+@pytest.fixture(autouse=True)
+def xonsh_execer_autouse(xession, xonsh_execer):
+    return xonsh_execer
+
+
+@pytest.fixture
+def path_env(xession):
+    xession.env = {
+        "GLOB_SORTED": True,
+        "SUBSEQUENCE_PATH_COMPLETION": False,
+        "FUZZY_PATH_COMPLETION": False,
+        "SUGGEST_THRESHOLD": 3,
+        "CDPATH": set(),
+    }
+    return xession.env
+
+
+def _apply(line, result):
+    """Apply each completion the way the shell does (replace the last
+    ``lprefix`` chars of ``line`` with the completion) and return the lines.
+    """
+    comps, lprefix = result
+    return sorted(line[: len(line) - lprefix] + str(c).rstrip() for c in comps)
+
+
+@pytest.mark.parametrize(
+    "opt",
+    ["--some-dash-path", "-opt-dash-opt", "if", "--out"],
+    ids=["double-dash", "single-dash", "no-dash", "short-opt"],
+)
+def test_option_value_completes_path_after_equals(
+    opt, path_env, completion_context_parse
+):
+    """``app <opt>=/dir/<TAB>`` completes the path, keeping ``<opt>=``."""
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "alpha"))
+        os.makedirs(os.path.join(td, "beta"))
+
+        line = f"app {opt}={td}{os.sep}al"
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+
+        # the directory after '=' is completed ...
+        assert applied == [f"app {opt}={td}{os.sep}alpha{os.sep}"]
+        # ... and the 'opt=' part is preserved (lprefix covers only the value)
+        assert all(a.startswith(f"app {opt}={td}{os.sep}") for a in applied)
+
+
+def test_option_value_empty_lists_cwd(path_env, completion_context_parse, monkeypatch):
+    """``app --out=<TAB>`` (empty value) lists the current directory."""
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "subdir"))
+        open(os.path.join(td, "afile"), "w").close()
+        monkeypatch.chdir(td)
+
+        line = "app --out="
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+
+        assert f"app --out=subdir{os.sep}" in applied
+        assert "app --out=afile" in applied
+
+
+def test_real_dir_containing_equals_is_not_split(
+    path_env, completion_context_parse, monkeypatch
+):
+    """A real directory named ``qwe=asd`` is completed whole, not split.
+
+    ``app qwe=asd/<TAB>`` must list the contents of ``qwe=asd/`` rather than
+    treating ``qwe=`` as an option and completing ``asd/`` in the cwd.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "qwe=asd", "inside1"))
+        os.makedirs(os.path.join(td, "qwe=asd", "inside2"))
+        monkeypatch.chdir(td)
+
+        # complete inside the real 'qwe=asd' directory
+        line = "app qwe=asd/"
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+        assert applied == [
+            f"app qwe=asd{os.sep}inside1{os.sep}",
+            f"app qwe=asd{os.sep}inside2{os.sep}",
+        ]
+
+        # partial inside the directory
+        line = "app qwe=asd/in"
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+        assert f"app qwe=asd{os.sep}inside1{os.sep}" in applied
+        assert f"app qwe=asd{os.sep}inside2{os.sep}" in applied
+
+        # partial of the directory name itself (still contains '=')
+        line = "app qwe=as"
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+        assert f"app qwe=asd{os.sep}" in applied
+
+
+def test_real_file_containing_equals_is_not_split(
+    path_env, completion_context_parse, monkeypatch
+):
+    """A real file named ``qwe=asd`` completes whole from a partial name."""
+    with tempfile.TemporaryDirectory() as td:
+        open(os.path.join(td, "qwe=asd"), "w").close()
+        monkeypatch.chdir(td)
+
+        line = "app qwe=as"
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+        # completes the literal 'qwe=asd' name, not a split 'as'
+        assert any(a.startswith("app qwe=asd") for a in applied)
+
+
+def test_plain_path_completion_unaffected(path_env, completion_context_parse):
+    """A normal path argument (no ``=``) is unchanged by the new logic."""
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "alpha"))
+
+        line = f"app {td}{os.sep}al"
+        applied = _apply(
+            line, xcp.complete_path(completion_context_parse(line, len(line)))
+        )
+        assert applied == [f"app {td}{os.sep}alpha{os.sep}"]

--- a/tests/completers/test_python_llm.py
+++ b/tests/completers/test_python_llm.py
@@ -1,0 +1,67 @@
+"""Path-vs-operator completion in ``xonsh/completers/python.py``.
+
+For an unknown command, the Python completer splits ``--home=/`` on ``=`` and
+used to offer operator tokens (``/`` ``//`` ``/=`` ``//=``) for the trailing
+``/``.  Being exclusive and running before the path completer, those tokens
+shadowed path completion.  A value that begins with a path separator must not
+get operator completions, so the path completer can list the directory.
+"""
+
+import os
+
+import pytest
+
+from xonsh.completers.python import complete_python
+from xonsh.pytest.tools import skip_if_on_windows
+
+
+@pytest.fixture(autouse=True)
+def xonsh_execer_autouse(xession, xonsh_execer):
+    return xonsh_execer
+
+
+def _values(result):
+    if not result:
+        return set()
+    comps = result[0] if isinstance(result, tuple) else result
+    return {str(c).strip() for c in comps}
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["qwewqe --home=/", "qwewqe if=/", "qwewqe --home=~"],
+    ids=["dashed-opt", "bare-opt", "tilde"],
+)
+def test_python_skips_operators_for_path_value(line, completion_context_parse):
+    """A path value after ``=`` must not yield Python operator tokens."""
+    res = complete_python(completion_context_parse(line, len(line)))
+    # tokens that collide with a leading '/' or '~'
+    assert _values(res) & {"/", "//", "/=", "//=", "~"} == set()
+
+
+@pytest.mark.parametrize("line", ["5 /", "x = /"])
+def test_python_keeps_operators_for_real_expression(line, completion_context_parse):
+    """Genuine operator completion (``/`` from an expression) is preserved.
+
+    Here ``/`` is the whole prefix (from the space split), so the first
+    completion attempt already matches operators and the ``=`` fallback that
+    the fix guards is never reached.
+    """
+    res = complete_python(completion_context_parse(line, len(line)))
+    assert {"/", "//", "/=", "//="} <= _values(res)
+
+
+@skip_if_on_windows
+def test_path_completion_not_shadowed_end_to_end(completer_obj):
+    """Full pipeline: ``app --home=/<TAB>`` yields paths, not ``/=``."""
+    line = "qwewqe --home=/"
+    comps, lprefix = completer_obj.complete_line(line)
+    vals = {str(c).rstrip() for c in comps}
+
+    # operator tokens no longer shadow the path completer ...
+    assert not (vals & {"/", "//", "/=", "//="})
+    # ... and the root directory is listed, replacing only the typed '/'.
+    assert lprefix == 1
+    assert vals, "expected root path completions"
+    assert all(v.startswith("/") for v in vals)
+    assert any(v.endswith(os.sep) for v in vals)

--- a/xonsh/completers/path.py
+++ b/xonsh/completers/path.py
@@ -1,6 +1,7 @@
 import ast
 import glob
 import os
+import re
 
 import xonsh.platform as xp
 import xonsh.tools as xt
@@ -494,29 +495,50 @@ def complete_path(context):
     return set(), 0
 
 
+# Matches an ``option=value`` argument so path completion can target only the
+# value (e.g. ``--path=/home/`` → ``/home/``).  The option name must not
+# contain a path separator, so a real path that contains ``=`` (``/home/a=b/``
+# or a directory named ``qwe=asd``) is never split.
+_OPTION_ASSIGN_RE = re.compile(r"^[^/\\=\s]*=(.*)$")
+
+
 def contextual_complete_path(command: CommandContext, cdpath=True, filtfunc=None):
-    # ``_complete_path_raw`` may add opening quotes:
+    def _complete(prefix):
+        # ``_complete_path_raw`` may add opening quotes.
+        # When the cursor is inside a closed string (before the closing quote),
+        # append the closing quote to the line so ``_complete_path_raw`` can
+        # detect it and set ``append_end = False``.  The completion will NOT
+        # include a closing quote, and lprefix will NOT cover the original
+        # closing quote — so the existing quote stays in place.
+        if command.closing_quote and not command.is_after_closing_quote:
+            line = prefix + command.closing_quote
+        else:
+            line = prefix
+        return _complete_path_raw(
+            prefix,
+            line,
+            0,
+            len(prefix),
+            ctx={},
+            cdpath=cdpath,
+            filtfunc=filtfunc,
+        )
+
     prefix = command.raw_prefix
+    completions, lprefix = _complete(prefix)
 
-    # When the cursor is inside a closed string (before the closing quote),
-    # append the closing quote to the line so ``_complete_path_raw`` can
-    # detect it and set ``append_end = False``.  The completion will NOT
-    # include a closing quote, and lprefix will NOT cover the original
-    # closing quote — so the existing quote stays in place.
-    if command.closing_quote and not command.is_after_closing_quote:
-        line = prefix + command.closing_quote
-    else:
-        line = prefix
-
-    completions, lprefix = _complete_path_raw(
-        prefix,
-        line,
-        0,
-        len(prefix),
-        ctx={},
-        cdpath=cdpath,
-        filtfunc=filtfunc,
-    )
+    # Complete the value of an ``option=value`` argument (e.g.
+    # ``--path=/home/`` or ``if=/dev/``): only the part after the first ``=``
+    # is treated as a path.  The whole prefix is tried first, so a real path
+    # that itself contains ``=`` (a file/dir literally named ``qwe=asd``)
+    # still completes as a whole — we only fall back to the value when the
+    # literal prefix matched nothing.  ``lprefix`` then covers only the value,
+    # so the ``option=`` part is preserved in the line.
+    if not completions and not command.opening_quote:
+        eq_match = _OPTION_ASSIGN_RE.match(prefix)
+        if eq_match:
+            prefix = eq_match.group(1)
+            completions, lprefix = _complete(prefix)
 
     # Set an explicit display on completions whose text no longer
     # starts with the typed prefix (e.g. expanded tilde on Windows:

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -217,7 +217,12 @@ def complete_python(context: CompletionContext) -> CompleterResult:
             if not prefix.startswith(",")
             else prefix
         )
-        rtn = _complete_python(prefix, context.python)
+        # A segment that begins with a path separator (e.g. the ``/`` left
+        # after splitting ``--home=/`` or ``if=/`` on ``=``) is a path, never
+        # Python.  Skip operator-token completion so it doesn't shadow the
+        # (exclusive, later-running) path completer with ``/`` ``//`` ``/=``.
+        if not prefix.startswith(("/", "\\", "~")):
+            rtn = _complete_python(prefix, context.python)
     return rtn, len(prefix)
 
 


### PR DESCRIPTION
In case the tool name is unknown the completer for path in argument is not working. This PR fixes this.

Before:
```xsh
cd /tmp
mkdir dir
mkdir dir/qwe
sometool --path=dir/<Tab>  # path completion is not working
```

After:
```xsh
sometool --path=dir/<Tab>  # path completion is working
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
