### PR TITLE
fix: Add helpful message in case of using `history` command without history object

### DIFF
--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -195,9 +195,7 @@ class History:
         """Remove duplicate commands, keeping only the latest occurrence.
 
         Backends that support deduplication override this. The base
-        implementation is a no-op so that backends without it (e.g.
-        :class:`~xonsh.history.dummy.DummyHistory`) degrade gracefully
-        instead of raising ``AttributeError``.
+        implementation is a no-op.
 
         Returns
         -------

--- a/xonsh/history/base.py
+++ b/xonsh/history/base.py
@@ -191,6 +191,22 @@ class History:
         """
         pass
 
+    def erasedups(self):
+        """Remove duplicate commands, keeping only the latest occurrence.
+
+        Backends that support deduplication override this. The base
+        implementation is a no-op so that backends without it (e.g.
+        :class:`~xonsh.history.dummy.DummyHistory`) degrade gracefully
+        instead of raising ``AttributeError``.
+
+        Returns
+        -------
+        tuple of int
+            ``(removed, total)`` — the number of duplicates removed and the
+            total number of entries considered.
+        """
+        return 0, 0
+
     @functools.cached_property
     def ignore_regex(self):
         compiled_regex = None

--- a/xonsh/history/main.py
+++ b/xonsh/history/main.py
@@ -554,6 +554,24 @@ class HistoryAlias(xcli.ArgParserAlias):
         return parser
 
     def __call__(self, args, *rest, **kwargs):
+        if XSH.history is None:
+            # The history backend is created during shell startup (see
+            # ``xonsh.main.start_services``). If a history command runs before
+            # that — most commonly from an RC file, which is loaded first —
+            # the backend is still None. Emit actionable guidance instead of
+            # crashing with an opaque ``AttributeError``.
+            print(
+                "history: the history backend is not ready or not "
+                "initialized yet.\n"
+                "If you are calling a history command from an RC file, run it "
+                "from the on_post_init event instead, which fires once the "
+                "backend is ready:\n\n"
+                "    @events.on_post_init\n"
+                "    def _my_post_init(**kw):\n"
+                "        history erasedups\n",
+                file=kwargs.get("stderr") or sys.stderr,
+            )
+            return
         if not args:
             args = ["show", "session"]
         else:


### PR DESCRIPTION
Related to https://github.com/xonsh/xonsh/issues/6539

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
