### PR TITLE
fix(tests): Drop the harness PYTHONPATH before completing pip

### DIFF
--- a/tests/completers/test_pip_completer.py
+++ b/tests/completers/test_pip_completer.py
@@ -56,6 +56,15 @@ def pip_installed():
     ],
 )
 def test_completions(line, prefix, exp, check_completer, xsh_with_env):
+    # The root conftest prepends the source tree to PYTHONPATH, and the completer
+    # passes the session env straight to the `pip` subprocess. That puts the repo
+    # root (with its build-time xonsh.egg-info) on pip's own sys.path, where it
+    # shadows the really-installed xonsh distribution. When pip runs from a venv
+    # it lists only distributions local to that venv, so the shadowed one drops
+    # out and `pip show <TAB>` falls back to option flags. No real shell sets
+    # PYTHONPATH this way, so drop it before completing.
+    xsh_with_env.env.pop("PYTHONPATH", None)
+
     # use the actual PATH from os. Otherwise subproc will fail on windows. `unintialized python...`
     comps = check_completer(line, prefix=prefix)
 


### PR DESCRIPTION
The root conftest prepends the source tree to PYTHONPATH so that subprocesses import xonsh from there. The pip completer hands the session env straight to its `pip` subprocess, so pip picks that up too and finds the build-time xonsh.egg-info sitting at the repo root, which shadows the really-installed xonsh distribution.

Whenever pip itself runs from a venv, its completion offers only the distributions local to that venv. The shadowed egg-info one is not, so `pip show <TAB>` has nothing left to offer and falls back to printing option flags, and test_completions fails. This is what any packaging build hits, where the suite runs inside a throwaway venv with xonsh as the only package installed into it.

No real shell exports PYTHONPATH like this, so unsetting it keeps the assertion honest rather than relaxing it.

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
