### PR TITLE
fix(which): fix output under `which -ap` flags

### DIFF
--- a/tests/xoreutils/test_which_llm.py
+++ b/tests/xoreutils/test_which_llm.py
@@ -1,0 +1,115 @@
+"""Tests for the ``which`` alias in ``xonsh.xoreutils.which``."""
+
+import io
+import os
+
+import pytest
+
+from xonsh.platform import ON_WINDOWS
+from xonsh.xoreutils import which as xxw
+
+#: Name of the file created on ``$PATH``; on Windows the extension is needed
+#: so that ``whichgen`` picks it up via ``$PATHEXT``.
+APP_FILE = "whichtestapp1.exe" if ON_WINDOWS else "whichtestapp1"
+
+#: Name the ``which`` alias is called with.
+APP = "whichtestapp1"
+
+
+class FakeSpec:
+    """Stand-in for the ``SubprocSpec`` a callable alias receives as ``spec``."""
+
+    def __init__(self, captured):
+        self.captured = captured
+
+
+@pytest.fixture
+def which_path(tmp_path, xession):
+    """Put two directories holding the same executable name on ``$PATH``."""
+    dirs = []
+    for name in ("bin1", "bin2"):
+        d = tmp_path / name
+        d.mkdir()
+        app = d / APP_FILE
+        app.write_bytes(b"")
+        os.chmod(app, 0o755)
+        dirs.append(str(d))
+    xession.env["PATH"] = dirs
+    xession.env["PATHEXT"] = [".EXE", ".BAT", ".CMD", ".COM"]
+    return dirs
+
+
+def _run(args, spec=None):
+    """Run the ``which`` alias and return ``(retcode, stdout, stderr)``."""
+    stdout, stderr = io.StringIO(), io.StringIO()
+    rtn = xxw.which(args, stdout=stdout, stderr=stderr, spec=spec)
+    return rtn, stdout.getvalue(), stderr.getvalue()
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        None,
+        FakeSpec(False),
+        FakeSpec("stdout"),
+        FakeSpec("object"),
+        FakeSpec("hiddenobject"),
+    ],
+    ids=["no-spec", "uncaptured", "stdout", "object", "hiddenobject"],
+)
+def test_all_plain_prints_one_path_per_line(which_path, spec):
+    """``which -ap`` must separate matches by newlines however it is called.
+
+    Under a capturing spec the paths used to be printed with ``end=""``,
+    which glued every match into a single unusable line.
+    """
+    rtn, out, err = _run(["-ap", APP], spec=spec)
+    assert rtn == 0
+    assert err == ""
+    assert out.count("\n") == 2
+    assert [os.path.dirname(line) for line in out.splitlines()] == which_path
+    assert all(os.path.basename(line) == APP_FILE for line in out.splitlines())
+
+
+@pytest.mark.parametrize(
+    "spec", [FakeSpec(False), FakeSpec("stdout")], ids=["uncaptured", "stdout"]
+)
+def test_single_match_is_one_line(which_path, spec):
+    """Without ``-a`` exactly one match is printed, as a single line.
+
+    ``$(which app)`` strips that trailing newline in
+    ``CommandPipeline.get_formatted_lines`` (single-line output only), so
+    the capture stays free of a trailing newline without ``which`` having
+    to suppress it.
+    """
+    rtn, out, err = _run(["-p", APP], spec=spec)
+    assert rtn == 0
+    assert err == ""
+    assert out.splitlines() == [os.path.join(which_path[0], APP_FILE)]
+    assert out.endswith("\n")
+
+
+def test_all_verbose_prints_one_path_per_line(which_path):
+    """``-a`` alone implies verbose; matches stay newline separated."""
+    rtn, out, err = _run(["-a", APP], spec=FakeSpec("stdout"))
+    assert rtn == 0
+    assert out.count("\n") == 2
+    assert all(line.endswith(")") for line in out.splitlines())
+
+
+def test_alias_and_paths_are_separated(which_path, xession):
+    """An alias match and the ``$PATH`` matches must not be glued together."""
+    xession.aliases[APP] = ["echo", "hi"]
+    rtn, out, err = _run(["-ap", APP], spec=FakeSpec("stdout"))
+    assert rtn == 0
+    lines = out.splitlines()
+    assert len(lines) == 3
+    assert lines[0] == "echo hi"
+    assert [os.path.dirname(line) for line in lines[1:]] == which_path
+
+
+def test_missing_command_reports_failure(which_path):
+    rtn, out, err = _run(["-ap", "not_a_command_at_all"], spec=FakeSpec("stdout"))
+    assert rtn == 1
+    assert out == ""
+    assert "not_a_command_at_all not in " in err

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -6,7 +6,6 @@ import os
 
 import xonsh
 import xonsh.platform as xp
-import xonsh.procs.pipelines as xpp
 from xonsh.built_ins import XSH
 from xonsh.xoreutils import _which
 

--- a/xonsh/xoreutils/which.py
+++ b/xonsh/xoreutils/which.py
@@ -81,7 +81,7 @@ def print_global_object(arg, stdout):
     print(f"global object of {type(obj)}", file=stdout)
 
 
-def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
+def print_path(abs_name, from_where, stdout, verbose=False):
     """Print the name and path of the command."""
     if xp.ON_WINDOWS:
         # Use list dir to get correct case for the filename
@@ -94,8 +94,7 @@ def print_path(abs_name, from_where, stdout, verbose=False, captured=False):
     if verbose:
         print(f"{abs_name} ({from_where})", file=stdout)
     else:
-        end = "" if captured else "\n"
-        print(abs_name, end=end, file=stdout)
+        print(abs_name, file=stdout)
 
 
 def print_alias(arg, stdout, verbose=False):
@@ -132,10 +131,6 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
 
     pargs = parser.parse_args(args)
     verbose = pargs.verbose or pargs.all
-    if spec is not None:
-        captured = spec.captured in xpp.STDOUT_CAPTURE_KINDS
-    else:
-        captured = False
     if pargs.plain:
         verbose = False
     if xp.ON_WINDOWS:
@@ -163,7 +158,7 @@ def which(args, stdin=None, stdout=None, stderr=None, spec=None):
                 if match is None:
                     continue
                 abs_name, from_where = match
-                print_path(abs_name, from_where, stdout, verbose, captured)
+                print_path(abs_name, from_where, stdout, verbose)
                 nmatches += 1
                 if not pargs.all:
                     break


### PR DESCRIPTION
Remove `captured` argument; no longer used.

Before:
```xsh
wombat@  which -ap avifenc
/home/wombat/bin/avifenc
/nix/store/g5jmc5pr1ayim5s7mbjvk7xz9a61n9ac-libavif-1.4.2/bin/avifenc

wombat@  $(which -ap avifenc)
'/home/wombat/bin/avifenc/nix/store/g5jmc5pr1ayim5s7mbjvk7xz9a61n9ac-libavif-1.4.2/bin/avifenc'

wombat@  $(@lines which -ap avifenc)
['/home/wombat/bin/avifenc/nix/store/g5jmc5pr1ayim5s7mbjvk7xz9a61n9ac-libavif-1.4.2/bin/avifenc']

```
After:
```xsh
wombat@  which -ap avifenc
/home/wombat/bin/avifenc
/nix/store/g5jmc5pr1ayim5s7mbjvk7xz9a61n9ac-libavif-1.4.2/bin/avifenc

wombat@  $(which -ap avifenc)
'/home/wombat/bin/avifenc\n/nix/store/g5jmc5pr1ayim5s7mbjvk7xz9a61n9ac-libavif-1.4.2/bin/avifenc\n'

wombat@  $(@lines which -ap avifenc)
['/home/wombat/bin/avifenc',
 '/nix/store/g5jmc5pr1ayim5s7mbjvk7xz9a61n9ac-libavif-1.4.2/bin/avifenc']

```

<!--- Thanks for opening a PR on xonsh!

Please do this:

1. Use Conventional Commits for PR title e.g. `feat(prompt): Add new color`.
2. Add the documentation to `/docs/`.
3. Add the example of usage or before-after behavior.
4. Mention the issue that this PR is addressing e.g. `Closes #1234`.
5. 🤖 Ask AI/LLM about using instructions from `CLAUDE.md`.

-->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
