### PR TITLE
fix(cwd): Fix exception in case of running command being in removed directory on macOS

### DIFF
--- a/tests/prompt/test_vc.py
+++ b/tests/prompt/test_vc.py
@@ -155,3 +155,34 @@ def test_git_dirty_working_directory_includes_untracked(
         )
 
     assert vc.git_dirty_working_directory() == include_untracked
+
+
+def test_is_in_git_repo_uses_pwd_only(set_xenv, monkeypatch, tmpdir):
+    """``$PWD`` is xonsh's own record of the location, so the prompt has no
+    reason to call ``os.getcwd()`` on every render -- and calling it used to
+    happen unconditionally, because ``env.get("PWD", os.getcwd())`` evaluates
+    its default eagerly.
+    """
+    set_xenv(str(tmpdir))
+    called = []
+    monkeypatch.setattr(os, "getcwd", lambda: called.append(1) or str(tmpdir))
+
+    vc._is_in_git_repo()
+
+    assert called == []
+
+
+def test_is_in_git_repo_with_unreachable_cwd(set_xenv, monkeypatch):
+    """With no ``$PWD`` and a working directory that has been removed (or an
+    ancestor that stopped being readable -- ``PermissionError`` on macOS),
+    the check reports "not a repo" instead of breaking the prompt.
+    """
+    set_xenv("")
+
+    def boom():
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(os, "getcwd", boom)
+
+    assert vc._is_in_git_repo() is False
+    assert vc.get_git_branch() is None

--- a/tests/shell/test_base_shell_llm.py
+++ b/tests/shell/test_base_shell_llm.py
@@ -1,0 +1,67 @@
+"""LLM-generated tests for ``xonsh.shells.base_shell``."""
+
+import errno
+import os
+
+import pytest
+
+from xonsh.built_ins import XSH
+from xonsh.shells.base_shell import BaseShell
+
+
+def _raiser(exc):
+    def raise_it(*args, **kwargs):
+        raise exc
+
+    return raise_it
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        FileNotFoundError(errno.ENOENT, "No such file or directory"),
+        PermissionError(errno.EPERM, "Operation not permitted"),
+        PermissionError(errno.EACCES, "Permission denied"),
+        OSError(errno.EIO, "Input/output error"),
+    ],
+    ids=["enoent", "eperm", "eacces", "eio"],
+)
+def test_precmd_survives_unreachable_cwd(
+    exc, xession, xonsh_execer, monkeypatch, tmpdir
+):
+    """``os.getcwd()`` fails for more reasons than a plain deletion: an
+    ancestor that stopped being readable, an unmounted volume, or a macOS
+    sandbox/TCC denial all arrive as ``PermissionError``. None of them may
+    escape ``precmd()`` -- an exception here reaches ``xonsh.main`` and gets
+    the whole interactive session replaced by another shell.
+    """
+    shell = BaseShell(xonsh_execer, None)
+    xession.env["PWD"] = str(tmpdir)
+    monkeypatch.setattr(os, "getcwd", _raiser(exc))
+
+    assert shell.precmd("echo test") == "echo test"
+    # $PWD is xonsh's own record of where the session is, so it beats
+    # pretending the command ran in the home directory.
+    assert shell.precwd == str(tmpdir)
+
+
+def test_precmd_falls_back_to_home_without_pwd(xession, xonsh_execer, monkeypatch):
+    """With no usable ``$PWD`` left there is nothing better than ``~``."""
+    shell = BaseShell(xonsh_execer, None)
+    xession.env["PWD"] = ""
+    monkeypatch.setattr(os, "getcwd", _raiser(PermissionError(errno.EPERM, "nope")))
+
+    shell.precmd("echo test")
+
+    assert shell.precwd == os.path.expanduser("~")
+
+
+def test_precmd_falls_back_to_home_without_env(xession, xonsh_execer, monkeypatch):
+    """The session may not carry an ``env`` at all (bare ``XSH``)."""
+    shell = BaseShell(xonsh_execer, None)
+    monkeypatch.setattr(os, "getcwd", _raiser(PermissionError(errno.EPERM, "nope")))
+    monkeypatch.setattr(XSH, "env", None)
+
+    shell.precmd("echo test")
+
+    assert shell.precwd == os.path.expanduser("~")

--- a/xonsh/prompt/vc.py
+++ b/xonsh/prompt/vc.py
@@ -12,6 +12,7 @@ import threading
 
 import xonsh.tools as xt
 from xonsh.built_ins import XSH
+from xonsh.dirstack import _get_cwd
 from xonsh.lib.lazyasd import LazyObject
 from xonsh.procs.executables import locate_executable
 
@@ -48,7 +49,9 @@ def _get_git_branch(q):
 def _is_in_git_repo():
     """Fast filesystem check for .git — avoids spawning git subprocess."""
     env = XSH.env
-    cwd = env.get("PWD", os.getcwd()) if env else os.getcwd()
+    cwd = (env.get("PWD") if env else None) or _get_cwd()
+    if cwd is None:
+        return False
     while True:
         if os.path.exists(os.path.join(cwd, ".git")):
             return True

--- a/xonsh/shells/base_shell.py
+++ b/xonsh/shells/base_shell.py
@@ -373,8 +373,16 @@ class BaseShell:
         """Called just before execution of line."""
         try:
             self.precwd = os.getcwd()
-        except FileNotFoundError:
-            self.precwd = os.path.expanduser("~")
+        except OSError:
+            # The working directory can stop being reachable at any moment:
+            # removed by another process, an unmounted volume, or an ancestor
+            # that is no longer readable -- macOS reports the latter (and any
+            # sandbox/TCC denial) as ``PermissionError``, not as the
+            # ``FileNotFoundError`` a plain deletion gives. ``$PWD`` is
+            # xonsh's own record of where the session is, so it stays closer
+            # to the truth than the home directory.
+            env = XSH.env
+            self.precwd = (env.get("PWD") if env else None) or os.path.expanduser("~")
         return line
 
     def default(self, line, raw_line=None):


### PR DESCRIPTION
### Before

macOS:
```xsh
cd /tmp
mkdir dir
cd dir
touch file
# Remove or move /tmp/dir to trash
ls
```
Result:
```xsh
Traceback (most recent call last):                                      
  File                                                                  
"/Users/pc/.local/xonsh-env/lib/python3.14/site-packages/xonsh/main.py",
line 1267, in main                                                      
    sys.exit(main_xonsh(args))                                          
             ~~~~~~~~~~^^^^^^                                           
  File                                                                  
"/Users/pc/.local/xonsh-env/lib/python3.14/site-packages/xonsh/main.py",
line 1314, in main_xonsh                                                
    shell.shell.cmdloop()                                               
    ~~~~~~~~~~~~~~~~~~~^^                                               
  File "/Users/pc/.local/xonsh-env/lib/python3.14/site-packages/xonsh/sh
ells/ptk_shell/__init__.py", line 561, in cmdloop                       
    line = self.precmd(line)                                            
  File "/Users/pc/.local/xonsh-env/lib/python3.14/site-packages/xonsh/sh
ells/base_shell.py", line 375, in precmd                                
    self.precwd = os.getcwd()                                           
                  ~~~~~~~~~^^                                           
PermissionError: [Errno 1] Operation not permitted                      
Xonsh encountered an issue during launch.                               
Please report to https://github.com/xonsh/xonsh/issues                  
Failback to /bin/zsh                           
```

### After

```xsh
ls
# ls: .: Operation not permitted
# xonsh: working directory does not exist: /private/tmp/dir
cd ..
```

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
