### PR TITLE
fix(which): decouple --all from --verbose

### DIFF
--- a/tests/xoreutils/test_which_llm.py
+++ b/tests/xoreutils/test_which_llm.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+from xonsh.aliases import ExecAlias
 from xonsh.pytest.tools import skip_if_on_windows
 from xonsh.xoreutils.which import which
 
@@ -35,7 +36,7 @@ def app_path(tmp_path):
 
 
 ALIAS_PLAIN = "echo hi"
-ALIAS_VERBOSE = f"aliases['{APP}'] = ['echo', 'hi']"
+ALIAS_VERBOSE = f"echo hi (from aliases['{APP}'])"
 
 
 @skip_if_on_windows
@@ -89,6 +90,24 @@ def test_which_alias_only(xsh_with_aliases, flags, expected):
     """An alias with no PATH match short-circuits before any path lookup."""
     xsh_with_aliases.aliases[APP] = ["echo", "hi"]
     assert run_which(*flags, APP) == [expected]
+
+
+def test_which_exec_alias(xsh_with_aliases):
+    """An ExecAlias reports its source, with provenance appended when verbose."""
+    xsh_with_aliases.aliases[APP] = ExecAlias("echo hi")
+    assert run_which(APP) == ["echo hi"]
+    assert run_which("-v", APP) == [f"echo hi (from aliases['{APP}'])"]
+
+
+def test_which_callable_alias(xsh_with_aliases):
+    """A callable alias reports its repr, with provenance appended when verbose."""
+
+    def _cb(args):
+        pass
+
+    xsh_with_aliases.aliases[APP] = _cb
+    expansion = run_which(APP)[0]
+    assert run_which("-v", APP) == [f"{expansion} (from aliases['{APP}'])"]
 
 
 @skip_if_on_windows

--- a/tests/xoreutils/test_which_llm.py
+++ b/tests/xoreutils/test_which_llm.py
@@ -1,0 +1,100 @@
+"""Tests for the ``which`` xoreutil (``xonsh/xoreutils/which.py``)."""
+
+import io
+import os
+
+import pytest
+
+from xonsh.pytest.tools import skip_if_on_windows
+from xonsh.xoreutils.which import which
+
+APP = "whichtestapp1"
+
+
+@pytest.fixture
+def which_session(xsh_with_aliases, tmp_path):
+    """Session with ``APP`` both aliased and present as a lone executable on PATH."""
+    exe = tmp_path / APP
+    exe.write_bytes(b"")
+    exe.chmod(0o755)
+    xsh_with_aliases.env["PATH"] = [str(tmp_path)]
+    xsh_with_aliases.aliases[APP] = ["echo", "hi"]
+    return xsh_with_aliases
+
+
+def run_which(*args):
+    """Run the which alias, returning its stdout as a list of lines."""
+    stdout = io.StringIO()
+    which(list(args), stdout=stdout, stderr=io.StringIO())
+    return stdout.getvalue().splitlines()
+
+
+def app_path(tmp_path):
+    """The path ``_which.whichgen`` reports for the executable in ``tmp_path``."""
+    return os.path.abspath(os.path.normpath(os.path.join(str(tmp_path), APP)))
+
+
+ALIAS_PLAIN = "echo hi"
+ALIAS_VERBOSE = f"aliases['{APP}'] = ['echo', 'hi']"
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize(
+    "flags, alias_line, want_path, path_verbose",
+    [
+        ([], ALIAS_PLAIN, False, False),
+        (["-v"], ALIAS_VERBOSE, False, False),
+        (["-a"], ALIAS_PLAIN, True, False),
+        (["-a", "-v"], ALIAS_VERBOSE, True, True),
+    ],
+    ids=["default", "verbose", "all", "all-verbose"],
+)
+def test_which_flag_matrix(
+    which_session, tmp_path, flags, alias_line, want_path, path_verbose
+):
+    """``--all`` and ``--verbose`` are orthogonal: neither implies the other."""
+    expected = [alias_line]
+    if want_path:
+        path = app_path(tmp_path)
+        expected.append(f"{path} (from given path element 0)" if path_verbose else path)
+    assert run_which(*flags, APP) == expected
+
+
+@skip_if_on_windows
+def test_which_all_does_not_imply_verbose(which_session):
+    """Regression for #5031: ``-a`` used to produce byte-identical output to ``-a -v``."""
+    assert run_which("-a", APP) != run_which("-a", "-v", APP)
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize(
+    "flags",
+    [["-p", "-v"], ["-p", "-a", "-v"], ["-p", "-a"]],
+    ids=["plain-verbose", "plain-all-verbose", "plain-all"],
+)
+def test_which_plain_overrides_verbose(which_session, tmp_path, flags):
+    """``--plain`` wins over ``--verbose`` whether or not ``--all`` is present."""
+    expected = [ALIAS_PLAIN]
+    if "-a" in flags:
+        expected.append(app_path(tmp_path))
+    assert run_which(*flags, APP) == expected
+
+
+@pytest.mark.parametrize(
+    "flags, expected",
+    [([], ALIAS_PLAIN), (["-v"], ALIAS_VERBOSE)],
+    ids=["default", "verbose"],
+)
+def test_which_alias_only(xsh_with_aliases, flags, expected):
+    """An alias with no PATH match short-circuits before any path lookup."""
+    xsh_with_aliases.aliases[APP] = ["echo", "hi"]
+    assert run_which(*flags, APP) == [expected]
+
+
+@skip_if_on_windows
+@pytest.mark.parametrize("flags", [[], ["-v"], ["-a"], ["-a", "-v"]])
+def test_which_skip_alias(which_session, tmp_path, flags):
+    """``--skip-alias`` drops the alias line under every verbosity combination."""
+    lines = run_which("-s", *flags, APP)
+    path = app_path(tmp_path)
+    assert lines == [f"{path} (from given path element 0)" if "-v" in flags else path]

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -101,21 +101,17 @@ def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
 def print_alias(arg, stdout, verbose=False):
     """Print the alias."""
     alias = XSH.aliases[arg]
-    if not verbose:
-        if not callable(alias):
-            print(" ".join(alias), file=stdout)
-        elif isinstance(alias, xonsh.aliases.ExecAlias):
-            print(alias.src, file=stdout)
-        else:
-            print(alias, file=stdout)
+    if not callable(alias):
+        expansion = " ".join(alias)
+    elif isinstance(alias, xonsh.aliases.ExecAlias):
+        expansion = alias.src
     else:
-        print(
-            f"aliases['{arg}'] = {alias}",
-            flush=True,
-            file=stdout,
-        )
-        if callable(alias) and not isinstance(alias, xonsh.aliases.ExecAlias):
-            XSH.superhelp(alias)
+        expansion = str(alias)
+    if verbose:
+        # Mirror the ``<match> (<where it came from>)`` shape of print_path.
+        print(f"{expansion} (from aliases['{arg}'])", flush=True, file=stdout)
+    else:
+        print(expansion, file=stdout)
 
 
 def which(args, stdin=None, stdout=None, stderr=None, spec=None):

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -131,7 +131,7 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
         return -1
 
     pargs = parser.parse_args(args)
-    verbose = pargs.verbose or pargs.all
+    verbose = pargs.verbose
     if spec is not None:
         captured = spec.captured in xpp.STDOUT_CAPTURE_KINDS
     else:


### PR DESCRIPTION
## Summary

- make `--all` control how many matches `which` returns without silently enabling `--verbose`
- make verbose alias output use the same `<match> (<source>)` shape as path matches
- stop dumping callable source inside `which -v`; xonsh's `?` and `??` help markers remain the explicit way to inspect it
- add the project-prescribed `test_which_llm.py` coverage for the flag matrix, alias kinds, `--plain`, and `--skip-alias`

Before:

```xsh
@ which -a ls
aliases['ls'] = ['echo', 'hi']
/bin/ls (from given path element 4)
```

After:

```xsh
@ which -a ls
echo hi
/bin/ls
@ which -a -v ls
echo hi (from aliases['ls'])
/bin/ls (from given path element 4)
```

Closes #5031.

## Validation

- `.venv/bin/python -m pytest tests/xoreutils/test_which.py tests/xoreutils/test_which_llm.py -q` — 21 passed
- `.venv/bin/ruff check xonsh/xoreutils/which.py tests/xoreutils/test_which_llm.py`
- `.venv/bin/ruff format --check xonsh/xoreutils/which.py tests/xoreutils/test_which_llm.py`

I also tried targeted mypy. The lean test environment lacks `xonsh_rd_parser`, `click`, and `ujson` stubs, so mypy stopped on pre-existing import and unrelated-module errors; it reported no error in the changed lines.

## AI assistance

I followed `CLAUDE.md` and read `AI_POLICY.md` before publication. Claude Opus 5 researched the issue, call sites, flag invariants, and existing behavior before implementing the two commits. OpenAI Codex then independently read the full maintainer discussion, reviewed the complete diff, and reran the focused tests and formatting checks. The generated tests live in `tests/xoreutils/test_which_llm.py` as required by the project policy.
