### PR TITLE
fix(completer): preserve Python completion after quoted aliases

### DIFF
--- a/tests/completers/test_python_llm.py
+++ b/tests/completers/test_python_llm.py
@@ -1,10 +1,14 @@
-"""Path-vs-operator completion in ``xonsh/completers/python.py``.
+"""Regression coverage for ``xonsh/completers/python.py``.
 
 For an unknown command, the Python completer splits ``--home=/`` on ``=`` and
 used to offer operator tokens (``/`` ``//`` ``/=`` ``//=``) for the trailing
 ``/``.  Being exclusive and running before the path completer, those tokens
 shadowed path completion.  A value that begins with a path separator must not
 get operator completions, so the path completer can list the directory.
+
+The command context can also interpret the first quoted string in a Python
+membership expression as a command name. Command-cache suppression must use
+the raw token so quoted Python literals remain distinct from actual commands.
 """
 
 import os
@@ -25,6 +29,35 @@ def _values(result):
         return set()
     comps = result[0] if isinstance(result, tuple) else result
     return {str(c).strip() for c in comps}
+
+
+@pytest.mark.parametrize("alias_name", ["less", "more", "dir"])
+@pytest.mark.parametrize("quote", ['"', "'"])
+def test_python_completion_after_quoted_alias_membership(
+    alias_name, quote, xession, completion_context_parse
+):
+    """Quoted alias names must not make Python expressions look like commands."""
+    xession.commands_cache.aliases[alias_name] = "echo"
+    xession.ctx["aliases"] = xession.commands_cache.aliases
+    line = f"{quote}{alias_name}{quote} in ali"
+
+    context = completion_context_parse(line, len(line))
+    result = complete_python(context)
+
+    assert "aliases" in _values(result)
+
+
+def test_python_completion_still_skips_real_alias_command(
+    xession, completion_context_parse
+):
+    """An unquoted alias in command position must retain command suppression."""
+    xession.commands_cache.aliases["less"] = "echo"
+    xession.ctx["aliases"] = xession.commands_cache.aliases
+    line = "less ali"
+
+    result = complete_python(completion_context_parse(line, len(line)))
+
+    assert result is None
 
 
 @pytest.mark.parametrize(

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -202,7 +202,9 @@ def complete_python(context: CompletionContext) -> CompleterResult:
 
     if context.command and context.command.arg_index != 0:
         # this can be a command (i.e. not a subexpression)
-        first = context.command.args[0].value
+        # Preserve quotes here: a quoted Python literal can be parsed as the
+        # first command argument, but it is not an executable command.
+        first = context.command.args[0].raw_value
         ctx = context.python.ctx or {}
         if first in XSH.commands_cache and first not in ctx:  # type: ignore
             # this is a known command, so it won't be python code


### PR DESCRIPTION
Closes #5285.

When a Python expression began with a quoted alias name, the completion parser preserved the quotes but `complete_python()` checked the stripped value against the command cache. For example, `"less" in ali` was treated as arguments to the `less` command, so Python completion returned nothing.

This change checks the raw first token, keeping quoted Python literals distinct from real command names. It adds regression coverage for single- and double-quoted alias keys and retains coverage for unquoted alias command suppression.

Validation:
- `pytest -q tests/completers/test_python_llm.py tests/completers/test_python.py` (58 passed)
- `pytest -q tests/completers` (328 passed, 25 skipped)
- `pre-commit run --files xonsh/completers/python.py tests/completers/test_python_llm.py` (all passed)

AI assistance was used to investigate, implement, and test this change; the resulting code and tests were reviewed against the repository policy and issue behavior.
