### PR TITLE
refactor: move `unquote` and `endswith_newline` to `xonsh.lib.string`

### DIFF
--- a/tests/lib/test_string_llm.py
+++ b/tests/lib/test_string_llm.py
@@ -1,0 +1,24 @@
+import pytest
+
+from xonsh.lib.string import endswith_newline, unquote
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ('"quoted"', "quoted"),
+        ("'quoted'", "quoted"),
+        ("\"mismatched'", "\"mismatched'"),
+        ("plain", "plain"),
+    ],
+)
+def test_unquote(value: str, expected: str):
+    assert unquote(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [("text", "text\n"), ("text\n", "text\n"), ("text\n\n", "text\n"), ("", "\n")],
+)
+def test_endswith_newline(value: str, expected: str):
+    assert endswith_newline(value) == expected

--- a/xonsh/lib/string.py
+++ b/xonsh/lib/string.py
@@ -12,3 +12,15 @@ def commonprefix(m: Iterable[str]) -> str:
         if c != s2[i]:
             return s1[:i]
     return s1
+
+
+def unquote(s: str, chars: str = "'\"") -> str:
+    """Strip one pair of matching quote characters from a string."""
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in chars:
+        return s[1:-1]
+    return s
+
+
+def endswith_newline(s: str) -> str:
+    """Return a string ending with exactly one newline character."""
+    return s.rstrip("\n") + "\n"

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -27,6 +27,7 @@ from xonsh.imphooks import install_import_hooks
 from xonsh.lib.lazyasd import lazyobject
 from xonsh.lib.lazyimps import pyghooks, pygments
 from xonsh.lib.pretty import pretty
+from xonsh.lib.string import unquote
 from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS
 from xonsh.procs.jobs import ignore_sigtstp
 from xonsh.shell import Shell
@@ -37,7 +38,6 @@ from xonsh.tools import (
     print_color,
     print_exception,
     to_bool_or_int,
-    unquote,
 )
 from xonsh.xonfig import print_welcome_screen
 from xonsh.xontribs import auto_load_xontribs_from_entrypoints, xontribs_load

--- a/xonsh/procs/proxies.py
+++ b/xonsh/procs/proxies.py
@@ -20,6 +20,7 @@ import xonsh.platform as xp
 import xonsh.tools as xt
 from xonsh.built_ins import XSH
 from xonsh.cli_utils import run_with_partial_args
+from xonsh.lib.string import endswith_newline
 from xonsh.procs.pipes import PipeChannel
 from xonsh.procs.readers import safe_fdclose
 
@@ -255,7 +256,7 @@ def parse_proxy_return(r, stdout, stderr):
             stdout.write(str(r[0]))
             stdout.flush()
         if rlen > 1 and r[1] is not None:
-            stderr.write(xt.endswith_newline(str(r[1])))
+            stderr.write(endswith_newline(str(r[1])))
             stderr.flush()
         if rlen > 2 and isinstance(r[2], int):
             cmd_result = r[2]

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -72,6 +72,8 @@ from contextlib import contextmanager
 # dependencies
 from xonsh import __version__
 from xonsh.lib.lazyasd import LazyDict, LazyObject, lazyobject
+from xonsh.lib.string import endswith_newline as endswith_newline
+from xonsh.lib.string import unquote as unquote
 from xonsh.platform import (
     DEFAULT_ENCODING,
     HAS_PYGMENTS,
@@ -3352,15 +3354,3 @@ def describe_waitpid_status(status):
     for f in funcs:
         s = f(status)
         print(f.__name__, "-", s, get_signal_name(s), "-", f.__doc__)
-
-
-def unquote(s: str, chars="'\""):
-    """Strip paired quotes from string once."""
-    if len(s) >= 2 and s[0] == s[-1] and s[0] in chars:
-        return s[1:-1]
-    return s
-
-
-def endswith_newline(s: str):
-    """Force one new line character end to string."""
-    return s.rstrip("\n") + "\n"


### PR DESCRIPTION
## Summary

- move `unquote` and `endswith_newline` into `xonsh.lib.string`
- update internal callers to import from the focused library module
- keep explicit compatibility re-exports in `xonsh.tools`
- add generated tests in the policy-required module-mirroring `_llm.py` file

Addresses #5563

## Validation

- targeted string tests: 15 passed
- Ruff check and format checks pass
- compatibility identity check confirms the old imports reference the moved functions

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍 comment**