### PR TITLE
fix(nix): Fixed new Nix pythonMetadataCheckHook + Cachix support

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,72 @@
+name: ci-nix-build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'nix/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'pyproject.toml'
+      - 'xonsh/__init__.py'
+      - '.github/workflows/nix-build.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: cachix/install-nix-action@v31
+
+      # Pushing needs the auth token, which forks and pull_request events
+      # don't have. They still build, they just don't populate the cache.
+      - uses: cachix/cachix-action@v17
+        if: github.repository == 'xonsh/xonsh' && github.event_name != 'pull_request'
+        with:
+          name: xonsh
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      # `.#default` is the same derivation as one of the py3xx variants,
+      # Nix deduplicates it.
+      - run: nix build -L --no-link --fallback .#default .#xonsh-py312 .#xonsh-py313 .#xonsh-py314
+
+  cachix-branch:
+    needs: build
+    if: github.repository == 'xonsh/xonsh' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward the `cachix` branch
+        run: |
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          git fetch --no-tags origin '+refs/heads/cachix:refs/remotes/origin/cachix' || true
+
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "$GITHUB_SHA is no longer on main, skipping"
+            exit 0
+          fi
+
+          if git rev-parse --verify -q origin/cachix >/dev/null &&
+             git merge-base --is-ancestor "$GITHUB_SHA" origin/cachix; then
+            echo "cachix branch already contains $GITHUB_SHA, skipping"
+            exit 0
+          fi
+
+          git push origin "$GITHUB_SHA":refs/heads/cachix --force

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -468,6 +468,27 @@ declared in ``nix/default.nix``. For example, to use Python 3.14:
     nix-build nix/ -A xonsh-py314
 
 
+Binary cache
+""""""""""""
+
+Building xonsh from the flake compiles it from source, which takes a while.
+Every push to ``main`` is built by CI and the results are pushed to a
+`Cachix <https://cachix.org>`_ binary cache. To use it, add the substituter
+to your Nix configuration:
+
+.. code-block:: bash
+
+    nix run nixpkgs#cachix -- use xonsh
+
+The ``cachix`` branch always points at the newest commit of ``main`` that was
+built successfully, so following it guarantees a cache hit instead of a local
+build:
+
+.. code-block:: bash
+
+    nix run github:xonsh/xonsh/cachix
+
+
 Container
 ^^^^^^^^^
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -472,13 +472,21 @@ Binary cache
 """"""""""""
 
 Building xonsh from the flake compiles it from source, which takes a while.
-Every push to ``main`` is built by CI and the results are pushed to a
-`Cachix <https://cachix.org>`_ binary cache. To use it, add the substituter
-to your Nix configuration:
+Every push to ``main`` is built by CI and the results are pushed to the
+`xonsh.cachix.org <https://app.cachix.org/cache/xonsh>`_ binary cache. To use it:
 
 .. code-block:: bash
 
     nix run nixpkgs#cachix -- use xonsh
+
+Or declare the substituter yourself, e.g. on NixOS:
+
+.. code-block:: nix
+
+    nix.settings = {
+      substituters = [ "https://xonsh.cachix.org" ];
+      trusted-public-keys = [ "xonsh.cachix.org-1:wwdHGMixIz1oZB0MtubjhZyCfWMWRLTQTT9zLO+DyMY=" ];
+    };
 
 The ``cachix`` branch always points at the newest commit of ``main`` that was
 built successfully, so following it guarantees a cache hit instead of a local

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -32,7 +32,17 @@
 
 buildPythonPackage {
   pname = "xonsh";
-  version = "main";
+  # `xonsh.__version__` is the single source of truth: setuptools reads it for
+  # the wheel metadata and buildPythonPackage checks that it matches `version`.
+  version =
+    let
+      matches = lib.filter (m: m != null) (
+        map (builtins.match "__version__ *= *\"([^\"]*)\".*") (
+          lib.splitString "\n" (builtins.readFile ../xonsh/__init__.py)
+        )
+      );
+    in
+    lib.head (lib.head matches);
   pyproject = true;
 
   src = ../.;


### PR DESCRIPTION
Fixes #6579

nixpkgs added `pythonMetadataCheckHook` (NixOS/nixpkgs@006c7936a, 2026-06-17),               
which parses both the derivation's `version` and the version in                              
`.dist-info/METADATA` with `packaging.version.Version`. The hardcoded                        
`version = "main"` is not a valid PEP 440 version, so every build failed with                
`InvalidVersion: Invalid version: 'main'`.                                                   
                                                                                             
Read the version from `xonsh/__init__.py` instead — the same source setuptools               
uses for the wheel metadata — so the check matches by construction and nothing               
needs updating on release.                                                                   
                                                                                             
Verified with a full `nix build .#xonsh` (7506 passed, 68 skipped, 3 xfailed);               
`version` resolves to 0.24.1 for `default`, `xonsh`, `xonsh-py312/313/314`.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
