### PR TITLE
fix(tools): accept a non-lowercase unit in the $XONSH_HISTORY_SIZE tuple

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -56,6 +56,7 @@ from xonsh.tools import (
     is_completions_display_value,
     is_dynamic_cwd_width,
     is_float,
+    is_history_tuple,
     is_int,
     is_int_as_str,
     is_logfile_opt,
@@ -90,6 +91,7 @@ from xonsh.tools import (
     to_completion_mode,
     to_completions_display_value,
     to_dynamic_cwd_tuple,
+    to_history_tuple,
     to_int_or_none,
     to_logfile_opt,
 )
@@ -2136,6 +2138,38 @@ def test_register_custom_style(name, styles, refrules):
 )
 def test_is_completion_mode(val, exp):
     assert is_completion_mode(val) is exp
+
+
+@pytest.mark.parametrize(
+    "val, exp",
+    [
+        ((10, "commands"), True),
+        ((10, "b"), True),
+        # Only the canonical units are valid; anything else has to go through
+        # to_history_tuple, so the validator must not fold the case itself.
+        ((10, "Commands"), False),
+        ((1, "GB"), False),
+        ((1, "gb"), False),
+        # A non-string unit is not a history tuple either.
+        ((10, 2), False),
+    ],
+)
+def test_is_history_tuple(val, exp):
+    assert is_history_tuple(val) is exp
+
+
+@pytest.mark.parametrize(
+    "val, exp",
+    [
+        ((1, "gb"), (1073741824, "b")),
+        # The docs advertise "1 GB"; the tuple form must accept it too.
+        ((1, "GB"), (1073741824, "b")),
+        ((10, "Commands"), (10, "commands")),
+        ("1 GB", (1073741824, "b")),
+    ],
+)
+def test_to_history_tuple_unit_case(val, exp):
+    assert to_history_tuple(val) == exp
 
 
 @pytest.mark.parametrize(

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2292,7 +2292,8 @@ def is_history_tuple(x):
         isinstance(x, cabc.Sequence)
         and len(x) == 2
         and isinstance(x[0], int | float)
-        and x[1].lower() in CANON_HISTORY_UNITS
+        and isinstance(x[1], str)
+        and x[1] in CANON_HISTORY_UNITS
     ):
         return True
     return False
@@ -2367,7 +2368,10 @@ def to_history_tuple(x):
         return to_history_tuple((m.group(1), m.group(3)))
     elif isinstance(x, float | int):
         return to_history_tuple((x, "commands"))
-    units, converter = HISTORY_UNITS[x[1]]
+    try:
+        units, converter = HISTORY_UNITS[str(x[1]).lower()]
+    except KeyError:
+        raise ValueError(f"could not parse history units: {x[1]!r}") from None
     value = converter(x[0])
     return (value, units)
 


### PR DESCRIPTION
## What

`$XONSH_HISTORY_SIZE` accepts `'1 GB'` as a string but raises `KeyError: 'GB'` when the same value is given as the documented tuple.

The variable's own docstring says *"Common abbreviations, such as '6 months' or '1 GB' are also allowed"*, and `Env`'s docs describe it as *"an (int | float, str) tuple"* — so `$XONSH_HISTORY_SIZE = (1, "GB")` is the natural reading, and it's the one that breaks.

## Before / after

```python
>>> to_history_tuple((1, "GB"))
KeyError: 'GB'                        # before
(1073741824, 'b')                     # after

>>> is_history_tuple((10, "Commands"))
True                                  # before  <- claims it's already canonical
False                                 # after

>>> is_history_tuple((10, 2))
AttributeError: 'int' object has no attribute 'lower'   # before
False                                                    # after
```

In a `.xonshrc`:

```xsh
$XONSH_HISTORY_SIZE = (1, "GB")       # before: KeyError: 'GB' traceback on startup
```

These still behave exactly as they did — the string path and the lowercase tuple were never affected:

```python
>>> to_history_tuple("1 GB")
(1073741824, 'b')
>>> to_history_tuple((1, "gb"))
(1073741824, 'b')
>>> to_history_tuple((10, "commands"))
(10, 'commands')
```

## Prior art

This is the other half of #860 (merged 2016), which added the `.lower()` to the string path for exactly this reason:

> Right now this will error out because the history tuple parsing only knows about lower-case units names. This behavior is supposed to work, I think, since upper-case `GB` is documented

The string path has worked ever since; the tuple path was never given the same treatment.

## Why

Two mirror-image slips, one in each function:

- **`to_history_tuple`** folds the case on the string path (`x.strip().lower()`) but not on the tuple path (`HISTORY_UNITS[x[1]]`), so `'GB'` misses. The `KeyError` also escapes `Env._set_item`'s `except (TypeError, ValueError)` as a raw traceback rather than a message.
- **`is_history_tuple`** lowercases *before* testing `CANON_HISTORY_UNITS`, which only holds canonical lowercase units. So `(10, 'Commands')` validates as already-canonical, `Env` skips the converter (`if not validator(val): val = converter(val)`), the uncanonicalised value is stored, and it fails much later in history GC instead. The same line assumes `x[1]` is a `str`.

The sibling enumerated validators deliberately test the canonical form so non-canonical input routes to the converter:

```python
>>> is_completions_display_value("NONE")   # False
>>> is_completion_mode("Default")          # False
```

`is_history_tuple` is the only one that folds the case itself. This makes it match them.

`to_history_tuple` now raises `ValueError` instead of `KeyError`/`AttributeError` for an unknown or non-string unit, which is what `Env._set_item` already catches.

## Tests

Added `test_is_history_tuple` and `test_to_history_tuple_unit_case` to `tests/test_tools.py`, next to `test_is_completion_mode` and the other converter tests. There was no existing coverage of either function — `grep` finds no test touching them, which is why this survived.

`tests/test_tools.py tests/test_environ.py tests/history/`: **739 passed, 1 skipped** with the fix vs. **729 passed, 1 skipped** on `main` — the ten extra are the new parametrised cases, and nothing regressed. `ruff check` and `ruff format` clean.

On `AI_POLICY.md`'s `test_<module>_llm.py` convention: that scopes to "a substantial block" of generated tests, and this is one focused regression whose siblings already live in `tests/test_tools.py`, so I put it there. Happy to move it to `tests/test_tools_llm.py` (mirroring the module, per the rule) if you'd rather keep the split strict.

## Disclosure

AI-assisted. The reproducer, the three controls, the sibling-validator comparison, the `Env._set_item` except-clause check, and the `main`-vs-branch test comparison are all things I ran and read rather than assumed.
