### PR TITLE
fix(ptk): Replace builtin `input()` to ptk implemented input hook

### DIFF
--- a/tests/shell/test_ptk_shell_llm.py
+++ b/tests/shell/test_ptk_shell_llm.py
@@ -129,3 +129,287 @@ def test_singleline_retries_on_eintr(ptk_shell):
     shell.prompter.prompt = flaky
     assert shell.singleline() == "echo ok"
     assert calls["n"] == 2
+
+
+#
+# builtins.input() served through prompt_toolkit (PTKInputHook)
+#
+
+
+@pytest.fixture
+def input_hook(xession):
+    """A hook wired to a fake tty, with ``builtins.input`` restored after."""
+    import builtins
+
+    from xonsh.shells.ptk_shell.input_hook import PTKInputHook
+
+    original = builtins.input
+    hook = PTKInputHook()
+    yield hook
+    builtins.input = original
+
+
+class FakeStream:
+    def __init__(self, tty=True):
+        self._tty = tty
+
+    def isatty(self):
+        return self._tty
+
+
+def make_tty(monkeypatch, stdin=True, stdout=True):
+    monkeypatch.setattr("sys.stdin", FakeStream(stdin))
+    monkeypatch.setattr("sys.stdout", FakeStream(stdout))
+
+
+def test_input_hook_install_and_restore(input_hook):
+    """``install`` swaps ``builtins.input`` and ``restore`` puts the
+    original back, byte for byte."""
+    import builtins
+
+    original = builtins.input
+    input_hook.install()
+    assert builtins.input is input_hook
+    assert input_hook.installed
+    input_hook.restore()
+    assert builtins.input is original
+    assert not input_hook.installed
+
+
+def test_input_hook_install_is_idempotent(input_hook):
+    """A second ``install`` must not record the hook as its own original —
+    that would make ``restore`` leave the hook in place forever."""
+    import builtins
+
+    original = builtins.input
+    input_hook.install()
+    input_hook.install()
+    input_hook.restore()
+    assert builtins.input is original
+
+
+def test_input_hook_restore_keeps_a_foreign_hook(input_hook):
+    """If something else replaced ``input`` after us (a xontrib, ``pdb``,
+    user code), ``restore`` must not clobber it."""
+    import builtins
+
+    input_hook.install()
+    foreign = lambda prompt="": "foreign"  # noqa: E731
+    builtins.input = foreign
+    input_hook.restore()
+    assert builtins.input is foreign
+
+
+def test_input_hook_reads_through_ptk(input_hook, monkeypatch, xession):
+    """On an interactive terminal the hook reads through prompt_toolkit,
+    which is not bound by the terminal's 1024-byte canonical-mode line
+    limit (issue behind this hook)."""
+    make_tty(monkeypatch)
+    token = "x" * 2000
+    seen = []
+    monkeypatch.setattr(input_hook, "prompt", lambda msg: seen.append(msg) or token)
+    input_hook.install()
+    assert input("token: ") == token
+    assert seen == ["token: "]
+
+
+def test_input_hook_prompt_argument_matches_builtin(input_hook, monkeypatch, xession):
+    """``input()`` takes the prompt positionally and stringifies it;
+    no argument means an empty prompt."""
+    make_tty(monkeypatch)
+    seen = []
+    monkeypatch.setattr(input_hook, "prompt", lambda msg: seen.append(msg) or "")
+    input_hook.install()
+    input()
+    input(42)
+    input(None)
+    assert seen == ["", "42", "None"]
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"stdin": False}, {"stdout": False}, {"stdin": False, "stdout": False}]
+)
+def test_input_hook_falls_back_without_a_tty(input_hook, monkeypatch, xession, kwargs):
+    """Redirected stdin/stdout means no prompt_toolkit prompt — the
+    interpreter's own ``input()`` handles it."""
+    make_tty(monkeypatch, **kwargs)
+    monkeypatch.setattr(
+        input_hook, "prompt", lambda msg: pytest.fail("ptk must not be used")
+    )
+    input_hook.install()
+    input_hook._original = lambda *a: "builtin"
+    assert input("p") == "builtin"
+
+
+def test_input_hook_falls_back_off_main_thread(input_hook, monkeypatch, xession):
+    """Callable aliases run in worker threads; prompt_toolkit needs the
+    main thread for its event loop and signal handlers."""
+    import threading
+
+    make_tty(monkeypatch)
+    monkeypatch.setattr(
+        input_hook, "prompt", lambda msg: pytest.fail("ptk must not be used")
+    )
+    input_hook.install()
+    input_hook._original = lambda *a: "builtin"
+    result = []
+    t = threading.Thread(target=lambda: result.append(input("p")))
+    t.start()
+    t.join()
+    assert result == ["builtin"]
+
+
+def test_input_hook_falls_back_inside_a_running_app(input_hook, monkeypatch, xession):
+    """Called from a completer or a key binding, i.e. from inside a
+    running prompt_toolkit application — nesting would deadlock."""
+    make_tty(monkeypatch)
+
+    class RunningApp:
+        is_running = True
+
+    monkeypatch.setattr(
+        "prompt_toolkit.application.current.get_app_or_none", lambda: RunningApp()
+    )
+    monkeypatch.setattr(
+        input_hook, "prompt", lambda msg: pytest.fail("ptk must not be used")
+    )
+    input_hook.install()
+    input_hook._original = lambda *a: "builtin"
+    assert input("p") == "builtin"
+
+
+def test_input_hook_disabled_by_env(input_hook, monkeypatch, xession):
+    """``$XONSH_PTK_INPUT_HOOK = False`` is honored per call, so it can be
+    flipped at runtime."""
+    make_tty(monkeypatch)
+    xession.env["XONSH_PTK_INPUT_HOOK"] = False
+    monkeypatch.setattr(
+        input_hook, "prompt", lambda msg: pytest.fail("ptk must not be used")
+    )
+    input_hook.install()
+    input_hook._original = lambda *a: "builtin"
+    assert input("p") == "builtin"
+
+
+@pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
+def test_input_hook_propagates_eof_and_sigint(input_hook, monkeypatch, xession, exc):
+    """Ctrl-D and Ctrl-C must raise, exactly as the built-in does — not
+    fall back and read a second time."""
+    make_tty(monkeypatch)
+
+    def raiser(msg):
+        raise exc()
+
+    monkeypatch.setattr(input_hook, "prompt", raiser)
+    input_hook.install()
+    input_hook._original = lambda *a: pytest.fail("must not fall back")
+    with pytest.raises(exc):
+        input("p")
+
+
+def test_input_hook_falls_back_on_ptk_failure(input_hook, monkeypatch, xession):
+    """A broken prompt_toolkit prompt must never make ``input()``
+    unusable."""
+    make_tty(monkeypatch)
+
+    def boom(msg):
+        raise RuntimeError("no terminal here")
+
+    monkeypatch.setattr(input_hook, "prompt", boom)
+    input_hook.install()
+    input_hook._original = lambda *a: "builtin"
+    assert input("p") == "builtin"
+
+
+def test_cmdloop_installs_and_restores_the_hook(ptk_shell, xession):
+    """The hook lives exactly as long as the interactive command loop:
+    ``cmdloop`` is only reached from ``main_xonsh`` in interactive mode,
+    so ``-c``, scripts and piped stdin keep the built-in ``input()``."""
+    import builtins
+
+    _, _, shell = ptk_shell
+    original = builtins.input
+    seen = []
+    shell.input_hook.install = lambda: seen.append(builtins.input)
+    xession.exit = 0  # loop body never runs
+    shell.cmdloop()
+    assert seen == [original]  # install was called from cmdloop
+    assert builtins.input is original  # and the hook was restored
+
+
+def test_shell_construction_does_not_touch_input(ptk_shell):
+    """Building the shell (as tests and non-interactive runs do) must
+    leave ``builtins.input`` alone."""
+    import builtins
+
+    _, _, shell = ptk_shell
+    assert builtins.input is not shell.input_hook
+    assert not shell.input_hook.installed
+
+
+class FakePromptSession:
+    """Records how the hook builds and drives its prompt_toolkit session."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls = []
+        FakePromptSession.instances.append(self)
+
+    def prompt(self, message, **kwargs):
+        self.calls.append((message, kwargs))
+        return "answer"
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    # Reach for the module through ``sys.modules``: ``prompt_toolkit.shortcuts``
+    # re-exports a *function* named ``prompt``, which shadows the submodule of
+    # the same name for both ``import ... as`` and the dotted-string form.
+    import sys
+
+    ptk_prompt = sys.modules["prompt_toolkit.shortcuts.prompt"]
+    FakePromptSession.instances = []
+    monkeypatch.setattr(ptk_prompt, "PromptSession", FakePromptSession)
+    return FakePromptSession
+
+
+def test_input_hook_enables_auto_suggest(input_hook, fake_session, xession):
+    """The ``input()`` prompt gets the same grey history suggestion as the
+    command prompt (accepted with the right arrow — prompt_toolkit loads
+    those key bindings itself)."""
+    from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+
+    xession.env["XONSH_PROMPT_AUTO_SUGGEST"] = True
+    input_hook.prompt("token: ")
+    (message, kwargs) = fake_session.instances[0].calls[0]
+    assert message == "token: "
+    assert isinstance(kwargs["auto_suggest"], AutoSuggestFromHistory)
+
+
+def test_input_hook_auto_suggest_follows_env(input_hook, fake_session, xession):
+    """``$XONSH_PROMPT_AUTO_SUGGEST`` is read per call, so turning
+    suggestions off applies to the very next ``input()``."""
+    xession.env["XONSH_PROMPT_AUTO_SUGGEST"] = False
+    input_hook.prompt("a: ")
+    xession.env["XONSH_PROMPT_AUTO_SUGGEST"] = True
+    input_hook.prompt("b: ")
+    session = fake_session.instances[0]
+    assert session.calls[0][1]["auto_suggest"] is None
+    assert session.calls[1][1]["auto_suggest"] is not None
+
+
+def test_input_hook_reuses_one_session(input_hook, fake_session, xession):
+    """Answers accumulate in a single session's history — that history is
+    what the suggestion is drawn from — and it is dropped on ``restore``."""
+    from prompt_toolkit.history import InMemoryHistory
+
+    input_hook.prompt("a: ")
+    input_hook.prompt("b: ")
+    assert len(fake_session.instances) == 1
+    assert isinstance(fake_session.instances[0].kwargs["history"], InMemoryHistory)
+    input_hook.install()
+    input_hook.restore()
+    input_hook.prompt("c: ")
+    assert len(fake_session.instances) == 2  # a fresh, empty history

--- a/xonsh/shells/ptk_shell/__init__.py
+++ b/xonsh/shells/ptk_shell/__init__.py
@@ -60,6 +60,7 @@ from xonsh.shells.base_shell import BaseShell
 from xonsh.shells.ptk_shell.completer import PromptToolkitCompleter
 from xonsh.shells.ptk_shell.formatter import PTKPromptFormatter
 from xonsh.shells.ptk_shell.history import PromptToolkitHistory, _cust_history_matches
+from xonsh.shells.ptk_shell.input_hook import PTKInputHook
 from xonsh.shells.ptk_shell.key_bindings import load_xonsh_bindings
 from xonsh.style_tools import DEFAULT_STYLE_DICT, _TokenType, partial_color_tokenize
 from xonsh.tools import carriage_return, print_exception, print_warning
@@ -232,6 +233,10 @@ class PromptToolkitShell(BaseShell):
                 except OSError:
                     pass  # stdin is not a real console (redirect/ConPTY)
         self._first_prompt = True
+        # Installed for the duration of ``cmdloop`` only, so that
+        # non-interactive runs (``-c``, scripts, piped stdin) keep the
+        # interpreter's own ``input()``.
+        self.input_hook = PTKInputHook(self)
         self.history = ThreadedHistory(PromptToolkitHistory())
         self.push = self._push
 
@@ -544,35 +549,39 @@ class PromptToolkitShell(BaseShell):
         if intro:
             print(intro)
         auto_suggest = AutoSuggestFromHistory()
-        while XSH.exit is None:
-            try:
-                line = self.singleline(auto_suggest=auto_suggest)
-                if not line:
-                    self.emptyline()
-                else:
-                    raw_line = line
-                    line = self.precmd(line)
-                    self.default(line, raw_line)
-            except (KeyboardInterrupt, SystemExit) as e:
-                self.reset_buffer()
-                if isinstance(e, KeyboardInterrupt):
-                    if XSH.env.get("XONSH_HISTORY_SIGINT_FLUSH", True):
-                        """
-                        Development tools like PyCharm send SIGINT before SIGKILL.
-                        This is the last chance to save history in this case.
-                        """
-                        if XSH.env.get("XONSH_DEBUG", False):
-                            print("Flushing history after SIGINT.", file=sys.stderr)
-                        XSH.history.flush()
-                if isinstance(e, SystemExit):
-                    get_app().reset()  # Reset TTY mouse and keys handlers.
-                    self.restore_tty_sanity()  # Reset TTY SIGINT handlers.
-                    raise
-            except EOFError:
-                if XSH.env.get("IGNOREEOF"):
-                    print('Use "exit" to leave the shell.', file=sys.stderr)
-                else:
-                    break
+        self.input_hook.install()
+        try:
+            while XSH.exit is None:
+                try:
+                    line = self.singleline(auto_suggest=auto_suggest)
+                    if not line:
+                        self.emptyline()
+                    else:
+                        raw_line = line
+                        line = self.precmd(line)
+                        self.default(line, raw_line)
+                except (KeyboardInterrupt, SystemExit) as e:
+                    self.reset_buffer()
+                    if isinstance(e, KeyboardInterrupt):
+                        if XSH.env.get("XONSH_HISTORY_SIGINT_FLUSH", True):
+                            """
+                            Development tools like PyCharm send SIGINT before SIGKILL.
+                            This is the last chance to save history in this case.
+                            """
+                            if XSH.env.get("XONSH_DEBUG", False):
+                                print("Flushing history after SIGINT.", file=sys.stderr)
+                            XSH.history.flush()
+                    if isinstance(e, SystemExit):
+                        get_app().reset()  # Reset TTY mouse and keys handlers.
+                        self.restore_tty_sanity()  # Reset TTY SIGINT handlers.
+                        raise
+                except EOFError:
+                    if XSH.env.get("IGNOREEOF"):
+                        print('Use "exit" to leave the shell.', file=sys.stderr)
+                    else:
+                        break
+        finally:
+            self.input_hook.restore()
 
     def _get_prompt_tokens(self, env_name: str, prompt_name: str, **kwargs):
         env = XSH.env  # type:ignore

--- a/xonsh/shells/ptk_shell/input_hook.py
+++ b/xonsh/shells/ptk_shell/input_hook.py
@@ -1,0 +1,140 @@
+"""Serve the built-in ``input()`` from a prompt_toolkit prompt.
+
+CPython's ``input()`` only gets line editing when the ``readline`` module
+has been imported: importing it installs ``PyOS_ReadlineFunctionPointer``,
+which ``input()`` calls whenever stdin and stdout are interactive. The
+prompt_toolkit shell never imports ``readline``, so ``input()`` falls back
+to a plain read from the terminal in canonical mode. There the kernel
+assembles the line and caps it at ``MAX_CANON`` — 1024 bytes on macOS and
+the BSDs, 4096 on Linux. Everything past the cap is discarded, *including*
+the terminating newline, so the read never completes and the call hangs
+until the user interrupts it. ``getpass.getpass()`` has the same problem:
+it clears ``ECHO`` but leaves canonical mode on.
+
+Routing ``input()`` through prompt_toolkit puts the terminal in raw mode
+for the duration of the read, which removes the limit and adds the usual
+line editing, kill/yank and history keys.
+
+The hook is installed only while the interactive prompt_toolkit shell is
+running its command loop (see ``PromptToolkitShell.cmdloop``), and it hands
+the call back to the original ``input()`` whenever a prompt_toolkit prompt
+cannot be driven safely — off the main thread, without a terminal, or
+while another prompt_toolkit application already owns the screen.
+"""
+
+import builtins
+import sys
+import threading
+
+from xonsh.built_ins import XSH
+
+_NOT_GIVEN = object()
+
+
+class PTKInputHook:
+    """Callable replacement for ``builtins.input``.
+
+    Parameters
+    ----------
+    shell : PromptToolkitShell
+        The shell that owns this hook. Only used to read the editing mode,
+        so the ``input()`` prompt matches the shell's key bindings.
+    """
+
+    def __init__(self, shell=None):
+        self.shell = shell
+        self.installed = False
+        self._original = None
+        self._session = None
+
+    def install(self):
+        """Replace ``builtins.input`` with this hook."""
+        if self.installed:
+            return
+        self._original = builtins.input
+        builtins.input = self
+        self.installed = True
+
+    def restore(self):
+        """Put the original ``builtins.input`` back."""
+        if not self.installed:
+            return
+        # Someone may have replaced ``input`` after us (a xontrib, ``pdb``,
+        # user code). Their hook wins — dropping ours on the floor is better
+        # than clobbering theirs.
+        if builtins.input is self:
+            builtins.input = self._original
+        self.installed = False
+        self._session = None
+
+    def usable(self):
+        """Whether a prompt_toolkit prompt can be driven right now."""
+        # Undeclared on purpose: an escape hatch, not a documented setting.
+        if not XSH.env.get("XONSH_PTK_INPUT_HOOK", True):
+            return False
+        # prompt_toolkit needs the main thread: it installs signal handlers
+        # and runs an event loop. Callable aliases execute in worker threads.
+        if threading.current_thread() is not threading.main_thread():
+            return False
+        try:
+            if not (sys.stdin.isatty() and sys.stdout.isatty()):
+                return False
+        except (AttributeError, OSError, ValueError):
+            # Detached, closed or replaced streams.
+            return False
+        from prompt_toolkit.application.current import get_app_or_none
+
+        app = get_app_or_none()
+        if app is not None and app.is_running:
+            # Called from a completer, a key binding or a prompt formatter,
+            # i.e. from inside a running application. Nesting would deadlock.
+            return False
+        return True
+
+    def prompt(self, message):
+        """Read one line through a dedicated prompt_toolkit session."""
+        if self._session is None:
+            from prompt_toolkit.enums import EditingMode
+            from prompt_toolkit.history import InMemoryHistory
+            from prompt_toolkit.shortcuts.prompt import PromptSession
+
+            editing_mode = (
+                EditingMode.VI if XSH.env.get("VI_MODE") else EditingMode.EMACS
+            )
+            # A session of its own, never the shell's: reusing the session
+            # that drives the command prompt hangs, and answers to ``input()``
+            # have no business in the command history.
+            self._session = PromptSession(
+                history=InMemoryHistory(), editing_mode=editing_mode
+            )
+        # Grey fish-style suggestion from earlier answers, accepted with the
+        # right arrow — the same mechanic as the command prompt, honoring the
+        # same setting. ``PromptSession`` loads the key bindings that accept a
+        # suggestion on its own. Read per call so the setting can be flipped
+        # while the session is running.
+        from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+
+        auto_suggest = (
+            AutoSuggestFromHistory()
+            if XSH.env.get("XONSH_PROMPT_AUTO_SUGGEST")
+            else None
+        )
+        return self._session.prompt(message, auto_suggest=auto_suggest)
+
+    def __call__(self, prompt=_NOT_GIVEN, /):
+        """Read a line, matching the semantics of the built-in ``input()``."""
+        if not self.usable():
+            if prompt is _NOT_GIVEN:
+                return self._original()
+            return self._original(prompt)
+        try:
+            return self.prompt("" if prompt is _NOT_GIVEN else str(prompt))
+        except (EOFError, KeyboardInterrupt):
+            # Ctrl-D / Ctrl-C: the built-in raises these too.
+            raise
+        except Exception:
+            # A broken prompt_toolkit prompt must never make ``input()``
+            # unusable — fall back to the interpreter's own implementation.
+            if prompt is _NOT_GIVEN:
+                return self._original()
+            return self._original(prompt)


### PR DESCRIPTION
Fixes https://github.com/xonsh/xonsh/issues/6561

Additional features:
* in-memory `input()` history
* in-memory `input()` autosuggestion

Can be disabled using `$XONSH_PTK_INPUT_HOOK=False`.

### Before

```xsh
echo @('-'*1025) | pbcopy
input('inp: ') 
# paste
# freeze 🔴 
# Ctrl+C
```

### After

```xsh
echo @('-'*1025) | pbcopy
input('inp: ') 
# paste
# working 🟢 
```

### getpass example

https://github.com/xonsh/xonsh/issues/6561#issuecomment-5133690466

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
