### PR TITLE
fix(glob): honor DOTGLOB for g-glob even with explicit-dot patterns

### DIFF
--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -92,6 +92,13 @@ class TestDotglob:
         self.xession.env["DOTGLOB"] = False
         assert ".hidden" not in self._glob()
 
+    def test_glob_explicit_dot_wildcard_respects_dotglob(self):
+        """g-glob of .* must not return hidden names when DOTGLOB is False."""
+        self.xession.env["DOTGLOB"] = False
+        assert ".hidden" not in self._basenames(globsearch(".*"))
+        self.xession.env["DOTGLOB"] = True
+        assert ".hidden" in self._basenames(globsearch(".*"))
+
     def test_glob_includes_dotfiles_when_enabled(self):
         self.xession.env["DOTGLOB"] = True
         assert ".hidden" in self._glob()

--- a/tests/test_tools_iglob_llm.py
+++ b/tests/test_tools_iglob_llm.py
@@ -166,6 +166,13 @@ def test_explicit_dot_wildcard_matches_dotfiles(tree):
 
 
 @skip_on_windows
+def test_explicit_dot_wildcard_respects_include_dotfiles_when_not_completer(tree):
+    # g-glob / $DOTGLOB=False: even '.*' must not return hidden names.
+    out = sorted(_case_insensitive_iglob(".*", explicit_dot_matches_hidden=False))
+    assert ".hidden" not in out
+
+
+@skip_on_windows
 def test_literal_hidden_segment_is_traversed(tmp_path):
     # A literal segment that happens to start with '.' (no glob meta)
     # must always be traversed — otherwise paths like '~/.config/<Tab>'

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -346,6 +346,7 @@ def globsearch(s):
             return_empty=True,
             sort_result=glob_sorted,
             include_dotfiles=dotglob,
+            explicit_dot_matches_hidden=False,
         )
     )
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -2933,7 +2933,12 @@ def expand_case_matching(s):
 
 
 def globpath(
-    s, ignore_case=False, return_empty=False, sort_result=None, include_dotfiles=None
+    s,
+    ignore_case=False,
+    return_empty=False,
+    sort_result=None,
+    include_dotfiles=None,
+    explicit_dot_matches_hidden=True,
 ):
     """Simple wrapper around glob that also expands home and env vars."""
     o, s = _iglobpath(
@@ -2941,6 +2946,7 @@ def globpath(
         ignore_case=ignore_case,
         sort_result=sort_result,
         include_dotfiles=include_dotfiles,
+        explicit_dot_matches_hidden=explicit_dot_matches_hidden,
     )
     o = list(o)
     no_match = [] if return_empty else [s]
@@ -2950,7 +2956,13 @@ def globpath(
 _GLOB_META = "*?["
 
 
-def _case_insensitive_iglob(pattern, *, include_dotfiles=False, recursive=False):
+def _case_insensitive_iglob(
+    pattern,
+    *,
+    include_dotfiles=False,
+    recursive=False,
+    explicit_dot_matches_hidden=True,
+):
     """Case-insensitive glob, tolerant of unreadable parent directories.
 
     Walks ``pattern`` segment by segment. At each segment:
@@ -2993,11 +3005,12 @@ def _case_insensitive_iglob(pattern, *, include_dotfiles=False, recursive=False)
             entries = os.listdir(d)
         except OSError:
             return None
-        # Mirror stdlib glob: a segment that starts with '.' is treated as
-        # an explicit request for hidden names (literal '.foo' or wildcard
-        # '.x*'), so the dotfile filter does not apply. Bare wildcards
-        # ('*', '**', 'foo*') still hide dotfiles unless include_dotfiles.
-        if not include_dotfiles and not part.startswith("."):
+        # Completer (#6402): a segment that starts with '.' is an explicit
+        # request for hidden names, so the filter is skipped. g-glob
+        # (#6551): $DOTGLOB=False must hide every dotfile, even for '.*'.
+        if not include_dotfiles and not (
+            explicit_dot_matches_hidden and part.startswith(".")
+        ):
             entries = [e for e in entries if not e.startswith(".")]
         return entries
 
@@ -3075,7 +3088,13 @@ def _case_insensitive_iglob(pattern, *, include_dotfiles=False, recursive=False)
         yield from cur
 
 
-def _iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
+def _iglobpath(
+    s,
+    ignore_case=False,
+    sort_result=None,
+    include_dotfiles=None,
+    explicit_dot_matches_hidden=True,
+):
     s = xsh.expand_path(s)
     if sort_result is None:
         sort_result = xsh.env.get("GLOB_SORTED")
@@ -3090,6 +3109,7 @@ def _iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
             s,
             include_dotfiles=bool(include_dotfiles),
             recursive=True,
+            explicit_dot_matches_hidden=explicit_dot_matches_hidden,
         )
     else:
         if ignore_case:
@@ -3105,7 +3125,13 @@ def _iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
     return paths, s
 
 
-def iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
+def iglobpath(
+    s,
+    ignore_case=False,
+    sort_result=None,
+    include_dotfiles=None,
+    explicit_dot_matches_hidden=True,
+):
     """Simple wrapper around iglob that also expands home and env vars."""
     try:
         return _iglobpath(
@@ -3113,6 +3139,7 @@ def iglobpath(s, ignore_case=False, sort_result=None, include_dotfiles=None):
             ignore_case=ignore_case,
             sort_result=sort_result,
             include_dotfiles=include_dotfiles,
+            explicit_dot_matches_hidden=explicit_dot_matches_hidden,
         )[0]
     except IndexError:
         # something went wrong in the actual iglob() call


### PR DESCRIPTION
## Summary

PR #6402 taught `_case_insensitive_iglob` to treat a leading `.` in a path segment as an explicit request for hidden names. That is the right completer behavior (`.git`, `~/.config/<Tab>`), but it also changed `g-glob`, so `g\`.*\`` listed dotfiles even when `$DOTGLOB` was `False`.

This splits the two call sites:

- Completers keep the #6402 default (`explicit_dot_matches_hidden=True`).
- `globsearch` (used by `g\`...\``) passes `explicit_dot_matches_hidden=False`, so `$DOTGLOB=False` hides every dotfile, including matches of `.*`.

Fixes #6551

## Test plan

- [x] `tests/test_tools_iglob_llm.py`: `.*` still matches `.hidden` for the completer default, and does not when `explicit_dot_matches_hidden=False`
- [x] `tests/test_builtins.py`: `globsearch(".*")` follows `$DOTGLOB`
- [x] existing completer tests in `tests/completers/test_path_dotfiles_llm.py` still pass