### PR TITLE
fix(completer): don't read a quoted first token as a command name

### DIFF
--- a/tests/completers/test_quoted_command_llm.py
+++ b/tests/completers/test_quoted_command_llm.py
@@ -1,0 +1,213 @@
+"""A quoted first token is a string literal, not a command name.
+
+Xonsh has no implicit subprocess form that starts with a quote -- ``"ls" -l``
+is a syntax error -- so a line like ``"less" in aliases`` is Python, and the
+completers that resolve "which executable does this line run" must not read it
+as an invocation of ``less``.  They all ask that question through
+``CommandContext.command_name``, which answers ``None`` for such a line while
+still resolving the shell quoting that *is* meaningful inside an explicit
+subprocess block (``![ "/opt/my prog" --help ]``).
+
+Covers ``CommandContext.command_name`` itself and its four callers: the python,
+import, man-page and alias completers.
+"""
+
+import pytest
+
+from xonsh.completers._aliases import complete_aliases
+from xonsh.completers.imports import complete_import
+from xonsh.completers.man import complete_from_man
+from xonsh.completers.python import complete_python
+from xonsh.parsers.completion_context import CommandArg, CommandContext
+from xonsh.pytest.tools import skip_if_on_windows
+
+# every way of opening a string literal the lexer reports as a quote
+QUOTES = ['"', "'", 'r"', 'f"', 'b"', 'rb"', '"""', "'''"]
+
+
+@pytest.fixture(autouse=True)
+def xonsh_execer_autouse(xession, xonsh_execer):
+    return xonsh_execer
+
+
+def _values(result):
+    """Flatten a completer result into a set of strings."""
+    if not result:
+        return set()
+    comps = result[0] if isinstance(result, tuple) else result
+    return {str(c).strip() for c in comps}
+
+
+#
+# CommandContext.command_name
+#
+
+
+def test_command_name_is_the_unquoted_first_arg():
+    ctx = CommandContext(args=(CommandArg("git"), CommandArg("log")), arg_index=2)
+    assert ctx.command_name == "git"
+
+
+def test_command_name_is_none_without_args():
+    assert CommandContext(args=(), arg_index=0).command_name is None
+
+
+@pytest.mark.parametrize("quote", QUOTES)
+def test_command_name_is_none_for_a_quoted_first_arg(quote):
+    closing = quote.lstrip("rbf")
+    ctx = CommandContext(
+        args=(CommandArg("less", quote, closing), CommandArg("in")), arg_index=2
+    )
+    assert ctx.command_name is None
+
+
+@pytest.mark.parametrize("subcmd_opening", ["![", "$[", "$(", "!("])
+def test_command_name_keeps_quoting_inside_a_subproc_block(subcmd_opening):
+    """``![ "/opt/my prog" -x ]`` really does name a command."""
+    ctx = CommandContext(
+        args=(CommandArg("/opt/my prog", '"', '"'),),
+        arg_index=1,
+        subcmd_opening=subcmd_opening,
+    )
+    assert ctx.command_name == "/opt/my prog"
+
+
+@pytest.mark.parametrize("quote", ['"', "'", 'r"', 'f"'])
+def test_command_name_from_a_parsed_line(quote, completion_context_parse):
+    closing = quote.lstrip("rbf")
+    line = f"{quote}less{closing} in ali"
+    assert completion_context_parse(line, len(line)).command.command_name is None
+
+    line = "less in ali"
+    assert completion_context_parse(line, len(line)).command.command_name == "less"
+
+
+#
+# complete_python -- the reported bug, xonsh/xonsh#5285
+#
+
+
+@pytest.fixture
+def aliased(xession):
+    """Register ``less`` as an alias and expose ``aliases`` to python."""
+    xession.commands_cache.aliases["less"] = "echo"
+    xession.ctx["aliases"] = xession.commands_cache.aliases
+    return xession
+
+
+@pytest.mark.parametrize("quote", ['"', "'", 'r"', 'f"', 'b"', 'rb"', '"""'])
+@pytest.mark.parametrize("op", ["in", "not in", "=="])
+def test_python_completes_after_a_quoted_command_name(
+    quote, op, aliased, completion_context_parse
+):
+    """``"less" in ali<TAB>`` must complete ``aliases``."""
+    closing = quote.lstrip("rbf")
+    line = f"{quote}less{closing} {op} ali"
+    result = complete_python(completion_context_parse(line, len(line)))
+    assert "aliases" in _values(result)
+
+
+@pytest.mark.parametrize("line", ["less ali", "less -x ali", "/bin/ls ali"])
+def test_python_still_skips_a_real_command_line(
+    line, aliased, completion_context_parse
+):
+    """An unquoted command keeps suppressing python completion."""
+    assert complete_python(completion_context_parse(line, len(line))) is None
+
+
+def test_python_completion_after_quoted_command_end_to_end(aliased, completer_obj):
+    """Full pipeline: ``"less" in ali<TAB>`` offers ``aliases``, not paths."""
+    line = '"less" in ali'
+    comps, _ = completer_obj.complete_line(line)
+    assert "aliases" in {str(c).strip() for c in comps}
+
+
+#
+# complete_import
+#
+
+
+@pytest.mark.parametrize("keyword", ["from", "import"])
+@pytest.mark.parametrize("quote", ['"', "'"])
+def test_import_ignores_a_quoted_keyword(
+    keyword, quote, xession, completion_context_parse
+):
+    """``"import" in aliases<TAB>`` is not an import statement."""
+    line = f"{quote}{keyword}{quote} in ali"
+    assert not _values(complete_import(completion_context_parse(line, len(line))))
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [("from os imp", "import"), ("import o", "os"), ("from o", "os")],
+)
+def test_import_still_completes_real_statements(
+    line, expected, xession, completion_context_parse
+):
+    assert expected in _values(
+        complete_import(completion_context_parse(line, len(line)))
+    )
+
+
+#
+# complete_from_man
+#
+
+
+@skip_if_on_windows
+def test_man_ignores_a_quoted_command_name(xession, completion_context_parse):
+    """``"less" -<TAB>`` must not offer ``less``'s options."""
+    line = '"less" -'
+    assert not _values(complete_from_man(completion_context_parse(line, len(line))))
+
+
+@skip_if_on_windows
+def test_man_still_completes_a_real_command(xession, completion_context_parse):
+    from xonsh.completers.man import _man_page_path
+
+    if _man_page_path("less") is None:
+        pytest.skip("no man page for 'less' on this host")
+    line = "less -"
+    assert _values(complete_from_man(completion_context_parse(line, len(line))))
+
+
+#
+# complete_aliases
+#
+
+
+@pytest.fixture
+def alias_with_completer(xession):
+    """An alias whose ``xonsh_complete`` records that it was called."""
+    calls = []
+
+    def completer(command, alias):
+        calls.append(command)
+        return {"FROM-THE-ALIAS"}
+
+    def func(args):
+        pass
+
+    func.xonsh_complete = completer
+    xession.aliases["mycmd"] = func
+    xession.ctx["aliases"] = xession.aliases
+    return calls
+
+
+def test_aliases_ignores_a_quoted_command_name(
+    alias_with_completer, completion_context_parse
+):
+    """``"mycmd" in aliases<TAB>`` must not run ``mycmd``'s completer."""
+    line = '"mycmd" in ali'
+    assert not _values(complete_aliases(completion_context_parse(line, len(line))))
+    assert alias_with_completer == []
+
+
+def test_aliases_still_completes_a_real_command(
+    alias_with_completer, completion_context_parse
+):
+    line = "mycmd ali"
+    assert "FROM-THE-ALIAS" in _values(
+        complete_aliases(completion_context_parse(line, len(line)))
+    )
+    assert len(alias_with_completer) == 1

--- a/xonsh/completers/_aliases.py
+++ b/xonsh/completers/_aliases.py
@@ -151,9 +151,9 @@ def complete_aliases(command: CommandContext):
     The said attribute should be a function. The current command context is passed to it.
     """
 
-    if not command.args:
+    cmd = command.command_name
+    if cmd is None:
         return
-    cmd = command.args[0].value
 
     resolved = XSH.aliases.get(cmd)
     if not resolved:

--- a/xonsh/completers/imports.py
+++ b/xonsh/completers/imports.py
@@ -189,20 +189,25 @@ def complete_import(context: CompletionContext):
         # can't have a quoted import
         return None
 
+    keyword = command.command_name
+    if keyword is None:
+        # a quoted first token is a string literal, not an import statement
+        return None
+
     arg_index = command.arg_index
     prefix = command.prefix
     args = command.args
 
-    if arg_index == 1 and args[0].value == "from":
+    if arg_index == 1 and keyword == "from":
         # completing module to import
         return complete_module(prefix)
-    if arg_index >= 1 and args[0].value == "import":
+    if arg_index >= 1 and keyword == "import":
         # completing module to import, might be multiple modules
         prefix = prefix.rsplit(",", 1)[-1]
         return complete_module(prefix), len(prefix)
-    if arg_index == 2 and args[0].value == "from":
+    if arg_index == 2 and keyword == "from":
         return {RichCompletion("import", append_space=True)}
-    if arg_index > 2 and args[0].value == "from" and args[2].value == "import":
+    if arg_index > 2 and keyword == "from" and args[2].value == "import":
         # complete thing inside a module, might be multiple objects
         module = args[1].value
         prefix = prefix.rsplit(",", 1)[-1]

--- a/xonsh/completers/man.py
+++ b/xonsh/completers/man.py
@@ -153,7 +153,9 @@ def complete_from_man(context: CommandContext):
 
     if context.arg_index == 0 or not context.prefix.startswith("-"):
         return
-    cmd = context.args[0].value
+    cmd = context.command_name
+    if cmd is None:
+        return
 
     # Tools like cargo, docker use per-subcommand man pages
     # (e.g. cargo-build). Try the hyphenated form first.

--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -201,10 +201,16 @@ def complete_python(context: CompletionContext) -> CompleterResult:
         return None
 
     if context.command and context.command.arg_index != 0:
-        # this can be a command (i.e. not a subexpression)
-        first = context.command.args[0].value
+        # this can be a command (i.e. not a subexpression).
+        # ``command_name`` is None when the first token cannot name a command at
+        # all -- a quoted string literal -- so ``"less" in aliases`` stays python.
+        first = context.command.command_name
         ctx = context.python.ctx or {}
-        if first in XSH.commands_cache and first not in ctx:  # type: ignore
+        if (
+            first is not None
+            and first in XSH.commands_cache  # type: ignore
+            and first not in ctx
+        ):
             # this is a known command, so it won't be python code
             return None
 

--- a/xonsh/parsers/completion_context.py
+++ b/xonsh/parsers/completion_context.py
@@ -87,6 +87,28 @@ class CommandContext(NamedTuple):
         return None
 
     @property
+    def command_name(self) -> "str | None":
+        """The name of the command this line runs, or ``None`` if it runs none.
+
+        A quoted first token is a Python string literal, not a command name:
+        xonsh has no implicit subprocess form that starts with a quote --
+        ``"ls" -l`` is a syntax error -- so ``"less" in aliases`` is Python and
+        must not be read as an invocation of ``less``. Inside an explicit
+        subprocess block the quotes are ordinary shell quoting instead, and
+        ``![ "/opt/my prog" --help ]`` does name a command.
+
+        Completers deciding *which executable* the line runs should use this
+        rather than ``args[0].value``, which drops that distinction, or
+        ``command``, which keeps the quotes as part of the name.
+        """
+        if not self.args:
+            return None
+        first = self.args[0]
+        if first.opening_quote and not self.subcmd_opening:
+            return None
+        return first.value
+
+    @property
     def words_before_cursor(self) -> str:
         """words without current prefix"""
         return " ".join([arg.raw_value for arg in self.args[: self.arg_index]])


### PR DESCRIPTION
Closes #5285 #6593.

## Problem

Typing `"less" in ali<TAB>` completes nothing. The same happens for `"more"`,
`"dir"` — in fact for every key of the `aliases` dict, and for every name on
`$PATH`.

```xonshcon
@ "less" in ali<TAB>
# nothing, or unrelated file names

@ "dirr" in ali<TAB>
"dirr" in aliases     # works, because `dirr` is not a command
```

`complete_python` skips Python completion when the line looks like a command
line. It decided that from `context.command.args[0].value`, which is the first
token **with the quotes stripped** — so the string literal `"less"` matched the
command cache entry for `less`, and the expression was mistaken for an
invocation of that command.

This is a regression from `224fc55e4` (#4017, March 2021). The original guard
in `1500a7770` used `line.split()[0]`, which kept the quotes and therefore never
matched.

While tracking that down, three more completers turned out to resolve "which
command does this line run" the same wrong way. Measured on `main`:

| Completer | Line | Current output |
| --- | --- | --- |
| `complete_python` | `"less" in ali<TAB>` | nothing (#5285) |
| `complete_import` | `"import" in ali<TAB>` | a list of importable modules |
| `complete_import` | `"from" in ali<TAB>` | `import` |
| `complete_from_man` | `"less" -<TAB>` | `less`'s options (`--CLEAR-SCREEN`, …) |
| `complete_aliases` | `"mycmd" in ali<TAB>` | runs `mycmd`'s `xonsh_complete` |

## Fix

A quoted first token can never name a command in an implicit subprocess line —
xonsh rejects it outright:

```xonshcon
@ "echo" hello
SyntaxError: code: hello
```

Inside an explicit subprocess block the quotes are ordinary quoting and the
token *does* name a command, which `![ "/opt/my prog" --help ]` relies on.

So the whole question collapses into one property on `CommandContext`, and all
four completers now ask it instead of reaching into `args[0].value`:

```python
@property
def command_name(self) -> "str | None":
    """The name of the command this line runs, or ``None`` if it runs none."""
    if not self.args:
        return None
    first = self.args[0]
    if first.opening_quote and not self.subcmd_opening:
        return None
    return first.value
```

`opening_quote` carries the complete literal prefix (`"`, `'`, `r"`, `f"`, `b"`,
`rb"`, `"""`), so every form of string literal is covered by that one check.
`CommandContext.command`, which keeps the quotes and is used to dispatch
xompletions, is left alone — it already behaves correctly.

## Before / after

Full completer pipeline in a live `xonsh --no-rc` session:

| Line | Before | After |
| --- | --- | --- |
| `"less" in ali<TAB>` | nothing | `aliases`, `default_aliases` |
| `"import" in ali<TAB>` | module names | `aliases`, `default_aliases` |
| `"from" in ali<TAB>` | `import` | `aliases`, `default_aliases` |
| `"less" -<TAB>` | `less`'s man-page options | nothing |
| `less ali<TAB>` | paths | paths (unchanged) |
| `import o<TAB>` | module names | module names (unchanged) |
| `from os imp<TAB>` | `import` | `import` (unchanged) |

## Not changed

An **unquoted** first token that collides with a command name — `less = ali`,
`less in ali`, `less + ali` — still suppresses Python completion. Unlike the
quoted case this is genuinely ambiguous: `less = ali` is a legal invocation of
`less` with the arguments `=` and `ali`. Guessing here would degrade completion
for ordinary command lines, which is by far the more common case at the prompt.

## Tests

`tests/completers/test_quoted_command_llm.py`, 54 tests. The file is
topic-scoped rather than module-mirroring because the behaviour spans the
completion-context parser and four completer modules — the exception `CLAUDE.md`
allows for exactly this shape. It covers `CommandContext.command_name`
(unquoted, every quote form, all four subprocess openings, no args) and the
before/after behaviour of each of the four completers, each paired with a test
that the corresponding real command line is untouched.

Against unmodified `main` the file reports **46 failed, 8 passed** — the 8 are
exactly the "real command line still works" cases.

## Validation

- `pytest tests/completers/test_quoted_command_llm.py` — 54 passed
- `pytest tests/completers/ tests/parsers/ tests/test_completer.py` — 3231 passed, 25 skipped, 1 xfailed
- `pytest tests/` — 7783 passed, 79 skipped, 3 xfailed, 1 xpassed (4 unrelated local-environment failures in `tests/lib/test_inspectors_llm.py` reproduce on unchanged `main`)
- `ruff check .`, `ruff format --check`, `mypy` — clean, no new findings

AI assisted the investigation, implementation and testing; the change and the
results above were reviewed.

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
