### PR TITLE
refactor(tools): move swap helpers to collections

### DIFF
--- a/tests/lib/test_collections.py
+++ b/tests/lib/test_collections.py
@@ -1,4 +1,24 @@
-from xonsh.lib.collections import ChainDB
+from types import SimpleNamespace
+
+from xonsh.lib.collections import ChainDB, swap, swap_values
+
+
+def test_swap_restores_attribute():
+    namespace = SimpleNamespace(value="before")
+
+    with swap(namespace, "value", "during"):
+        assert namespace.value == "during"
+
+    assert namespace.value == "before"
+
+
+def test_swap_values_restores_mapping():
+    mapping = {"existing": "before"}
+
+    with swap_values(mapping, {"existing": "during", "added": True}):
+        assert mapping == {"existing": "during", "added": True}
+
+    assert mapping == {"existing": "before"}
 
 
 def test_dddi():

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -31,6 +31,7 @@ from xonsh.foreign_shells import (
     DEFAULT_SOURCERS,
     foreign_shell_data,
 )
+from xonsh.lib.collections import swap_values
 from xonsh.lib.lazyasd import lazyobject
 from xonsh.parsers.ast import isexpression
 from xonsh.platform import (
@@ -56,7 +57,6 @@ from xonsh.tools import (
     print_color,
     print_exception,
     strip_simple_quotes,
-    swap_values,
     threadable,
     to_repr_pretty_,
     to_shlvl,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -31,6 +31,7 @@ from xonsh.codecache import run_script_with_cache
 from xonsh.debug import is_breakpoint_engine, to_breakpoint_engine
 from xonsh.dirstack import _get_cwd
 from xonsh.events import events
+from xonsh.lib.collections import swap_values
 from xonsh.lib.lazyasd import LazyBool, lazyobject
 from xonsh.platform import (
     BASH_COMPLETIONS_DEFAULT,
@@ -92,7 +93,6 @@ from xonsh.tools import (
     qualified_name,
     seq_to_upper_pathsep,
     set_to_csv,
-    swap_values,
     to_bool,
     to_bool_or_int,
     to_bool_or_none,

--- a/xonsh/lib/collections.py
+++ b/xonsh/lib/collections.py
@@ -1,5 +1,6 @@
-"""Base class for chaining DBs"""
+"""Collection helpers."""
 
+import contextlib
 import itertools
 import typing as tp
 from collections import ChainMap
@@ -18,6 +19,37 @@ class ChainDBDefaultType:
 
 
 ChainDBDefault = ChainDBDefaultType()
+
+_DEFAULT_SENTINEL = object()
+
+
+@contextlib.contextmanager
+def swap(namespace, name, value, default=_DEFAULT_SENTINEL):
+    """Swaps a current variable name in a namespace for another value, and then
+    replaces it when the context is exited.
+    """
+    old = getattr(namespace, name, default)
+    setattr(namespace, name, value)
+    yield value
+    if old is default:
+        delattr(namespace, name)
+    else:
+        setattr(namespace, name, old)
+
+
+@contextlib.contextmanager
+def swap_values(mapping, updates, default=_DEFAULT_SENTINEL):
+    """Updates a dictionary (or other mapping) with values from another mapping,
+    and then restores the original mapping when the context is exited.
+    """
+    old = {key: mapping.get(key, default) for key in updates}
+    mapping.update(updates)
+    yield
+    for key, value in old.items():
+        if value is default and key in mapping:
+            del mapping[key]
+        else:
+            mapping[key] = value
 
 
 class ChainDB(ChainMap):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -48,7 +48,6 @@ from the IPython project and retain their upstream copyrights:
 import ast
 import collections
 import collections.abc as cabc
-import contextlib
 import ctypes
 import datetime
 import functools
@@ -71,6 +70,8 @@ from contextlib import contextmanager
 # adding imports from further xonsh modules is discouraged to avoid circular
 # dependencies
 from xonsh import __version__
+from xonsh.lib.collections import swap as swap
+from xonsh.lib.collections import swap_values as swap_values
 from xonsh.lib.lazyasd import LazyDict, LazyObject, lazyobject
 from xonsh.platform import (
     DEFAULT_ENCODING,
@@ -1563,38 +1564,6 @@ def argvquote(arg, force=False):
 def on_main_thread():
     """Checks if we are on the main thread or not."""
     return threading.current_thread() is threading.main_thread()
-
-
-_DEFAULT_SENTINEL = object()
-
-
-@contextlib.contextmanager
-def swap(namespace, name, value, default=_DEFAULT_SENTINEL):
-    """Swaps a current variable name in a namespace for another value, and then
-    replaces it when the context is exited.
-    """
-    old = getattr(namespace, name, default)
-    setattr(namespace, name, value)
-    yield value
-    if old is default:
-        delattr(namespace, name)
-    else:
-        setattr(namespace, name, old)
-
-
-@contextlib.contextmanager
-def swap_values(d, updates, default=_DEFAULT_SENTINEL):
-    """Updates a dictionary (or other mapping) with values from another mapping,
-    and then restores the original mapping when the context is exited.
-    """
-    old = {k: d.get(k, default) for k in updates}
-    d.update(updates)
-    yield
-    for k, v in old.items():
-        if v is default and k in d:
-            del d[k]
-        else:
-            d[k] = v
 
 
 #


### PR DESCRIPTION
## Summary

- move `swap` and `swap_values` from `xonsh.tools` to `xonsh.lib.collections`
- update internal consumers to import from the focused library module
- retain compatibility re-exports from `xonsh.tools` and add collection-helper coverage

Refs #5563

## Validation

- `ruff check` and `ruff format --check` on the modified Python files
- `pytest tests/lib/test_collections.py tests/test_tools.py` (`584 passed, 9 skipped`)