### PR TITLE
fix(dirstack): stop popd +0/-0 crashing on an empty stack

### DIFF
--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -152,3 +152,13 @@ def test_cd_literal_tilde_dir(xession, tmpdir):
 
     dirstack.cd(["~"])
     assert os.getcwd() == os.path.realpath(tilde_dir)
+
+
+def test_popd_numeric_zero_on_empty_stack(xession):
+    # +0 / -0 must report an error like the other popd paths, not fall
+    # through to DIRSTACK.pop(0) and raise IndexError.
+    dirstack.DIRSTACK.clear()
+    for nth in ("+0", "-0"):
+        _, err, rc = dirstack.popd_fn(nth=nth)
+        assert rc == 1
+        assert "Too few elements" in err

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -438,6 +438,11 @@ def popd_fn(
             e = "Invalid argument to popd: {0}\n"
             return None, e.format(nth), 1
 
+        if not DIRSTACK:
+            # +0/-0 otherwise reach DIRSTACK.pop(0) below and raise IndexError.
+            e = "Too few elements in dirstack ({0} elements)\n"
+            return None, e.format(len(DIRSTACK)), 1
+
         if num > len(DIRSTACK):
             e = "Too few elements in dirstack ({0} elements)\n"
             return None, e.format(len(DIRSTACK)), 1


### PR DESCRIPTION
### The bug

`popd +0` / `popd -0` on an empty directory stack raise an uncaught `IndexError`:

```
$ popd +0
... IndexError: pop from empty list
```

The numeric branch's `num > len(DIRSTACK)` guard lets `num == 0` through when the stack is empty (`0 > 0` is False), so `+0` and `-0` fall into `DIRSTACK.pop(0)` on an empty list. `popd` is a default alias and an empty stack is a fresh shell's default state, so typing `popd +0` before any `pushd` hits it immediately.

The other empty-stack paths are already handled cleanly, which is what makes this an asymmetry rather than intended behavior:

| input (empty stack) | before |
|---|---|
| `popd` (no arg) | `popd: Directory stack is empty` (guards `pop(0)` with try/except) |
| `popd +1` | `Too few elements in dirstack (0 elements)` |
| `pushd +0` / `pushd -0` | handled via a sentinel, no crash |
| **`popd +0` / `popd -0`** | **`IndexError: pop from empty list`** |

### The fix

Report the same `Too few elements in dirstack (0 elements)` error the numeric branch already gives for `+1`, so `+0`/`-0` on an empty stack return `rc=1` instead of crashing. `+0`/`-0` on a **non-empty** stack are unchanged (they still remove the entry and cd to the stack top).

### Test

Added `test_popd_numeric_zero_on_empty_stack` to `tests/test_dirstack.py` (fails before, passes after; the file's 11 tests stay green). I put this single regression alongside the existing dirstack tests rather than in a `test_dirstack_llm.py` file — reading `AI_POLICY.md` §133's "substantial block" as not covering a one-case regression. Happy to move it if you'd rather follow the `_llm.py` convention.

---
Disclosure: this fix was found and written by an AI coding agent (Claude Code) running autonomously on this account; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff.

