### PR TITLE
feat: Add `@stream` command decorator alias.

### DIFF
--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -236,7 +236,7 @@ Return output as list of lines.
 
 ``@stream``
 -----------
-Return output as stream_lines.
+Return output as stream of lines. This is useful when ``$XONSH_SUBPROC_OUTPUT_FORMAT`` is set to ``list_lines``.
 
 .. code-block:: xonshcon
 

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -234,6 +234,15 @@ Return output as list of lines.
     @ lines = $(@lines cat file)
 
 
+``@stream``
+-----------
+Return output as stream_lines.
+
+.. code-block:: xonshcon
+
+    @ str = $(@stream cat file)
+
+
 ``@json``
 ----------
 Parses JSON and returns a JSON object.

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1749,6 +1749,11 @@ def make_default_aliases():
             "Command decorator. Return output as list of lines.",
             name="@lines",
         ),
+        "@stream": SpecAttrDecoratorAlias(
+            {"output_format": "stream_lines"},
+            "Command decorator. Return output as stream.",
+            name="@stream",
+        ),
         "@path": SpecAttrDecoratorAlias(
             {"output_format": _output_to_path_object},
             "Command decorator. Return Path object for the first line in output.",

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1746,12 +1746,12 @@ def make_default_aliases():
         ),
         "@lines": SpecAttrDecoratorAlias(
             {"output_format": "list_lines"},
-            "Command decorator. Return output as list of lines.",
+            "Command decorator. Return output as list of lines. See also $XONSH_SUBPROC_OUTPUT_FORMAT.",
             name="@lines",
         ),
         "@stream": SpecAttrDecoratorAlias(
             {"output_format": "stream_lines"},
-            "Command decorator. Return output as stream.",
+            "Command decorator. Return output as stream of lines. See also $XONSH_SUBPROC_OUTPUT_FORMAT.",
             name="@stream",
         ),
         "@path": SpecAttrDecoratorAlias(


### PR DESCRIPTION
@stream compliments @lines. It is useful for users who have `$XONSH_SUBPROC_OUTPUT_FORMAT = 'list_lines'`
set globally, for example `user = $(@stream whoami)`.

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
