### PR TITLE
fix(history): never let JSON history flushing block shell exit 

### DIFF
--- a/tests/history/test_history_json_llm.py
+++ b/tests/history/test_history_json_llm.py
@@ -1,0 +1,270 @@
+"""Concurrency tests for the json history backend.
+
+These cover the access queue that serializes readers and writers of a history
+file: nobody may be left behind in it, waiters must always be woken, and the
+final flush at shell exit must be bounded so history can never hold up
+shutdown.
+"""
+
+# pylint: disable=protected-access
+
+import collections
+import os
+import threading
+
+import pytest
+
+import xonsh.lib.lazyjson as xlj
+from xonsh.history.json import JsonHistory, JsonHistoryFlusher, _xhj_queue_turn
+
+
+@pytest.fixture
+def hist(tmpdir, xession, monkeypatch):
+    file = tmpdir / "xonsh-HISTORY-TEST-LLM.json"
+    h = JsonHistory(filename=str(file), here="yup", sessionid="SESSIONID", gc=False)
+    monkeypatch.setattr(xession, "history", h)
+    xession.env["HISTCONTROL"] = set()
+    yield h
+
+
+def wait_for(predicate, timeout=5.0):
+    """Spin until ``predicate`` holds, returning whether it did."""
+    deadline = threading.TIMEOUT_MAX if timeout is None else timeout
+    step = 0.005
+    waited = 0.0
+    while waited < deadline:
+        if predicate():
+            return True
+        threading.Event().wait(step)
+        waited += step
+    return predicate()
+
+
+def run_in_thread(func):
+    """Start ``func`` on a daemon thread and return a done-event for it."""
+    done = threading.Event()
+
+    def target():
+        try:
+            func()
+        finally:
+            done.set()
+
+    threading.Thread(target=target, daemon=True).start()
+    return done
+
+
+#
+# _xhj_queue_turn
+#
+
+
+def test_queue_turn_hands_out_turns_in_order():
+    queue = collections.deque()
+    cond = threading.Condition()
+    order = []
+    release = threading.Event()
+    items = ["a", "b", "c"]
+    for item in items:
+        queue.append(item)
+
+    def take(item):
+        with _xhj_queue_turn(queue, item, cond) as my_turn:
+            assert my_turn
+            order.append(item)
+            release.wait(5.0)
+
+    events = [run_in_thread(lambda item=item: take(item)) for item in items]
+    assert wait_for(lambda: order == ["a"])
+    release.set()
+    for done in events:
+        assert done.wait(5.0)
+    assert order == items
+    assert not queue
+
+
+def test_queue_turn_releases_the_slot_when_the_body_raises():
+    """An item left in the queue would wedge every later reader and writer."""
+    queue = collections.deque()
+    cond = threading.Condition()
+    queue.append("boom")
+
+    with pytest.raises(ZeroDivisionError):
+        with _xhj_queue_turn(queue, "boom", cond):
+            raise ZeroDivisionError("the body blew up")
+
+    assert not queue
+
+    # the queue is still usable afterwards
+    queue.append("next")
+    with _xhj_queue_turn(queue, "next", cond) as my_turn:
+        assert my_turn
+    assert not queue
+
+
+def test_queue_turn_wakes_the_next_waiter():
+    """The turn holder must notify on the way out, not only on timeout."""
+    queue = collections.deque()
+    cond = threading.Condition()
+    queue.append("first")
+    queue.append("second")
+    reached = threading.Event()
+
+    def second():
+        with _xhj_queue_turn(queue, "second", cond) as my_turn:
+            assert my_turn
+            reached.set()
+
+    done = run_in_thread(second)
+    assert not reached.wait(0.1)
+    with _xhj_queue_turn(queue, "first", cond):
+        pass
+    assert done.wait(5.0)
+    assert reached.is_set()
+    assert not queue
+
+
+def test_queue_turn_gives_up_after_the_timeout():
+    queue = collections.deque()
+    cond = threading.Condition()
+    stuck = object()
+    queue.append(stuck)
+    queue.append("me")
+
+    with _xhj_queue_turn(queue, "me", cond, timeout=0.05) as my_turn:
+        assert my_turn is False
+
+    assert list(queue) == [stuck]
+
+
+#
+# JsonHistoryFlusher
+#
+
+
+def test_flusher_threads_are_daemon(hist, xession):
+    """Non-daemon flushers are joined before the at-exit flush even runs."""
+    hist.append({"inp": "still alive", "rtn": 0})
+    hf = hist.flush()
+    assert hf.daemon
+    hf.join(5.0)
+    assert not hf.is_alive()
+
+
+def test_exit_flush_gives_up_on_a_wedged_writer(hist, xession, capsys):
+    """A writer stuck inside dump() must not block shutdown."""
+    xession.env["XONSH_HISTORY_EXIT_FLUSH_TIMEOUT"] = 0.05
+    wedged = threading.Event()
+    release = threading.Event()
+
+    class WedgedFlusher(JsonHistoryFlusher):
+        def dump(self):
+            wedged.set()
+            release.wait(10.0)
+
+    WedgedFlusher(hist.filename, (), hist._queue, hist._cond, skip=None)
+    assert wedged.wait(5.0)
+
+    hist.append({"inp": "lost to the timeout", "rtn": 0})
+    done = run_in_thread(lambda: hist.flush(at_exit=True))
+    assert done.wait(5.0), "the exit flush blocked on a wedged writer"
+
+    err = capsys.readouterr().err
+    assert "dropping 1 command(s)" in err
+    assert "XONSH_HISTORY_EXIT_FLUSH_TIMEOUT" in err
+
+    release.set()
+
+
+def test_exit_flush_gives_up_on_a_stalled_queue_entry(hist, xession):
+    xession.env["XONSH_HISTORY_EXIT_FLUSH_TIMEOUT"] = 0.05
+    stalled = object()
+    hist._queue.append(stalled)
+    hist.append({"inp": "lost to the timeout", "rtn": 0})
+
+    done = run_in_thread(lambda: hist.flush(at_exit=True))
+    assert done.wait(5.0), "the exit flush blocked on a stalled queue entry"
+    assert list(hist._queue) == [stalled], "the exit flush stayed in the queue"
+
+
+def test_exit_flush_still_writes_when_the_queue_is_free(hist, xession):
+    hist.append({"inp": "kept", "rtn": 0})
+    hist.flush(at_exit=True)
+    with xlj.LazyJSON(hist.filename) as lj:
+        assert [cmd["inp"] for cmd in lj["cmds"].load()] == ["kept"]
+        assert lj["locked"] is False
+    assert not hist._queue
+
+
+def test_dump_removes_the_temp_file_when_the_write_fails(
+    hist, xession, monkeypatch, capsys
+):
+    def boom(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(xlj, "ljdump", boom)
+    hist.append({"inp": "doomed", "rtn": 0})
+    hist.flush(at_exit=True)
+
+    assert "failed to write" in capsys.readouterr().err
+    dirname = os.path.dirname(hist.filename)
+    leftovers = [f for f in os.listdir(dirname) if f.endswith(".json.tmp")]
+    assert leftovers == []
+
+
+#
+# JsonCommandField
+#
+
+
+def flush_and_wait(hist):
+    hf = hist.flush()
+    if hf is not None:
+        hf.join(5.0)
+    assert wait_for(lambda: not hist._queue)
+
+
+def test_command_field_read_wakes_waiters(hist, xession):
+    """Reading a field pops the queue; it must notify or waiters park forever."""
+    hist.append({"inp": "one", "rtn": 0})
+    hist.append({"inp": "two", "rtn": 0})
+    flush_and_wait(hist)
+
+    blocker = object()
+    hist._queue.append(blocker)
+
+    read = []
+    reader_done = run_in_thread(lambda: read.append(hist.inps[0]))
+    assert wait_for(lambda: len(hist._queue) == 2)
+
+    waiter = object()
+    hist._queue.append(waiter)
+    waiter_reached = threading.Event()
+
+    def behind_the_reader():
+        with _xhj_queue_turn(hist._queue, waiter, hist._cond):
+            waiter_reached.set()
+
+    waiter_done = run_in_thread(behind_the_reader)
+    assert wait_for(lambda: len(hist._queue) == 3)
+
+    with hist._cond:
+        hist._queue.remove(blocker)
+        hist._cond.notify_all()
+
+    assert reader_done.wait(5.0)
+    assert read == ["one"]
+    assert waiter_done.wait(5.0), "the field read did not wake the next waiter"
+    assert waiter_reached.is_set()
+    assert not hist._queue
+
+
+def test_command_field_read_error_does_not_wedge_the_queue(hist, xession):
+    hist.append({"inp": "one", "rtn": 0})
+    flush_and_wait(hist)
+    os.remove(hist.filename)
+
+    with pytest.raises(OSError):
+        _ = hist.inps[0]
+
+    assert not hist._queue, "the failed read stayed at the head of the queue"

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -2001,6 +2001,15 @@ class PromptHistorySetting(Xettings):
         "Common abbreviations, such as '6 months' or '1 GB' are also allowed.",
         doc_default="``(8128, 'commands')`` or ``'8128 commands'``",
     )
+    XONSH_HISTORY_EXIT_FLUSH_TIMEOUT = Var.with_default(
+        2.0,
+        "Number of seconds the final history flush waits for an earlier, still "
+        "unfinished history write when the shell is exiting. Once the timeout "
+        "expires the buffered commands are dropped and shutdown continues, so "
+        "that a history file on an unresponsive filesystem cannot keep the "
+        "shell alive. Only the ``json`` history backend uses this.",
+        doc_default="2.0",
+    )
     XONSH_STORE_STDOUT = Var.with_default(
         False,
         "Store the ``stdout`` and ``stderr`` streams to the history. "

--- a/xonsh/history/json.py
+++ b/xonsh/history/json.py
@@ -2,6 +2,7 @@
 
 import collections
 import collections.abc as cabc
+import contextlib
 import os
 import re
 import sys
@@ -324,6 +325,57 @@ class JsonHistoryGC(threading.Thread):
         return files
 
 
+@contextlib.contextmanager
+def _xhj_queue_turn(queue, item, cond, timeout=None):
+    """Take a turn at the head of a history file access queue.
+
+    ``queue`` holds every reader and writer waiting for exclusive access to a
+    history file, oldest first, and ``cond`` guards it. Callers append ``item``
+    themselves before entering, at the moment the access is requested, so that
+    the queue order matches the order the reads and writes were issued in.
+
+    Sitting at the head of ``queue`` *is* the exclusive access token, so ``cond``
+    is only ever held for the queue bookkeeping and never for the file I/O
+    itself. That matters at shutdown: a writer wedged on an unresponsive
+    filesystem parks at the head of the queue without holding ``cond``, which
+    leaves everyone behind it waiting on the condition rather than on the lock,
+    and so still able to time out.
+
+    Yields ``True`` once ``item`` reaches the head, and always drops it from the
+    queue and wakes the next waiter on the way out, including when the body
+    raises. An item left behind would sit at the head forever and block every
+    later reader and writer for the rest of the session.
+
+    If ``timeout`` seconds pass without the turn coming, ``item`` is dropped
+    from the queue and ``False`` is yielded, without exclusive access ever
+    having been granted.
+
+    Parameters
+    ----------
+    queue : collections.deque
+        The FIFO of pending history file users.
+    item : object
+        The entry the caller has already appended to ``queue``.
+    cond : threading.Condition
+        The condition guarding ``queue``.
+    timeout : float or None, optional
+        Seconds to wait for the turn, or ``None`` to wait indefinitely.
+    """
+    with cond:
+        if not cond.wait_for(lambda: bool(queue) and item is queue[0], timeout):
+            with contextlib.suppress(ValueError):
+                queue.remove(item)
+            cond.notify_all()
+            yield False
+            return
+    try:
+        yield True
+    finally:
+        with cond:
+            queue.popleft()
+            cond.notify_all()
+
+
 class JsonHistoryFlusher(threading.Thread):
     """Flush shell history to disk periodically."""
 
@@ -332,6 +384,11 @@ class JsonHistoryFlusher(threading.Thread):
     ):
         """Thread for flushing history."""
         super().__init__(*args, **kwargs)
+        # History must never be the reason the interpreter cannot shut down:
+        # non-daemon threads are joined before the at-exit flush handler even
+        # runs, so a flusher stuck on an unresponsive filesystem would hang the
+        # process past any timeout the exit path could apply.
+        self.daemon = True
         self.filename = filename
         self.buffer = buffer
         self.queue = queue
@@ -340,24 +397,25 @@ class JsonHistoryFlusher(threading.Thread):
         self.at_exit = at_exit
         self.skip = skip
         if at_exit:
-            with self.cond:
-                self.cond.wait_for(self.i_am_at_the_front)
-                self.dump()
-                self.queue.popleft()
-                self.cond.notify_all()
+            timeout = XSH.env.get("XONSH_HISTORY_EXIT_FLUSH_TIMEOUT", 2.0)
+            with _xhj_queue_turn(queue, self, cond, timeout=timeout) as my_turn:
+                if my_turn:
+                    self.dump()
+                else:
+                    print(
+                        f"history: dropping {len(self.buffer)} command(s): an "
+                        f"earlier history write did not finish within {timeout}s "
+                        "(see $XONSH_HISTORY_EXIT_FLUSH_TIMEOUT).",
+                        file=sys.stderr,
+                    )
         else:
             self.start()
 
     def run(self):
-        with self.cond:
-            self.cond.wait_for(self.i_am_at_the_front)
+        # No timeout here: a background flusher may wait as long as it takes,
+        # and being a daemon thread it cannot hold up shutdown.
+        with _xhj_queue_turn(self.queue, self, self.cond):
             self.dump()
-            self.queue.popleft()
-            self.cond.notify_all()
-
-    def i_am_at_the_front(self):
-        """Tests if the flusher is at the front of the queue."""
-        return self is self.queue[0]
 
     def dump(self):
         """Write the cached history to external storage."""
@@ -401,6 +459,8 @@ class JsonHistoryFlusher(threading.Thread):
                 xlj.ljdump(hist, f, sort_keys=True)
         except Exception as err:
             print(f"history: failed to write {tmpname!r}: {err}", file=sys.stderr)
+            with contextlib.suppress(OSError):
+                os.unlink(tmpname)
             return
         try:
             os.replace(tmpname, self.filename)
@@ -409,6 +469,8 @@ class JsonHistoryFlusher(threading.Thread):
                 f"history: failed to replace {tmpname!r} -> {self.filename!r}: {err}",
                 file=sys.stderr,
             )
+            with contextlib.suppress(OSError):
+                os.unlink(tmpname)
 
 
 class JsonCommandField(cabc.Sequence):
@@ -455,19 +517,13 @@ class JsonCommandField(cabc.Sequence):
         # now we know we have to go into the file
         queue = self.hist._queue
         queue.append(self)
-        with self.hist._cond:
-            self.hist._cond.wait_for(self.i_am_at_the_front)
+        with _xhj_queue_turn(queue, self, self.hist._cond):
             with open(self.hist.filename, newline="\n", encoding="utf-8") as f:
                 lj = xlj.LazyJSON(f, reopen=False)
                 rtn = lj["cmds"][key].get(self.field, self.default)
                 if isinstance(rtn, xlj.LJNode):
                     rtn = rtn.load()
-            queue.popleft()
         return rtn
-
-    def i_am_at_the_front(self):
-        """Tests if the command field is at the front of the queue."""
-        return self is self.hist._queue[0]
 
 
 class JsonHistory(History):


### PR DESCRIPTION
Fixes issues that found in https://github.com/xonsh/xonsh/pull/6592 but not fixed completely in that PR.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
