### PR TITLE
refactor(platforms): move Windows color helpers

### DIFF
--- a/tests/platforms/test_win_colors.py
+++ b/tests/platforms/test_win_colors.py
@@ -1,0 +1,31 @@
+from xonsh import tools
+from xonsh.platforms import win_colors
+
+
+def test_win10_color_map():
+    assert win_colors.WIN10_COLOR_MAP["ansired"] == "#c50f1f"
+    assert win_colors.WIN10_COLOR_MAP["ansibrightcyan"] == "#61d6d6"
+
+
+def test_hardcode_colors_for_win10(xession):
+    xession.env["PROMPT_TOOLKIT_COLOR_DEPTH"] = ""
+    style_map = {
+        "plain": "ansired",
+        "bold": "bold ansiblue",
+        "nobold": "nobold ansigreen",
+    }
+
+    result = win_colors.hardcode_colors_for_win10(style_map)
+
+    assert result == {
+        "plain": "#c50f1f",
+        "bold": " #3b78ff",
+        "nobold": "nobold #13a10e",
+    }
+    assert xession.env["PROMPT_TOOLKIT_COLOR_DEPTH"] == "DEPTH_24_BIT"
+
+
+def test_tools_reexports_windows_color_helpers():
+    assert tools.WIN10_COLOR_MAP == win_colors.WIN10_COLOR_MAP
+    assert tools.WIN_BOLD_COLOR_MAP == win_colors.WIN_BOLD_COLOR_MAP
+    assert tools.hardcode_colors_for_win10 is win_colors.hardcode_colors_for_win10

--- a/xonsh/platforms/win_colors.py
+++ b/xonsh/platforms/win_colors.py
@@ -1,0 +1,71 @@
+"""Color helpers for the Windows console host."""
+
+from xonsh.lib.lazyasd import LazyObject
+
+__all__ = ("WIN10_COLOR_MAP", "WIN_BOLD_COLOR_MAP", "hardcode_colors_for_win10")
+
+
+def _win10_color_map():
+    cmap = {
+        "ansiblack": (12, 12, 12),
+        "ansiblue": (0, 55, 218),
+        "ansigreen": (19, 161, 14),
+        "ansicyan": (58, 150, 221),
+        "ansired": (197, 15, 31),
+        "ansimagenta": (136, 23, 152),
+        "ansiyellow": (193, 156, 0),
+        "ansigray": (204, 204, 204),
+        "ansibrightblack": (118, 118, 118),
+        "ansibrightblue": (59, 120, 255),
+        "ansibrightgreen": (22, 198, 12),
+        "ansibrightcyan": (97, 214, 214),
+        "ansibrightred": (231, 72, 86),
+        "ansibrightmagenta": (180, 0, 158),
+        "ansibrightyellow": (249, 241, 165),
+        "ansiwhite": (242, 242, 242),
+    }
+    return {k: f"#{r:02x}{g:02x}{b:02x}" for k, (r, g, b) in cmap.items()}
+
+
+WIN10_COLOR_MAP = LazyObject(_win10_color_map, globals(), "WIN10_COLOR_MAP")
+
+
+def _win_bold_color_map():
+    """Map dark ANSI colors to their lighter variants."""
+    return {
+        "ansiblack": "ansibrightblack",
+        "ansiblue": "ansibrightblue",
+        "ansigreen": "ansibrightgreen",
+        "ansicyan": "ansibrightcyan",
+        "ansired": "ansibrightred",
+        "ansimagenta": "ansibrightmagenta",
+        "ansiyellow": "ansibrightyellow",
+        "ansigray": "ansiwhite",
+    }
+
+
+WIN_BOLD_COLOR_MAP = LazyObject(_win_bold_color_map, globals(), "WIN_BOLD_COLOR_MAP")
+
+
+def hardcode_colors_for_win10(style_map):
+    """Replace ANSI colors with readable RGB values for ``conhost.exe``."""
+    from xonsh.built_ins import XSH
+
+    modified_style = {}
+    if not XSH.env["PROMPT_TOOLKIT_COLOR_DEPTH"]:
+        XSH.env["PROMPT_TOOLKIT_COLOR_DEPTH"] = "DEPTH_24_BIT"
+    for token, style_str in style_map.items():
+        for ansicolor in WIN10_COLOR_MAP:
+            if ansicolor in style_str:
+                if "bold" in style_str and "nobold" not in style_str:
+                    # Win10 does not handle bold colors. Map dark colors to
+                    # their lighter variants to simulate the same effect.
+                    style_str = style_str.replace("bold", "")
+                    hexcolor = WIN10_COLOR_MAP[
+                        WIN_BOLD_COLOR_MAP.get(ansicolor, ansicolor)
+                    ]
+                else:
+                    hexcolor = WIN10_COLOR_MAP[ansicolor]
+                style_str = style_str.replace(ansicolor, hexcolor)
+        modified_style[token] = style_str
+    return modified_style

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -50,6 +50,7 @@ from xonsh.platform import (
     pygments_version_info,
     win_ansi_support,
 )
+from xonsh.platforms.win_colors import hardcode_colors_for_win10
 from xonsh.procs.executables import locate_executable
 from xonsh.pygments_cache import add_custom_style, get_style_by_name
 from xonsh.style_tools import DEFAULT_STYLE_DICT, norm_name
@@ -58,7 +59,6 @@ from xonsh.tools import (
     FORMATTER,
     ON_WINDOWS,
     PTK_NEW_OLD_COLOR_MAP,
-    hardcode_colors_for_win10,
     intensify_colors_for_cmd_exe,
 )
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -81,6 +81,13 @@ from xonsh.platform import (
     os_environ,
     pygments_version_info,
 )
+from xonsh.platforms import win_colors as _win_colors
+
+WIN10_COLOR_MAP = _win_colors.WIN10_COLOR_MAP
+WIN_BOLD_COLOR_MAP = _win_colors.WIN_BOLD_COLOR_MAP
+_win10_color_map = _win_colors._win10_color_map
+_win_bold_color_map = _win_colors._win_bold_color_map
+hardcode_colors_for_win10 = _win_colors.hardcode_colors_for_win10
 
 
 @lazyobject
@@ -2541,75 +2548,6 @@ ANSICOLOR_NAMES_MAP = LazyObject(
     globals(),
     "ANSICOLOR_NAMES_MAP",
 )
-
-
-def _win10_color_map():
-    cmap = {
-        "ansiblack": (12, 12, 12),
-        "ansiblue": (0, 55, 218),
-        "ansigreen": (19, 161, 14),
-        "ansicyan": (58, 150, 221),
-        "ansired": (197, 15, 31),
-        "ansimagenta": (136, 23, 152),
-        "ansiyellow": (193, 156, 0),
-        "ansigray": (204, 204, 204),
-        "ansibrightblack": (118, 118, 118),
-        "ansibrightblue": (59, 120, 255),
-        "ansibrightgreen": (22, 198, 12),
-        "ansibrightcyan": (97, 214, 214),
-        "ansibrightred": (231, 72, 86),
-        "ansibrightmagenta": (180, 0, 158),
-        "ansibrightyellow": (249, 241, 165),
-        "ansiwhite": (242, 242, 242),
-    }
-    return {k: f"#{r:02x}{g:02x}{b:02x}" for k, (r, g, b) in cmap.items()}
-
-
-WIN10_COLOR_MAP = LazyObject(_win10_color_map, globals(), "WIN10_COLOR_MAP")
-
-
-def _win_bold_color_map():
-    """Map dark ansi colors to lighter version."""
-    return {
-        "ansiblack": "ansibrightblack",
-        "ansiblue": "ansibrightblue",
-        "ansigreen": "ansibrightgreen",
-        "ansicyan": "ansibrightcyan",
-        "ansired": "ansibrightred",
-        "ansimagenta": "ansibrightmagenta",
-        "ansiyellow": "ansibrightyellow",
-        "ansigray": "ansiwhite",
-    }
-
-
-WIN_BOLD_COLOR_MAP = LazyObject(_win_bold_color_map, globals(), "WIN_BOLD_COLOR_MAP")
-
-
-def hardcode_colors_for_win10(style_map):
-    """Replace all ansi colors with hardcoded colors to avoid unreadable defaults
-    in conhost.exe
-    """
-    modified_style = {}
-    if not xsh.env["PROMPT_TOOLKIT_COLOR_DEPTH"]:
-        xsh.env["PROMPT_TOOLKIT_COLOR_DEPTH"] = "DEPTH_24_BIT"
-    # Replace all ansi colors with hardcoded colors to avoid unreadable defaults
-    # in conhost.exe
-    for token, style_str in style_map.items():
-        for ansicolor in WIN10_COLOR_MAP:
-            if ansicolor in style_str:
-                if "bold" in style_str and "nobold" not in style_str:
-                    # Win10  doesn't yet handle bold colors. Instead dark
-                    # colors are mapped to their lighter version. We simulate
-                    # the same here.
-                    style_str = style_str.replace("bold", "")
-                    hexcolor = WIN10_COLOR_MAP[
-                        WIN_BOLD_COLOR_MAP.get(ansicolor, ansicolor)
-                    ]
-                else:
-                    hexcolor = WIN10_COLOR_MAP[ansicolor]
-                style_str = style_str.replace(ansicolor, hexcolor)
-        modified_style[token] = style_str
-    return modified_style
 
 
 def ansicolors_to_ptk1_names(stylemap):


### PR DESCRIPTION
## Summary

- move the Windows 10 console color maps and `hardcode_colors_for_win10()` into `xonsh.platforms.win_colors`
- keep compatibility re-exports in `xonsh.tools` while updating the internal consumer to import from the focused module
- add coverage for the color mappings, bold-color conversion, color-depth setup, and compatibility exports

## Rationale

These helpers are specific to the Windows console host but were implemented in the general-purpose `xonsh.tools` module. Moving them into `xonsh.platforms` reduces that module's responsibilities while preserving downstream imports.

Refs #5563

## Tests

- `python -m ruff check xonsh/platforms/win_colors.py xonsh/tools.py xonsh/pyghooks.py tests/platforms/test_win_colors.py`
- `python -m pytest -q` — 6,821 passed, 901 skipped, 2 xfailed, 2 xpassed
