### PR TITLE
fix(history): bound JSON exit flush wait

### DIFF
--- a/tests/history/test_history_json.py
+++ b/tests/history/test_history_json.py
@@ -2,12 +2,15 @@
 
 # pylint: disable=protected-access
 
+import collections
 import shlex
+import threading
 
 import pytest
 
 from xonsh.history.json import (
     JsonHistory,
+    JsonHistoryFlusher,
     _xhj_gc_bytes_to_rmfiles,
     _xhj_gc_commands_to_rmfiles,
     _xhj_gc_files_to_rmfiles,
@@ -68,6 +71,25 @@ def test_hist_flush(hist, xession):
         cmd = lj["cmds"][0]
         assert cmd["inp"] == "still alive?"
         assert not cmd.get("out", None)
+
+
+def test_at_exit_flush_timeout_does_not_block_shutdown(xession):
+    """A stuck earlier flush must not prevent the exit flush from returning."""
+    blocker = object()
+    queue = collections.deque([blocker])
+    cond = threading.Condition()
+    finished = threading.Event()
+    xession.env["XONSH_HISTORY_EXIT_FLUSH_TIMEOUT"] = 0.01
+
+    def flush_at_exit():
+        JsonHistoryFlusher("unused", (), queue, cond, at_exit=True)
+        finished.set()
+
+    thread = threading.Thread(target=flush_at_exit, daemon=True)
+    thread.start()
+
+    assert finished.wait(timeout=1.0)
+    assert list(queue) == [blocker]
 
 
 def test_hist_flush_on_xonsh_unload(hist, xession):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2001,6 +2001,13 @@ class PromptHistorySetting(Xettings):
         "Common abbreviations, such as '6 months' or '1 GB' are also allowed.",
         doc_default="``(8128, 'commands')`` or ``'8128 commands'``",
     )
+    XONSH_HISTORY_EXIT_FLUSH_TIMEOUT = Var.with_default(
+        2.0,
+        "Maximum seconds to wait for earlier JSON history writes when the shell "
+        "exits. If the timeout expires, the final buffered commands are discarded "
+        "so history flushing cannot block shell shutdown indefinitely.",
+        doc_default="2.0",
+    )
     XONSH_STORE_STDOUT = Var.with_default(
         False,
         "Store the ``stdout`` and ``stderr`` streams to the history. "

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -341,7 +341,11 @@ class JsonHistoryFlusher(threading.Thread):
         self.skip = skip
         if at_exit:
             with self.cond:
-                self.cond.wait_for(self.i_am_at_the_front)
+                timeout = XSH.env.get("XONSH_HISTORY_EXIT_FLUSH_TIMEOUT", 2.0)
+                if not self.cond.wait_for(self.i_am_at_the_front, timeout=timeout):
+                    self.queue.remove(self)
+                    self.cond.notify_all()
+                    return
                 self.dump()
                 self.queue.popleft()
                 self.cond.notify_all()


### PR DESCRIPTION
## Summary

Bound the JSON history exit flush wait with a configurable `XONSH_HISTORY_EXIT_FLUSH_TIMEOUT` (2 seconds by default). If an earlier writer remains stuck, the final flusher removes itself from the queue and lets shutdown continue.

Closes #6588

## Verification

- Regression test failed before the fix and passes after it
- History and environment tests: 166 passed, 1 skipped
- Full suite: 7708 passed, 80 skipped, 4 xfailed; 5 unrelated macOS/PATH failures reproduced on unchanged `main`
- `pre-commit run --all-files`

AI assisted the investigation and implementation. I reviewed the change and verified the results above.

## For community

Please click the 👍 reaction instead of leaving a `+1` or 👍 comment.
